### PR TITLE
fix(research): resolve biblatex cite destinations and reclaim numeric equation fragments

### DIFF
--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -500,6 +500,170 @@ describe('PDF semantic reconstruction', () => {
     expect(resolution.ledger).toEqual({ expected: 1, mapped: 0 })
   })
 
+  it('resolves a biblatex refsection citation destination through named-destination geometry', () => {
+    const { block, box } = canonicalHyperlinkTestBlock()
+    const annotation = {
+      id: 'pdf-link-p001-a0001',
+      page: 1,
+      status: 'internal',
+      destination: 'cite.0@creativex',
+      destinationEvidence: {
+        source: 'pdfjs-named-destination',
+        destination: 'cite.0@creativex',
+        view: 'XYZ',
+        page: 11,
+        point: {
+          page: 11,
+          x: 0.11068,
+          y: 0.41442,
+          rotation: 0,
+          method: 'pdf-destination',
+        },
+        box: null,
+      },
+      box,
+    } as const
+
+    const resolution = resolveCanonicalHyperlinkObligations({
+      blocks: [block],
+      annotations: [annotation],
+      canonicalTargets: [
+        {
+          kind: 'reference',
+          label: 'Reference 3',
+          nodeId: 'bibliography-creativex',
+          sourceBoxes: [
+            {
+              page: 11,
+              x: 0.11905,
+              y: 0.41561,
+              width: 0.36667,
+              height: 0.01183,
+              rotation: 0,
+              method: 'pdf-text',
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(resolution.mappings).toEqual([])
+    expect(resolution.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'UNRESOLVED_HYPERLINK',
+        severity: 'error',
+        message: expect.stringMatching(/no exact canonical inline owner/iu),
+      }),
+    ])
+    expect(resolution.ledger).toEqual({ expected: 1, mapped: 0 })
+  })
+
+  it('resolves a biblatex citation destination whose entry key contains path characters', () => {
+    const { block, box } = canonicalHyperlinkTestBlock()
+    const destination =
+      'cite.0@annurev:/content/journals/10.1146/annurev-control-090523-100059'
+    const annotation = {
+      id: 'pdf-link-p001-a0001',
+      page: 1,
+      status: 'internal',
+      destination,
+      destinationEvidence: {
+        source: 'pdfjs-named-destination',
+        destination,
+        view: 'XYZ',
+        page: 11,
+        point: {
+          page: 11,
+          x: 0.11068,
+          y: 0.41442,
+          rotation: 0,
+          method: 'pdf-destination',
+        },
+        box: null,
+      },
+      box,
+    } as const
+
+    const resolution = resolveCanonicalHyperlinkObligations({
+      blocks: [block],
+      annotations: [annotation],
+      canonicalTargets: [
+        {
+          kind: 'reference',
+          label: 'Reference 9',
+          nodeId: 'bibliography-annurev',
+          sourceBoxes: [
+            {
+              page: 11,
+              x: 0.11905,
+              y: 0.41561,
+              width: 0.36667,
+              height: 0.01183,
+              rotation: 0,
+              method: 'pdf-text',
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(resolution.mappings).toEqual([])
+    expect(resolution.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'UNRESOLVED_HYPERLINK',
+        severity: 'error',
+        message: expect.stringMatching(/no exact canonical inline owner/iu),
+      }),
+    ])
+    expect(resolution.ledger).toEqual({ expected: 1, mapped: 0 })
+  })
+
+  it('keeps a biblatex citation destination without named-destination geometry unsupported', () => {
+    const { block, box } = canonicalHyperlinkTestBlock()
+    const annotation = {
+      id: 'pdf-link-p001-a0001',
+      page: 1,
+      status: 'internal',
+      destination: 'cite.0@creativex',
+      box,
+    } as const
+
+    const resolution = resolveCanonicalHyperlinkObligations({
+      blocks: [block],
+      annotations: [annotation],
+      canonicalTargets: [
+        {
+          kind: 'reference',
+          label: 'Reference 3',
+          nodeId: 'bibliography-creativex',
+          sourceBoxes: [
+            {
+              page: 11,
+              x: 0.11905,
+              y: 0.41561,
+              width: 0.36667,
+              height: 0.01183,
+              rotation: 0,
+              method: 'pdf-text',
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(resolution.mappings).toEqual([])
+    expect(resolution.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'UNRESOLVED_HYPERLINK',
+        severity: 'error',
+        message: expect.stringMatching(
+          /unsupported internal PDF destination scheme/iu,
+        ),
+      }),
+    ])
+    expect(resolution.ledger).toEqual({ expected: 1, mapped: 0 })
+  })
+
   it('coalesces contiguous same-target URL fragments into one canonical hyperlink range', () => {
     const text = 'https://leandojo.org.'
     const { block, annotations } = splitExternalHyperlinkTestBlock({

--- a/src/research/pdf-links.ts
+++ b/src/research/pdf-links.ts
@@ -823,9 +823,16 @@ function destinationGeometryKind(
   parsed: ParsedPdfInternalDestination | null,
 ): PdfCanonicalInternalLinkTargetKind | null {
   if (parsed) return parsed.kind
-  return /^Hfootnote\.[\p{L}\p{N}._:-]{1,128}$/u.test(destination)
-    ? 'note'
-    : null
+  if (/^Hfootnote\.[\p{L}\p{N}._:-]{1,128}$/u.test(destination)) return 'note'
+  // biblatex names each bibliography anchor `cite.<refsection>@<entrykey>`,
+  // and an entry key may contain characters (`@`, `:`, `/`) that the parsed
+  // label alphabet rejects. The name still identifies a bibliography entry,
+  // so resolution may proceed on named-destination geometry alone; without
+  // geometry evidence the destination stays unsupported.
+  if (/^cite\.[^\u0000-\u0020\u007f]{1,192}$/u.test(destination)) {
+    return 'reference'
+  }
+  return null
 }
 
 function validTargetSourceBox(box: NormalizedSourceBox) {

--- a/src/research/pdf-visuals.test.ts
+++ b/src/research/pdf-visuals.test.ts
@@ -2642,6 +2642,129 @@ describe('PDF visual association graph', () => {
     })
   })
 
+  it('absorbs a bare Computer Modern numeric fraction part into the display crop scope', async () => {
+    const formula = equationRegion(
+      'fraction-with-detached-denominator',
+      'p t = 1.58 t (p c + p r + p g )',
+      box(0.599, 0.6137, 0.284, 0.0238),
+    )
+    formula.lines[0].runs[0].fontName = 'CJMJKD+CMMI10'
+    // The denominator reaches line assembly as the first line of the body
+    // paragraph that follows the display equation, so only line-level
+    // absorption can reclaim it for the crop scope.
+    const denominatorBox = { ...box(0.7012, 0.634, 0.0364, 0.013), method: 'pdf-text' as const }
+    const proseBox = { ...box(0.599, 0.655, 0.284, 0.013), method: 'pdf-text' as const }
+    const followingParagraph = {
+      ...textRegion(
+        'fraction-following-paragraph',
+        '1000 where p c is the average power draw',
+        box(0.599, 0.634, 0.284, 0.034),
+      ),
+      lines: [
+        {
+          id: 'fraction-following-paragraph-denominator-line',
+          text: '1000',
+          fontSize: 9,
+          box: denominatorBox,
+          runs: [
+            {
+              ...denominatorBox,
+              text: '1000',
+              fontName: 'CJMJKD+CMR10',
+              fontSize: 9,
+              confidence: 0.99,
+            },
+          ],
+        },
+        {
+          id: 'fraction-following-paragraph-prose-line',
+          text: 'where p c is the average power draw',
+          fontSize: 9,
+          box: proseBox,
+          runs: [
+            {
+              ...proseBox,
+              text: 'where p c is the average power draw',
+              fontName: 'NimbusRomanNo9L',
+              fontSize: 9,
+              confidence: 0.99,
+            },
+          ],
+        },
+      ],
+    }
+    const rasterizeFigure = vi.fn(
+      async (input: Parameters<PdfFigureRasterizer>[0]) =>
+        createSourcePageCropAsset({
+          kind: 'equation',
+          cropBox: input.sourceBox,
+          sourceObjectIds: input.sourceObjectIds,
+          sourceBoxes: input.sourceBoxes,
+          width: 96,
+          height: 20,
+          pixels: new Uint8Array(96 * 20 * 4).fill(72),
+        }),
+    )
+
+    const result = await reconstructPdfVisuals({
+      pages: [page([])],
+      regions: [formula, followingParagraph],
+      rasterizeFigure,
+    })
+
+    expect(rasterizeFigure).toHaveBeenCalledOnce()
+    expect(result.relationships).toHaveLength(1)
+    expect(result.relationships[0]).toMatchObject({
+      status: 'matched',
+      evidence: expect.arrayContaining(['source-page-crop']),
+    })
+    expect(result.relationships[0].sourceLineIds).toContain(
+      'fraction-following-paragraph-denominator-line',
+    )
+    expect(result.relationships[0].sourceLineIds).not.toContain(
+      'fraction-following-paragraph-prose-line',
+    )
+  })
+
+  it('never absorbs Computer Modern prose beside a display equation into its crop scope', async () => {
+    const formula = equationRegion(
+      'fraction-beside-prose',
+      'p t = 1.58 t (p c + p r + p g )',
+      box(0.599, 0.6137, 0.284, 0.0238),
+    )
+    formula.lines[0].runs[0].fontName = 'CJMJKD+CMMI10'
+    const prose = textRegion(
+      'fraction-neighboring-prose',
+      'the market makers utility function',
+      box(0.6, 0.634, 0.28, 0.013),
+    )
+    prose.lines[0].runs[0].fontName = 'CJMJKD+CMR10'
+    const rasterizeFigure = vi.fn(
+      async (input: Parameters<PdfFigureRasterizer>[0]) =>
+        createSourcePageCropAsset({
+          kind: 'equation',
+          cropBox: input.sourceBox,
+          sourceObjectIds: input.sourceObjectIds,
+          sourceBoxes: input.sourceBoxes,
+          width: 96,
+          height: 20,
+          pixels: new Uint8Array(96 * 20 * 4).fill(72),
+        }),
+    )
+
+    const result = await reconstructPdfVisuals({
+      pages: [page([])],
+      regions: [formula, prose],
+      rasterizeFigure,
+    })
+
+    expect(result.relationships).toHaveLength(1)
+    expect(result.relationships[0].sourceRegionIds).not.toContain(prose.id)
+    expect(result.relationships[0].sourceLineIds).not.toContain(
+      prose.lines[0].id,
+    )
+  })
+
   it('uses an aligned printed number to crop a formula whose transcript is unsafe to publish', async () => {
     const formula = equationRegion(
       'garbled-numbered-equation',

--- a/src/research/pdf-visuals.ts
+++ b/src/research/pdf-visuals.ts
@@ -4956,6 +4956,36 @@ function numericListAssignmentFragment(region: PdfPageRegion) {
   )
 }
 
+function bareNumericMathFragment(region: PdfPageRegion) {
+  // A display-equation fraction part (for example the bare denominator
+  // `1000`) can reach line assembly as a line of the neighboring paragraph.
+  // Reclaim it for the display scope only when every glyph run uses a
+  // Computer Modern math-family font and the text is one short unparenthesized
+  // number, so prose, printed equation numbers, and operator expressions can
+  // never join an equation through this path.
+  if (!['body', 'spanning', 'equation'].includes(region.kind)) return false
+  const text = region.text.replace(/\s+/gu, ' ').trim()
+  if (
+    !text ||
+    Array.from(text).length > 16 ||
+    region.lines.length !== 1 ||
+    region.box.width > 0.28 ||
+    region.box.height > 0.04
+  ) {
+    return false
+  }
+  if (!/^[\p{N}][\p{N}.,]{0,11}$/u.test(text)) return false
+  const runs = region.lines[0].runs.filter((run) => run.text.trim())
+  return (
+    runs.length > 0 &&
+    runs.every(
+      (run) =>
+        computerModernMathFont(run.fontName) ||
+        computerModernMathGlyphFont(run.fontName),
+    )
+  )
+}
+
 function sourceMathFragment(region: PdfPageRegion) {
   const text = region.text.replace(/\s+/gu, ' ').trim()
   if (
@@ -5435,7 +5465,8 @@ function attachedEquationRegions(
           return (
             mathExtensionGlyphFragment(lineFragment) ||
             sourceMathFragment(lineFragment) ||
-            numericListAssignmentFragment(lineFragment)
+            numericListAssignmentFragment(lineFragment) ||
+            bareNumericMathFragment(lineFragment)
           )
         })
         if (selectedMathLines.length > 0) {


### PR DESCRIPTION
## Summary

Two surgical fixes for failure classes observed while running the headless PDF-to-EPUB pipeline on six real scholarly PDFs (arXiv LaTeX, ACL anthology, Elsevier journal, NeurIPS workshop, InDesign-typeset):

1. **biblatex citation destinations** (`src/research/pdf-links.ts`): biblatex names bibliography anchors `cite.<refsection>@<entrykey>`, and entry keys may contain `@`, `:`, `/` outside the parsed destination alphabet. These failed as `unsupported internal PDF destination scheme` even with exact named-destination geometry. They now resolve through the same geometry path already used for `Hfootnote.*` anchors, and still fail closed without geometry evidence.

2. **Detached equation fraction parts** (`src/research/pdf-visuals.ts`): a bare denominator (e.g. `1000` in Equation 1 of arXiv 1906.02243) can reach line assembly as the first line of the following body paragraph, making the equation crop veto itself over what is really its own ink. Line-level absorption now reclaims a single short unparenthesized number whose glyph runs are all Computer Modern math-family fonts. Prose, printed equation numbers, and operator expressions remain excluded (a looser first draft regressed one 1206.5252 equation from matched to unresolved and was tightened until the frozen relationship set was byte-stable).

## Validation

- `npx vitest run src/research/pdf-visuals.test.ts src/research/pdf-layout.test.ts src/research/pdf-fidelity-regression.test.ts src/research/epub.test.ts` — 509 passed (new red tests added first for both fixes)
- `npm test` — passes except 3 pre-existing `tools/pdf-fidelity-mineru-adapter.test.mjs` failures on Node 22.13 (subprocess imports a `.ts` file; needs Node type-stripping ≥22.18 — unrelated, reproduce on clean main)
- `npx tsc --noEmit` clean
- Synthetic fidelity fixture: A/B exports byte-identical; strict benchmark compare vs main reports 0 regressed / 0 improved / 1 unchanged (no fixture drift)
- Real papers (owner-local, aggregates only): NeurIPS workshop paper unresolved-hyperlink diagnostics 11 → 7 (all four `cite.0@…` destinations now resolve); 1906.02243v1 Equation 1 unresolved → matched bounded source crop, unresolved visual objects 2 → 1; 1206.5252v1 and ACL 2023.190 unchanged (their blockers are table-scope proving and PAX destinations, tracked separately)