### PR TITLE
docs: add next SRT issue ledger

### DIFF
--- a/docs/issues/018-srt-note-relationship-corpus-resolution.md
+++ b/docs/issues/018-srt-note-relationship-corpus-resolution.md
@@ -1,0 +1,59 @@
+# Resolve note-reference relationships on real scholarly PDFs at corpus scale
+
+depends-on: 012,016
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Eliminate the dominant completeness-gate blockers on real papers — `UNRESOLVED_NOTE_REFERENCE`, `AMBIGUOUS_NOTE_MATCH`, and `UNREFERENCED_NOTE`, which together produce roughly 9,900 blocking errors across a 72-document corpus audit (about 96 unresolved references per document) — by first classifying what the note detector currently treats as note references on real scholarly pages, then reclassifying or resolving the classes where evidence is decisive while keeping genuine ambiguity fail-closed.
+
+## Acceptance tests
+
+- Build synthetic fixtures reproducing the marker patterns real papers contain: bracketed numeric citations in running prose, superscript citation clusters, author-affiliation superscripts on title pages, equation and section number references, per-page footnote bands, and end-of-document endnote or reference sections; classify every current note-reference detection on these fixtures into a named taxonomy recorded in the diagnostics.
+- Markers that are bibliography citations rather than note references (evidence: a detected reference-list section, bracket syntax, citation-marker density, absence of any footnote band) are reclassified as citation semantics or plain text with recorded deciding evidence, and stop emitting note diagnostics entirely.
+- True footnote references resolve to their note bodies across the common scholarly layouts (same-page footnote band, endnote section) with the existing confidence scoring; matcher improvements record their evidence per relationship, and no relationship is ever accepted silently below the documented threshold.
+- `UNREFERENCED_NOTE` no longer fires for note bodies whose reference was reclassified as a citation, and still fires for genuinely orphaned notes.
+- Fixtures that previously emitted `UNRESOLVED_NOTE_REFERENCE` or `AMBIGUOUS_NOTE_MATCH` now compose with zero blocking note diagnostics, with node-by-node order and relationship assertions in tests; genuinely ambiguous fixtures remain blocked.
+- Existing note fixtures from the issue-012 work show no regressions; any intentional relationship change is listed with its evidence.
+- A privacy-preserving before/after count of note diagnostics from `npm run pdf:corpus-audit` on locally supplied PDFs is included in evidence (basenames, hashes, and counts only).
+
+## Validation command
+
+```bash
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. All analysis runs locally; document bytes and prose must not enter reports or telemetry.
+
+## Artifact outputs
+
+Marker taxonomy with evidence-recording classifier, citation-versus-note reclassification in `src/research/pdf-layout.ts` and `src/research/pdf-quality.ts`, synthetic regression fixtures, and before/after corpus metrics.
+
+## Stop conditions
+
+Stop before accepting uncertain note matches silently, deleting detected markers to reduce counts, weakening the completeness thresholds, or tuning against private corpus documents committed to the repository.
+
+## Human clarification protocol
+
+If citation semantics need a policy decision (for example whether reclassified citations should become structured citation nodes now or plain text with provenance until a citation model exists), present the smallest candidate options with their observable differences.
+
+## Recommended response
+
+Treat this as detector precision before matcher recall: most of the corpus errors are citation markers mis-scoped as note references, so reclassification with recorded evidence should remove the bulk of the blockers without loosening any matching threshold.
+
+## Trade-offs
+
+Aggressive reclassification raises pass-rate but risks silently downgrading a real footnote reference to plain text, losing its relationship; the classifier must therefore record evidence per marker and leave low-confidence markers blocking, trading some coverage for inspectable correctness.
+
+## Free-form response
+
+The corpus audit shows note diagnostics outnumber reading-order ambiguities by more than an order of magnitude (6,882 unresolved references and 2,184 ambiguous matches versus 215 reading-order errors), so this issue, not reading order, decides whether real arXiv papers ever pass the gate.

--- a/docs/issues/019-srt-docx-import.md
+++ b/docs/issues/019-srt-docx-import.md
@@ -1,0 +1,59 @@
+# Import born-structured DOCX manuscripts into the SRT pipeline
+
+depends-on: 013
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Add a local DOCX import path that maps the explicit structure of an OOXML manuscript — heading hierarchy, paragraphs with inline formatting, footnotes and endnotes with explicit references, embedded images with captions, and tables — into the same canonical research-paper graph and completeness gate the PDF importer feeds, so born-structured manuscripts export EPUBs deterministically without any of the PDF reconstruction ambiguity.
+
+## Acceptance tests
+
+- A `.docx` file parses fully locally (the OOXML zip container read with the `fflate` dependency already in the tree; no new network or native dependencies) into the same reconstruction and paper types defined in `src/research/import-types.ts` and `src/research/schema.ts`.
+- Heading levels map to the section hierarchy; paragraphs preserve bold, italic, and hyperlink runs; footnotes and endnotes map to note nodes with their references resolved deterministically from the explicit OOXML relationship ids — never through the geometric note matcher — and report relationship coverage of 1.0.
+- Embedded images are extracted with their captions associated from adjacent caption paragraphs, and tables map to structured table nodes, reusing the asset node shapes the issue-013 work established.
+- A well-formed synthetic fixture manuscript passes the completeness gate with full text, asset, and relationship coverage and exports a valid EPUB verified by `inspectEpub` plus the structural invariants; a deliberately malformed fixture (a missing image part, a dangling note reference) fails closed with named diagnostics.
+- The publication importer at `src/components/research/PublicationImporter.tsx` accepts `.docx` alongside `.pdf`, and the e2e flow imports the fixture manuscript and downloads its EPUB.
+- Provenance records the source SHA-256, package part inventory, and importer version; repeated imports of the same bytes are byte-identical through export.
+- Synthetic fixtures exercise headings, nested lists, footnotes, endnotes, images with captions, tables, and multilingual text. New files to add: `src/research/docx-import.ts`, `src/research/docx-import.test.ts`, and fixtures under `tests/fixtures/docx/` with a generator script mirroring `tests/fixtures/pdf/generate-fixtures.mjs`. No private manuscripts may be committed.
+
+## Validation command
+
+```bash
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Parsing runs locally; document bytes, text, and local paths must not be uploaded or logged.
+
+## Artifact outputs
+
+DOCX importer module and tests, importer UI acceptance of `.docx`, synthetic fixture generator and fixtures, provenance and determinism evidence, and EPUB export evidence for the fixture manuscript.
+
+## Stop conditions
+
+Stop before adding a heavyweight DOCX library or native dependency, rendering DOCX through an intermediate PDF, committing private manuscripts as fixtures, or weakening the completeness gate to admit partially parsed documents.
+
+## Human clarification protocol
+
+If OOXML features in scope are ambiguous (tracked changes, comments, content controls, embedded charts), propose the smallest deferral list with named diagnostics for the deferred features rather than silently dropping content.
+
+## Recommended response
+
+Parse `word/document.xml`, `word/footnotes.xml`, `word/endnotes.xml`, and the relationship parts directly with the existing zip and XML tooling; explicit OOXML ids make note and image relationships exact, so this path should reach relationship coverage of 1.0 by construction.
+
+## Trade-offs
+
+A hand-rolled OOXML subset parser covers the scholarly-manuscript features deterministically but will not cover arbitrary Word documents; named fail-closed diagnostics for unsupported features keep the boundary honest, trading breadth for the same inspectability contract as the PDF path.
+
+## Free-form response
+
+The owner's first real acceptance document is a revised humanities manuscript in DOCX with footnotes and figure images; DOCX carries explicit note relationships, so it bypasses the note-matching failures that currently block every corpus PDF and gives the composition and export spine its first end-to-end run on a real paper.

