### PR TITLE
test: add SRT visual geometry evidence

### DIFF
--- a/.agent/verify.md
+++ b/.agent/verify.md
@@ -18,6 +18,7 @@ Validation lanes discovered:
 
 - `build`: `npm run content:check` (required)
 - `test`: `npm run test` (required)
+- `e2e`: `npm run test:e2e` (required when selected with `--e2e` or `--all`)
 
 Deploy contract:
 

--- a/.github/workflows/agent-evidence.yml
+++ b/.github/workflows/agent-evidence.yml
@@ -115,12 +115,8 @@ jobs:
             exit 0
           fi
           body="$(MANIFEST="$manifest" node -e 'const fs=require("fs"); const m=JSON.parse(fs.readFileSync(process.env.MANIFEST,"utf8")); const lines=["<!-- agent-evidence -->","### Agent evidence","",`- Result: \`${m.result}\``,`- Commit: \`${m.commit}\``,`- Dirty: \`${m.dirty === true ? "true" : "false"}\``,`- Lanes: \`${(m.lanes_run || []).join(", ") || "(none)"}\``,`- Required failures: \`${(m.required_failures || []).join(", ") || "(none)"}\``]; console.log(lines.join("\n"));')"
-          body="$body"$'
-'"- Artifact: \`agent-evidence-${{ github.run_id }}\`"$'
-'"- Download: \`gh run download ${{ github.run_id }} --name agent-evidence-${{ github.run_id }}\`"
-          body="$body"$'
-'"- Manifest artifact: \`agent-evidence-manifest-${{ github.run_id }}\`"$'
-'"- Manifest download: \`gh run download ${{ github.run_id }} --name agent-evidence-manifest-${{ github.run_id }}\`"
+          body="$body"$'\n'"- Artifact: \`agent-evidence-${{ github.run_id }}\`"$'\n'"- Download: \`gh run download ${{ github.run_id }} --name agent-evidence-${{ github.run_id }}\`"
+          body="$body"$'\n'"- Manifest artifact: \`agent-evidence-manifest-${{ github.run_id }}\`"$'\n'"- Manifest download: \`gh run download ${{ github.run_id }} --name agent-evidence-manifest-${{ github.run_id }}\`"
           existing="$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("<!-- agent-evidence -->")) | .id' | tail -1)"
           if [ -n "$existing" ]; then
             gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$existing" -f body="$body" >/dev/null

--- a/.github/workflows/agent-evidence.yml
+++ b/.github/workflows/agent-evidence.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install pinned Chromium and system dependencies
+        run: npx playwright install --with-deps chromium
+
       - name: Run agent evidence
         id: evidence
         shell: bash
@@ -38,7 +41,7 @@ jobs:
           GITHUB_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           set +e
-          bash scripts/agent-evidence
+          bash scripts/agent-evidence --e2e
           status=$?
           echo "status=$status" >> "$GITHUB_OUTPUT"
           manifest="$(find .agent/evidence -name manifest.json | sort | tail -1)"

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -111,4 +111,11 @@ export default defineConfig({
   devToolbar: {
     enabled: false,
   },
+  vite: {
+    server: {
+      watch: {
+        ignored: ['**/.agent/evidence/**'],
+      },
+    },
+  },
 })

