### PR TITLE
fix(research): bound table crop scopes to their own column lane (#82)

### DIFF
--- a/docs/issues/033-column-bounded-table-crop-scope.md
+++ b/docs/issues/033-column-bounded-table-crop-scope.md
@@ -1,0 +1,51 @@
+# Bound table crop scopes to their own column lane
+
+depends-on: 013,025,032
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Stop the line-band table scope from unioning two page columns into one crop. On a multi-column page the neighbouring column's body prose shares row coordinates with a table, so grouping candidate lines by `y` alone produces a crop box spanning the whole text measure. The exported raster then bakes neighbouring prose and section headings into the table image, and the same prose is also emitted as reflowable text, so the reader sees it twice — once live, once as a picture.
+
+## Observed failure
+
+An owner-local run over a public two-column paper produced a `text-tabular-line-band` scope whose crop box was `x=0.12101 y=0.07296 w=0.75121 h=0.11286` on a page whose table occupies only `x>=0.527`. Its proved line lineage contained both the right-column table lines and two left-column body-prose regions. A second table on the same document produced `x=0.10701 w=0.7969`, baking a section heading and three prose lines into the raster. A third, genuinely page-spanning table on the same document cropped correctly, so the defect is specific to per-column tables.
+
+## Acceptance tests
+
+- A candidate line set that contains a vertical corridor which no candidate line crosses, whose width and centre are consistent with a page gutter, and whose two sides the region classifier independently reads as opposite columns, never produces one row, one band, or one crop box spanning that corridor.
+- A genuinely page-spanning table whose cells tile across the gutter keeps banding as one lane and retains its existing full-measure crop box, source lineage, and asset identity. Column lane separation may not be inferred from `region.column` alone, because a spanning table's cells carry mixed `left`/`right`/`span` labels by x position.
+- Each column lane bands independently. Interleaving two columns' rows by `y` and banding the merged sequence may neither union the columns nor shatter both into single rows.
+- A per-column table whose own lane proves a band exports a crop box contained in that lane, with no source line from the opposite column in its lineage.
+- A per-column table whose own lane cannot prove a band remains review-required with bounded candidate evidence. It is never exported with an opposite-column crop, and the metric change is visible in the audit rather than silently absorbed.
+- A regression fixture reduced from the observed page geometry — faithful bounding geometry, synthetic text, no bytes or prose copied from any source paper — reproduces the gutter-crossing scope before the fix and a lane-bounded scope after it.
+- Repeated reconstruction of the same source produces byte-identical scope ids, crop boxes, and packaged asset hashes.
+
+## TDD sequence
+
+1. **Red:** add a fragmented two-column fixture to `src/research/pdf-table-scope.test.ts` whose right-column table splits into many single-line regions so the grid detector cannot own it and the line-band fallback runs. Preserve the failure proving the resolved scope claims the left-column prose regions.
+2. **Green:** prove the separating gutter from the candidate lines, assign lanes geometrically, and band each lane independently. Do not widen or relax an existing proof threshold.
+3. **Red then green:** confirm on an owner-local named paper that the per-column table crop becomes lane-bounded, the page-spanning table is unchanged, and text coverage does not regress.
+4. **Refactor:** only after scope, detection, fallback, integration, and visual suites pass unchanged.
+
+## Exact-head definition of done
+
+- The named-paper per-column table exports a crop containing only its own column; the page-spanning table on the same document is byte-identical to its accepted baseline.
+- No suite is skipped, no locator relaxed, and no threshold widened to accept the new geometry.
+- Any table that loses its export because its own lane cannot prove a band is reported as review-required with its diagnostic code, not silently dropped.
+- From a clean checkout of the immutable PR head, `scripts/agent-evidence --all` records `commit` equal to that head, `dirty: false`, and `result: passed`.
+
+## Validation command
+
+```bash
+npx vitest run src/research/pdf-table-scope.test.ts src/research/pdf-table-scope-integration.test.ts src/research/pdf-table-detection.test.ts src/research/pdf-table-fallback.test.ts src/research/pdf-visuals.test.ts
+npm test
+npm run build
+```
+
+## Allowed secrets
+
+None. Source papers, rasters, and audit output remain owner-local.

--- a/docs/issues/034-semantic-tables-and-equation-math.md
+++ b/docs/issues/034-semantic-tables-and-equation-math.md
@@ -1,0 +1,52 @@
+# Emit semantic tables and source-derived math instead of defaulting to rasters
+
+depends-on: 013,024,032,033
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Close the gap between the specified scientific-object contract and what the pipeline actually emits. Specs 013 and 032 require semantic HTML tables when aligned structure validates and MathML when it is recoverable from source semantics, with a bounded source-backed raster only as the fallback. In practice the fallback is the default: on real scholarly papers almost every table is exported as an image and every display equation is exported as a raster or text-derived SVG. A rasterized table does not reflow on a 6-inch e-ink page, does not scale with reader font size, and is not selectable, searchable, or accessible — which defeats the purpose of a device-profile EPUB.
+
+## Observed baseline
+
+Owner-local audits over six public scholarly papers recorded `semanticTableCoverage` of `0` on three documents that each declare multiple expected semantic tables, `0.189` on another, and `1` only where no table existed. On one paper all four expected semantic tables resolved to zero, so every table reached the reader as an image crop. Separately, no MathML emission path exists anywhere in the pipeline: the only MathML references in the codebase are tests asserting that MathML is *not* invented, and the equation path chooses between a native rendition, a text-derived SVG, and a page-crop raster.
+
+## Acceptance tests
+
+- The audit reports, per document, how many tables reached the reader as semantic markup, as a bounded raster fallback, and as unresolved, and the same three-way split for display equations. The counts are exact and reconcile with the packaged asset manifest.
+- A table whose aligned multi-row/multi-column structure validates is emitted as semantic HTML with typed header scope, preserved cell order, and per-cell source provenance. A structure that does not validate keeps the existing bounded raster fallback; neither path invents a cell, a header, or a span.
+- The gap between "structure detected" and "structure promoted to semantic" is itself measured. Where a detector proves a grid but promotion fails, the blocking reason is recorded as a named diagnostic rather than an unexplained fallback, so the dominant promotion blockers on real papers are visible and rankable.
+- MathML is emitted only when operator containment, script nesting, and ordered baselines are proved from source geometry, per the failure taxonomy. An unproved formula keeps its bounded source-backed asset and stays review-required. No LaTeX, MathML, variable, or equation number is ever invented, and an equation's visible label and source order are preserved either way.
+- Semantic tables and MathML survive the reflow contract: they consume canonical reading order, reflow within the Mobile and both e-ink profiles without horizontal overflow, and carry their caption relationship and canonical position.
+- Browser coverage proves a semantic table reflows and remains readable at the narrowest supported profile, and that a rasterized fallback is explicitly labelled as a fallback rather than presented as equivalent.
+- Repeated reconstruction produces byte-identical semantic table structure, MathML, and asset hashes.
+
+## TDD sequence
+
+1. **Red:** extend `src/research/semantic-table.test.ts`, `src/research/pdf-table-detection.test.ts`, and `src/research/epub.test.ts` with generated fixtures covering a validating grid, a non-validating grid, and a display equation with provable structure. Preserve failures for the missing three-way audit split, the unexplained promotion failure, and the absent math path.
+2. **Green:** add the audit instrumentation first so the promotion blockers are measurable, then close the highest-ranked blocker. Do not relax `isStrictSemanticTable`; a table that is not rectangular with proved header scope must keep failing closed.
+3. **Red then green:** add the math emission path behind proved source geometry, with the existing "never invent" assertions kept intact.
+4. **Refactor:** share the semantic materializer between preview and export only after provenance, ordering, and byte-stability assertions pass.
+
+## Exact-head definition of done
+
+- The audit publishes the semantic/raster/unresolved split for tables and equations on every document, and the dominant promotion blockers are named diagnostics.
+- At least the top-ranked promotion blocker is closed, with the coverage change demonstrated on owner-local papers and no widened threshold.
+- No test asserting that LaTeX or MathML is never invented is weakened or removed.
+- From a clean checkout of the immutable PR head, `scripts/agent-evidence --all` records `commit` equal to that head, `dirty: false`, and `result: passed`.
+
+## Validation command
+
+```bash
+npx vitest run src/research/semantic-table.test.ts src/research/semantic-table-source.test.ts src/research/pdf-table-detection.test.ts src/research/pdf-table-fallback.test.ts src/research/epub.test.ts
+npm test
+npm run build
+npm run test:e2e -- tests/e2e/publication-importer.spec.ts
+```
+
+## Allowed secrets
+
+None. Source papers and rendered evidence remain owner-local.

--- a/src/research/pdf-table-scope.test.ts
+++ b/src/research/pdf-table-scope.test.ts
@@ -3,6 +3,7 @@ import type {
   NormalizedSourceBox,
   PdfNativeObject,
   PdfPageRegion,
+  PdfRegionColumn,
   PdfRegionLine,
   PdfSourceRun,
 } from './import-types'
@@ -3897,5 +3898,159 @@ describe('bounded PDF table source scoping', () => {
     })
 
     expect(JSON.stringify(reverse)).toBe(JSON.stringify(forward))
+  })
+
+  it('does not band a fragmented right-column table across the gutter', () => {
+    // Region and line geometry reduced from an observed two-column scholarly
+    // page. Its right-column table fragments into many single-line regions, so
+    // the grid detector cannot own it and the line-band fallback runs. Left
+    // column prose shares the same row coordinates. Text is synthetic; only
+    // the bounding geometry is faithful.
+    const lineHeight = 0.01296
+    const lineage: Array<{
+      id: string
+      column: PdfRegionColumn
+      lines: Array<[string, number, number, number]>
+    }> = [
+      { id: 'r01', column: 'right', lines: [['l01', 0.52739, 0.07296, 0.07508]] },
+      {
+        id: 'r02',
+        column: 'right',
+        lines: [
+          ['l02', 0.65486, 0.07296, 0.21736],
+          ['l05', 0.52739, 0.09191, 0.04364],
+        ],
+      },
+      {
+        id: 'r03',
+        column: 'left',
+        lines: [
+          ['l03', 0.12101, 0.07481, 0.36675],
+          ['l04', 0.12101, 0.09092, 0.36671],
+          ['l09', 0.12101, 0.10702, 0.3061],
+        ],
+      },
+      { id: 'r04', column: 'right', lines: [['l06', 0.67503, 0.09191, 0.03342]] },
+      { id: 'r05', column: 'right', lines: [['l07', 0.73795, 0.09191, 0.079]] },
+      {
+        id: 'r06',
+        column: 'right',
+        lines: [
+          ['l08', 0.84787, 0.09191, 0.02435],
+          ['l10', 0.52739, 0.10802, 0.06786],
+        ],
+      },
+      { id: 'r07', column: 'right', lines: [['l11', 0.67502, 0.10802, 0.03342]] },
+      {
+        id: 'r08',
+        column: 'right',
+        lines: [
+          ['l12', 0.73795, 0.10802, 0.13426],
+          ['l14', 0.52739, 0.12412, 0.09809],
+        ],
+      },
+      {
+        id: 'r09',
+        column: 'left',
+        lines: [
+          ['l13', 0.13936, 0.12355, 0.34836],
+          ['l16', 0.12101, 0.13966, 0.36675],
+          ['l19', 0.12101, 0.15576, 0.36655],
+          ['l22', 0.12101, 0.17172, 0.36671],
+        ],
+      },
+      {
+        id: 'r10',
+        column: 'right',
+        lines: [
+          ['l15', 0.67503, 0.12412, 0.19719],
+          ['l17', 0.52739, 0.14065, 0.1072],
+        ],
+      },
+      {
+        id: 'r11',
+        column: 'right',
+        lines: [
+          ['l18', 0.67503, 0.14065, 0.19719],
+          ['l20', 0.52739, 0.15676, 0.05372],
+        ],
+      },
+      {
+        id: 'r12',
+        column: 'right',
+        lines: [
+          ['l21', 0.67503, 0.15676, 0.19719],
+          ['l23', 0.52739, 0.17286, 0.07185],
+        ],
+      },
+      { id: 'r13', column: 'right', lines: [['l24', 0.67502, 0.17286, 0.19719]] },
+    ]
+
+    const regions = lineage.map<PdfPageRegion>((spec) => {
+      const lines = spec.lines.map<PdfRegionLine>(([id, x, y, width]) => {
+        const header = id === 'l01' || id === 'l02'
+        const text =
+          spec.column === 'left'
+            ? `Left column body text fragment ${id} continues across the measure`
+            : header
+              ? `Header ${id}`
+              : `${id.slice(1)}%`
+        const run: PdfSourceRun = {
+          ...box(x, y, width, lineHeight),
+          text,
+          fontName: spec.column === 'left' ? 'BodySerif' : 'TableSerif',
+          fontSize: spec.column === 'left' ? 10 : 8,
+          confidence: 0.99,
+          ...(header ? { bold: true } : {}),
+        }
+        return {
+          id,
+          text,
+          fontSize: run.fontSize,
+          box: box(x, y, width, lineHeight),
+          runs: [run],
+        }
+      })
+      const left = Math.min(...lines.map((item) => item.box.x))
+      const top = Math.min(...lines.map((item) => item.box.y))
+      const right = Math.max(...lines.map((item) => item.box.x + item.box.width))
+      const bottom = Math.max(
+        ...lines.map((item) => item.box.y + item.box.height),
+      )
+      return {
+        id: spec.id,
+        page: 1,
+        kind: 'body',
+        column: spec.column,
+        text: lines.map((item) => item.text).join(' '),
+        confidence: 0.98,
+        box: box(left, top, right - left, bottom - top),
+        lines,
+        nativeObjectIds: [],
+        includedInReadingOrder: true,
+      }
+    })
+
+    const tableCaption: PdfPageRegion = {
+      ...caption('caption-table', 0.19, 'Table 1. Synthetic column results.'),
+      column: 'right',
+      box: box(0.52739, 0.19, 0.34496, 0.024),
+    }
+
+    const result = resolvePdfTableScope({
+      caption: tableCaption,
+      pageRegions: [...regions, tableCaption],
+      nativeObjects: [],
+    })
+
+    // The scope may fail closed, but it may never claim the other column.
+    expect(result.scope?.sourceRegionIds ?? []).not.toContain('r03')
+    expect(result.scope?.sourceRegionIds ?? []).not.toContain('r09')
+    if (result.scope) {
+      expect(result.scope.cropBox.x).toBeGreaterThanOrEqual(0.5)
+      expect(
+        result.scope.cropBox.x + result.scope.cropBox.width,
+      ).toBeLessThanOrEqual(0.9)
+    }
   })
 })

