### PR TITLE
Harden scholarly PDF reflow geometry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,13 +27,13 @@
         "@tesseract.js-data/eng": "1.0.0",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
-        "astro": "^7.0.9",
+        "astro": "^7.1.3",
         "astro-icon": "^1.1.4",
         "bootstrap-icons": "^1.11.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fast-xml-parser": "^5.10.1",
         "fflate": "0.8.3",
-        "fast-xml-parser": "^5.10.0",
         "lucide-react": "^0.469.0",
         "pdfjs-dist": "5.4.624",
         "react": "^18.3.1",
@@ -71,7 +71,7 @@
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
         "vitest": "^4.1.10",
-        "wrangler": "4.110.0",
+        "wrangler": "^4.113.0",
         "yaml": "^2.9.0"
       },
       "engines": {
@@ -373,30 +373,6 @@
       "dependencies": {
         "@shikijs/types": "4.3.1",
         "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@astrojs/internal-helpers/node_modules/@shikijs/langs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
-      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@astrojs/internal-helpers/node_modules/@shikijs/themes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
-      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -1039,17 +1015,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
@@ -1153,9 +1118,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260708.1.tgz",
-      "integrity": "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260721.1.tgz",
+      "integrity": "sha512-VivNMhiEdZIB4JBWxf1RMJGROErv53qmQ+dvhjA1evrCouvqRYW718VqDideU3PSV7Ythl5Df48NqZYWoaEHpQ==",
       "cpu": [
         "x64"
       ],
@@ -1170,9 +1135,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-k7oye1ZiuwnnBBA2eTMduconr/ud5ZxFtRNTsYwMdmJeeeislw2+M72otrHxxvybCP7JWPPlJ38uhfajpcyhOA==",
       "cpu": [
         "arm64"
       ],
@@ -1187,9 +1152,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260708.1.tgz",
-      "integrity": "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260721.1.tgz",
+      "integrity": "sha512-hon0lW4ZQ4boAVgaw+0ZFTNS8v5MWPWvK0HZnt4tDpKYnDUviLZawtUW3KqvFmCQTipVHl1S34j3J8Eqb93hGQ==",
       "cpu": [
         "x64"
       ],
@@ -1204,9 +1169,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260721.1.tgz",
+      "integrity": "sha512-nAl+HRQqpX5b7xVwWcvLPZmCk8NQ2yjI0yvJTWcHiRswbMEg1ZZckVmjJUAn0PHzZARbCSyIV7v3UjM+SPRmIQ==",
       "cpu": [
         "arm64"
       ],
@@ -1221,9 +1186,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260708.1.tgz",
-      "integrity": "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260721.1.tgz",
+      "integrity": "sha512-9paFG5cMTKz/CRixnEEnZbe5uvFPBFSDthxJHANfCWhUtBj49GSL1FPIokIg+Q+H8DGJEExU0lL92LtxD0lTxQ==",
       "cpu": [
         "x64"
       ],
@@ -1317,12 +1282,11 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -1927,52 +1891,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
     "node_modules/@img/sharp-freebsd-wasm32": {
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
@@ -1992,57 +1910,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
@@ -2050,74 +1917,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2143,46 +1942,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
@@ -2205,98 +1964,6 @@
         "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
@@ -2317,29 +1984,6 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
@@ -2372,66 +2016,6 @@
       },
       "engines": {
         "node": ">=20.9.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2809,9 +2393,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -3768,17 +3352,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
@@ -3856,51 +3429,81 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
-      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.4.tgz",
+      "integrity": "sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/engine-javascript": "1.24.4",
+        "@shikijs/engine-oniguruma": "1.24.4",
+        "@shikijs/types": "1.24.4",
+        "@shikijs/vscode-textmate": "^9.3.1",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.4"
       }
     },
+    "node_modules/@shikijs/core/node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "license": "MIT"
+    },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
-      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.4.tgz",
+      "integrity": "sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "^2.2.0"
+        "@shikijs/types": "1.24.4",
+        "@shikijs/vscode-textmate": "^9.3.1",
+        "oniguruma-to-es": "0.8.1"
       }
+    },
+    "node_modules/@shikijs/engine-javascript/node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
+      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "1.24.4",
+        "@shikijs/vscode-textmate": "^9.3.1"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "license": "MIT"
+    },
     "node_modules/@shikijs/langs": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
-      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
+      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs/node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
@@ -3931,13 +3534,28 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
-      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
+      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes/node_modules/@shikijs/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/transformers": {
@@ -3949,42 +3567,7 @@
         "shiki": "1.24.4"
       }
     },
-    "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.4.tgz",
-      "integrity": "sha512-jjLsld+xEEGYlxAXDyGwWsKJ1sw5Pc1pnp4ai2ORpjx2UX08YYTC0NNqQYO1PaghYaR+PvgMOGuvzw2he9sk0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
-      }
-    },
-    "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-javascript": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.4.tgz",
-      "integrity": "sha512-TClaQOLvo9WEMJv6GoUsykQ6QdynuKszuORFWCke8qvi6PeLm7FcD9+7y45UenysxEWYpDL5KJaVXTngTE+2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "oniguruma-to-es": "0.8.1"
-      }
-    },
-    "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.4.tgz",
-      "integrity": "sha512-Do2ry6flp2HWdvpj2XOwwa0ljZBRy15HKZITzPcNIBOGSeprnA8gOooA/bLsSPuy8aJBa+Q/r34dMmC3KNL/zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1"
-      }
-    },
-    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+    "node_modules/@shikijs/types": {
       "version": "1.24.4",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.4.tgz",
       "integrity": "sha512-0r0XU7Eaow0PuDxuWC1bVqmWCgm3XqizIaT7SM42K03vc69LGooT0U8ccSR44xP/hGlNx4FKhtYpV+BU6aaKAA==",
@@ -3994,47 +3577,11 @@
         "@types/hast": "^3.0.4"
       }
     },
