### PR TITLE
Align research pages with the site shell

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -2,20 +2,21 @@
 
 ### Users
 
-Researchers and curious readers who have a paper as a PDF or a direct downloadable link and want a clean, reflowable EPUB for phones and e-ink readers. Authors also use the research section to publish papers, prototypes, methods, and reconstruction evidence.
+Researchers and curious Ernie.SG readers who want to browse published work or turn a downloadable, born-digital paper into an EPUB for phones and e-ink readers. Authors also use the section to publish papers, prototypes, and methods. The main reader task is simple: upload a PDF or paste a direct PDF link, then download the EPUB.
 
 ### Brand Personality
 
-Editorial, exacting, and quietly experimental. The interface should feel like a working publication instrument, not a startup dashboard or a decorative magazine template.
+Quiet, personal, direct, and exacting. The research pages should sound like the rest of Ernie.SG: technically informed without performing technicality, confident without marketing language, and occasionally blunt.
 
 ### Aesthetic Direction
 
-Artifact-led museum publishing: warm paper, dense ink, one restrained archival accent, strong reading typography, and visible technical evidence. The converter is the primary research-home interaction. Published papers and the Semantic Responsive Typesetting notebook are secondary proof surfaces. Preserve the SRT studio's useful controls, target switching, paper viewport, and inspector; change its palette without replacing its interaction model.
+Inherit the existing site's minimalist editorial shell: the shared `max-w-screen-md` content column, Geist typography, restrained borders, and existing light/dark themes. Research tools should feel like native parts of the blog. Preserve the SRT studio's useful target switching, paper viewport, and inspector. A rendered paper or device preview may establish its own internal canvas, but the surrounding page chrome should not become a separate visual identity.
 
 ### Design Principles
 
-- Put the real job first: PDF or direct paper link in, EPUB out.
-- Preserve useful instruments and evidence; remove decorative structure that delays the task.
-- Keep publication reading, conversion, and SRT experimentation visually related but structurally distinct.
-- Design for long reading across web, print, mobile, and monochrome e-ink.
-- State reconstruction limits honestly; never imply OCR or layout fidelity that has not been verified.
+- Start with the reader's action, not the implementation.
+- Use the shared site width and spacing rhythm for page-level content.
+- Keep one obvious path: PDF or link in, EPUB out.
+- Put provenance and diagnostics behind progressive disclosure.
+- Preserve experimental controls, but remove decorative technical language and oversized display treatment around them.
+- State conversion limits honestly; never imply OCR or layout fidelity that has not been verified.

--- a/src/components/research/PublicationImporter.tsx
+++ b/src/components/research/PublicationImporter.tsx
@@ -31,7 +31,11 @@ function formatBytes(value: number) {
   return `${(value / 1024 / 1024).toFixed(1)} MB`
 }
 
