### PR TITLE
docs(issues): restore specs 027-031 for the publication-contracts ladder

### DIFF
--- a/docs/issues/027-define-universal-publication-and-capability-contracts.md
+++ b/docs/issues/027-define-universal-publication-and-capability-contracts.md
@@ -1,0 +1,80 @@
+<!-- rucksack-autopilot-provider:vm-codex -->
+<!-- rucksack-autopilot-depends-on:002,003,019,026 -->
+
+# Define universal publication and capability contracts
+
+depends-on: 002,003,019,026
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Introduce a source-neutral, versioned compiler boundary—`PublicationGraph`, `CompositionContext`, and `TransformationPolicy`—that can represent an Astro post, Payload document, DOCX manuscript, or repaired PDF without making a scholarly `ResearchPaper` or a rendered page the universal source of truth.
+
+## Acceptance tests
+
+- A strict, bounded `PublicationGraph` schema represents publication metadata and ordered heading, paragraph, list, quote, code, figure, caption, table, equation, aside, note, reference, and media nodes with stable ids and explicit relationships.
+- Every node records locale/direction, required-or-optional status, editorial importance, source provenance, accessibility alternatives, authored compact/monochrome/static variants where present, permitted transformation ids, and explicit edition linkage for Astro translations and Payload locales. Page coordinates are forbidden from canonical content.
+- A versioned `PublicationSourceAdapter` returns `{ graph, assetBundle, diagnostics, provenance }`. `assetBundle` contains bounded content-addressed descriptors and a byte-resolver interface; graph JSON never embeds bytes, local paths, credentials, or source-specific runtime objects.
+- `CompositionContext` describes continuous or paged flow, logical/physical dimensions and units, orientation, color capability, resolution, refresh behavior, interaction, font control, locale/script, accessibility preferences, duplex, binding, bleed, and offline constraints. Named presets are data, not branches in compiler code.
+- `TransformationPolicy` declares legal representation changes, preservation class, required authored alternatives, and hard/soft constraints. Omission, summarization, reading-order changes, and meaning-changing crops are illegal unless an explicit reviewed variant permits them.
+- The existing `TargetProfile` plus issue-026 orientation and export-authority contract maps losslessly into `CompositionContext`. Dimensions, margins, orientation, reader-control assumptions, and pagination authority have exactly one registry; `src/publication/profiles.ts` may expose adapters/presets but cannot duplicate those facts.
+- Codecs reject unknown versions, extra fields, duplicate ids, dangling relationships, unsafe URLs, unbounded text/collections, invalid ranges/units, and source fields containing secret or local-path material. Round trips are deterministic.
+- An adapter maps the existing golden `ResearchPaper` into the new graph and back to its current supported subset with identical canonical ids, text, relationships, inline semantics, and asset references. A separately typed annotation/anchor bundle round-trips beside the graph; the adapter does not pretend those values live in `ResearchPaper`.
+- New files to add: `src/publication/schema.ts`, `src/publication/source-adapter.ts`, `src/publication/asset-bundle.ts`, `src/publication/profiles.ts`, `src/publication/transformation-policy.ts`, `src/publication/research-paper-adapter.ts`, `src/publication/annotation-bundle.ts`, one matching `*.test.ts` for each contract/adapter, and `docs/adr/009-universal-publication-contracts.md`.
+
+## TDD sequence
+
+1. **Red:** add the seven exact-path contract/adapter test files, run their focused Vitest command, and preserve failures for versions, extra fields, ids/relationships, unsafe URLs, bounds/units, embedded bytes/paths, and target geometry in canonical nodes.
+2. **Green:** implement only the strict graph, source-adapter, asset-bundle, context, and policy codecs needed for those rejection boundaries; do not add a renderer.
+3. **Red then green:** add `ResearchPaper`, separate annotation/anchor, and issue-026 profile-authority round-trip failures, then implement lossless thin adapters without duplicating facts.
+4. **Refactor:** consolidate bounded primitives and presets only after deterministic edition linkage, byte resolution, compatibility, and security tests pass; then freeze fixture hashes and run full validation.
+
+## Exact-head definition of done
+
+- All contracts reject invalid/unsafe data and round-trip the supported research-paper/profile subset byte-deterministically at the exact PR head, including separately typed annotations and content-addressed assets.
+- Focused contract/security tests, build, full validation, and exact-head evidence pass with no ignored unknown field, lossy compatibility snapshot, or second profile authority.
+- The ADR names versioning, source/asset boundaries, unsupported features, migration rules, and non-goals; no renderer, binary asset, secret, local path, or target coordinate enters canonical graph data.
+- From a clean checkout of the immutable PR head, the canonical evidence manifest records `commit` equal to that head, `dirty: false`, `result: passed`, and every required lane; a post-lane clean-worktree check proves validation did not modify tracked or generated source files.
+- Canonical fixture receipts bind graph/asset hashes, schema and profile versions, adapter version, and toolchain versions to that exact head.
+
+## Validation command
+
+```bash
+npx vitest run src/publication/schema.test.ts src/publication/source-adapter.test.ts src/publication/asset-bundle.test.ts src/publication/profiles.test.ts src/publication/transformation-policy.test.ts src/publication/research-paper-adapter.test.ts src/publication/annotation-bundle.test.ts
+npm test
+npm run build
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Contracts and fixtures are repository-only data.
+
+## Artifact outputs
+
+Versioned universal schemas/codecs, profile fixtures, transformation-policy fixtures, `ResearchPaper` compatibility adapter, ADR, and deterministic round-trip/security tests.
+
+## Stop conditions
+
+Stop before adding a renderer dependency, inventing a general optimizer, embedding binary assets in graph JSON, duplicating existing target/profile facts, renaming the existing SRT runtime prematurely, or allowing source adapters to smuggle target-specific layout into canonical nodes.
+
+## Human clarification protocol
+
+If one source feature has no medium-independent representation, present a typed extension, an opaque-but-preserved node, and an explicit unsupported diagnostic with their round-trip consequences.
+
+## Recommended response
+
+Extract the smallest compiler and adapter contracts from the invariants the SRT proof already enforces, then prove lossless compatibility with the existing profile and research-paper boundaries before moving any current renderer or importer onto them.
+
+## Trade-offs
+
+A broad graph risks becoming an abstract document standard; restricting the first node set to content already present in Astro, Payload Lexical, DOCX, and the SRT proof keeps it implementable while versioned extensions preserve room to grow.
+
+## Free-form response
+
+This is the architectural seam that changes the product from PDF-to-EPUB into write-once publishing. Source adapters and output adapters can then evolve independently around one inspectable meaning graph.
+

--- a/docs/issues/028-compile-one-astro-post-into-webpub-epub-and-paged-pdf.md
+++ b/docs/issues/028-compile-one-astro-post-into-webpub-epub-and-paged-pdf.md
@@ -1,0 +1,86 @@
+<!-- rucksack-autopilot-provider:vm-codex -->
+<!-- rucksack-autopilot-depends-on:027 -->
+
+# Compile one Astro post into WebPub, EPUB, and paged PDF
+
+depends-on: 027
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Ship the source-first beachhead: compile one published `ernie.sg` Astro MDX post through a source-neutral `PublicationBundle` into a phone WebPub, a reflowable monochrome e-ink EPUB, and deterministic A4 and A5 PDFs using one pinned, replaceable HTML/CSS renderer adapter. The existing responsive Astro route remains a same-source sibling, not yet a graph-rendered output.
+
+## Acceptance tests
+
+- `publication:build` selects a registered source adapter, resolves its source locator into a `PublicationBundle`, and then invokes source-neutral renderers. A renderer cannot import Astro types or inspect adapter provenance to branch its output.
+- The Astro adapter accepts a stable blog entry id from the existing `blog` collection and emits phone WebPub, monochrome e-ink EPUB, A4 PDF, A5 PDF, and one `PublicationReceipt`; the existing Astro route remains the canonical responsive web edition.
+- The adapter preserves frontmatter title, description, date, authors, locale, translation key, headings, paragraphs, emphasis, links, lists, quotes, code, math, images/captions, footnotes, and source order in `PublicationGraph`. Unsupported MDX components fail with named node/source locations instead of being dropped.
+- The first real golden input is the published `src/content/blog/moving-to-cloudflare-with-astro/index.mdx`; add an authored hero-image alternative to the validated content schema/post, then resolve its local image and translation linkage without a network request and include the asset exactly once in each applicable package with that alt text and provenance. Reusing the post title as an invented image description is not accepted.
+- A named synthetic MDX fixture covers code, math, quotes, footnotes, captions, links, one local image, and one unsupported component. Supported semantics survive; the unsupported component fails with its type and source location instead of being flattened or evaluated.
+- A pinned Vivliostyle CLI adapter consumes repository-owned semantic HTML and CSS to create WebPub, EPUB, and PDF. It runs with the network disabled after `npm ci`, never auto-installs a theme, and can be replaced behind the renderer interface without changing the graph.
+- Vivliostyle and Node wrappers are exact `package-lock.json` dependencies; the browser revision, repository font-file checksums, and EPUBCheck version/checksum live in a reviewed toolchain manifest. No release tool is resolved from an unpinned global executable.
+- The required output matrix is phone WebPub, monochrome e-ink EPUB, A5 PDF, and A4 PDF. The two print profiles differ in page dimensions, margins, type scale, measure, page count, and figure placement while every output preserves required nodes and relationships; EPUB remains reflowable and reader-overridable.
+- WebPub checks language/direction, headings, landmarks, links, canonical order, and image alternatives. EPUB checks navigation, landmarks, accessibility metadata, reading order, references, and assets with structural inspection plus EPUBCheck. PDF checks selectable text, page geometry, embedded fonts, glyphs/assets, clipping/overflow, figure-caption integrity, widows/orphans, and links; tagged PDF/PDF-UA, PDF/X, full CMYK, imposition, and newspaper production are explicitly outside this issue.
+- The published Astro route and compiled WebPub receive a structural comparison for canonical order and local assets. This proves same-source sibling parity without claiming that the current route consumes `PublicationGraph`.
+- Repeated builds from the same source, compiler/profile/policy versions, pinned renderer, and fonts produce stable semantic/layout receipts. Any unavoidable binary metadata variance is normalized or documented and cannot change page geometry or content checksums.
+- `publication:build` and `publication:check` are required commands in `.github/workflows/ci.yml` and `scripts/agent-evidence`; register them inside the evidence schema's existing `build` and `test` lane ids unless the allowlist, `.agent/commands.yaml`, `.agent/verify.md`, local evidence script, and immutable-head workflow are intentionally migrated together. Exact-head evidence cannot pass when the matrix or toolchain is missing.
+- New files to add: `src/publication/adapters/astro.ts`, `src/publication/adapters/astro.test.ts`, `src/publication/adapter-registry.ts`, `src/publication/renderers/vivliostyle.ts`, `src/publication/renderers/vivliostyle.test.ts`, `src/publication/toolchain.ts`, `src/publication/toolchain.test.ts`, `src/publication/toolchain-manifest.json`, `tools/publication-build.mjs`, `tools/publication-build.test.mjs`, `tools/publication-check.mjs`, `tools/publication-check.test.mjs`, `tests/fixtures/publication/astro/synthetic-publication.mdx`, `tests/fixtures/publication/astro/unsupported-component.mdx`, and repository-owned CSS under `src/styles/publication/`. Add `publication:build` and `publication:check` scripts to the existing `package.json`.
+
+## TDD sequence
+
+1. **Red:** create the named Astro/renderer/toolchain/CLI tests and MDX fixtures, run their focused Vitest command, and preserve failures for supported/unsupported MDX, missing alt text, traversal, attempted execution, missing/mismatched toolchains, and an incomplete output matrix.
+2. **Green:** implement the adapter registry and bundle handoff, then make a source-neutral renderer produce and structurally check only phone WebPub from repository-owned HTML/CSS.
+3. **Red then green:** add EPUB, A5, and A4 artifact/check failures; pin and wire Vivliostyle, fonts, browser, and EPUBCheck until the exact four-output matrix passes offline and from a clean install.
+4. **Refactor:** enforce one publication traversal and renderer boundary only after determinism, route-sibling parity, accessibility boundaries, and build/test evidence-lane failures pass; repeat the build and compare normalized receipt hashes before full validation.
+
+## Exact-head definition of done
+
+- The published entry and synthetic fixture pass the declared adapter boundary; unsupported/unsafe input fails closed, and all four real artifacts preserve required semantics at the exact PR head.
+- `publication:build`, `publication:check`, focused tests, normal build, CI, and exact-head evidence all pass from a clean dependency install with network-disabled rendering and no skipped matrix cell.
+- Toolchain and font versions/checksums are pinned; artifacts stay in ignored evidence storage; renderers import no Astro types; PDF accessibility/production claims remain within the stated boundary.
+- From a clean checkout of the immutable PR head, the canonical evidence manifest records `commit` equal to that head, `dirty: false`, `result: passed`, and the existing evidence lane ids containing both publication commands; a post-lane clean-worktree check proves validation did not modify tracked or generated source files.
+- One receipt binds source/graph/assets, all four profile and policy versions, the pinned Node/browser/Vivliostyle/font/EPUBCheck toolchain, and all four artifact hashes to that exact head; the browser and EPUB validators install portably in CI and do not rely on desktop-bundled paths.
+
+## Validation command
+
+```bash
+npx vitest run src/publication/adapters/astro.test.ts src/publication/renderers/vivliostyle.test.ts src/publication/toolchain.test.ts tools/publication-build.test.mjs tools/publication-check.test.mjs
+npm test
+npm run build
+npm run publication:build -- --adapter astro --entry moving-to-cloudflare-with-astro --output .agent/evidence/publication
+npm run publication:check -- --input .agent/evidence/publication --matrix phone-webpub,eink-epub,a5-pdf,a4-pdf
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Source, assets, rendering, and validation run locally without hosted services.
+
+## Artifact outputs
+
+Astro source adapter and registry, pinned replaceable renderer/toolchain, repository-owned themes, multi-output CLI, A4/A5/WebPub/EPUB artifacts in ignored evidence storage, publication receipt, required CI/evidence lanes, and semantic/visual/accessibility/conformance tests.
+
+## Stop conditions
+
+Stop before scraping the public blog HTML as canonical content, silently flattening or executing MDX, letting a renderer import Astro types, fetching a theme/tool/asset during the build, committing generated publications, weakening the existing production build, or marketing A4/A5 proof as arbitrary magazine/newspaper production.
+
+## Human clarification protocol
+
+If an existing MDX component cannot map losslessly, report the component, affected post ids, and smallest authored static or print alternative rather than embedding client-only behavior in EPUB/PDF.
+
+## Recommended response
+
+Use Astro's validated collection as one registered source adapter and Vivliostyle as a pinned output engine, keeping all editorial meaning and transformation decisions in repository-owned contracts and themes and all source-specific knowledge outside renderers.
+
+## Trade-offs
+
+Vivliostyle accelerates a real multi-output release and supports custom page sizes, but it does not supply editorial intelligence. Keeping it behind an adapter avoids coupling the future planner to one paged-media engine.
+
+## Free-form response
+
+This is the first user-visible proof of “write once, publish beautifully everywhere”: one published post already authored on `ernie.sg`, not a reconstructed PDF, produces compiler-generated WebPub, ebook, and print artifacts alongside its existing responsive route.
+