--- a/src/research/pdf-table-scope.ts
+++ b/src/research/pdf-table-scope.ts
@@ -49,6 +49,9 @@ const MIN_LABELED_RECORD_ROWS = 3
 const MIN_LABELED_RECORD_WIDTH = 0.5
 const MAX_UNPROVEN_PAGE_TOP_TABLE_START = 0.105
 const TABLE_BORDER_INK_PADDING = 0.004
+const MIN_COLUMN_GUTTER_WIDTH = 0.02
+const MIN_COLUMN_GUTTER_CENTRE = 0.25
+const MAX_COLUMN_GUTTER_CENTRE = 0.75
 
 export type PdfTableScopeProof =
   | 'text-grid'
@@ -922,6 +925,8 @@ function ordinalGridProof(rows: AtomicGridRow[]) {
   }
 }
 
+type TableColumnLane = 'left' | 'right' | 'full'
+
 type TableLineEntry = {
   region: PdfPageRegion
   line: PdfRegionLine
@@ -929,6 +934,7 @@ type TableLineEntry = {
 
 type TableLineRow = {
   y: number
+  lane: TableColumnLane
   box: NormalizedSourceBox
   entries: TableLineEntry[]
   anchors: number[]
@@ -950,9 +956,77 @@ function validTableLineEntry(entry: TableLineEntry) {
   )
 }
 
+// Row membership is a page-layout fact, not only a vertical one. On a
+// multi-column page the neighbouring column's body prose shares row
+// coordinates with a table, so grouping by `y` alone unions both columns into
+// one row and lets a band claim the whole text measure.
+//
+// The separating gutter is proved from the candidate lines themselves: a
+// vertical corridor that no candidate line crosses, wide enough and central
+// enough to be a page gutter, with the region classifier independently
+// agreeing that the two sides are opposite columns. A genuinely page-spanning
+// table has cells tiling across the gutter, so no such corridor exists and it
+// keeps banding as one lane.
+function candidateColumnGutter(entries: TableLineEntry[]) {
+  const intervals = entries
+    .map((entry) => ({
+      left: entry.line.box.x,
+      right: entry.line.box.x + entry.line.box.width,
+      column: entry.region.column,
+    }))
+    .sort((left, right) => left.left - right.left)
+  if (intervals.length === 0) return null
+
+  const corridors: Array<{ from: number; to: number }> = []
+  let covered = intervals[0].right
+  for (const interval of intervals.slice(1)) {
+    if (interval.left > covered) {
+      corridors.push({ from: covered, to: interval.left })
+    }
+    covered = Math.max(covered, interval.right)
+  }
+
+  const qualifying = corridors
+    .filter((corridor) => {
+      const width = corridor.to - corridor.from
+      const centre = (corridor.from + corridor.to) / 2
+      if (
+        width < MIN_COLUMN_GUTTER_WIDTH ||
+        centre < MIN_COLUMN_GUTTER_CENTRE ||
+        centre > MAX_COLUMN_GUTTER_CENTRE
+      ) {
+        return false
+      }
+      // The region classifier must independently read the two sides as
+      // opposite columns; an internal cell gap never satisfies this.
+      const before = intervals.filter((item) => item.right <= corridor.from)
+      const after = intervals.filter((item) => item.left >= corridor.to)
+      return (
+        before.length > 0 &&
+        after.length > 0 &&
+        before.every((item) => item.column === 'left') &&
+        after.every((item) => item.column === 'right')
+      )
+    })
+    .sort(
+      (left, right) =>
+        right.to - right.from - (left.to - left.from) || left.from - right.from,
+    )
+
+  return qualifying[0] ?? null
+}
+
 function tableLineRows(entries: TableLineEntry[]) {
+  const gutter = candidateColumnGutter(entries)
+  const columnLane = (entry: TableLineEntry): TableColumnLane =>
+    gutter === null
+      ? 'full'
+      : entry.line.box.x >= gutter.to
+        ? 'right'
+        : 'left'
   const rows: Array<{
     y: number
+    lane: TableColumnLane
     entries: TableLineEntry[]
   }> = []
   for (const entry of [...entries].sort(
@@ -962,16 +1036,20 @@ function tableLineRows(entries: TableLineEntry[]) {
       left.region.id.localeCompare(right.region.id) ||
       left.line.id.localeCompare(right.line.id),
   )) {
+    const lane = columnLane(entry)
     const row = rows.find(
-      (candidate) => Math.abs(candidate.y - entry.line.box.y) <= BOX_TOLERANCE,
+      (candidate) =>
+        candidate.lane === lane &&
+        Math.abs(candidate.y - entry.line.box.y) <= BOX_TOLERANCE,
     )
     if (row) row.entries.push(entry)
-    else rows.push({ y: entry.line.box.y, entries: [entry] })
+    else rows.push({ y: entry.line.box.y, lane, entries: [entry] })
   }
   return rows.map<TableLineRow>((row) => {
     const boxes = row.entries.map((entry) => entry.line.box)
     return {
       y: row.y,
+      lane: row.lane,
       box: unionBoxes(
         boxes,
         boxes.some((sourceBox) => sourceBox.method === 'ocr')
@@ -1086,7 +1164,11 @@ function startsSparseContinuation(
   )
 }
 
-function tableLineBands(rows: TableLineRow[]) {
+// Band each column lane independently. Interleaving two columns' rows by `y`
+// and banding the merged sequence would either union the columns into one
+// band or shatter both into single rows, so neither column could ever prove a
+// table on a multi-column page.
+function tableLineBandsWithinLane(rows: TableLineRow[]) {
   const bands: TableLineRow[][] = []
   for (const [rowIndex, row] of rows.entries()) {
     const band = bands.at(-1)
@@ -1104,6 +1186,14 @@ function tableLineBands(rows: TableLineRow[]) {
     }
   }
   return bands
+}
+
+const TABLE_COLUMN_LANE_ORDER: TableColumnLane[] = ['full', 'left', 'right']
+
+function tableLineBands(rows: TableLineRow[]) {
+  return TABLE_COLUMN_LANE_ORDER.flatMap((lane) =>
+    tableLineBandsWithinLane(rows.filter((row) => row.lane === lane)),
+  )
 }
 
 function lineHeightMatchesBand(


### PR DESCRIPTION
Closes #82

## Problem

The `text-tabular-line-band` table scope grouped candidate lines into rows by vertical coordinate alone. On a multi-column page the neighbouring column's body prose shares row coordinates with a table, so a row unioned both columns and the crop box spanned the whole text measure.

Observed on a public two-column paper: a right-column table produced the scope `x=0.12101 y=0.07296 w=0.75121 h=0.11286` whose proved line lineage contained two left-column body-prose regions. The exported raster baked two paragraphs of body prose into the table image — and the same prose was also emitted as reflowable text, so the reader saw it twice, once live and once as a picture. A second table on the same document baked in a section heading and three prose lines.

## Fix

Prove the separating gutter from the candidate lines themselves: a vertical corridor that no candidate line crosses, wide and central enough to be a page gutter, and which the region classifier independently reads as opposite columns. Assign lanes geometrically and band each lane independently.

`region.column` alone is not a usable lane signal — a genuinely page-spanning table's cells carry mixed `left`/`right`/`span` labels by x position, so keying on the label shatters spanning tables. That was the first attempt, and it cost a correctly-cropped spanning table. Under the corridor rule a spanning table's cells tile across the gutter, no empty corridor exists, and it keeps its existing full-measure crop.

## Evidence

Owner-local A/B on the same paper, same toolchain:

| | before | after |
|---|---|---|
| per-column table crop | `x=0.107 w=0.779` (contains prose) | `x=0.515 w=0.369` (table only) |
| page-spanning table on same doc | `x=0.119 w=0.778` | unchanged |
| textCoverage | 0.97277 | 0.99879 |
| exported assets | 5 | 4 |
| unresolved tables | 1 | 2 |

The lost asset is a third table whose own lane cannot prove a band. It now fails closed as review-required rather than exporting an opposite-column crop, and the change is visible in the audit rather than silently absorbed.

## Tests

New regression case in `pdf-table-scope.test.ts` built from the observed page's region/line geometry with synthetic text — no bytes or prose copied from any source paper. It reproduces the gutter-crossing scope before the fix and a lane-bounded scope after.

`npx vitest run src/research/pdf-table-scope.test.ts src/research/pdf-table-scope-integration.test.ts src/research/pdf-table-detection.test.ts src/research/pdf-table-fallback.test.ts src/research/pdf-visuals.test.ts` — 262 passed.

## Also included

Specs `033` (this fix) and `034` (the semantic-table / MathML gap, filed as #83).