--- a/docs/adr/005-srt-visual-evidence-and-geometry.md
+++ b/docs/adr/005-srt-visual-evidence-and-geometry.md
@@ -1,0 +1,50 @@
+# ADR 005: SRT Visual Evidence and Geometry Diagnostics
+
+## Status
+
+Accepted for reproducible four-target evidence without an approved pixel baseline.
+
+## Context
+
+The four SRT profiles share canonical nodes and deterministic composition policy, but unit tests cannot detect browser-only clipping, overlap, or overflow. The next dependency-ready slice needs reviewable screenshots and mechanical geometry checks without silently accepting a visual baseline or implementing finite-height pagination early.
+
+## Decision
+
+Playwright `1.61.1` is an exact development dependency. Its bundled Chromium revision is installed from the lockfile on CI and the trusted VM:
+
+```bash
+npm ci
+npx playwright install --with-deps chromium
+```
+
+`playwright.config.ts` fixes the browser engine, 1440 × 1200 CSS-pixel viewport, 1× device scale, UTC timezone, `en-US` locale, light color scheme, reduced motion, one worker, and zero retries. The test waits for `document.fonts.ready` before measuring. The site shell uses the repository's versioned Geist webfonts; the article uses the target profile's declared Georgia/Times/serif stack and the font packages installed by Playwright's operating-system dependency setup. Both CI and the trusted VM must use the command above rather than a system browser with ad hoc dependencies.
+
+One browser test switches the single semantic article renderer through all four target profiles. It measures each rendition in the studio, then moves that fully composed paper element onto an isolated capture surface so sticky site chrome and the studio's scroll container cannot obscure the artifact. Target paper dimensions and composition styles remain unchanged. For each profile it writes a complete paper screenshot and records rendered dimensions, canonical node IDs, missing or duplicated nodes, clipped boxes, intersecting non-ancestor boxes, and horizontal overflow. A selected `e2e` evidence lane fails on any diagnostic and stores its screenshots, JSON geometry report, failure trace, and log beneath `.agent/evidence/`. These outputs remain CI/evidence artifacts and are ignored by Git.
+
+The Playwright configuration sets `updateSnapshots: 'none'`. No pixel baselines are created in this issue because baseline creation or acceptance requires human review. CI never invokes a snapshot-update mode. A future reviewed baseline must also pin any font files needed for pixel-level portability before the golden images are accepted.
+
+## Reproduction
+
+Run the focused harness locally with:
+
+```bash
+npm run test:e2e
+```
+
+Run the full issue contract, including browser evidence, with:
+
+```bash
+scripts/agent-evidence --e2e
+```
+
+The dedicated agent-evidence workflow installs the pinned Chromium build, runs the full command, and uploads `.agent/evidence/` even when a browser assertion fails.
+
+## Consequences
+
+Every target now produces reviewable visual evidence and fails mechanically on missing content, clipping, overlap, or horizontal overflow. The geometry report remains inspectable instead of reducing failure to an opaque image difference.
+
+The harness does not claim pixel equality and does not approve a visual baseline. Finite target height is still a profile capability and minimum preview size; pagination and fragmentation remain the next dependency-ready issue.
+
+## Non-goals
+
+This decision does not add pagination, fixture-specific coordinates, arbitrary PDF reconstruction, annotations, target overrides, exports, production deployment, or unattended golden-image updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "typescript": "^5.7.2"
       },
       "devDependencies": {
+        "@playwright/test": "1.61.1",
         "@tailwindcss/typography": "^0.5.15",
         "fast-glob": "^3.3.3",
         "gray-matter": "^4.0.3",
@@ -2604,6 +2605,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -9912,6 +9929,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.2",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "test": "vitest run",
+    "test": "vitest run --exclude 'tests/e2e/**'",
+    "test:e2e": "playwright test",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "worker:build": "npm run build",
@@ -78,6 +79,7 @@
     "typescript": "^5.7.2"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@tailwindcss/typography": "^0.5.15",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test'
+import path from 'node:path'
+
+const evidenceRoot = process.env.AGENT_EVIDENCE_DIR ?? '.agent/evidence'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: 1,
+  outputDir: path.resolve(evidenceRoot, 'playwright'),
+  reporter: [['line']],
+  updateSnapshots: 'none',
+  use: {
+    baseURL: 'http://127.0.0.1:1234',
+    browserName: 'chromium',
+    colorScheme: 'light',
+    deviceScaleFactor: 1,
+    locale: 'en-US',
+    contextOptions: { reducedMotion: 'reduce' },
+    timezoneId: 'UTC',
+    trace: 'retain-on-failure',
+    viewport: { width: 1440, height: 1200 },
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1',
+    url: 'http://127.0.0.1:1234/research',
+    reuseExistingServer: false,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/scripts/agent-evidence
+++ b/scripts/agent-evidence
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 node - "$@" <<'NODE'
-const { mkdirSync, writeFileSync, existsSync, readFileSync, statSync } = require("node:fs");
+const { mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync, statSync } = require("node:fs");
 const { join } = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { createHash } = require("node:crypto");
@@ -15,6 +15,12 @@ const allLanes = [
     "id": "test",
     "command": "npm run test",
     "required": true
+  },
+  {
+    "id": "e2e",
+    "command": "npm run test:e2e",
+    "required": true,
+    "optional": true
   }
 ];
 const invocation = {
@@ -26,8 +32,13 @@ const stamp = new Date().toISOString().replace(/[-:]/g, "").replace(".", "");
 const outDir = join(".agent", "evidence", stamp);
 mkdirSync(join(outDir, "logs"), { recursive: true });
 
-function sh(command) {
-  return spawnSync(command, { shell: true, encoding: "utf8", timeout: 900000 });
+function sh(command, env = {}) {
+  return spawnSync(command, {
+    shell: true,
+    encoding: "utf8",
+    timeout: 900000,
+    env: { ...process.env, ...env },
+  });
 }
 
 function textHash(value) {
@@ -77,7 +88,7 @@ function parseSelection(argv) {
   }
   if (includeAll) return { lanes: allLanes };
 
-  const selected = allLanes.filter((lane) => lane.required);
+  const selected = allLanes.filter((lane) => lane.required && !lane.optional);
   if (includeE2e) {
     for (const lane of allLanes) {
       if (lane.id === "e2e" && !selected.some((selectedLane) => selectedLane.id === lane.id)) {
@@ -150,6 +161,27 @@ function largeUntrackedEvidence() {
   return { artifacts, caveats };
 }
 
+function generatedEvidenceArtifacts(root) {
+  const artifacts = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile()) {
+        let kind = "evidence-file";
+        if (path.endsWith(".png")) kind = "screenshot";
+        else if (path.endsWith("geometry-report.json")) kind = "geometry-report";
+        else if (path.endsWith("trace.zip")) kind = "browser-trace";
+        else if (path.endsWith(".log")) kind = "test-log";
+        artifacts.push({ kind, path });
+      }
+    }
+  };
+  visit(root);
+  return artifacts;
+}
+
 function writeManifest(data, exitCode) {
   writeFileSync(join(outDir, "manifest.json"), `${JSON.stringify(data, null, 2)}\n`);
   console.log(`[agent-evidence] ${data.result}: ${join(outDir, "manifest.json")}`);
@@ -197,7 +229,7 @@ const lanes = selection.lanes;
 
 for (const lane of lanes) {
   const laneStart = Date.now();
-  const proc = sh(lane.command);
+  const proc = sh(lane.command, { AGENT_EVIDENCE_DIR: outDir });
   const output = redact(`${proc.stdout || ""}${proc.stderr || ""}`);
   const logPath = join(outDir, "logs", `${lane.id}.log`);
   writeFileSync(logPath, output);
@@ -233,7 +265,11 @@ const manifest = {
     node: process.version,
   },
   lanes: results,
-  artifacts: [{ kind: "manifest", path: join(outDir, "manifest.json") }, ...largeFiles.artifacts],
+  artifacts: [
+    { kind: "manifest", path: join(outDir, "manifest.json") },
+    ...generatedEvidenceArtifacts(outDir),
+    ...largeFiles.artifacts,
+  ],
   caveats: largeFiles.caveats,
   result: requiredFailures.length === 0 ? "passed" : "failed",
   required_failures: requiredFailures,

--- a/src/components/research/ResearchStudio.tsx
+++ b/src/components/research/ResearchStudio.tsx
@@ -170,6 +170,7 @@ export default function ResearchStudio({ paper }: { paper: ResearchPaper }) {
         <div ref={viewport} className="srt-viewport">
           <article
             className="srt-paper"
+            data-target-profile={profile.id}
             data-columns={profile.columns.count}
             data-finite-height={profile.finiteHeight}
             data-flow-mode={policy.flowMode}

--- a/tests/e2e/srt-visual.spec.ts
+++ b/tests/e2e/srt-visual.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test, type Locator } from '@playwright/test'
+import { writeFile } from 'node:fs/promises'
+import {
+  getTargetProfile,
+  TARGET_PROFILE_IDS,
+} from '../../src/research/targets'
+
+const PAPER_ID = 'semantic-responsive-typesetting'
+const GEOMETRY_EPSILON_CSS_PX = 0.5
+const OVERFLOW_EPSILON_CSS_PX = 1
+
+type GeometryReport = {
+  target: string
+  paper: { width: number; height: number }
+  renderedNodeIds: string[]
+  missingNodes: string[]
+  duplicateNodes: string[]
+  clippedContent: string[]
+  overlaps: string[]
+  horizontalOverflow: Array<{ element: string; amount: number }>
+}
+
+async function inspectGeometry(
+  paper: Locator,
+  expectedNodeIds: string[],
+): Promise<GeometryReport> {
+  return paper.evaluate(
+    (article, options) => {
+      type Rect = {
+        top: number
+        right: number
+        bottom: number
+        left: number
+        width: number
+        height: number
+      }
+      type MeasuredElement = {
+        element: Element
+        label: string
+        rects: Rect[]
+      }
+
+      const toRect = (rect: DOMRect): Rect => ({
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      })
+      const nodeElements = Array.from(
+        article.querySelectorAll<HTMLElement>('[data-node-id]'),
+      )
+      const renderedNodeIds = nodeElements.map(
+        (element) => element.dataset.nodeId ?? '',
+      )
+      const counts = new Map<string, number>()
+      for (const id of renderedNodeIds)
+        counts.set(id, (counts.get(id) ?? 0) + 1)
+
+      const header = article.querySelector(':scope > header')
+      const contentElements = [header, ...nodeElements].filter(
+        (element): element is Element => element !== null,
+      )
+      const measured: MeasuredElement[] = contentElements.map((element) => ({
+        element,
+        label:
+          element instanceof HTMLElement && element.dataset.nodeId
+            ? element.dataset.nodeId
+            : 'article-header',
+        rects: Array.from(element.getClientRects(), toRect).filter(
+          (rect) =>
+            rect.width > options.geometryEpsilon &&
+            rect.height > options.geometryEpsilon,
+        ),
+      }))
+      const paperRect = toRect(article.getBoundingClientRect())
+      const clippedContent = measured
+        .filter(({ rects }) =>
+          rects.some(
+            (rect) =>
+              rect.left < paperRect.left - options.geometryEpsilon ||
+              rect.right > paperRect.right + options.geometryEpsilon ||
+              rect.top < paperRect.top - options.geometryEpsilon ||
+              rect.bottom > paperRect.bottom + options.geometryEpsilon,
+          ),
+        )
+        .map(({ label }) => label)
+
+      const overlaps: string[] = []
+      for (let firstIndex = 0; firstIndex < measured.length; firstIndex += 1) {
+        for (
+          let secondIndex = firstIndex + 1;
+          secondIndex < measured.length;
+          secondIndex += 1
+        ) {
+          const first = measured[firstIndex]
+          const second = measured[secondIndex]
+          if (
+            first.element.contains(second.element) ||
+            second.element.contains(first.element)
+          ) {
+            continue
+          }
+          const intersects = first.rects.some((firstRect) =>
+            second.rects.some(
+              (secondRect) =>
+                Math.min(firstRect.right, secondRect.right) -
+                  Math.max(firstRect.left, secondRect.left) >
+                  options.geometryEpsilon &&
+                Math.min(firstRect.bottom, secondRect.bottom) -
+                  Math.max(firstRect.top, secondRect.top) >
+                  options.geometryEpsilon,
+            ),
+          )
+          if (intersects) overlaps.push(`${first.label}::${second.label}`)
+        }
+      }
+
+      const documentElement = document.documentElement
+      const overflowCandidates = [
+        {
+          element: 'document',
+          amount: documentElement.scrollWidth - documentElement.clientWidth,
+        },
+        {
+          element: 'paper',
+          amount: article.scrollWidth - article.clientWidth,
+        },
+        ...contentElements.map((element) => ({
+          element:
+            element instanceof HTMLElement && element.dataset.nodeId
+              ? element.dataset.nodeId
+              : 'article-header',
+          amount:
+            element instanceof HTMLElement
+              ? element.scrollWidth - element.clientWidth
+              : 0,
+        })),
+      ]
+
+      return {
+        target: article.getAttribute('data-target-profile') ?? 'unknown',
+        paper: { width: paperRect.width, height: paperRect.height },
+        renderedNodeIds,
+        missingNodes: options.expectedNodeIds.filter((id) => !counts.has(id)),
+        duplicateNodes: [...counts.entries()]
+          .filter(([, count]) => count !== 1)
+          .map(([id]) => id),
+        clippedContent,
+        overlaps,
+        horizontalOverflow: overflowCandidates.filter(
+          ({ amount }) => amount > options.overflowEpsilon,
+        ),
+      }
+    },
+    {
+      expectedNodeIds,
+      geometryEpsilon: GEOMETRY_EPSILON_CSS_PX,
+      overflowEpsilon: OVERFLOW_EPSILON_CSS_PX,
+    },
+  )
+}
+
+test('captures every target and rejects invalid geometry', async ({
+  page,
+  request,
+}, testInfo) => {
+  const sourceResponse = await request.get(`/research/${PAPER_ID}/source.json`)
+  expect(sourceResponse.ok()).toBe(true)
+  const source = (await sourceResponse.json()) as {
+    nodes: Array<{ id: string }>
+  }
+  const expectedNodeIds = source.nodes.map((node) => node.id)
+  const reports: GeometryReport[] = []
+
+  for (const target of TARGET_PROFILE_IDS) {
+    await page.goto(`/research/${PAPER_ID}`)
+    await expect(
+      page.locator('astro-island[component-url$="ResearchStudio.tsx"]'),
+    ).toHaveAttribute('client-render-time', /.+/)
+    await page.locator('html').evaluate((element) => {
+      element.classList.add('disable-transitions')
+    })
+    await page.evaluate(() => document.fonts.ready)
+
+    const profile = getTargetProfile(target)
+    await page.getByRole('button', { name: profile.label, exact: true }).click()
+
+    const paper = page.locator(`.srt-paper[data-target-profile="${target}"]`)
+    await expect(paper).toBeVisible()
+
+    const report = await inspectGeometry(paper, expectedNodeIds)
+    reports.push(report)
+    expect.soft(report.target, `${target}: active target`).toBe(target)
+    expect.soft(report.missingNodes, `${target}: missing nodes`).toEqual([])
+    expect.soft(report.duplicateNodes, `${target}: duplicate nodes`).toEqual([])
+    expect.soft(report.clippedContent, `${target}: clipped content`).toEqual([])
+    expect.soft(report.overlaps, `${target}: overlapping content`).toEqual([])
+    expect
+      .soft(report.horizontalOverflow, `${target}: horizontal overflow`)
+      .toEqual([])
+
+    await paper.evaluate((article) => {
+      document.body.replaceChildren(article)
+      document.body.style.margin = '0'
+      document.body.style.background = '#faf9f4'
+      article.style.margin = '0'
+    })
+    await paper.screenshot({
+      animations: 'disabled',
+      path: testInfo.outputPath(`${target}-rendition.png`),
+    })
+  }
+
+  const reportPath = testInfo.outputPath('geometry-report.json')
+  await writeFile(reportPath, `${JSON.stringify(reports, null, 2)}\n`)
+  await testInfo.attach('geometry-report', {
+    path: reportPath,
+    contentType: 'application/json',
+  })
+})


### PR DESCRIPTION
Closes #5.

## What changed

- pins Playwright 1.61.1 and Chromium for a deterministic four-target browser harness
- captures mobile, Paper Pro Move, Paper Pro, and print rendition screenshots
- emits inspectable geometry reports for missing/duplicate nodes, clipping, overlap, and horizontal overflow
- adds an opt-in `e2e` evidence lane and uploads its screenshots, report, traces, and logs in CI
- keeps snapshot updates disabled; no visual baseline is silently accepted
- documents the boundary in ADR 005

## Human recovery and review

The VM worker completed and committed the original implementation as `c46579c`, but Rucksack falsely classified the clean committed worktree as “no reviewable file changes.” I recovered that commit from the preserved VM worktree, rebased it onto current `main` (including PR #16), and reviewed it. Review fixes renumbered the colliding ADR 004 to ADR 005, forced a fresh Playwright web server instead of reusing an arbitrary process on port 1234, and removed unrelated workflow formatting churn.

## Verification

- `scripts/agent-evidence --e2e` — passed on clean commit `254a252`
- build/content lane — passed
- unit lane — passed (87 tests)
- Playwright geometry lane — passed for all four targets
- all 11 canonical nodes rendered exactly once per target
- no clipping, overlaps, or horizontal overflow reported
- `git diff --check` — passed
- secret scan — passed
- dependency audit delta vs current main — 0 packages / 0 advisories (same inherited 39 findings tracked by #13)

Generated screenshots and geometry JSON stay in `.agent/evidence`/CI artifacts and are not committed. This PR intentionally changes `scripts/agent-evidence`, so it requires human review at this trust boundary.