--- a/docs/issues/029-plan-transformations-with-semantic-and-renderer-preflight.md
+++ b/docs/issues/029-plan-transformations-with-semantic-and-renderer-preflight.md
@@ -1,0 +1,82 @@
+<!-- rucksack-autopilot-provider:vm-codex -->
+<!-- rucksack-autopilot-depends-on:027,028 -->
+
+# Plan transformations with semantic and renderer preflight
+
+depends-on: 027,028
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Add the missing dynamic-typesetting middle layer: enumerate deterministic representation and layout candidates for a `CompositionContext`, reject static semantic failures, probe bounded survivors with the renderer, reject measured geometric/production failures, and explain the selected eligible plan and artifact.
+
+## Acceptance tests
+
+- A renderer-neutral `LayoutPlan` records every canonical node exactly once or as ordered fragments, selected representation, flow region, keep/split rules, source/output anchors, reasons, policy versions, hard violations, soft trade-offs, and remaining uncertainty.
+- The planner chooses from bounded authored modes—editorial spread, conventional page, compact page, single-column reading, and sequence—without free coordinates or target-name conditionals.
+- Component policies demonstrate at least: figure inline/full-span; table conventional/stacked-records; aside margin/inline/endnote; interactive media authored-static alternative; and color chart authored-monochrome alternative. Required authored variants fail closed when absent.
+- Static semantic preflight rejects unreachable required content, changed reading order, dangling relationships, missing required representations/alternatives, policy violations, known legibility floors, insufficient declared asset resolution, and incompatible bleed/binding constraints before rendering.
+- The issue-028 Vivliostyle adapter is migrated to consume `LayoutPlan` and return a versioned renderer probe with actual page count, shaped glyph coverage, line/page breaks, overflow, clipping, figure-caption geometry, link targets, and output anchors. Renderer-specific facts remain probe evidence and never enter `PublicationGraph` or standing policy.
+- Geometric/production validation rejects unusable table/equation fallback, unexpected clipping/overflow, unsupported glyph shaping or hyphenation, broken keeps/relationships, and actual print constraints. A bounded failed candidate may advance to the next deterministic candidate; no artifact is final until one candidate passes both stages.
+- Soft comparison applies only to candidates that pass static and measured hard gates and exposes page count, density, hierarchy, figure prominence, whitespace, and policy preference separately; no weighted aesthetic score can compensate for a hard failure.
+- A four-profile fixture renders phone WebPub, six-inch monochrome e-ink EPUB, A5 PDF, and A4 PDF with materially different but eligible plans, stable source/output anchors, identical required-content reachability, and successful `publication:check`. An undersized custom profile returns no eligible plan plus the smallest actionable alternatives without emitting a final artifact.
+- New files to add: `src/publication/planner.ts`, `src/publication/planner.test.ts`, `src/publication/static-preflight.ts`, `src/publication/static-preflight.test.ts`, `src/publication/renderer-probe.ts`, `src/publication/renderer-probe.test.ts`, `src/publication/production-validation.ts`, `src/publication/production-validation.test.ts`, `src/publication/vivliostyle-renderer.test.ts`, `tests/fixtures/publication/four-profile-publication.json`, and `tests/fixtures/publication/undersized-profile.json`. Preview matrix and editorial-lock UI are excluded and tracked by issue 031.
+
+## TDD sequence
+
+1. **Red:** add the five exact-path planner/preflight/probe tests and two fixtures, run their focused Vitest command, and preserve failures for bounded candidate order, policy bounds, semantic rejection, missing alternatives, and an undersized no-eligible-plan context.
+2. **Green:** implement only candidate enumeration, one figure/table transformation, and static semantic preflight until statically legal `LayoutPlan` values are the only values reaching a renderer.
+3. **Red then green:** add renderer-probe failures for overflow, clipping, glyphs, keeps/links, and unusable fallbacks; migrate the issue-028 adapter to return measured evidence and parameterize the remaining bounded policies.
+4. **Refactor:** separate static from measured facts and stabilize reason codes only after next-candidate selection, four receipts, repeated plan/probe bytes, and normalized output hashes are deterministic; then run full validation.
+
+## Exact-head definition of done
+
+- No final artifact exists without a static-pass plan and measured production-pass probe; hard failures cannot be outweighed, hidden, or converted into a soft score at the exact PR head.
+- Planner/probe/production unit tests, four-output build/check, normal build, and exact-head evidence pass with a second failure fixture and no UI or editorial-lock scope leakage.
+- Graph and standing policy remain renderer-neutral, every required node has lineage, no authored alternative is invented, and no model participates in a gating decision.
+- From a clean checkout of the immutable PR head, the canonical evidence manifest records `commit` equal to that head, `dirty: false`, `result: passed`, and every required lane; a post-lane clean-worktree check proves validation did not modify tracked or generated source files.
+- Plan/probe/artifact receipts bind source and graph hashes, profile/policy/planner/probe versions, pinned toolchain versions, selected-candidate reasons, and all four artifact hashes to that exact head.
+
+## Validation command
+
+```bash
+npx vitest run src/publication/planner.test.ts src/publication/static-preflight.test.ts src/publication/renderer-probe.test.ts src/publication/production-validation.test.ts src/publication/vivliostyle-renderer.test.ts
+npm test
+npm run build
+npm run publication:build -- --adapter astro --entry moving-to-cloudflare-with-astro --planner semantic-v1 --output .agent/evidence/publication-planner
+npm run publication:check -- --input .agent/evidence/publication-planner --matrix phone-webpub,eink-epub,a5-pdf,a4-pdf
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Planning is deterministic and offline; no model call is required.
+
+## Artifact outputs
+
+Deterministic planner, static semantic preflight, versioned renderer probe, geometric/production validation, eligible candidate comparison, renderer-neutral plans, four rendered profile artifacts, and receipts.
+
+## Stop conditions
+
+Stop before adding an LLM as the deciding planner, treating unmeasured geometry as proven, letting an aesthetic score hide semantic loss, producing a summary or crop that lacks an authored variant, optimizing against one golden fixture, or copying Vivliostyle-specific measurements into canonical graph/policy fields.
+
+## Human clarification protocol
+
+When no eligible plan exists, report the conflicting hard constraints and smallest legal authored alternative or profile relaxation; ask for editorial judgment only when standing policy cannot choose among those options.
+
+## Recommended response
+
+Build a deterministic constraint/policy layer and explicit renderer feedback loop first, then use model-assisted proposals only as non-gating candidates with provenance after a human-labelled evaluation set exists.
+
+## Trade-offs
+
+Bounded modes cannot invent every art-directed spread, but they are testable, explainable, and stable. Renderer probes add build cost, but geometric truth cannot be inferred from semantic plans alone.
+
+## Free-form response
+
+Renderers already solve much of HTML, EPUB, and paged CSS. This planner is the product innovation: preserving editorial intent while changing representation and geometry across capabilities.
+

--- a/docs/issues/030-map-payload-lexical-documents-into-the-publication-compiler.md
+++ b/docs/issues/030-map-payload-lexical-documents-into-the-publication-compiler.md
@@ -1,0 +1,82 @@
+<!-- rucksack-autopilot-provider:vm-codex -->
+<!-- rucksack-autopilot-depends-on:027,028 -->
+
+# Map Payload Lexical documents into the publication compiler
+
+depends-on: 027,028
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Add a Payload CMS source adapter that maps typed Lexical JSON, blocks, uploads, relationships, and locales into the same `PublicationGraph` consumed by Astro, so Payload-authored publications reach every existing output without a Payload-specific renderer branch.
+
+## Acceptance tests
+
+- A strict adapter accepts a documented local Payload export shape plus a field-mapping policy and maps title, description, authors, locale, status/version, and Lexical rich text into `PublicationGraph`.
+- Paragraphs, headings, bold, italic, underline, strike, subscript, superscript, inline code, links, lists, quotes, uploads, relationships, and configured block types preserve source order, semantics, and source provenance. Unsupported enabled Lexical nodes fail with their type and tree location.
+- Uploads map to content-addressed assets with alt text, dimensions, media type, focal/crop metadata when supplied, and a declared missing-asset diagnostic when the export is incomplete. No remote URL is fetched implicitly.
+- Block and relationship mappings are explicit configuration, versioned in the receipt, and cannot execute functions or arbitrary Payload hooks from untrusted export JSON.
+- Locale variants become linked publication editions. Fallback locale use is recorded per node; it never silently mixes languages in one edition.
+- When stored Lexical data lacks stable node ids, the adapter derives deterministic ids from document id, structural path, and content digest, marks them as derived, and proves how insertions affect anchor stability.
+- One committed synthetic fixture under the new `tests/fixtures/payload/` directory registers through the same `PublicationSourceAdapter` registry as Astro, then builds and passes `publication:check` for phone WebPub, monochrome e-ink EPUB, A5 PDF, and A4 PDF. No renderer imports Payload types or branches on source provenance.
+- An equivalent Astro/Payload fixture pair produces the same canonical semantic subset and traverses identical renderer, profile, transformation-policy, and check versions. Their receipts may differ in source adapter/provenance and source hashes only; output lineage and required-content checks use the same schema and gates.
+- An optional live reader remains a separate boundary. If later enabled through Payload Local API or REST, it passes only the resulting data object into this adapter and keeps authentication names/values out of source, logs, issues, and receipts. New files to add: `src/publication/adapters/payload-lexical.ts`, `src/publication/adapters/payload-lexical.test.ts`, `src/publication/adapter-conformance.test.ts`, `tests/fixtures/payload/publication.json`, `tests/fixtures/payload/mapping.json`, `tests/fixtures/payload/equivalent-publication.json`, `tests/fixtures/publication/astro/payload-equivalent.mdx`, and `tests/fixtures/payload/README.md`.
+
+## TDD sequence
+
+1. **Red:** create the exact adapter/conformance tests and local fixtures, run `npx vitest run src/publication/adapters/payload-lexical.test.ts src/publication/adapter-conformance.test.ts`, and preserve failures for supported/unknown Lexical nodes, assets/relationships, locales, drafts, derived ids, and executable mapping input.
+2. **Green:** implement only the pure field mapping and Lexical-to-`PublicationBundle` adapter needed for graph/asset/provenance tests, without Payload packages, transport, hooks, or network access.
+3. **Red then green:** add the equivalent Astro/Payload fixture pair and receipt failures, then register Payload through the same source boundary and real renderer/check matrix.
+4. **Refactor:** separate generic Lexical walking from mapping policy only after both sources traverse identical renderer/profile/policy versions and all four real outputs pass; then run full validation.
+
+## Exact-head definition of done
+
+- Supported local Payload JSON maps deterministically; every unknown/incomplete/unsafe case fails with the named diagnostic; draft/locale/derived-id provenance is explicit at the exact PR head.
+- Adapter tests, equivalent-source comparison, four-output build/check, normal build, and exact-head evidence pass with identical renderer/profile/policy identifiers and no skipped matrix cell.
+- No Payload dependency, database, credential, live request, implicit upload fetch, serialized hook, customer content, or source-specific renderer branch is added.
+- From a clean checkout of the immutable PR head, the canonical evidence manifest records `commit` equal to that head, `dirty: false`, `result: passed`, and every required lane; a post-lane clean-worktree check proves validation did not modify tracked or generated source files.
+- Astro/Payload conformance and output receipts bind both source hashes, their shared canonical subset hash, adapter versions, identical profile/policy/renderer/toolchain versions, and every artifact hash to that exact head.
+
+## Validation command
+
+```bash
+npx vitest run src/publication/adapters/payload-lexical.test.ts src/publication/adapter-conformance.test.ts
+npm test
+npm run build
+npm run publication:build -- --adapter payload --input tests/fixtures/payload/publication.json --mapping tests/fixtures/payload/mapping.json --output .agent/evidence/payload-publication
+npm run publication:check -- --input .agent/evidence/payload-publication --matrix phone-webpub,eink-epub,a5-pdf,a4-pdf
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None for the adapter and fixtures. A future live reader may name an external auth requirement but is not part of this issue.
+
+## Artifact outputs
+
+Payload export schema, field-mapping policy, registered Lexical-to-bundle adapter, synthetic/equivalent-source fixtures, provenance/locale/anchor tests, four checked output artifacts, cross-adapter receipt comparison, renderer-interface conformance, and adapter documentation.
+
+## Stop conditions
+
+Stop before installing or provisioning Payload, connecting to a live CMS, committing real customer/editor content, fetching uploads implicitly, executing serialized hooks, or branching output renderers on `source === payload`.
+
+## Human clarification protocol
+
+If a custom Lexical node or Payload block lacks a mapping, present preserve-as-opaque, typed adapter extension, and explicit unsupported options with their downstream reachability effects.
+
+## Recommended response
+
+Start from local typed JSON fixtures and a pure registered adapter, then prove real multi-output parity through the existing renderer/check stack; add Local API or REST transport only after the compiler contract and access policy are stable.
+
+## Trade-offs
+
+A pure export adapter does not provide live collaborative CMS updates, but it proves the important architectural claim—that Payload and Astro share one compiler and output stack—without adding database, auth, or deployment scope.
+
+## Free-form response
+
+Payload already stores rich text as structured Lexical JSON and exposes it through Local, REST, and GraphQL APIs. The adapter should preserve that structure rather than converting to flat HTML and then reconstructing meaning.
+