-export default function PublicationImporter() {
+export default function PublicationImporter({
+  showIntro = true,
+}: {
+  showIntro?: boolean
+}) {
   const [state, setState] = useState<StudioState>({ status: 'idle' })
   const [dragging, setDragging] = useState(false)
   const [paperUrl, setPaperUrl] = useState('')
@@ -109,20 +113,20 @@ export default function PublicationImporter() {
       : 0
 
   return (
-    <section className="publication-importer" aria-labelledby="studio-heading">
-      <div className="publication-importer-intro">
-        <div>
-          <p className="srt-kicker">Local publication studio</p>
-          <h2 id="studio-heading">
-            Drop a paper. Get a reflowable publication.
-          </h2>
+    <section
+      className="publication-importer"
+      aria-label={showIntro ? undefined : 'PDF to EPUB converter'}
+      aria-labelledby={showIntro ? 'studio-heading' : undefined}
+    >
+      {showIntro && (
+        <div className="publication-importer-intro">
+          <h2 id="studio-heading">Make an EPUB from a PDF</h2>
+          <p>
+            Upload a paper or paste a direct PDF link. The conversion runs in
+            your browser.
+          </p>
         </div>
-        <p>
-          Drop a file or paste a direct paper link. Its bytes are processed in
-          this browser; embedded text and source boxes become a semantic reading
-          flow, and an EPUB is packaged only after reconstruction succeeds.
-        </p>
-      </div>
+      )}
 
       {state.status === 'idle' && (
         <div className="publication-intake">
@@ -144,21 +148,16 @@ export default function PublicationImporter() {
               onChange={(event) => void processFile(event.target.files?.[0])}
             />
             <label htmlFor="publication-pdf">
-              <span aria-hidden="true">PDF → EPUB</span>
-              <strong>Choose a PDF or drop it here</strong>
-              <small>
-                Born-digital PDF · up to 50 MB · stays in this browser
-              </small>
+              <strong>Choose a PDF</strong>
+              <span>or drop it here</span>
+              <small>Up to 50 MB. Your file stays on this device.</small>
             </label>
           </div>
 
           <form className="publication-url" onSubmit={processUrl}>
-            <div>
-              <span>Or use a link</span>
-              <strong>Paste a direct PDF URL</strong>
-            </div>
             <label htmlFor="publication-url">
-              HTTPS link to a downloadable paper
+              <strong>Or paste a PDF link</strong>
+              <span>Use a direct download link.</span>
             </label>
             <div className="publication-url__field">
               <input
@@ -170,11 +169,10 @@ export default function PublicationImporter() {
                 placeholder="https://…/paper.pdf"
                 onChange={(event) => setPaperUrl(event.target.value)}
               />
-              <button type="submit">Make EPUB</button>
+              <button type="submit">Create EPUB</button>
             </div>
             <small>
-              The publisher must permit direct browser downloads. If it blocks
-              the request, download the PDF and drop it above.
+              If the link is blocked, download the PDF and upload it instead.
             </small>
           </form>
         </div>
@@ -199,9 +197,9 @@ export default function PublicationImporter() {
       {state.status === 'error' && (
         <div className="publication-failure" role="alert">
           <span>{state.code.replaceAll('_', ' ')}</span>
-          <h3>That paper could not be reconstructed.</h3>
+          <h3>I couldn't turn that PDF into an EPUB.</h3>
           <p>{state.message}</p>
-          <button onClick={reset}>Try another PDF</button>
+          <button onClick={reset}>Choose another PDF</button>
         </div>
       )}
 
@@ -210,14 +208,13 @@ export default function PublicationImporter() {
           <div className="publication-result-bar">
             <div>
               <span className="srt-kicker">
-                {state.status === 'ready'
-                  ? 'Reconstruction ready'
-                  : 'Review required'}
+                {state.status === 'ready' ? 'EPUB ready' : 'Needs OCR'}
               </span>
               <strong>{state.result.source.fileName}</strong>
               <small>
                 {state.result.source.pageCount} pages ·{' '}
-                {formatBytes(state.result.source.byteLength)} · local only
+                {formatBytes(state.result.source.byteLength)} · processed
+                locally
               </small>
             </div>
             <div className="publication-actions">
@@ -240,12 +237,11 @@ export default function PublicationImporter() {
 
           {state.status === 'needs-ocr' && (
             <div className="publication-ocr-gate" role="alert">
-              <span>OCR required</span>
-              <h3>Some pages are images, not trustworthy embedded text.</h3>
+              <span>Scanned pages found</span>
+              <h3>This PDF needs OCR before it can become an EPUB.</h3>
               <p>
-                This build preserves the page diagnosis and refuses a partial
-                EPUB. Local OCR is the next adapter; the document has not left
-                your browser.
+                OCR support is still in progress, so this version won't make a
+                partial EPUB. Your file has not left this device.
               </p>
             </div>
           )}
@@ -255,8 +251,8 @@ export default function PublicationImporter() {
             open={state.status === 'needs-ocr'}
           >
             <summary>
-              Reconstruction evidence · {state.result.diagnostics.length}{' '}
-              diagnostics
+              Conversion details · {state.result.diagnostics.length}{' '}
+              {state.result.diagnostics.length === 1 ? 'note' : 'notes'}
             </summary>
             <div className="publication-diagnostic-grid">
               <div>
@@ -274,7 +270,7 @@ export default function PublicationImporter() {
                 </ol>
               </div>
               <div>
-                <h3>Source-box provenance</h3>
+                <h3>Recovered text</h3>
                 <ol>
                   {state.result.paper.nodes.slice(0, 12).map((node) => {
                     const evidence = state.result.provenance[node.id]

--- a/src/components/research/ResearchPaperActions.tsx
+++ b/src/components/research/ResearchPaperActions.tsx
@@ -35,7 +35,7 @@ export default function ResearchPaperActions({
     <nav aria-label="Paper downloads">
       <button onClick={() => window.print()}>Print / PDF</button>
       <EpubDownloadLink epub={epub} pendingLabel="Preparing EPUB…" />
-      <a href={`/research/${paper.id}/source.json`}>Source JSON</a>
+      <a href={`/research/${paper.id}/source.json`}>Source data</a>
       {error && <small role="alert">{error}</small>}
     </nav>
   )

--- a/src/components/research/ResearchStudio.tsx
+++ b/src/components/research/ResearchStudio.tsx
@@ -147,10 +147,10 @@ export default function ResearchStudio({ paper }: { paper: ResearchPaper }) {
   const margins = `${profile.margins.top} ${profile.margins.right} ${profile.margins.bottom} ${profile.margins.left} ${profile.margins.unit}`
 
   return (
-    <section className="srt-studio" aria-label="Composition studio">
+    <section className="srt-studio" aria-label="Paper preview">
       <header className="srt-toolbar">
         <div>
-          <span className="srt-kicker">Live composition</span>
+          <span className="srt-kicker">Preview</span>
           <strong>{profile.note}</strong>
         </div>
         <div className="srt-profiles" aria-label="Target profile">
@@ -201,7 +201,7 @@ export default function ResearchStudio({ paper }: { paper: ResearchPaper }) {
           </article>
         </div>
         <aside className="srt-inspector">
-          <span className="srt-kicker">Current semantic anchor</span>
+          <span className="srt-kicker">Selected section</span>
           <code>{selectedNode.id}</code>
           <dl>
             <div>
@@ -263,9 +263,7 @@ export default function ResearchStudio({ paper }: { paper: ResearchPaper }) {
               </div>
             )}
           </dl>
-          <a href={`/research/${paper.id}/manifest.json`}>
-            Open layout manifest →
-          </a>
+          <a href={`/research/${paper.id}/manifest.json`}>View layout data →</a>
         </aside>
       </div>
     </section>

--- a/src/pages/research/[id].astro
+++ b/src/pages/research/[id].astro
@@ -16,7 +16,9 @@ const isFellowshipPaper = paper.id === 'if-letters-home-could-sing'
 <Layout
   title={paper.title}
   description={paper.abstract}
-  image={isFellowshipPaper ? '/research/if-letters-home-could-sing/media/image3.jpg' : undefined}
+  image={isFellowshipPaper
+    ? '/research/if-letters-home-could-sing/media/image3.jpg'
+    : undefined}
 >
   {
     isFellowshipPaper ? (
@@ -24,9 +26,9 @@ const isFellowshipPaper = paper.id === 'if-letters-home-could-sing'
     ) : (
       <>
         <section class="research-paper-hero">
-          <a href="/research">← All research</a>
+          <a href="/research">← Research</a>
           <div>
-            <p>Research note 002 · {paper.status}</p>
+            <p>Research paper · {paper.status}</p>
             <h1>{paper.title}</h1>
             <p>{paper.subtitle}</p>
           </div>

--- a/src/pages/research/index.astro
+++ b/src/pages/research/index.astro
@@ -1,154 +1,49 @@
 ---
+import Container from '@/components/Container.astro'
 import PublicationImporter from '@/components/research/PublicationImporter'
 import Layout from '@/layouts/Layout.astro'
 import { papers } from '@/research/papers'
 ---
 
 <Layout
-  title="Research publishing"
-  description="Turn a born-digital research PDF or direct paper link into a reflowable EPUB, then inspect the reconstruction evidence."
+  title="Research"
+  description="Papers, prototypes, and a small tool for turning research PDFs into EPUBs."
 >
-  <main class="research-home">
-    <header class="research-home__masthead">
-      <div>
-        <span>Research · publishing instrument</span>
-        <strong>PDF or link → semantic reconstruction → EPUB</strong>
-      </div>
-      <p>
-        The useful thing is the conversion. Papers, prototypes, and the SRT
-        notebook below show what the pipeline can preserve and where it still
-        fails.
+  <Container class="flex flex-col gap-y-12 pb-24">
+    <header class="flex flex-col gap-y-3 border-b pb-6">
+      <h1 class="text-3xl font-bold">Research</h1>
+      <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Papers, prototypes, and small tools for reading research across screens
+        and e-ink.
       </p>
     </header>
 
     <PublicationImporter client:load />
 
-    <section class="research-home__work" aria-labelledby="research-work-title">
-      <header>
-        <span>Published work & open methods</span>
-        <h1 id="research-work-title">Read the output. Inspect the method.</h1>
-      </header>
-      <ol>
+    <section class="flex flex-col gap-y-4" aria-labelledby="published-work">
+      <h2 id="published-work" class="text-2xl font-semibold">Published work</h2>
+      <ul class="border-t">
         {
-          papers.map((paper, index) => (
-            <li>
-              <span>{String(index + 1).padStart(2, '0')}</span>
-              <a href={`/research/${paper.id}`}>
-                <small>
-                  {paper.status} · updated {paper.updated}
+          papers.map((paper) => (
+            <li class="border-b py-6">
+              <a
+                class="group flex flex-col gap-y-2"
+                href={`/research/${paper.id}`}
+              >
+                <small class="text-xs text-muted-foreground">
+                  {paper.status} · Updated {paper.updated}
                 </small>
-                <h2>{paper.title}</h2>
-                <p>{paper.abstract}</p>
+                <h3 class="text-xl font-semibold group-hover:underline group-hover:underline-offset-4">
+                  {paper.title}
+                </h3>
+                <p class="text-sm leading-relaxed text-muted-foreground">
+                  {paper.abstract}
+                </p>
               </a>
-              <i aria-hidden="true">↗</i>
             </li>
           ))
         }
-      </ol>
+      </ul>
     </section>
-  </main>
+  </Container>
 </Layout>
-
-<style>
-  .research-home {
-    --instrument-accent: light-dark(oklch(0.43 0.105 32), oklch(0.72 0.08 32));
-    padding: 2rem 0 7rem;
-  }
-  .research-home :global(.publication-importer) {
-    padding-bottom: 0;
-  }
-  .research-home__masthead {
-    align-items: end;
-    border-bottom: 1px solid color-mix(in oklch, currentColor 20%, transparent);
-    display: grid;
-    gap: 1.5rem 4rem;
-    grid-template-columns: minmax(18rem, 1fr) minmax(18rem, 34rem);
-    margin: 0 auto;
-    max-width: 100rem;
-    padding: 1rem clamp(1.25rem, 3vw, 2rem) 2rem;
-  }
-  .research-home__masthead div {
-    display: grid;
-    gap: 0.55rem;
-  }
-  .research-home__masthead span,
-  .research-home__work > header span,
-  .research-home__work small,
-  .research-home__work li > span {
-    font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: 0.65rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
-  .research-home__masthead span,
-  .research-home__work > header span {
-    color: var(--instrument-accent);
-  }
-  .research-home__masthead strong {
-    font-size: clamp(1.05rem, 2vw, 1.35rem);
-    font-weight: 560;
-  }
-  .research-home__masthead p {
-    color: color-mix(in oklch, currentColor 64%, transparent);
-    line-height: 1.6;
-    margin: 0;
-  }
-  .research-home__work {
-    display: grid;
-    gap: clamp(3rem, 7vw, 7rem);
-    grid-template-columns: minmax(15rem, 0.65fr) minmax(0, 1.35fr);
-    margin: clamp(4rem, 8vw, 7rem) auto 0;
-    max-width: 82rem;
-    padding: 0 clamp(1.25rem, 3vw, 2rem);
-  }
-  .research-home__work > header {
-    align-self: start;
-    display: grid;
-    gap: 1.25rem;
-  }
-  .research-home__work h1 {
-    font-size: clamp(2rem, 4vw, 3.8rem);
-    font-weight: 560;
-    letter-spacing: -0.045em;
-    line-height: 0.98;
-    margin: 0;
-  }
-  .research-home__work ol {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-  .research-home__work li {
-    border-top: 1px solid color-mix(in oklch, currentColor 18%, transparent);
-    display: grid;
-    gap: 1rem;
-    grid-template-columns: 2rem minmax(0, 1fr) auto;
-    padding: 1.5rem 0 2rem;
-  }
-  .research-home__work li > span,
-  .research-home__work small {
-    color: color-mix(in oklch, currentColor 58%, transparent);
-  }
-  .research-home__work h2 {
-    font-size: clamp(1.55rem, 3vw, 2.6rem);
-    font-weight: 560;
-    letter-spacing: -0.035em;
-    line-height: 1.05;
-    margin: 0.8rem 0;
-  }
-  .research-home__work p {
-    color: color-mix(in oklch, currentColor 64%, transparent);
-    line-height: 1.55;
-    margin: 0;
-    max-width: 64ch;
-  }
-  .research-home__work i {
-    font-style: normal;
-  }
-  @media (max-width: 760px) {
-    .research-home__masthead,
-    .research-home__work {
-      grid-template-columns: 1fr;
-    }
-  }
-</style>

--- a/src/pages/research/studio.astro
+++ b/src/pages/research/studio.astro
@@ -1,23 +1,27 @@
 ---
+import Container from '@/components/Container.astro'
 import PublicationImporter from '@/components/research/PublicationImporter'
 import Layout from '@/layouts/Layout.astro'
 ---
 
 <Layout
-  title="PDF to EPUB publication studio"
-  description="Privately reconstruct a born-digital PDF into a responsive research publication and reflowable EPUB."
+  title="PDF to EPUB"
+  description="Turn a born-digital research PDF into a reflowable EPUB in your browser."
 >
-  <section class="research-paper-hero publication-studio-hero">
-    <a href="/research">← All research</a>
-    <div>
-      <p>Research studio · local first</p>
-      <h1>Reverse the page.<br />Recover the paper.</h1>
-      <p>Fixed PDF evidence in; semantic, reflowable publication out.</p>
-    </div>
-    <aside>
-      <span>Private by default</span>
-      <small>Document bytes remain in browser memory.</small>
-    </aside>
-  </section>
-  <PublicationImporter client:load />
+  <Container class="flex flex-col gap-y-8 pb-24">
+    <a
+      class="text-sm text-muted-foreground hover:text-foreground"
+      href="/research"
+    >
+      ← Research
+    </a>
+    <header class="flex flex-col gap-y-3 border-b pb-6">
+      <h1 class="text-3xl font-bold">PDF to EPUB</h1>
+      <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Upload a paper or paste a direct PDF link. The conversion runs in your
+        browser, and your file stays on this device.
+      </p>
+    </header>
+    <PublicationImporter showIntro={false} client:load />
+  </Container>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -191,198 +191,279 @@
 }
 
 @layer components {
-  .research-index { @apply mx-auto max-w-6xl px-5 pb-24 pt-12 sm:px-8 sm:pt-24; }
-  .research-hero > p:first-child, .research-paper-hero > div > p, .srt-kicker { @apply font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground; }
-  .research-hero h1 { @apply mt-7 max-w-5xl text-5xl font-semibold leading-[0.94] tracking-[-0.055em] sm:text-7xl lg:text-8xl; }
-  .research-deck { @apply ml-auto mt-10 max-w-md text-lg leading-relaxed text-muted-foreground; }
-  .research-studio-link {
-    @apply mt-12 grid max-w-xl grid-cols-[1fr_auto] items-end gap-x-6 border-y border-foreground/25 py-5;
+  .research-paper-hero {
+    @apply mx-auto flex max-w-screen-md flex-col gap-6 px-4 pb-8;
   }
-  .research-studio-link span {
-    @apply font-mono text-[10px] uppercase tracking-[.18em] text-muted-foreground;
+  .research-paper-hero > a {
+    @apply text-sm text-muted-foreground hover:text-foreground;
   }
-  .research-studio-link strong {
-    @apply col-start-1 mt-2 text-xl font-medium;
+  .research-paper-hero > div > p:first-child,
+  .srt-kicker {
+    @apply text-xs text-muted-foreground;
   }
-  .research-studio-link i {
-    @apply row-span-2 row-start-1 self-center text-2xl not-italic;
+  .research-paper-hero h1 {
+    @apply mt-2 text-3xl font-bold;
   }
-  .research-rule { @apply my-12 h-px bg-foreground/20; }
-  .research-list { @apply list-none p-0; }
-  .research-list li { @apply grid grid-cols-[2rem_1fr_auto] gap-4 border-b border-foreground/15 py-8; }
-  .research-list li > span { @apply font-mono text-xs text-muted-foreground; }
-  .research-list a h2 { @apply mt-2 text-2xl font-semibold tracking-tight sm:text-4xl; }
-  .research-list a p { @apply mt-3 max-w-2xl leading-relaxed text-muted-foreground; }
-  .research-list small { @apply font-mono text-[11px] uppercase tracking-widest text-muted-foreground; }
-
-  .research-paper-hero { @apply mx-auto grid max-w-7xl gap-8 px-5 pb-10 pt-10 sm:px-8 lg:grid-cols-[10rem_1fr_auto] lg:pt-20; }
-  .research-paper-hero > a { @apply text-sm text-muted-foreground hover:text-foreground; }
-  .research-paper-hero h1 { @apply mt-4 max-w-4xl text-5xl font-semibold leading-none tracking-[-0.05em] sm:text-7xl; }
-  .research-paper-hero > div > p:last-child { @apply mt-5 text-xl italic text-muted-foreground; }
-  .research-paper-hero nav { @apply flex items-start gap-4 text-sm lg:flex-col; }
-  .research-paper-hero nav a, .research-paper-hero nav button { @apply border-b border-foreground/40 pb-1 hover:border-foreground; }
+  .research-paper-hero > div > p:last-child {
+    @apply mt-3 text-sm leading-relaxed text-muted-foreground;
+  }
+  .research-paper-hero nav {
+    @apply flex flex-wrap items-start gap-4 text-sm;
+  }
+  .research-paper-hero nav a,
+  .research-paper-hero nav button {
+    @apply border-b border-foreground/40 pb-1 hover:border-foreground;
+  }
 
   .srt-studio {
-    --srt-canvas: oklch(0.88 0.018 74);
-    --srt-paper-surface: oklch(0.965 0.014 78);
-    --srt-ink: oklch(0.25 0.018 52);
-    --srt-accent: oklch(0.44 0.11 32);
-    @apply border-y;
+    --srt-canvas: hsl(var(--background));
+    --srt-paper-surface: oklch(0.97 0 0);
+    --srt-paper-ink: oklch(0.18 0 0);
+    --srt-ui-ink: hsl(var(--foreground));
+    --srt-accent: hsl(var(--muted-foreground));
+    @apply mx-auto max-w-screen-md border;
     background: var(--srt-canvas);
-    border-color: color-mix(in oklch, var(--srt-ink) 22%, transparent);
-    color: var(--srt-ink);
+    border-color: hsl(var(--border));
+    color: var(--srt-ui-ink);
   }
-  .srt-studio .srt-kicker { color: var(--srt-accent); }
-  .srt-toolbar { @apply flex flex-col gap-5 border-b border-black/20 px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8; }
-  .srt-toolbar > div:first-child { @apply flex items-center gap-4; }
-  .srt-toolbar strong { @apply text-xs font-medium; }
-  .srt-profiles { @apply flex overflow-x-auto border border-black/20; }
-  .srt-profiles button { @apply whitespace-nowrap border-r border-black/20 px-3 py-2 font-mono text-[10px] uppercase tracking-wider last:border-0; }
-  .srt-profiles button.active { background: var(--srt-accent); color: var(--srt-paper-surface); }
-  .srt-stage { @apply grid min-h-[720px] lg:grid-cols-[1fr_260px]; }
-  .srt-viewport { @apply max-h-[780px] overflow-auto p-4 transition-all duration-500 sm:p-10; }
-  .srt-paper { @apply mx-auto min-h-full shadow-[0_10px_50px_rgba(53,38,25,.14)] transition-all duration-500; background: var(--srt-paper-surface); padding: var(--srt-margin-top) var(--srt-margin-right) var(--srt-margin-bottom) var(--srt-margin-left); font-family: var(--srt-font-family); column-count: var(--srt-column-count); column-gap: var(--srt-column-gap); }
-  .srt-paper header { @apply mb-12 border-b border-black/20 pb-8; }
-  .srt-paper header small { @apply font-sans text-[10px] uppercase tracking-[.16em] text-black/60; }
-  .srt-paper h1 { @apply mt-4 font-normal leading-[.95] tracking-[-.04em]; font-size: var(--srt-title-size); }
-  .srt-paper .srt-subtitle { @apply mt-3 text-lg italic text-black/60; }
-  .srt-paper .srt-authors { @apply mt-6 font-sans text-xs text-black/60; }
-  .srt-paper .srt-abstract { @apply mt-7 text-sm leading-relaxed; }
-  .srt-paper h2 { @apply mb-3 mt-9 font-normal; font-size: var(--srt-heading-size); break-after: avoid; }
-  .srt-paper > p, .srt-paper blockquote { @apply my-4; font-size: var(--srt-body-size); line-height: var(--srt-line-height); }
-  .srt-paper blockquote { @apply border-y border-black/30 py-5 italic; font-size: var(--srt-quote-size); }
-  .srt-paper figure { @apply my-8 border-y border-black/30 py-7; break-inside: avoid; }
-  .srt-pipeline { @apply flex flex-wrap items-center justify-center gap-3 font-sans text-[10px] uppercase tracking-widest; }
-  .srt-pipeline span { @apply border border-black px-3 py-2; }
-  .srt-pipeline i { @apply not-italic text-black/50; }
-  .srt-paper figcaption { @apply mt-5 text-xs leading-relaxed; }
-  .srt-paper[data-columns='2'] > header { column-span: all; }
-  .srt-paper[data-columns='2'] h2 { break-inside: avoid; }
-  .srt-paper[data-finite-height='false'] { @apply shadow-none; }
-  .srt-paper figure[data-variant='full-span'] { column-span: all; }
-  .srt-paper figure[data-variant='compact-stack'] .srt-pipeline { @apply flex-col; }
-  .srt-paper figure[data-variant='compact-stack'] figcaption { @apply text-[11px]; }
-  .srt-paper figure[data-variant='edge-to-edge'] { margin-left: calc(-1 * var(--srt-margin-left)); margin-right: calc(-1 * var(--srt-margin-right)); padding-left: var(--srt-margin-left); padding-right: var(--srt-margin-right); }
-  .srt-inspector { @apply border-t border-black/20 p-6 font-sans lg:border-l lg:border-t-0; }
-  .srt-inspector code { @apply mt-3 block break-all bg-transparent p-0 font-mono text-sm font-semibold; }
-  .srt-inspector dl { @apply my-8 border-y border-black/20 py-3 text-xs; }
-  .srt-inspector dl div { @apply grid grid-cols-[5.25rem_1fr] gap-2 py-2; }
-  .srt-inspector dt { @apply text-black/50; }
-  .srt-inspector a { @apply text-xs underline underline-offset-4; }
-  .publication-studio-hero {
-    @apply items-start;
+  .srt-studio .srt-kicker {
+    color: var(--srt-accent);
   }
-  .publication-studio-hero aside {
-    @apply border-l border-foreground/30 pl-4 font-mono text-[10px] uppercase tracking-wider;
+  .srt-toolbar {
+    @apply flex flex-col gap-5 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8;
   }
-  .publication-studio-hero aside span,
-  .publication-studio-hero aside small {
-    @apply block;
+  .srt-toolbar > div:first-child {
+    @apply flex items-center gap-4;
   }
-  .publication-studio-hero aside small {
-    @apply mt-2 max-w-40 normal-case leading-relaxed tracking-normal text-muted-foreground;
+  .srt-toolbar strong {
+    @apply text-xs font-medium;
+  }
+  .srt-profiles {
+    @apply flex overflow-x-auto border;
+  }
+  .srt-profiles button {
+    @apply whitespace-nowrap border-r px-3 py-2 font-mono text-[10px] uppercase tracking-wider last:border-0;
+  }
+  .srt-profiles button.active {
+    @apply bg-foreground text-background;
+  }
+  .srt-stage {
+    @apply grid min-h-[720px] lg:grid-cols-[1fr_260px];
+  }
+  .srt-viewport {
+    @apply max-h-[780px] overflow-auto bg-muted/20 p-4 transition-all duration-500 sm:p-10;
+  }
+  .srt-paper {
+    @apply mx-auto min-h-full shadow-sm transition-all duration-500;
+    background: var(--srt-paper-surface);
+    color: var(--srt-paper-ink);
+    padding: var(--srt-margin-top) var(--srt-margin-right)
+      var(--srt-margin-bottom) var(--srt-margin-left);
+    font-family: var(--srt-font-family);
+    column-count: var(--srt-column-count);
+    column-gap: var(--srt-column-gap);
+  }
+  .srt-paper header {
+    @apply mb-12 border-b border-black/20 pb-8;
+  }
+  .srt-paper header small {
+    @apply font-sans text-[10px] uppercase tracking-[.16em] text-black/60;
+  }
+  .srt-paper h1 {
+    @apply mt-4 font-normal leading-[.95] tracking-[-.04em];
+    font-size: var(--srt-title-size);
+  }
+  .srt-paper .srt-subtitle {
+    @apply mt-3 text-lg italic text-black/60;
+  }
+  .srt-paper .srt-authors {
+    @apply mt-6 font-sans text-xs text-black/60;
+  }
+  .srt-paper .srt-abstract {
+    @apply mt-7 text-sm leading-relaxed;
+  }
+  .srt-paper h2 {
+    @apply mb-3 mt-9 font-normal;
+    font-size: var(--srt-heading-size);
+    break-after: avoid;
+  }
+  .srt-paper > p,
+  .srt-paper blockquote {
+    @apply my-4;
+    font-size: var(--srt-body-size);
+    line-height: var(--srt-line-height);
+  }
+  .srt-paper blockquote {
+    @apply border-y border-black/30 py-5 italic;
+    font-size: var(--srt-quote-size);
+  }
+  .srt-paper figure {
+    @apply my-8 border-y border-black/30 py-7;
+    break-inside: avoid;
+  }
+  .srt-pipeline {
+    @apply flex flex-wrap items-center justify-center gap-3 font-sans text-[10px] uppercase tracking-widest;
+  }
+  .srt-pipeline span {
+    @apply border border-black px-3 py-2;
+  }
+  .srt-pipeline i {
+    @apply not-italic text-black/50;
+  }
+  .srt-paper figcaption {
+    @apply mt-5 text-xs leading-relaxed;
+  }
+  .srt-paper[data-columns='2'] > header {
+    column-span: all;
+  }
+  .srt-paper[data-columns='2'] h2 {
+    break-inside: avoid;
+  }
+  .srt-paper[data-finite-height='false'] {
+    @apply shadow-none;
+  }
+  .srt-paper figure[data-variant='full-span'] {
+    column-span: all;
+  }
+  .srt-paper figure[data-variant='compact-stack'] .srt-pipeline {
+    @apply flex-col;
+  }
+  .srt-paper figure[data-variant='compact-stack'] figcaption {
+    @apply text-[11px];
+  }
+  .srt-paper figure[data-variant='edge-to-edge'] {
+    margin-left: calc(-1 * var(--srt-margin-left));
+    margin-right: calc(-1 * var(--srt-margin-right));
+    padding-left: var(--srt-margin-left);
+    padding-right: var(--srt-margin-right);
+  }
+  .srt-inspector {
+    @apply border-t p-6 font-sans lg:border-l lg:border-t-0;
+  }
+  .srt-inspector code {
+    @apply mt-3 block break-all bg-transparent p-0 font-mono text-sm font-semibold;
+  }
+  .srt-inspector dl {
+    @apply my-8 border-y py-3 text-xs;
+  }
+  .srt-inspector dl div {
+    @apply grid grid-cols-[5.25rem_1fr] gap-2 py-2;
+  }
+  .srt-inspector dt {
+    @apply text-muted-foreground;
+  }
+  .srt-inspector a {
+    @apply text-xs underline underline-offset-4;
   }
   .publication-importer {
-    @apply mx-auto max-w-[100rem] border-t border-foreground/20 pb-24;
+    @apply w-full pb-4;
   }
   .publication-importer-intro {
-    @apply grid gap-8 px-5 py-12 sm:px-8 lg:grid-cols-[1fr_30rem] lg:items-end lg:py-20;
+    @apply flex flex-col gap-2;
   }
   .publication-importer-intro h2 {
-    @apply mt-4 max-w-4xl text-4xl font-semibold leading-[.95] tracking-[-.045em] sm:text-6xl;
+    @apply text-2xl font-semibold;
   }
   .publication-importer-intro > p {
-    @apply max-w-xl text-lg leading-relaxed text-muted-foreground;
+    @apply max-w-2xl text-sm leading-relaxed text-muted-foreground;
   }
   .publication-intake {
-    @apply mx-5 grid border-y border-foreground/25 sm:mx-8 lg:grid-cols-[1.12fr_.88fr];
+    @apply mt-6 grid overflow-hidden rounded-lg border;
   }
   .publication-dropzone {
-    @apply min-h-[24rem] border border-dashed border-foreground/45 bg-foreground/[.025] p-6 transition-colors;
+    @apply min-h-48 border-b border-dashed bg-transparent p-4 transition-colors;
   }
   .publication-dropzone.is-dragging {
-    @apply border-solid bg-foreground/[.08];
+    @apply border-solid bg-muted/40;
   }
   .publication-dropzone input {
     @apply sr-only;
   }
   .publication-dropzone label {
-    @apply flex min-h-[21rem] cursor-pointer flex-col items-center justify-center text-center outline-none;
-  }
-  .publication-dropzone label > span {
-    @apply mb-10 border border-foreground/30 px-4 py-3 font-mono text-[11px] uppercase tracking-[.16em];
+    @apply flex min-h-44 cursor-pointer flex-col items-center justify-center text-center outline-none;
   }
   .publication-dropzone label > strong {
-    @apply text-2xl font-medium sm:text-4xl;
+    @apply text-lg font-medium;
+  }
+  .publication-dropzone label > span {
+    @apply mt-1 text-sm text-muted-foreground;
   }
   .publication-dropzone label > small {
-    @apply mt-4 font-mono text-[10px] uppercase tracking-wider text-muted-foreground;
+    @apply mt-4 text-xs text-muted-foreground;
   }
   .publication-dropzone:focus-within {
     @apply outline outline-2 outline-offset-4 outline-foreground;
   }
   .publication-url {
-    @apply flex min-h-[24rem] flex-col justify-center border-t border-foreground/25 p-7 lg:border-l lg:border-t-0 lg:p-12;
+    @apply flex flex-col p-5 sm:p-6;
   }
-  .publication-url > div:first-child { @apply flex flex-col gap-2; }
-  .publication-url > div:first-child span,
-  .publication-url > label,
+  .publication-url > label {
+    @apply flex flex-col gap-1;
+  }
+  .publication-url > label strong {
+    @apply text-base font-medium;
+  }
+  .publication-url > label span,
   .publication-url > small {
-    @apply font-mono text-[10px] uppercase tracking-[.13em] text-muted-foreground;
+    @apply text-xs text-muted-foreground;
   }
-  .publication-url > div:first-child span { color: light-dark(oklch(0.43 0.105 32), oklch(0.72 0.08 32)); }
-  .publication-url > div:first-child strong { @apply text-2xl font-medium sm:text-3xl; }
-  .publication-url > label { @apply mt-10; }
-  .publication-url__field { @apply mt-3 grid grid-cols-[minmax(0,1fr)_auto]; }
+  .publication-url__field {
+    @apply mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-0;
+  }
   .publication-url__field input {
-    @apply min-h-12 min-w-0 border border-foreground/35 bg-transparent px-3 text-sm outline-none focus:border-foreground;
+    @apply min-h-12 min-w-0 rounded-md border bg-transparent px-3 text-sm outline-none focus:border-foreground sm:rounded-r-none;
   }
   .publication-url__field button {
-    @apply min-h-12 border border-l-0 border-foreground bg-foreground px-4 font-mono text-[10px] uppercase tracking-wider text-background;
+    @apply min-h-12 rounded-md border border-foreground bg-foreground px-4 text-sm font-medium text-background sm:rounded-l-none sm:border-l-0;
   }
-  .publication-url > small { @apply mt-4 max-w-md normal-case leading-relaxed tracking-normal; }
+  .publication-url > small {
+    @apply mt-3 max-w-md leading-relaxed;
+  }
   .publication-progress {
-    @apply mx-5 grid min-h-56 content-center gap-8 border-y border-foreground/30 px-6 sm:mx-8 sm:px-12;
+    @apply mt-6 grid min-h-48 content-center gap-6 rounded-lg border px-6;
   }
   .publication-progress div {
     @apply flex flex-col gap-2;
   }
   .publication-progress span {
-    @apply font-mono text-[10px] uppercase tracking-wider text-muted-foreground;
+    @apply truncate text-xs text-muted-foreground;
   }
   .publication-progress strong {
-    @apply text-2xl font-medium;
+    @apply text-lg font-medium;
   }
   .publication-progress progress {
     @apply h-2 w-full accent-foreground;
   }
   .publication-failure,
   .publication-ocr-gate {
-    @apply mx-5 border border-foreground/40 p-8 sm:mx-8 sm:p-12;
+    @apply mt-6 rounded-lg border p-6;
   }
   .publication-failure span,
   .publication-ocr-gate span {
-    @apply font-mono text-[10px] uppercase tracking-[.18em];
+    @apply text-xs text-muted-foreground;
   }
   .publication-failure h3,
   .publication-ocr-gate h3 {
-    @apply mt-5 max-w-3xl text-3xl font-semibold tracking-tight sm:text-5xl;
+    @apply mt-3 max-w-2xl text-xl font-semibold;
   }
   .publication-failure p,
   .publication-ocr-gate p {
-    @apply mt-5 max-w-2xl leading-relaxed text-muted-foreground;
+    @apply mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground;
   }
   .publication-failure button {
-    @apply mt-8 border border-foreground px-5 py-3 font-mono text-[10px] uppercase tracking-wider;
+    @apply mt-5 min-h-11 rounded-md border px-4 py-2 text-sm font-medium;
   }
   .publication-ocr-gate {
-    @apply my-8 bg-foreground text-background;
+    @apply bg-foreground text-background;
+  }
+  .publication-ocr-gate span {
+    @apply text-background/70;
   }
   .publication-ocr-gate p {
     @apply text-background/75;
   }
   .publication-result-bar {
-    @apply sticky top-0 z-20 flex flex-col gap-6 border-y border-foreground/25 bg-background/95 px-5 py-5 backdrop-blur sm:px-8 lg:flex-row lg:items-center lg:justify-between;
+    @apply mt-6 flex flex-col gap-5 rounded-lg border bg-background p-4 sm:flex-row sm:items-center sm:justify-between;
   }
   .publication-result-bar > div:first-child {
     @apply flex flex-col gap-1;
@@ -391,26 +472,26 @@
     @apply max-w-xl truncate text-lg;
   }
   .publication-result-bar > div:first-child small {
-    @apply font-mono text-[10px] uppercase tracking-wider text-muted-foreground;
+    @apply text-xs text-muted-foreground;
   }
   .publication-actions {
     @apply flex flex-wrap items-center gap-2;
   }
   .publication-actions button,
   .publication-actions a {
-    @apply inline-flex min-h-11 items-center border border-foreground bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-wider text-background disabled:cursor-wait disabled:opacity-40;
+    @apply inline-flex min-h-11 items-center rounded-md border border-foreground bg-foreground px-4 py-2 text-sm font-medium text-background disabled:cursor-wait disabled:opacity-40;
   }
   .publication-actions button.secondary {
     @apply bg-transparent text-foreground;
   }
   .publication-actions > span {
-    @apply font-mono text-[10px] uppercase tracking-wider text-muted-foreground;
+    @apply text-xs text-muted-foreground;
   }
   .publication-diagnostics {
-    @apply mx-5 my-8 border-y border-foreground/25 sm:mx-8;
+    @apply my-6 border-y;
   }
   .publication-diagnostics summary {
-    @apply cursor-pointer py-5 font-mono text-[10px] uppercase tracking-[.14em];
+    @apply cursor-pointer py-4 text-sm font-medium;
   }
   .publication-diagnostic-grid {
     @apply grid gap-10 border-t border-foreground/20 py-8 lg:grid-cols-2;


### PR DESCRIPTION
## What changed

- align `/research`, `/research/studio`, and research-paper chrome with the site's shared `max-w-screen-md` content column
- replace the oversized technical/promotional copy with a concise PDF-or-link to EPUB flow
- simplify importer labels, progress, OCR, error, and diagnostics language
- retain the semantic responsive typesetting target switcher, paper viewport, and inspector while moving its surrounding palette back into the site's neutral theme
- record the corrected research design context for future work

## Why

The research section had grown a separate, much wider visual shell and used copy that sounded unlike the minimalist personal site around it. This restores a single site-wide rhythm while keeping the useful research controls and paper preview intact.

## Validation

- `npm test` — 94 tests passed
- `npm run build` — Astro check: 0 errors, 0 warnings, 0 hints; 131 pages built
- `scripts/agent-evidence` — passed
- `git diff --check`
- browser comparison against the live home-page content measure and local research pages

## Notes

- Local evidence, build output, and dependencies remain ignored and are not part of this PR.
- `npm ci` continues to report the repository's existing audit baseline (39 vulnerabilities); no force audit fix is included in this design change.