--- a/docs/issues/020-srt-pluggable-ocr-engines.md
+++ b/docs/issues/020-srt-pluggable-ocr-engines.md
@@ -1,0 +1,60 @@
+# Pluggable OCR engines: Apple Vision local backend and explicit opt-in remote worker
+
+depends-on: 014,017
+
+labels: rucksack-blocked
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Generalize the issue-014 OCR integration behind an engine interface so alternative engines can be benchmarked and selected per run: the vendored Tesseract engine stays the default everywhere, an Apple Vision backend becomes available in the headless CLI on macOS hosts, and a remote GPU worker backend (for example Modal running a document OCR model) exists only as an explicit, documented opt-in that is disabled by default. Held until the issue-017 corpus benchmark reports Tesseract accuracy on the scanned corpus documents; if Tesseract clears the completeness gate on them, this issue should be closed unstarted.
+
+## Acceptance tests
+
+- An OCR engine interface carries the issue-014 contract unchanged: word and line bounding boxes, confidence, page rotation, engine and model versions, and source hashes; the existing Tesseract path becomes the reference implementation with no behavior change and remains the default.
+- On macOS hosts, the headless CLI can select an Apple Vision engine that fulfills the same contract via a small local helper invoked per page image; on non-macOS hosts the engine reports itself unavailable with a named diagnostic instead of failing obscurely.
+- A remote engine adapter defines the request and response schema for a self-hosted GPU OCR worker, is disabled by default, requires an explicit per-run flag plus an environment-variable endpoint to activate, and refuses to run when the completeness policy marks the document private; activating it is recorded in provenance and the export manifest.
+- The corpus benchmark from the issue-017 work can run the same scanned fixtures through each available engine and report per-engine accuracy, gate pass-rate, and per-page latency side by side.
+- Engine selection, versions, and provenance appear in the reconstruction diagnostics so two runs with different engines are distinguishable artifacts.
+- Browser studio behavior is unchanged: it uses only the bundled local engine.
+
+## Validation command
+
+```bash
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+A remote OCR endpoint URL and token as environment-variable names only, read exclusively by the opt-in remote adapter; never written to files, logs, or evidence. All default paths require no secrets.
+
+## Artifact outputs
+
+Engine interface refactor, Apple Vision CLI backend with availability diagnostics, remote adapter schema and opt-in gating, per-engine benchmark report, and provenance evidence.
+
+## Stop conditions
+
+Stop before making any remote engine a default or silent fallback, uploading document bytes without the explicit opt-in flag, adding a hosted OCR SaaS dependency, or duplicating the issue-014 merge and review semantics per engine.
+
+## Human clarification protocol
+
+If Apple Vision cannot express word-level boxes for a script the corpus needs, present the observable accuracy difference against Tesseract and ask whether line-level boxes are acceptable for that engine.
+
+## Recommended response
+
+Keep this issue held until the issue-017 benchmark quantifies Tesseract on the real scanned documents; only the measured gap justifies the added surface, and the engine interface should be extracted in the smallest refactor that leaves the issue-014 tests green.
+
+## Trade-offs
+
+Multiple engines add configuration surface and test matrix cost for accuracy the corpus may not need; the opt-in remote path trades the local-only privacy guarantee for GPU-class accuracy and speed, which is why it must stay off by default with activation recorded in provenance.
+
+## Free-form response
+
+Only 18 of the 72 corpus documents require OCR at all, so engine work is deliberately sequenced behind the benchmark rather than ahead of it; the owner's interest is cheap serverless OCR (Modal-style scale-to-zero GPU) if and only if local engines prove insufficient.

--- a/docs/issues/021-srt-visual-diagnostic-evidence.md
+++ b/docs/issues/021-srt-visual-diagnostic-evidence.md
@@ -1,0 +1,58 @@
+# Visual diagnostic evidence for imports, corpus audits, and PRs
+
+depends-on: 013
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Make every blocking diagnostic humanly inspectable: render page rasters with the diagnostic's source boxes overlaid — note reference markers linked to their candidate note bodies with scores and evidence, ambiguous reading-order regions with the competing orders drawn — in the browser studio, and emit the same renders as static evidence artifacts so every SRT pull request carries before/after visual proof of what its change did instead of a sealed-bundle hash and a text log.
+
+## Acceptance tests
+
+- The studio importer shows a per-page inspector for a blocked document: the rendered page with color-coded boxes per diagnostic category, and selecting a diagnostic in the existing list highlights its source boxes; selecting a note-relationship diagnostic draws the reference marker, every candidate note body, and each candidate's score and evidence strings from the existing relationship data in `src/research/import-types.ts`.
+- Ambiguous reading-order pages render both candidate orders as numbered region sequences so a human can see exactly which two orders the geometry could not separate.
+- A local command renders the same overlays headlessly for the committed synthetic fixtures under `tests/fixtures/pdf/` and writes deterministic PNG or self-contained HTML artifacts into the `.agent/evidence` output alongside the existing lanes in `scripts/agent-evidence`; repeated runs are byte-identical apart from documented fields.
+- The corpus audit gains an opt-in overlay output for locally supplied PDFs that writes renders only to a local directory the caller names, never into the repository, and the machine-readable report still contains basenames, hashes, and counts only.
+- Evidence for any SRT rule change includes before/after overlay renders of at least one fixture the change affects, and the evidence README names which fixture, rule, and diagnostic each image demonstrates so a reviewer can trace what produced what.
+- New files to add: an overlay renderer module and test under `src/research/`, a headless evidence tool under `tools/`, and studio inspector wiring in `src/components/research/PublicationImporter.tsx`; the diagnostic text list remains for accessibility.
+
+## Validation command
+
+```bash
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Rendering runs locally; private document rasters and text must never be committed, uploaded, or logged.
+
+## Artifact outputs
+
+Studio diagnostic inspector with box overlays, headless fixture-overlay evidence tool wired into the evidence lanes, opt-in local corpus overlay output, and documented before/after evidence conventions for SRT PRs.
+
+## Stop conditions
+
+Stop before committing rasters of non-fixture documents, adding a hosted rendering service, replacing the accessible diagnostic list with canvas-only output, or letting overlay rendering block or slow the import path itself.
+
+## Human clarification protocol
+
+If rendering fidelity forces a trade-off (canvas raster size versus repository weight for committed evidence), present measured sizes for the smallest viable options.
+
+## Recommended response
+
+Reuse the pdfjs page rendering the importer already performs and the normalized source boxes every diagnostic already carries; this issue is presentation and evidence plumbing, not new analysis.
+
+## Trade-offs
+
+Committed image evidence grows the repository and can go stale against rule changes; keeping committed renders fixture-only and regenerating them in the evidence lane bounds the weight while private-corpus renders stay local-only.
+
+## Free-form response
+
+The owner reviews rucksack PRs whose bodies currently contain only a sealed-bundle identifier, and the corpus audit emits thousands of note diagnostics no human can adjudicate from text alone; visual evidence is the precondition for the human feedback loop and for trusting any auto-resolved diagnostic later.