--- a/docs/issues/031-review-every-rendition-and-apply-scoped-editorial-locks.md
+++ b/docs/issues/031-review-every-rendition-and-apply-scoped-editorial-locks.md
@@ -1,0 +1,85 @@
+<!-- rucksack-autopilot-provider:vm-codex -->
+<!-- rucksack-autopilot-depends-on:026,029,030 -->
+
+# Review every rendition and apply scoped editorial locks
+
+depends-on: 026,029,030
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Give an editor one truthful preview matrix for Astro and Payload publications: trace a semantic node through every rendered profile, inspect transformations and hard/soft evidence, and apply only versioned planner choices without turning the publication into target-specific page coordinates.
+
+## Acceptance tests
+
+- The matrix consumes `PublicationBundle`, `LayoutPlan`, renderer probes, checked artifacts, and receipts produced by issues 029 and 030; it does not independently reinterpret source nodes or estimate output geometry.
+- Selecting a source node highlights its output anchors in phone WebPub, monochrome e-ink EPUB, A5 PDF, and A4 PDF and shows the selected representation, transformation reasons, profile/policy versions, hard-gate result, and soft trade-offs before raw renderer diagnostics.
+- Astro and equivalent Payload fixtures use the same matrix components and output-adapter identifiers. Missing, failed, or stale artifacts show a bounded unavailable state instead of a synthetic preview.
+- A strict `EditorialLock` names graph hash, canonical node id, profile id/version, policy version, transformation family, and one choice already enumerated by the planner. It contains no coordinates, CSS, source text, binary data, arbitrary patch, or source-adapter branch.
+- Applying a lock reruns planning, renderer probe, production validation, and receipt generation. It may select among eligible choices but cannot suppress a hard violation, change canonical reading order, omit required content, or authorize an unauthored summary/crop.
+- A changed graph/profile/policy or missing candidate reports `STALE_EDITORIAL_LOCK`; it is never rebound by list position. Removing the lock restores deterministic standing policy.
+- Keyboard and screen-reader flows can select a node, move between the four outputs, read transformation/violation summaries, apply or remove a legal lock, and return focus to the same source node.
+- Browser coverage locks one figure full-span only in A4, proves phone/e-ink/A5 plans and bytes remain unchanged, verifies the regenerated A4 receipt and geometry, and exercises a stale lock plus a no-eligible-plan state.
+- New files to add: `src/publication/editorial-lock.ts`, `src/publication/editorial-lock.test.ts`, `src/components/publication/PublicationPreviewMatrix.tsx`, `src/components/publication/PublicationPreviewMatrix.test.tsx`, `src/components/publication/publication-preview-matrix.css`, and `tests/e2e/publication-preview-matrix.spec.ts`.
+
+## TDD sequence
+
+1. **Red:** create the lock and matrix component tests, run `npx vitest run src/publication/editorial-lock.test.ts src/components/publication/PublicationPreviewMatrix.test.tsx`, and preserve failures for legal choices, forbidden patches/coordinates, scope/version/hash mismatches, stale candidates, hard-gate bypass, accessibility, and focus return.
+2. **Green:** implement only the strict lock codec/applier, source-neutral receipt selectors, and accessible checked-artifact matrix needed for those tests.
+3. **Red then green:** add the A4-only browser journey, generate both source matrices, and wire lock application through replan, renderer probe, production validation, and receipt regeneration while comparing the other three artifact hashes.
+4. **Refactor:** extract source-neutral navigation/focus management only after stale-lock and no-eligible-plan browser cases pass; then regenerate/check both matrices and run full validation.
+
+## Exact-head definition of done
+
+- The matrix displays only checked artifacts/receipts, legal locks cannot override a hard gate or mutate canonical content, and profile isolation plus stale behavior is proven at the exact PR head.
+- Schema/component/browser tests, four-output checks, normal build, and exact-head evidence pass for Astro and Payload fixtures with no skipped accessibility or failure state.
+- Locks contain no coordinates, CSS, source/artifact bytes, secrets, source-CMS branch, or implicit model choice; unsupported artifacts remain explicitly unavailable.
+- From a clean checkout of the immutable PR head, the canonical evidence manifest records `commit` equal to that head, `dirty: false`, `result: passed`, and every required lane; a post-lane clean-worktree check proves validation did not modify tracked or generated source files.
+- The Astro and Payload matrices are generated before browser review; their receipts bind source/graph hashes, locks, profile/policy/planner/probe/toolchain versions, and all four artifact hashes to that exact head, while untouched-profile hashes remain byte-identical after an A4-only lock.
+
+## Validation command
+
+```bash
+npx vitest run src/publication/editorial-lock.test.ts src/components/publication/PublicationPreviewMatrix.test.tsx
+npm test
+npm run build
+npm run publication:build -- --adapter astro --entry moving-to-cloudflare-with-astro --planner semantic-v1 --output .agent/evidence/publication-matrix/astro
+npm run publication:check -- --input .agent/evidence/publication-matrix/astro --matrix phone-webpub,eink-epub,a5-pdf,a4-pdf
+npm run publication:build -- --adapter payload --input tests/fixtures/payload/publication.json --mapping tests/fixtures/payload/mapping.json --planner semantic-v1 --output .agent/evidence/publication-matrix/payload
+npm run publication:check -- --input .agent/evidence/publication-matrix/payload --matrix phone-webpub,eink-epub,a5-pdf,a4-pdf
+npm run test:e2e -- tests/e2e/publication-preview-matrix.spec.ts
+scripts/agent-evidence --all
+git diff --check
+```
+
+## Allowed secrets
+
+None. Source content, artifacts, locks, and review state remain local.
+
+## Artifact outputs
+
+Versioned editorial-lock schema/applier, source-to-output preview matrix, accessible comparison and evidence UI, stale/failed states, regenerated receipts, and browser evidence across Astro and Payload fixtures.
+
+## Stop conditions
+
+Stop before adding a coordinate/page editor, letting a lock bypass static or measured hard gates, embedding source or artifact bytes in lock files, branching UI behavior by source CMS, or presenting an unvalidated browser mock as a final PDF/EPUB preview.
+
+## Human clarification protocol
+
+When standing policy leaves several eligible material choices, show their rendered evidence and affected profiles, recommend the smallest scoped lock, and ask which choice should be persisted.
+
+## Recommended response
+
+Treat the matrix as an evidence and policy interface over compiled artifacts: editors choose among legal plans, while the compiler remains responsible for semantic preservation and geometric validation.
+
+## Trade-offs
+
+Editors cannot drag arbitrary boxes or tune one line break. That constraint keeps locks replayable across content changes and future renderers, while scoped profile-specific choices preserve meaningful art direction.
+
+## Free-form response
+
+This issue is the mixed-initiative product surface. Model-proposed layouts may be added later as clearly attributed candidate plans, but no model suggestion becomes a lock or final artifact without the same gates and explicit editor action.
+