-    "node_modules/@shikijs/transformers/node_modules/@shikijs/vscode-textmate": {
+    "node_modules/@shikijs/types/node_modules/@shikijs/vscode-textmate": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
       "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
       "license": "MIT"
-    },
-    "node_modules/@shikijs/transformers/node_modules/oniguruma-to-es": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.1.tgz",
-      "integrity": "sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.0.2",
-        "regex-recursion": "^5.0.0"
-      }
-    },
-    "node_modules/@shikijs/transformers/node_modules/shiki": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.4.tgz",
-      "integrity": "sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "1.24.4",
-        "@shikijs/engine-javascript": "1.24.4",
-        "@shikijs/engine-oniguruma": "1.24.4",
-        "@shikijs/types": "1.24.4",
-        "@shikijs/vscode-textmate": "^9.3.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4"
-      }
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
@@ -4229,12 +3776,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse5": {
@@ -4736,9 +4283,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.0.9.tgz",
-      "integrity": "sha512-WB5pA4LLQnmqjBh6EIu0z8aUV4q2/AoThgSZq57Rsp+oqqvPu7OwZ5eF+W4ku20TUTxIhiJW8dccuGvJPiW2UA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.3.tgz",
+      "integrity": "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.1",
@@ -4755,7 +4302,7 @@
         "ci-info": "^4.4.0",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
-        "cookie": "^1.1.1",
+        "cookie": "^2.0.1",
         "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
@@ -4772,7 +4319,7 @@
         "magic-string": "^0.30.21",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
-        "neotraverse": "^0.6.18",
+        "neotraverse": "^1.0.1",
         "obug": "^2.1.1",
         "p-limit": "^7.3.0",
         "p-queue": "^9.1.0",
@@ -4868,30 +4415,6 @@
       "dependencies": {
         "@shikijs/types": "4.3.1",
         "@shikijs/vscode-textmate": "^10.0.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/astro/node_modules/@shikijs/langs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
-      "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/astro/node_modules/@shikijs/themes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
-      "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "4.3.1"
       },
       "engines": {
         "node": ">=20"
@@ -5588,12 +5111,12 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
@@ -6284,9 +5807,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -6325,9 +5848,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
-      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -6336,7 +5859,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.2.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",
@@ -9002,16 +8525,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260708.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260708.1.tgz",
-      "integrity": "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==",
+      "version": "4.20260721.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260721.0.tgz",
+      "integrity": "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260708.1",
+        "workerd": "1.20260721.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -9020,164 +8543,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/miniflare/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/miniflare/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/miniflare/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/minipass": {
@@ -9281,9 +8646,9 @@
       }
     },
     "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -9450,15 +8815,14 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.1.tgz",
+      "integrity": "sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.1.1",
-        "regex-recursion": "^5.1.1"
+        "regex": "^5.0.2",
+        "regex-recursion": "^5.0.0"
       }
     },
     "node_modules/openai": {
@@ -10006,10 +9370,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "devOptional": true,
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -11927,21 +11290,24 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
-      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.4.tgz",
+      "integrity": "sha512-aVGSFAOAr1v26Hh/+GBIsRVDWJ583XYV7CuNURKRWh9gpGv4OdbisZGq96B9arMYTZhTQkmRF5BrShOSTvNqhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/langs": "1.29.2",
-        "@shikijs/themes": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/core": "1.24.4",
+        "@shikijs/engine-javascript": "1.24.4",
+        "@shikijs/engine-oniguruma": "1.24.4",
+        "@shikijs/types": "1.24.4",
+        "@shikijs/vscode-textmate": "^9.3.1",
         "@types/hast": "^3.0.4"
       }
+    },
+    "node_modules/shiki/node_modules/@shikijs/vscode-textmate": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+      "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -11974,21 +11340,6 @@
         "node": ">=20.19.5",
         "npm": ">=10.8.2"
       }
-    },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/sitemap/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "license": "MIT"
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -12638,9 +11989,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -13309,12 +12660,6 @@
         "vscode-uri": "^3.1.0"
       }
     },
-    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT"
-    },
     "node_modules/vscode-html-languageservice": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
@@ -13344,9 +12689,9 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
-      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -13365,37 +12710,6 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
-      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "9.0.1",
-        "vscode-languageserver-types": "3.18.0"
-      }
-    },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver-types": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
-      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
-      "license": "MIT"
-    },
-    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
@@ -13405,7 +12719,13 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
@@ -13494,9 +12814,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260708.1.tgz",
-      "integrity": "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==",
+      "version": "1.20260721.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260721.1.tgz",
+      "integrity": "sha512-b/DWhpV0jTudzQpLhDovcOgBz233386q+3Hbari7CLCNT9UXxjQziSTZ9yCoKdT2K3TSx5jrwlOisq8hlLWXYg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -13507,17 +12827,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260708.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260708.1",
-        "@cloudflare/workerd-linux-64": "1.20260708.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260708.1",
-        "@cloudflare/workerd-windows-64": "1.20260708.1"
+        "@cloudflare/workerd-darwin-64": "1.20260721.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260721.1",
+        "@cloudflare/workerd-linux-64": "1.20260721.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260721.1",
+        "@cloudflare/workerd-windows-64": "1.20260721.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.110.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.110.0.tgz",
-      "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
+      "version": "4.113.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.113.0.tgz",
+      "integrity": "sha512-ROGzSloJv0y21It6Oc9LaruNcu1tdiQ/XzL3Jc3YkFjzXEMXzTqVhA8vQaGMTdZHTjFP0PVcwAHNgaw3gXu4wA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -13525,10 +12845,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260708.1",
+        "miniflare": "4.20260721.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260708.1"
+        "workerd": "1.20260721.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -13542,7 +12862,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260708.1"
+        "@cloudflare/workers-types": "^5.20260721.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -13684,21 +13004,6 @@
         "yaml-language-server": "bin/yaml-language-server"
       }
     },