--- a/docs/issues/022-srt-human-adjudication-loop.md
+++ b/docs/issues/022-srt-human-adjudication-loop.md
@@ -1,0 +1,58 @@
+# Human adjudication loop for blocked imports
+
+depends-on: 021
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Let a human resolve what the deterministic gate correctly refuses to guess: from the visual inspector, accept a note-match candidate, reclassify a marker as a citation, choose a reading-order candidate, or dismiss a diagnostic — each decision persisted as a local, replayable decision record that re-applies deterministically on re-import, clears the specific blocker it addresses, and appears in export provenance, so a paper with a handful of genuine ambiguities becomes exportable through minutes of review instead of staying blocked forever.
+
+## Acceptance tests
+
+- Each blocking diagnostic rendered by the issue-021 inspector offers its legal resolutions: note relationships accept one candidate or reclassification to citation or plain text; ambiguous reading-order pages accept one of the rendered candidate orders; every decision captures the diagnostic code, the stable region and marker identifiers, and the chosen resolution.
+- Decisions persist as a sidecar decision file keyed by the document's SHA-256 and schema version, exportable and importable as JSON from the studio; no document text or rasters enter the decision file.
+- Re-importing the same bytes with the decision file applies every decision deterministically before the completeness gate runs: resolved diagnostics no longer block, unresolved ones still do, and a decision whose target identifiers no longer match (after a rule change) is reported as stale instead of silently dropped or misapplied.
+- Applied decisions appear in reconstruction provenance and the export manifest as human adjudications with counts per diagnostic code, so an EPUB produced with human decisions is distinguishable from one that passed the gate unaided.
+- A decision can never widen scope: it resolves exactly the identified diagnostic, cannot alter thresholds, and cannot suppress a diagnostic category globally.
+- E2e coverage: a fixture blocked by an ambiguous note match and an ambiguous reading order is adjudicated in the studio, exports its EPUB, and the decision file replays headlessly to the same EPUB bytes. New files to add: a decision-record module and tests under `src/research/`, and studio adjudication wiring in `src/components/research/PublicationImporter.tsx`.
+
+## Validation command
+
+```bash
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Decisions and documents stay local; decision files contain identifiers, codes, and choices only.
+
+## Artifact outputs
+
+Decision record schema and applier, studio adjudication controls, stale-decision diagnostics, provenance and manifest integration, and replay determinism evidence.
+
+## Stop conditions
+
+Stop before letting decisions modify gate thresholds or apply across documents, auto-generating decisions from any model in this issue, storing document content in decision files, or accepting decisions without stable-identifier verification.
+
+## Human clarification protocol
+
+If stable identifiers cannot survive a planned rule change (region ids shifting under the issue-016 resolver), propose the smallest identifier scheme that stays stable across re-imports of identical bytes and report its collision behavior.
+
+## Recommended response
+
+Model the decision file on the same evidence-and-provenance contract the pipeline already uses; the applier should run as a pre-gate pass that rewrites relationship or order state exactly as if the analyzer had resolved it, leaving every downstream invariant untouched.
+
+## Trade-offs
+
+Per-document human decisions do not generalize — the same ambiguity in the next paper needs its own click; that is intentional, since generalization belongs in rule improvements like issue 018, and the decision corpus itself becomes the evidence for which rules to improve next. A model-assisted proposer that pre-fills suggested resolutions for human confirmation is a deliberate follow-on, not part of this issue; the evaluation schema already reserves provider, model-version, and cost fields for it.
+
+## Free-form response
+
+The corpus audit produces diagnostics at a volume no human can review as text, but per real document the genuine ambiguities after issues 016 and 018 land should number in the tens; this loop is what turns fail-closed from a dead end into a review workflow, and the decision records double as ground truth for evaluating future auto-resolution.


### PR DESCRIPTION
## Summary\n\nAdds reviewed canonical specs 018-022 for:\n\n- note-reference relationship resolution\n- DOCX manuscript import\n- pluggable OCR providers (held behind dependencies)\n- visual diagnostic evidence\n- a human adjudication loop\n\nThis gives the VM bounded follow-on work without mixing it with unrelated site changes.\n\n## Validation\n\n- Rucksack ledger seed dry-run parsed specs 001-022\n- clean [agent-evidence] passed: .agent/evidence/20260717T095251497Z/manifest.json run passed required build and test lanes\n- 
added 827 packages, and audited 828 packages in 11s

292 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities reported 0 vulnerabilities\n- secret scan passed\n\nThe issues should remain held until this ledger PR is merged and the source commit is default-branch reachable.