### PR DESCRIPTION
## Why

Issues #59–#63 were seeded with `rucksack-issue-spec:027`–`031` markers, but the matching spec files exist **nowhere** — not on `main`, not on any remote branch. `docs/issues/` jumps from `026` straight to `032`.

Consequence: `rucksack autopilot reconcile --issue-dir docs/issues` maps 001–026 and 032 only. The five publication-contracts issues are orphaned from the ledger, so autopilot can never select them and the whole ladder (#59 → #63) sits dormant behind #58.

## What

Reconstructs `027`–`031` verbatim from the issue bodies. Each body already carried the complete spec (all 13 `##` sections, provider marker, `depends-on` line), so this is a faithful restore, not new authoring. Only the `rucksack-issue-spec` marker comment is stripped (reconcile derives it from the filename prefix).

## Evidence

Before:

```
update: 026 -> #58 Bind preview profiles to authoritative exports and orientation
update: 032 -> #65 Close the 2408.10903v5 PDF-to-EPUB fidelity regression
```

After:

```
update: 026 -> #58 Bind preview profiles to authoritative exports and orientation
update: 027 -> #59 Define universal publication and capability contracts
update: 028 -> #60 Compile one Astro post into WebPub, EPUB, and paged PDF
update: 029 -> #61 Plan transformations with semantic and renderer preflight
update: 030 -> #62 Map Payload Lexical documents into the publication compiler
update: 031 -> #63 Review every rendition and apply scoped editorial locks
update: 032 -> #65 Close the 2408.10903v5 PDF-to-EPUB fidelity regression
```

Docs-only change; no source or test files touched.