-    "node_modules/yaml-language-server/node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
@@ -13801,6 +13106,20 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/zlibjs": {

--- a/package.json
+++ b/package.json
@@ -72,13 +72,13 @@
     "@tesseract.js-data/eng": "1.0.0",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
-    "astro": "^7.0.9",
+    "astro": "^7.1.3",
     "astro-icon": "^1.1.4",
     "bootstrap-icons": "^1.11.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fast-xml-parser": "^5.10.1",
     "fflate": "0.8.3",
-    "fast-xml-parser": "^5.10.0",
     "lucide-react": "^0.469.0",
     "pdfjs-dist": "5.4.624",
     "react": "^18.3.1",
@@ -116,8 +116,11 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vitest": "^4.1.10",
-    "wrangler": "4.110.0",
+    "wrangler": "^4.113.0",
     "yaml": "^2.9.0"
+  },
+  "overrides": {
+    "sharp": "0.35.3"
   },
   "prettier": {
     "semi": false,

--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -255,6 +255,85 @@ describe('PDF semantic reconstruction', () => {
     expect(result.completeness.textCoverage).toBe(1)
   })
 
+  it('separates adjacent section headings before semantic classification', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(1, '1 Introduction', 0.1, 0.22, 0.35, 10),
+          run(
+            1,
+            'Continuous body prose starts immediately below.',
+            0.1,
+            0.239,
+            0.72,
+          ),
+        ]),
+      ],
+      sourceHash: 'b'.repeat(64),
+      fileName: 'adjacent-heading.pdf',
+      byteLength: 4096,
+    })
+
+    expect(
+      result.paper.nodes.map((node) =>
+        'text' in node ? { type: node.type, text: node.text } : null,
+      ),
+    ).toEqual([
+      { type: 'heading', text: '1 Introduction' },
+      {
+        type: 'paragraph',
+        text: 'Continuous body prose starts immediately below.',
+      },
+    ])
+  })
+
+  it('recognizes adjacent author names separated by affiliation markers', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(1, 'Marker-aware authors', 0.1, 0.08, 0.72, 18),
+          run(1, 'Ada Example2 Ben Reader1', 0.1, 0.15, 0.6, 11),
+          run(1, '1 Example University', 0.1, 0.21, 0.7, 9),
+          run(1, 'Abstract', 0.1, 0.3, 0.25, 16),
+          run(1, 'The abstract remains canonical prose.', 0.1, 0.36, 0.72),
+        ]),
+      ],
+      sourceHash: 'c'.repeat(64),
+      fileName: 'marker-aware-authors.pdf',
+      byteLength: 4096,
+    })
+
+    expect(result.paper.authors).toEqual(['Ada Example', 'Ben Reader'])
+  })
+
+  it('collects right-side authors above an abstract despite column-major order', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(1, 'A Four-Author Paper', 0.16, 0.08, 0.68, 18),
+          run(1, 'Kevin Yang1 Yuandong Tian2', 0.16, 0.15, 0.31, 11),
+          run(1, 'Nanyun Peng3 Dan Klein1', 0.54, 0.15, 0.3, 11),
+          run(1, '1UC Berkeley, 2Meta AI, 3UCLA', 0.16, 0.19, 0.31, 9),
+          run(1, 'Research Group', 0.54, 0.19, 0.3, 9),
+          run(1, 'Abstract', 0.16, 0.27, 0.31, 16),
+          run(1, 'Visual summary', 0.54, 0.27, 0.3, 9),
+          run(1, 'The abstract remains canonical prose.', 0.16, 0.33, 0.31),
+          run(1, 'Diagram evidence', 0.54, 0.33, 0.3, 9),
+        ]),
+      ],
+      sourceHash: 'a'.repeat(64),
+      fileName: 'column-major-authors.pdf',
+      byteLength: 4096,
+    })
+
+    expect(result.paper.authors).toEqual([
+      'Kevin Yang',
+      'Yuandong Tian',
+      'Nanyun Peng',
+      'Dan Klein',
+    ])
+  })
+
   it('proves shared author markers from stripped source while retaining a raw affiliation marker', async () => {
     const result = await reconstructPageAnalyses({
       pages: [
@@ -489,6 +568,31 @@ describe('PDF semantic reconstruction', () => {
       }),
     ])
     expect(new Set(lists.map((list) => list.numberingId)).size).toBe(1)
+  })
+
+  it('does not interpret a two-column list transition as deep nesting', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(1, '1. Left item one', 0.08, 0.2, 0.34),
+          run(1, '1. Right item one', 0.56, 0.2, 0.34),
+          run(1, '2. Left item two', 0.08, 0.26, 0.34),
+          run(1, '2. Right item two', 0.56, 0.26, 0.34),
+          run(1, '3. Left item three', 0.08, 0.32, 0.34),
+          run(1, '3. Right item three', 0.56, 0.32, 0.34),
+        ]),
+      ],
+      sourceHash: 'c'.repeat(64),
+      fileName: 'two-column-lists.pdf',
+      byteLength: 4096,
+    })
+
+    const lists = result.paper.nodes.flatMap((node) =>
+      node.type === 'paragraph' && node.list ? [node.list] : [],
+    )
+    expect(lists).toHaveLength(6)
+    expect(lists.map((list) => list.level)).toEqual([1, 1, 1, 1, 1, 1])
+    expect(new Set(lists.map((list) => list.numberingId)).size).toBe(2)
   })
 
   it('preserves bracketed, parenthesized, and suffixed list markers with gaps', async () => {
@@ -731,6 +835,55 @@ describe('PDF semantic reconstruction', () => {
     })
 
     expect(Object.values(result.provenance)[0].links).toEqual(linked.links)
+  })
+
+  it('does not project a link annotation onto matching geometry on another page', async () => {
+    const first = page(1, [
+      run(1, 'Linked text on the annotated page.', 0.1, 0.2, 0.7),
+    ])
+    first.links = [
+      {
+        url: 'https://example.test/page-one',
+        box: {
+          page: 1,
+          x: 0.1,
+          y: 0.2,
+          width: 0.3,
+          height: 0.018,
+          rotation: 0,
+          method: 'pdf-link',
+        },
+      },
+    ]
+    const second = page(2, [
+      run(2, 'Plain text at matching coordinates.', 0.1, 0.2, 0.7),
+    ])
+
+    const result = await reconstructPageAnalyses({
+      pages: [first, second],
+      sourceHash: 'd'.repeat(64),
+      fileName: 'page-scoped-link.pdf',
+      byteLength: 2048,
+    })
+    const linked = result.paper.nodes.find(
+      (node) => 'text' in node && node.text.includes('Linked text'),
+    )
+    const plain = result.paper.nodes.find(
+      (node) => 'text' in node && node.text.includes('Plain text'),
+    )
+
+    expect(
+      linked && 'inlineRuns' in linked
+        ? linked.inlineRuns?.some(
+            (inline) => inline.href === 'https://example.test/page-one',
+          )
+        : false,
+    ).toBe(true)
+    expect(
+      plain && 'inlineRuns' in plain
+        ? plain.inlineRuns?.some((inline) => inline.href)
+        : false,
+    ).toBe(false)
   })
 
   it('orders detected columns left before right without storing target geometry', async () => {

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -142,8 +142,13 @@ function headingLevel(text: string, largestFont: number, bodySize: number) {
 }
 
 function likelyAffiliation(value: string) {
-  return /(?:university|institute|department|laborator(?:y|ies)|\blab\b|school|college|centre|center|hospital|academy|research group|corporation|\binc\b|@|https?:\/\/)/i.test(
-    value,
+  return (
+    /(?:university|institute|department|laborator(?:y|ies)|\blab\b|school|college|centre|center|hospital|academy|research group|corporation|\binc\b|@|https?:\/\/)/i.test(
+      value,
+    ) ||
+    /(?:\b[A-Z]{2,}\s+\p{Lu}\p{Ll}[\p{L}.-]*|\p{Lu}\p{Ll}[\p{L}.-]*\s+[A-Z]{2,}\b)/u.test(
+      value,
+    )
   )
 }
 
@@ -165,12 +170,20 @@ function likelyPersonName(value: string) {
 }
 
 function authorNamesFromLine(value: string) {
+  const hasAttachedAffiliationMarkers =
+    /(\p{L})[\d*†‡§⁰¹²³⁴⁵⁶⁷⁸⁹]+\s+(?=\p{Lu}\p{Ll})/u.test(value)
   const separated = value
+    .replace(/(\p{L})[\d*†‡§⁰¹²³⁴⁵⁶⁷⁸⁹]+\s+(?=\p{Lu}\p{Ll})/gu, '$1; ')
+    .replace(/\s+\d+(?=[A-Z]{2,}\b)/g, '; ')
     .split(/\s+(?:and|&)\s+|\s*[;,]\s*/i)
     .map(normalizedAuthorName)
     .filter(Boolean)
-  if (separated.length > 1 && separated.every(likelyPersonName)) {
-    return separated
+  const names = separated.filter(likelyPersonName)
+  if (
+    names.length > 0 &&
+    (!likelyAffiliation(value) || hasAttachedAffiliationMarkers)
+  ) {
+    return names
   }
   return likelyPersonName(value) ? [normalizedAuthorName(value)] : []
 }
@@ -222,10 +235,16 @@ function classifyFrontMatter(blocks: RegionBlock[], metadataTitle?: string) {
   if (!hasTitlePageEvidence) {
     return { title: undefined, authors: [], affiliations: [], abstract: '' }
   }
-  const beforeAbstract =
-    abstractIndex >= 0
-      ? firstPage.slice(0, abstractIndex)
-      : firstPage.filter((block) => block.region.box.y < 0.32)
+  const abstractBlock =
+    abstractIndex >= 0 ? firstPage[abstractIndex] : undefined
+  const beforeAbstract = abstractBlock
+    ? firstPage.filter(
+        (block) =>
+          block !== abstractBlock &&
+          block.region.box.y + block.region.box.height <=
+            abstractBlock.region.box.y + 0.01,
+      )
+    : firstPage.filter((block) => block.region.box.y < 0.32)
   const metadataTitleBlock = comparableMetadataTitle
     ? beforeAbstract.find(
         (block) => comparableTitle(block.text) === comparableMetadataTitle,
@@ -273,8 +292,6 @@ function classifyFrontMatter(blocks: RegionBlock[], metadataTitle?: string) {
     }
   }
 
-  const abstractBlock =
-    abstractIndex >= 0 ? firstPage[abstractIndex] : undefined
   let abstractText = ''
   if (abstractBlock) {
     const inlineAbstract = abstractBlock.text
@@ -831,13 +848,20 @@ function blocksFromRegions(
       region.box.y < 0.28 &&
       !/[.!?](?:\s|$)/.test(region.text) &&
       authorNamesFromLine(region.text).length > 0
+    const fontOnlyHeading =
+      region.text.trim().length > 1 &&
+      largestFont >= bodySize * 1.18 &&
+      (region.kind === 'equation' ||
+        /^\p{Lu}/u.test(region.text.trim()) ||
+        /^\d+(?:\.\d+){1,3}\s+\p{Lu}/u.test(region.text.trim())) &&
+      !/[,;]/u.test(region.text)
     const heading =
       !probableFirstPageAuthorLine &&
       headingBoundaryEvidence &&
       (namedSectionHeading ||
         numberedSectionHeading ||
         sequencedNumberedHeadingRegions.has(region) ||
-        (region.text.trim().length > 1 && largestFont >= bodySize * 1.18))
+        fontOnlyHeading)
     return {
       type: heading ? 'heading' : 'paragraph',
       region,
@@ -853,6 +877,7 @@ function blocksFromRegions(
   let activeList:
     | {
         page: number
+        column: PdfPageRegion['column']
         baseX: number
         numberingId: string
         ordered: boolean
@@ -941,6 +966,7 @@ function blocksFromRegions(
         appendBlockContinuation(lastListBlock, block)
         mergedContinuationBlocks.add(block)
         activeList.page = block.region.page
+        activeList.column = block.region.column
         continue
       }
       activeList = undefined
@@ -959,12 +985,15 @@ function blocksFromRegions(
     const isNestedItem = Boolean(
       activeList &&
         activeList.page === block.region.page &&
+        activeList.column === block.region.column &&
         block.region.box.x > activeList.baseX + 0.012,
     )
     const continuesCurrentList = Boolean(
       activeList &&
         (isNestedItem ||
           ((activeList.page === block.region.page || continuesAcrossPage) &&
+            (activeList.page !== block.region.page ||
+              activeList.column === block.region.column) &&
             activeList.ordered === Boolean(ordered) &&
             activeList.markerStyle === (marker?.markerStyle ?? 'disc') &&
             (!marker ||
@@ -976,6 +1005,7 @@ function blocksFromRegions(
       listCounts.set(block.region.page, sequence)
       activeList = {
         page: block.region.page,
+        column: block.region.column,
         baseX: block.region.box.x,
         numberingId: `pdf-list-p${String(block.region.page).padStart(3, '0')}-${String(sequence).padStart(3, '0')}`,
         ordered: Boolean(ordered),
@@ -984,6 +1014,7 @@ function blocksFromRegions(
       }
     } else if (activeList && !isNestedItem) {
       activeList.page = block.region.page
+      activeList.column = block.region.column
       activeList.lastOrdinal = marker?.ordinal
     }
     const list = activeList
@@ -1336,10 +1367,25 @@ function matchNotes(
 }
 
 function boxesOverlap(
-  left: { x: number; y: number; width: number; height: number },
-  right: { x: number; y: number; width: number; height: number },
+  left: {
+    page?: number
+    x: number
+    y: number
+    width: number
+    height: number
+  },
+  right: {
+    page?: number
+    x: number
+    y: number
+    width: number
+    height: number
+  },
 ) {
   return (
+    (left.page === undefined ||
+      right.page === undefined ||
+      left.page === right.page) &&
     Math.min(left.x + left.width, right.x + right.width) >
       Math.max(left.x, right.x) &&
     Math.min(left.y + left.height, right.y + right.height) >

--- a/src/research/pdf-lines.test.ts
+++ b/src/research/pdf-lines.test.ts
@@ -545,6 +545,57 @@ describe('PDF line joining', () => {
 })
 
 describe('PDF run grouping', () => {
+  it('keeps staggered two-column runs separate regardless of merge direction', () => {
+    const sourceRun = (
+      text: string,
+      x: number,
+      y: number,
+      width: number,
+    ): PdfSourceRun => ({
+      page: 1,
+      text,
+      x,
+      y,
+      width,
+      height: 0.013,
+      fontSize: 10,
+      fontName: 'SyntheticBody',
+      rotation: 0,
+      method: 'pdf-text',
+      confidence: 1,
+    })
+    const page: PdfPageAnalysis = {
+      page: 1,
+      kind: 'born-digital',
+      width: 595,
+      height: 842,
+      rotation: 0,
+      textCharacters: 71,
+      imageCount: 0,
+      objects: [],
+      runs: [
+        sourceRun('Earlier left column.', 0.119, 0.7, 0.37),
+        sourceRun('Earlier right column.', 0.514, 0.7, 0.37),
+        sourceRun('Second left column.', 0.119, 0.75, 0.37),
+        sourceRun('Second right column.', 0.514, 0.75, 0.37),
+        sourceRun('Left column begins', 0.119, 0.8134, 0.212),
+        sourceRun('and continues.', 0.343, 0.8134, 0.146),
+        sourceRun('Right column remains separate.', 0.514, 0.8063, 0.37),
+      ],
+    }
+
+    expect(groupRunsIntoLines(page).map((candidate) => candidate.text)).toEqual(
+      [
+        'Earlier left column.',
+        'Earlier right column.',
+        'Second left column.',
+        'Second right column.',
+        'Right column remains separate.',
+        'Left column begins and continues.',
+      ],
+    )
+  })
+
   it('attaches staggered small-cap fragments to the nearest baseline line', () => {
     const sourceRun = (
       text: string,

--- a/src/research/pdf-lines.ts
+++ b/src/research/pdf-lines.ts
@@ -398,17 +398,34 @@ function crossesProbableColumnGutter(
   line: PdfTextLine,
   run: PdfSourceRun,
   horizontalGap: number,
+  gutterCenter: number | null,
 ) {
   if (
     horizontalGap < Math.max(0.012, Math.min(line.height, run.height) * 0.65)
   ) {
     return false
   }
+  const combinedText = [...line.runs, run]
+    .sort((left, right) => left.x - right.x)
+    .map((candidate) => candidate.text.trim())
+    .filter(Boolean)
+    .join(' ')
+  if (
+    /^(?:(?:fig(?:ure)?|table|eq(?:uation)?)\.?\s*(?:\d+|[ivxlcdm]+)(?:\s*[.:–—-]|\s)|figure\s*[:.–—-])/i.test(
+      combinedText,
+    )
+  ) {
+    return false
+  }
   const lineRight = line.x + line.width
   const runRight = run.x + run.width
-  const gapCenter = (lineRight + run.x) / 2
+  const leftRight = line.x <= run.x ? lineRight : runRight
+  const rightLeft = line.x <= run.x ? run.x : line.x
+  const gapCenter = (leftRight + rightLeft) / 2
   const combinedWidth = Math.max(lineRight, runRight) - Math.min(line.x, run.x)
-  return gapCenter >= 0.35 && gapCenter <= 0.65 && combinedWidth >= 0.55
+  return gutterCenter === null
+    ? gapCenter >= 0.35 && gapCenter <= 0.65 && combinedWidth >= 0.55
+    : Math.abs(gapCenter - gutterCenter) <= 0.03
 }
 
 function horizontalGap(
@@ -422,7 +439,11 @@ function horizontalGap(
   )
 }
 
-function runFitsLine(line: PdfTextLine, run: PdfSourceRun) {
+function runFitsLine(
+  line: PdfTextLine,
+  run: PdfSourceRun,
+  gutterCenter: number | null,
+) {
   const center = run.y + run.height / 2
   const lineCenter = line.y + line.height / 2
   const gap = horizontalGap(line, run)
@@ -430,8 +451,59 @@ function runFitsLine(line: PdfTextLine, run: PdfSourceRun) {
     Math.abs(center - lineCenter) <=
       Math.max(0.004, run.height * 0.65, line.height * 0.65) &&
     gap <= Math.max(0.025, run.height * 2) &&
-    !crossesProbableColumnGutter(line, run, gap)
+    !crossesProbableColumnGutter(line, run, gap, gutterCenter)
   )
+}
+
+function probableColumnGutterCenter(runs: PdfSourceRun[]) {
+  const bands: Array<{ center: number; runs: PdfSourceRun[] }> = []
+  for (const run of [...runs].sort(
+    (left, right) => left.y - right.y || left.x - right.x,
+  )) {
+    const center = run.y + run.height / 2
+    const band = bands.find(
+      (candidate) =>
+        Math.abs(candidate.center - center) <=
+        Math.max(0.004, run.height * 0.65),
+    )
+    if (band) band.runs.push(run)
+    else bands.push({ center, runs: [run] })
+  }
+
+  const candidates: Array<{ center: number; band: number }> = []
+  for (const [bandIndex, band] of bands.entries()) {
+    const ordered = [...band.runs].sort((left, right) => left.x - right.x)
+    for (let index = 1; index < ordered.length; index += 1) {
+      const left = ordered[index - 1]
+      const right = ordered[index]
+      const gap = right.x - (left.x + left.width)
+      if (gap < Math.max(0.012, Math.min(left.height, right.height) * 0.65)) {
+        continue
+      }
+      const center = left.x + left.width + gap / 2
+      if (center >= 0.25 && center <= 0.75) {
+        candidates.push({ center, band: bandIndex })
+      }
+    }
+  }
+  const clusters = candidates.map((seed) => {
+    const members = candidates.filter(
+      (candidate) => Math.abs(candidate.center - seed.center) <= 0.025,
+    )
+    return {
+      members,
+      center:
+        members.reduce((total, member) => total + member.center, 0) /
+        members.length,
+      bandCount: new Set(members.map((member) => member.band)).size,
+    }
+  })
+  const strongest = clusters.sort(
+    (left, right) =>
+      right.bandCount - left.bandCount ||
+      Math.abs(left.center - 0.5) - Math.abs(right.center - 0.5),
+  )[0]
+  return strongest && strongest.bandCount >= 3 ? strongest.center : null
 }
 
 function mergeLineInto(target: PdfTextLine, source: PdfTextLine) {
@@ -449,11 +521,12 @@ export function groupRunsIntoLines(page: PdfPageAnalysis): PdfTextLine[] {
   const runs = page.runs
     .filter((run) => run.text.trim())
     .sort((left, right) => left.y - right.y || left.x - right.x)
+  const gutterCenter = probableColumnGutterCenter(runs)
 
   for (const run of runs) {
     const center = run.y + run.height / 2
     const matching = lines
-      .filter((line) => runFitsLine(line, run))
+      .filter((line) => runFitsLine(line, run, gutterCenter))
       .sort((left, right) => {
         const leftCenter = left.y + left.height / 2
         const rightCenter = right.y + right.height / 2
@@ -477,8 +550,8 @@ export function groupRunsIntoLines(page: PdfPageAnalysis): PdfTextLine[] {
           candidate.runs.some((candidateRun) =>
             matching.runs.some(
               (matchingRun) =>
-                runFitsLine(candidate, matchingRun) ||
-                runFitsLine(matching, candidateRun),
+                runFitsLine(candidate, matchingRun, gutterCenter) ||
+                runFitsLine(matching, candidateRun, gutterCenter),
             ),
           )
         ) {

--- a/src/research/pdf-regions.ts
+++ b/src/research/pdf-regions.ts
@@ -698,10 +698,30 @@ function unionBox(lines: PdfRegionLine[]): NormalizedSourceBox {
   }
 }
 
+function standaloneSectionHeading(line: ClassifiedLine) {
+  if (line.kind !== 'body' && line.kind !== 'spanning') return false
+  const text = line.text.replace(/\s+/g, ' ').trim()
+  if (!text || text.length > 120) return false
+  if (
+    /^(?:abstract|acknowledg(?:e)?ments?|limitations?|ethics statement|references|bibliography|appendix)$/i.test(
+      text,
+    )
+  ) {
+    return true
+  }
+  return (
+    /^\d{1,3}(?:\.\d+){0,3}\s+\p{Lu}[^.,;:!?]{0,100}$/u.test(text) ||
+    /^[A-Z](?:\.\d+)?\s+\p{Lu}[^,;:!?]{0,100}$/u.test(text)
+  )
+}
+
 function joinsRegion(previous: ClassifiedLine, line: ClassifiedLine) {
   if (previous.page !== line.page) return false
   if (previous.kind !== line.kind || previous.column !== line.column)
     return false
+  if (standaloneSectionHeading(previous) || standaloneSectionHeading(line)) {
+    return false
+  }
   if (
     (line.kind === 'footnote' || line.kind === 'endnote') &&
     line.noteLabel !== null

--- a/src/research/pdf-table-scope.test.ts
+++ b/src/research/pdf-table-scope.test.ts
@@ -126,6 +126,66 @@ function objectRegion(
 }
 
 describe('bounded PDF table source scoping', () => {
+  it('rejects a numbered prose sequence that competes with the actual table', () => {
+    const tableLines = [
+      line('header', 0.26, [0.14, 0.3, 0.46]),
+      line('row-1', 0.284, [0.14, 0.3, 0.46]),
+      line('row-2', 0.308, [0.14, 0.3, 0.46]),
+      line('row-3', 0.332, [0.14, 0.3, 0.46]),
+    ]
+    const table = textRegion(
+      'actual-table',
+      box(0.14, 0.26, 0.395, 0.088),
+      tableLines,
+    )
+    const listRegions = [1, 2, 3].map((ordinal, index) => {
+      const y = 0.42 + index * 0.024
+      const runs = [
+        {
+          ...box(0.52, y, 0.035, 0.016),
+          text: `${ordinal}.`,
+          fontName: 'BodySerif',
+          fontSize: 10,
+          confidence: 0.99,
+        },
+        {
+          ...box(0.6, y, 0.24, 0.016),
+          text: `Prose item ${ordinal}.`,
+          fontName: 'BodySerif',
+          fontSize: 10,
+          confidence: 0.99,
+        },
+      ]
+      const sourceLine = {
+        id: `list-line-${ordinal}`,
+        text: `${ordinal}. Prose item ${ordinal}.`,
+        fontSize: 10,
+        box: box(0.52, y, 0.32, 0.016),
+        runs,
+      }
+      return textRegion(`list-region-${ordinal}`, sourceLine.box, [sourceLine])
+    })
+    const tableCaption = caption('caption-between-table-and-list', 0.38)
+
+    expect(
+      resolvePdfTableScope({
+        caption: tableCaption,
+        pageRegions: [table, tableCaption, ...listRegions],
+        nativeObjects: [],
+      }),
+    ).toMatchObject({
+      status: 'matched',
+      candidates: [
+        {
+          sourceRegionIds: [table.id],
+        },
+      ],
+      scope: {
+        sourceRegionIds: [table.id],
+      },
+    })
+  })
+
   it('returns one exact crop scope for a wide contiguous single-anchor slab above its caption', () => {
     const slabLines = Array.from({ length: 8 }, (_, index) => {
       const y = 0.18 + index * 0.024
@@ -654,6 +714,55 @@ describe('bounded PDF table source scoping', () => {
         ),
       ),
     ).toBe(true)
+  })
+
+  it('assigns an adjacent table band to its closer numbered caption', () => {
+    const aboveLines = [
+      line('above-row-1', 0.38, [0.12, 0.4, 0.67]),
+      line('above-row-2', 0.42, [0.12, 0.4, 0.67]),
+      line('above-row-3', 0.46, [0.12, 0.4, 0.67]),
+    ]
+    const belowLines = [
+      line('below-row-1', 0.544, [0.12, 0.4, 0.67]),
+      line('below-row-2', 0.584, [0.12, 0.4, 0.67]),
+      line('below-row-3', 0.624, [0.12, 0.4, 0.67]),
+    ]
+    const above = textRegion(
+      'table-14-grid',
+      box(0.12, 0.38, 0.63, 0.096),
+      aboveLines,
+    )
+    const below = textRegion(
+      'table-15-grid',
+      box(0.12, 0.544, 0.63, 0.096),
+      belowLines,
+    )
+    const currentCaption = caption(
+      'caption-table-14',
+      0.5,
+      'Table 14. Baseline results.',
+    )
+    const nextCaption = caption(
+      'caption-table-15',
+      0.65,
+      'Table 15. Ablation results.',
+    )
+
+    const result = resolvePdfTableScope({
+      caption: currentCaption,
+      pageRegions: [above, currentCaption, below, nextCaption],
+      nativeObjects: [],
+    })
+
+    expect(result).toMatchObject({
+      status: 'matched',
+      scope: {
+        direction: 'above',
+        sourceRegionIds: ['table-14-grid'],
+      },
+      candidates: [{ sourceRegionIds: ['table-14-grid'] }],
+      ambiguity: { code: 'none' },
+    })
   })
 
   it('recognizes dense repeated columns without splitting ordinary word gaps', () => {

--- a/src/research/pdf-table-scope.ts
+++ b/src/research/pdf-table-scope.ts
@@ -1814,6 +1814,56 @@ function unresolved(
   }
 }
 
+function orderedProseScope(
+  scope: PdfTableScope,
+  regionsById: ReadonlyMap<string, PdfPageRegion>,
+) {
+  const scopedRegions = scope.sourceRegionIds
+    .map((id) => regionsById.get(id))
+    .filter((region): region is PdfPageRegion => Boolean(region))
+    .sort((left, right) => left.box.y - right.box.y || left.box.x - right.box.x)
+  if (scopedRegions.length < 2) return false
+  const ordinals = scopedRegions.map((region) => {
+    const match = region.text.trim().match(/^(\d+)[.)]\s+\p{L}/u)
+    return match ? Number(match[1]) : null
+  })
+  return ordinals.every(
+    (ordinal, index) =>
+      ordinal !== null &&
+      (index === 0 || ordinal === (ordinals[index - 1] ?? 0) + 1),
+  )
+}
+
+function arabicTableNumber(region: PdfPageRegion) {
+  const match = region.text.match(/^\s*table(?:\s|[.:])*(\d+)\b/i)
+  return match ? Number(match[1]) : null
+}
+
+function belongsToFollowingNumberedCaption(
+  scope: PdfTableScope,
+  caption: PdfPageRegion,
+  pageRegions: PdfPageRegion[],
+) {
+  if (scope.direction !== 'below') return false
+  const currentNumber = arabicTableNumber(caption)
+  if (currentNumber === null) return false
+  const currentGap = gapBetween(scope.cropBox, caption.box).vertical
+  return pageRegions.some((candidate) => {
+    if (
+      candidate.id === caption.id ||
+      arabicTableNumber(candidate) !== currentNumber + 1 ||
+      candidate.box.y < scope.cropBox.y + scope.cropBox.height ||
+      !overlapsCaption(candidate, scope.cropBox)
+    ) {
+      return false
+    }
+    return (
+      gapBetween(scope.cropBox, candidate.box).vertical + BOX_TOLERANCE / 2 <
+      currentGap
+    )
+  })
+}
+
 /**
  * Resolves only an exact, caption-bounded source scope for a PDF table.
  *
@@ -1874,6 +1924,22 @@ export function resolvePdfTableScope({
           ...ruled.candidates,
         ]
   ).sort((left, right) => left.id.localeCompare(right.id))
+  const regionsById = new Map(regions.map((region) => [region.id, region]))
+  const captionOwnedCandidates = candidates.some(
+    (candidate) => candidate.direction === 'above',
+  )
+    ? candidates.filter(
+        (candidate) =>
+          !belongsToFollowingNumberedCaption(candidate, caption, regions),
+      )
+    : candidates
+  const nonProseCandidates = captionOwnedCandidates.filter(
+    (candidate) => !orderedProseScope(candidate, regionsById),
+  )
+  const resolvedCandidates =
+    captionOwnedCandidates.length > 1 && nonProseCandidates.length === 1
+      ? nonProseCandidates
+      : captionOwnedCandidates
   const duplicateObjectIds = [
     ...new Set([...raster.duplicateObjectIds, ...ruled.duplicateObjectIds]),
   ].sort()
@@ -1881,19 +1947,19 @@ export function resolvePdfTableScope({
     return unresolved(
       caption,
       'duplicate-source-lineage',
-      candidates,
+      resolvedCandidates,
       duplicateObjectIds,
     )
   }
-  if (candidates.length === 0) {
+  if (resolvedCandidates.length === 0) {
     const evidence = ['deterministic-geometry-required']
     if (lanes.some((lane) => lane.interveningCaptionRegionId)) {
       evidence.push('intervening-caption-boundary')
     }
     return unresolved(caption, 'no-proven-scope', [], evidence)
   }
-  if (candidates.length > 1) {
-    return unresolved(caption, 'competing-scopes', candidates, [
+  if (resolvedCandidates.length > 1) {
+    return unresolved(caption, 'competing-scopes', resolvedCandidates, [
       'more-than-one-bounded-scope',
     ])
   }
@@ -1902,8 +1968,8 @@ export function resolvePdfTableScope({
     captionRegionId: caption.id,
     page: caption.page,
     status: 'matched',
-    scope: candidates[0],
-    candidates,
+    scope: resolvedCandidates[0],
+    candidates: resolvedCandidates,
     ambiguity: { code: 'none', candidateIds: [], evidence: [] },
   }
 }


### PR DESCRIPTION
Fixes the 2210.06774v3 regressions found during full-output review:\n\n- prevent symmetric cross-column line joins and preserve standalone section boundaries\n- recover title-page authors with attached affiliation markers\n- reset list structure at column transitions\n- scope PDF link annotations to their source page\n- disambiguate adjacent table captures and reject numbered prose as a table\n\nValidation:\n- 617 unit tests pass\n- staging production build passes (0 errors)\n- 2/2 browser upload/preview tests pass\n- EPUBCheck passes for the 86-page 2210.06774v3 readable fallback\n- 10 seeded random corpus samples complete without conversion crashes and fail closed when incomplete\n- preview deployed at https://erniesg-workers-preview.erniesg.workers.dev/research/studio/\n\nThe production importer remains release-gated; this change does not weaken completeness policy.