### PR TITLE
feat: Bind preview profiles to authoritative exports and orientation (#58)

### DIFF
--- a/src/components/research/EpubRenditionPreview.test.tsx
+++ b/src/components/research/EpubRenditionPreview.test.tsx
@@ -11,7 +11,10 @@ import EpubRenditionPreview, {
   epubPreviewArtifactKey,
   selectCurrentProfileEpub,
 } from './EpubRenditionPreview'
-import { TARGET_PROFILE_VERSION } from '../../research/targets'
+import {
+  getTargetProfile,
+  TARGET_PROFILE_VERSION,
+} from '../../research/targets'
 
 const epub: EpubExport = {
   bytes: new Uint8Array(),
@@ -24,6 +27,7 @@ const epub: EpubExport = {
 }
 
 function profiled(id: 'mobile' | 'paperProMove' | 'paperPro'): EpubExport {
+  const target = getTargetProfile(id)
   return {
     ...epub,
     identifier: `preview-${id}`,
@@ -36,6 +40,8 @@ function profiled(id: 'mobile' | 'paperProMove' | 'paperPro'): EpubExport {
     profile: {
       id,
       version: TARGET_PROFILE_VERSION,
+      orientation: target.orientation,
+      artifact: target.artifact,
       compositionPolicy: {} as NonNullable<
         EpubExport['profile']
       >['compositionPolicy'],
@@ -119,7 +125,7 @@ describe('EPUB rendition preview', () => {
     )
     expect(markup).not.toContain('1,872 × 2,480')
     expect(markup).toContain('aria-pressed="true"')
-    expect(markup.match(/aria-pressed="false"/g)).toHaveLength(2)
+    expect(markup.match(/aria-pressed="false"/g)).toHaveLength(3)
     expect(markup).toContain('data-profile-id="paperPro"')
     expect(markup).toContain(`data-profile-version="${TARGET_PROFILE_VERSION}"`)
     expect(markup).toContain(`data-artifact-sha256="${'c'.repeat(64)}"`)
@@ -227,8 +233,8 @@ describe('EPUB rendition preview', () => {
       />,
     )
 
-    expect(markup.match(/<button/g)).toHaveLength(3)
-    expect(markup.match(/type="button"/g)).toHaveLength(3)
+    expect(markup.match(/<button/g)).toHaveLength(5)
+    expect(markup.match(/type="button"/g)).toHaveLength(5)
     expect(markup).not.toContain('<a ')
     expect(markup).not.toContain('download=')
   })
@@ -243,7 +249,7 @@ describe('EPUB rendition preview', () => {
       />,
     )
 
-    expect(markup.match(/<button/g)).toHaveLength(3)
+    expect(markup.match(/<button/g)).toHaveLength(5)
     expect(markup.match(/data-artifact-status="ready"/g)).toHaveLength(1)
     expect(markup.match(/data-artifact-status="unbuilt"/g)).toHaveLength(1)
     expect(markup.match(/data-artifact-status="building"/g)).toHaveLength(1)

--- a/src/components/research/EpubRenditionPreview.tsx
+++ b/src/components/research/EpubRenditionPreview.tsx
@@ -4,7 +4,12 @@ import {
   EPUB_EXPORT_POLICY_VERSION,
   type EpubExport,
 } from '../../research/epub'
-import { TARGET_PROFILES, type TargetProfileId } from '../../research/targets'
+import {
+  resolveTargetProfile,
+  TARGET_PROFILES,
+  type TargetOrientation,
+  type TargetProfileId,
+} from '../../research/targets'
 
 const previewProfileIds = ['mobile', 'paperProMove', 'paperPro'] as const
 export type PreviewProfileId = Extract<
@@ -43,12 +48,15 @@ function isCurrentPreviewArtifact(epub: EpubExport) {
 export function selectCurrentProfileEpub(
   epubs: EpubExport[],
   selectedProfileId: PreviewProfileId,
+  selectedOrientation: TargetOrientation = 'portrait',
 ) {
   const profileVersion = TARGET_PROFILES[selectedProfileId].version
   return epubs.find(
     (candidate) =>
       candidate.profile?.id === selectedProfileId &&
       candidate.profile.version === profileVersion &&
+      (candidate.profile.orientation?.selected ?? 'portrait') ===
+        selectedOrientation &&
       candidate.profile.exportPolicy?.id === 'profile-tuned-reflowable' &&
       candidate.profile.exportPolicy.version === EPUB_EXPORT_POLICY_VERSION,
   )
@@ -222,6 +230,7 @@ export function epubPreviewArtifactKey(epub: EpubExport) {
   return [
     epub.profile?.id ?? 'unprofiled',
     epub.profile?.version ?? 'unversioned',
+    epub.profile?.orientation?.selected ?? 'portrait',
     epub.profile?.exportPolicy?.id ?? 'unidentified-policy',
     epub.profile?.exportPolicy?.version ?? 'unversioned-policy',
     epub.mode,
@@ -284,14 +293,18 @@ export function createEpubPreviewCache(
 export default function EpubRenditionPreview({
   epubs,
   selectedProfileId,
+  selectedOrientation = 'portrait',
   buildingProfileId,
   onSelectedProfileChange,
+  onSelectedOrientationChange,
   onPreviewReadyChange,
 }: {
   epubs: EpubExport[]
   selectedProfileId?: PreviewProfileId
+  selectedOrientation?: TargetOrientation
   buildingProfileId?: PreviewProfileId
   onSelectedProfileChange?: (profileId: PreviewProfileId) => void
+  onSelectedOrientationChange?: (orientation: TargetOrientation) => void
   onPreviewReadyChange?: (artifactKey?: string) => void
 }) {
   const availableScreens = previewScreens.filter((screen) =>
@@ -321,11 +334,24 @@ export default function EpubRenditionPreview({
   const [, setPreviewRevision] = useState(0)
   const cache = useRef<ReturnType<typeof createEpubPreviewCache> | null>(null)
   if (!cache.current) cache.current = createEpubPreviewCache()
-  const epub = selectCurrentProfileEpub(epubs, profileId)
-  const screen =
+  const epub = selectCurrentProfileEpub(epubs, profileId, selectedOrientation)
+  const baseScreen =
     previewScreens.find((candidate) => candidate.id === profileId) ??
     availableScreens[0] ??
     previewScreens[2]
+  const resolvedProfile = resolveTargetProfile(
+    baseScreen.id,
+    baseScreen.id === 'mobile' ? 'portrait' : selectedOrientation,
+  )
+  const screen = {
+    ...baseScreen,
+    width: resolvedProfile.dimensions.width,
+    height:
+      resolvedProfile.dimensions.height ??
+      resolvedProfile.preview.continuousWindowHeightCssPx!,
+    previewWidth: resolvedProfile.preview.widthCssPx,
+    truth: resolvedProfile.truth,
+  }
   const preview = epub ? cache.current.get(epub) : undefined
   const readyArtifactKey =
     epub && preview?.srcDoc ? epubPreviewArtifactKey(epub) : undefined
@@ -406,9 +432,15 @@ export default function EpubRenditionPreview({
           <legend>Preview screen</legend>
           <div>
             {selectableScreens.map((candidate) => {
+              const candidateOrientation = TARGET_PROFILES[
+                candidate.id
+              ].orientation.supported.includes(selectedOrientation)
+                ? selectedOrientation
+                : 'portrait'
               const artifactStatus = selectCurrentProfileEpub(
                 epubs,
                 candidate.id,
+                candidateOrientation,
               )
                 ? 'ready'
                 : buildingProfileId === candidate.id
@@ -447,6 +479,21 @@ export default function EpubRenditionPreview({
             </p>
           )}
         </fieldset>
+        {resolvedProfile.orientation.supported.length > 1 && (
+          <fieldset className="epub-device-switcher">
+            <legend>Orientation</legend>
+            {resolvedProfile.orientation.supported.map((candidate) => (
+              <button
+                aria-pressed={selectedOrientation === candidate}
+                key={candidate}
+                onClick={() => onSelectedOrientationChange?.(candidate)}
+                type="button"
+              >
+                {candidate === 'portrait' ? 'Portrait' : 'Landscape'}
+              </button>
+            ))}
+          </fieldset>
+        )}
         {epub && (
           <dl
             className="epub-preview-receipt"
@@ -466,6 +513,10 @@ export default function EpubRenditionPreview({
               <dd>
                 <code>{epub.sha256}</code>
               </dd>
+            </div>
+            <div>
+              <dt>Selected orientation</dt>
+              <dd>{selectedOrientation}</dd>
             </div>
             {(
               [

--- a/src/components/research/PublicationImporter.test.tsx
+++ b/src/components/research/PublicationImporter.test.tsx
@@ -4,7 +4,10 @@ import {
   EPUB_EXPORT_POLICY_VERSION,
   type EpubExport,
 } from '../../research/epub'
-import { TARGET_PROFILE_VERSION } from '../../research/targets'
+import {
+  getTargetProfile,
+  TARGET_PROFILE_VERSION,
+} from '../../research/targets'
 import { epubPreviewArtifactKey } from './EpubRenditionPreview'
 
 vi.mock('./ResearchStudio', () => ({ default: () => null }))
@@ -95,6 +98,7 @@ describe('publication importer OCR controls', () => {
   })
 
   it('withholds the selected download until that exact EPUB preview is ready', () => {
+    const target = getTargetProfile('paperPro')
     const candidate: EpubExport = {
       bytes: new Uint8Array(),
       entries: [],
@@ -106,6 +110,8 @@ describe('publication importer OCR controls', () => {
       profile: {
         id: 'paperPro',
         version: TARGET_PROFILE_VERSION,
+        orientation: target.orientation,
+        artifact: target.artifact,
         compositionPolicy: {} as NonNullable<
           EpubExport['profile']
         >['compositionPolicy'],

--- a/src/components/research/PublicationImporter.tsx
+++ b/src/components/research/PublicationImporter.tsx
@@ -45,7 +45,11 @@ import {
   type PdfLineJoinReviewContext,
 } from '../../research/pdf-lines'
 import { downloadLinkedPdf } from '../../research/pdf-url'
-import { getTargetProfile } from '../../research/targets'
+import {
+  getTargetProfile,
+  resolveTargetProfile,
+  type TargetOrientation,
+} from '../../research/targets'
 import EpubDownloadLink from './EpubDownloadLink'
 import EpubRenditionPreview, {
   epubPreviewArtifactKey,
@@ -74,11 +78,13 @@ type StudioState =
 type ActiveProfileBuild = {
   controller: AbortController
   profileId: PreviewProfileId
+  orientation: TargetOrientation
 }
 
 type ProfileBuildIssue = {
   controller: AbortController
   profileId: PreviewProfileId
+  orientation: TargetOrientation
   message: string
 }
 
@@ -774,6 +780,8 @@ export default function PublicationImporter({
   const [ocrLanguage, setOcrLanguage] = useState<'auto' | 'eng'>('auto')
   const [selectedProfileId, setSelectedProfileId] =
     useState<PreviewProfileId>('mobile')
+  const [selectedOrientation, setSelectedOrientation] =
+    useState<TargetOrientation>('portrait')
   const [previewReadyArtifactKey, setPreviewReadyArtifactKey] =
     useState<string>()
   const [profileBuilds, setProfileBuilds] = useState<ActiveProfileBuild[]>([])
@@ -882,6 +890,7 @@ export default function PublicationImporter({
     const isCurrent = () =>
       activeImport.current === controller && !controller.signal.aborted
     setSelectedProfileId('mobile')
+    setSelectedOrientation('portrait')
     setPreviewReadyArtifactKey(undefined)
     setProfileBuildIssues({})
     setState({
@@ -980,6 +989,7 @@ export default function PublicationImporter({
     setPendingDecisionFile(undefined)
     setDecisionError(undefined)
     setSelectedProfileId('mobile')
+    setSelectedOrientation('portrait')
     setPreviewReadyArtifactKey(undefined)
     setProfileBuilds([])
     activeProfileBuildIssues.current = {}
@@ -1055,21 +1065,30 @@ export default function PublicationImporter({
       [...activeProfileBuilds.current].some(
         (build) =>
           build.controller === controller &&
-          build.profileId === selectedProfileId,
+          build.profileId === selectedProfileId &&
+          build.orientation === selectedOrientation,
       )
     ) {
       return
     }
     if (
       state.epubs &&
-      selectCurrentProfileEpub(state.epubs, selectedProfileId)
+      selectCurrentProfileEpub(
+        state.epubs,
+        selectedProfileId,
+        selectedOrientation,
+      )
     ) {
       return
     }
     if (
-      activeProfileBuildIssues.current[selectedProfileId]?.controller ===
-        controller ||
-      profileBuildIssues[selectedProfileId]?.controller === controller
+      (activeProfileBuildIssues.current[selectedProfileId]?.controller ===
+        controller &&
+        activeProfileBuildIssues.current[selectedProfileId]?.orientation ===
+          selectedOrientation) ||
+      (profileBuildIssues[selectedProfileId]?.controller === controller &&
+        profileBuildIssues[selectedProfileId]?.orientation ===
+          selectedOrientation)
     ) {
       return
     }
@@ -1079,11 +1098,13 @@ export default function PublicationImporter({
 
     const result = state.result
     const profileId = selectedProfileId
+    const orientation = selectedOrientation
     const isCurrent = () =>
       activeImport.current === controller && !controller.signal.aborted
     const activeBuild: ActiveProfileBuild = {
       controller,
       profileId,
+      orientation,
     }
     activeProfileBuilds.current.add(activeBuild)
     setProfileBuilds((current) => [...current, activeBuild])
@@ -1095,7 +1116,7 @@ export default function PublicationImporter({
     })
     void Promise.resolve().then(async () => {
       try {
-        const profile = getTargetProfile(profileId)
+        const profile = resolveTargetProfile(profileId, orientation)
         const epub = result.readiness.ready
           ? await buildEpub(result.paper, result, profile)
           : isPdfReconstruction(result)
@@ -1112,7 +1133,8 @@ export default function PublicationImporter({
             return current
           }
           const epubs = current.epubs ?? []
-          if (selectCurrentProfileEpub(epubs, profileId)) return current
+          if (selectCurrentProfileEpub(epubs, profileId, orientation))
+            return current
           return { ...current, epubs: [...epubs, epub] }
         })
       } catch (error) {
@@ -1120,6 +1142,7 @@ export default function PublicationImporter({
         const issue = {
           controller,
           profileId,
+          orientation,
           message:
             error instanceof Error
               ? error.message
@@ -1140,7 +1163,13 @@ export default function PublicationImporter({
         }
       }
     })
-  }, [profileBuildIssues, profileBuilds, selectedProfileId, state])
+  }, [
+    profileBuildIssues,
+    profileBuilds,
+    selectedOrientation,
+    selectedProfileId,
+    state,
+  ])
 
   const progressPercent =
     state.status === 'processing'
@@ -1151,7 +1180,11 @@ export default function PublicationImporter({
   const selectedEpub =
     (state.status === 'ready' || state.status === 'review-required') &&
     state.epubs
-      ? selectCurrentProfileEpub(state.epubs, selectedProfileId)
+      ? selectCurrentProfileEpub(
+          state.epubs,
+          selectedProfileId,
+          selectedOrientation,
+        )
       : undefined
   const selectedEpubPreviewReady = selectedEpub
     ? isSelectedEpubPreviewReady(selectedEpub, previewReadyArtifactKey)
@@ -1159,16 +1192,23 @@ export default function PublicationImporter({
   const buildingProfileId = profileBuilds.find(
     (build) =>
       build.controller === activeImport.current &&
-      build.profileId === selectedProfileId,
+      build.profileId === selectedProfileId &&
+      build.orientation === selectedOrientation,
   )?.profileId
   const selectedIssue = profileBuildIssues[selectedProfileId]
   const selectedProfileBuildIssue =
-    selectedIssue?.controller === activeImport.current
+    selectedIssue?.controller === activeImport.current &&
+    selectedIssue?.orientation === selectedOrientation
       ? selectedIssue
       : undefined
   const retrySelectedProfileBuild = () => {
     const issue = activeProfileBuildIssues.current[selectedProfileId]
-    if (!issue || issue.controller !== activeImport.current) return
+    if (
+      !issue ||
+      issue.controller !== activeImport.current ||
+      issue.orientation !== selectedOrientation
+    )
+      return
     delete activeProfileBuildIssues.current[selectedProfileId]
     setProfileBuildIssues((current) => {
       const next = { ...current }
@@ -1422,11 +1462,24 @@ export default function PublicationImporter({
             <EpubRenditionPreview
               epubs={state.epubs}
               selectedProfileId={selectedProfileId}
+              selectedOrientation={selectedOrientation}
               buildingProfileId={buildingProfileId}
               onSelectedProfileChange={(profileId) => {
                 if (profileId === selectedProfileId) return
                 setPreviewReadyArtifactKey(undefined)
                 setSelectedProfileId(profileId)
+                if (
+                  !getTargetProfile(profileId).orientation.supported.includes(
+                    selectedOrientation,
+                  )
+                ) {
+                  setSelectedOrientation('portrait')
+                }
+              }}
+              onSelectedOrientationChange={(orientation) => {
+                if (orientation === selectedOrientation) return
+                setPreviewReadyArtifactKey(undefined)
+                setSelectedOrientation(orientation)
               }}
               onPreviewReadyChange={setPreviewReadyArtifactKey}
             />

--- a/src/components/research/ResearchStudio.test.tsx
+++ b/src/components/research/ResearchStudio.test.tsx
@@ -405,7 +405,7 @@ describe('research studio imported preview', () => {
     const markup = importedMarkup()
     const profiles = markup.slice(
       markup.indexOf('aria-label="Target profile"'),
-      markup.indexOf('aria-label="Reflow controls"'),
+      markup.indexOf('aria-label="Reader simulations"'),
     )
 
     expect(profiles.match(/<button/g)).toHaveLength(1)
@@ -424,12 +424,29 @@ describe('research studio imported preview', () => {
   })
 
   it('keeps the authored demo annotated and on its full profile matrix', () => {
-    const markup = renderToStaticMarkup(<ResearchStudio paper={importedPaper} />)
+    const markup = renderToStaticMarkup(
+      <ResearchStudio paper={importedPaper} />,
+    )
 
     expect(markup).toContain('srt-annotation-highlight')
     expect(markup).toContain('data-reading-anchor="true"')
     expect(markup).toContain('>Mobile</button>')
     expect(markup).toContain('>Paper Pro</button>')
     expect(markup).toContain('Semantic composition pipeline')
+  })
+
+  it('renders a controlled landscape selection and labels reader-only simulations', () => {
+    const markup = renderToStaticMarkup(
+      <ResearchStudio
+        paper={importedPaper}
+        selection={{ profileId: 'paperPro', orientation: 'landscape' }}
+      />,
+    )
+
+    expect(markup).toContain('data-target-profile="paperPro"')
+    expect(markup).toContain('data-orientation="landscape"')
+    expect(markup).toContain('2160 × 1620 device-px')
+    expect(markup).toContain('>Simulate narrow reader</button>')
+    expect(markup).toContain('>Simulate larger reader text</button>')
   })
 })

--- a/src/components/research/ResearchStudio.tsx
+++ b/src/components/research/ResearchStudio.tsx
@@ -36,7 +36,9 @@ import type { ResearchNode, ResearchPaper } from '../../research/schema'
 import {
   getPreviewMetrics,
   getTargetProfile,
+  resolveTargetProfile,
   TARGET_PROFILE_IDS,
+  type TargetOrientation,
   type TargetProfileId,
 } from '../../research/targets'
 
@@ -494,18 +496,66 @@ function PaperNode({
   )
 }
 
-function DocumentHeader({ paper }: { paper: ResearchPaper }) {
+function DocumentHeader({
+  paper,
+  compact = false,
+}: {
+  paper: ResearchPaper
+  compact?: boolean
+}) {
   return (
-    <header className="srt-document-header">
-      <small>
+    <header
+      className="srt-document-header"
+      style={compact ? { paddingBottom: 8 } : undefined}
+    >
+      <small style={compact ? { fontSize: 8, lineHeight: '9px' } : undefined}>
         {paper.status} paper · v{paper.version}
       </small>
-      <h1>{paper.title}</h1>
-      <p className="srt-subtitle">{paper.subtitle}</p>
-      <p className="srt-authors">
+      <h1
+        style={
+          compact
+            ? { fontSize: 'calc(var(--srt-title-size) * .72)', marginTop: 6 }
+            : undefined
+        }
+      >
+        {paper.title}
+      </h1>
+      <p
+        className="srt-subtitle"
+        style={
+          compact
+            ? {
+                fontSize: 'calc(var(--srt-subtitle-size) * .72)',
+                lineHeight: 1.2,
+                marginTop: 4,
+              }
+            : undefined
+        }
+      >
+        {paper.subtitle}
+      </p>
+      <p
+        className="srt-authors"
+        style={
+          compact
+            ? { fontSize: 9, lineHeight: '10px', marginTop: 6 }
+            : undefined
+        }
+      >
         {paper.authors.join(', ')} · updated {paper.updated}
       </p>
-      <p className="srt-abstract">
+      <p
+        className="srt-abstract"
+        style={
+          compact
+            ? {
+                fontSize: 'calc(var(--srt-abstract-size) * .72)',
+                lineHeight: 1.3,
+                marginTop: 8,
+              }
+            : undefined
+        }
+      >
         <b>Abstract.</b> {paper.abstract}
       </p>
     </header>
@@ -517,14 +567,32 @@ export default function ResearchStudio({
   reconstruction,
   initialAnnotations,
   initialProfileId = 'paperPro',
+  selection,
+  onSelectionChange,
 }: {
   paper: ResearchPaper
   reconstruction?: DocumentReconstruction
   initialAnnotations?: TextAnnotation[]
   initialProfileId?: TargetProfileId
+  selection?: {
+    profileId: TargetProfileId
+    orientation: TargetOrientation
+  }
+  onSelectionChange?: (selection: {
+    profileId: TargetProfileId
+    orientation: TargetOrientation
+  }) => void
 }) {
-  const [profileId, setProfileId] = useState<TargetProfileId>(() =>
-    reconstruction ? 'mobile' : initialProfileId,
+  const [internalProfileId, setInternalProfileId] = useState<TargetProfileId>(
+    () => (reconstruction ? 'mobile' : initialProfileId),
+  )
+  const [internalOrientation, setInternalOrientation] =
+    useState<TargetOrientation>('portrait')
+  const profileId = selection?.profileId ?? internalProfileId
+  const orientation = selection?.orientation ?? internalOrientation
+  const profile = useMemo(
+    () => resolveTargetProfile(profileId, orientation),
+    [orientation, profileId],
   )
   const [widthScale, setWidthScale] = useState(1)
   const [fontScale, setFontScale] = useState(1)
@@ -543,12 +611,14 @@ export default function ResearchStudio({
   const stabilityNodeId = readingAnchor?.nodeId ?? paper.nodes[0].id
   const stabilityAnchor = useRef(stabilityNodeId)
   const basePagination = useMemo(() => {
-    const preview = getPreviewMetrics(getTargetProfile(profileId))
+    const preview = getPreviewMetrics(profile)
     return paginateResearchPaper(paper, profileId, {
       widthCssPx: preview.widthCssPx * widthScale,
+      heightCssPx: preview.minHeightCssPx ?? null,
       fontScale,
+      profile,
     })
-  }, [fontScale, paper, profileId, widthScale])
+  }, [fontScale, paper, profile, profileId, widthScale])
   const pagination = useMemo(() => {
     const previous = previousPagination.current
     if (!previous) return basePagination
@@ -564,7 +634,21 @@ export default function ResearchStudio({
 
   const switchProfile = (next: TargetProfileId) => {
     stabilityAnchor.current = stabilityNodeId
-    setProfileId(next)
+    const nextProfile = getTargetProfile(next)
+    const nextOrientation = nextProfile.orientation.supported.includes(
+      orientation,
+    )
+      ? orientation
+      : nextProfile.orientation.selected
+    setInternalProfileId(next)
+    setInternalOrientation(nextOrientation)
+    onSelectionChange?.({ profileId: next, orientation: nextOrientation })
+  }
+
+  const switchOrientation = (next: TargetOrientation) => {
+    stabilityAnchor.current = stabilityNodeId
+    setInternalOrientation(next)
+    onSelectionChange?.({ profileId, orientation: next })
   }
 
   const toggleWidth = () => {
@@ -586,7 +670,6 @@ export default function ResearchStudio({
   const selectedPagination = pagination.nodes.find(
     (node) => node.canonicalId === selectedNode.id,
   )
-  const profile = getTargetProfile(profileId)
   const policy = getCompositionPolicy(profileId)
   const selectedComposition = resolveNodeComposition(profileId, selectedNode)
   const preview = getPreviewMetrics(profile)
@@ -778,20 +861,34 @@ export default function ResearchStudio({
             </button>
           ))}
         </div>
-        <div className="srt-reflow-controls" aria-label="Reflow controls">
+        {profile.orientation.supported.length > 1 && (
+          <div className="srt-profiles" aria-label="Orientation">
+            {profile.orientation.supported.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                aria-pressed={orientation === candidate}
+                onClick={() => switchOrientation(candidate)}
+              >
+                {candidate === 'portrait' ? 'Portrait' : 'Landscape'}
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="srt-reflow-controls" aria-label="Reader simulations">
           <button
             type="button"
             aria-pressed={widthScale !== 1}
             onClick={toggleWidth}
           >
-            Narrow width
+            Simulate narrow reader
           </button>
           <button
             type="button"
             aria-pressed={fontScale !== 1}
             onClick={toggleFont}
           >
-            Larger text
+            Simulate larger reader text
           </button>
         </div>
       </header>
@@ -801,6 +898,7 @@ export default function ResearchStudio({
           <div
             className="srt-paper"
             data-target-profile={profile.id}
+            data-orientation={orientation}
             data-columns={profile.columns.count}
             data-finite-height={profile.finiteHeight}
             data-flow-mode={policy.flowMode}
@@ -831,7 +929,12 @@ export default function ResearchStudio({
                   data-page={page.number}
                   data-continuous={pagination.mode === 'continuous'}
                 >
-                  {page.number === 1 && <DocumentHeader paper={paper} />}
+                  {page.number === 1 && (
+                    <DocumentHeader
+                      paper={paper}
+                      compact={orientation === 'landscape'}
+                    />
+                  )}
                   <div
                     className="srt-page-regions"
                     data-spanning={hasSpanningContent}
@@ -881,6 +984,12 @@ export default function ResearchStudio({
             <div>
               <dt>Dimensions</dt>
               <dd>{dimensions}</dd>
+            </div>
+            <div>
+              <dt>Orientation</dt>
+              <dd>
+                {orientation} · {profile.orientation.control}
+              </dd>
             </div>
             <div>
               <dt>Margins</dt>

--- a/src/research/epub.test.ts
+++ b/src/research/epub.test.ts
@@ -20,7 +20,7 @@ import { reconstructPageAnalyses } from './pdf-layout'
 import { assessPdfCompleteness } from './pdf-quality'
 import { validatedPdfVisualRelationships } from './pdf-visual-validation'
 import { researchPaperSchema } from './schema'
-import { getTargetProfile } from './targets'
+import { getTargetProfile, resolveTargetProfile } from './targets'
 import { createSourcePageCropAsset } from './visual-assets'
 
 const paper = researchPaperSchema.parse(rawPaper)
@@ -3279,6 +3279,32 @@ describe('EPUB 3 export', () => {
           typography: 'advisory',
           pagination: 'reader-controlled',
           orientation: 'reader-controlled',
+        },
+      },
+    })
+  })
+
+  it('binds a landscape EPUB filename, bytes, and manifest to transposed profile geometry', async () => {
+    const portrait = getTargetProfile('paperPro')
+    const landscape = resolveTargetProfile('paperPro', 'landscape')
+    const [portraitEpub, landscapeEpub] = await Promise.all([
+      buildEpub(paper, portrait),
+      buildEpub(paper, landscape),
+    ])
+    const inspected = inspectEpub(landscapeEpub.bytes, landscape)
+
+    expect(landscapeEpub.fileName).toContain('-paper-pro-landscape-')
+    expect(landscapeEpub.bytes).not.toEqual(portraitEpub.bytes)
+    expect(landscapeEpub.profile?.orientation.selected).toBe('landscape')
+    expect(inspected.manifest).toMatchObject({
+      profile: {
+        orientation: {
+          selected: 'landscape',
+          supported: ['portrait', 'landscape'],
+        },
+        dimensions: {
+          width: portrait.dimensions.height,
+          height: portrait.dimensions.width,
         },
       },
     })

--- a/src/research/epub.ts
+++ b/src/research/epub.ts
@@ -40,7 +40,7 @@ import {
 } from './pdf-scholarly-label'
 import type { ResearchNode, ResearchPaper } from './schema'
 import {
-  getTargetProfile,
+  resolveTargetProfile,
   type TargetProfile,
   type TargetProfileId,
 } from './targets'
@@ -683,6 +683,8 @@ function validatePdfCrossReferenceEvidence({
 export type EpubProfileMetadata = {
   id: TargetProfileId
   version: string
+  orientation: TargetProfile['orientation']
+  artifact: TargetProfile['artifact']
   compositionPolicy: ReturnType<typeof getCompositionPolicy>
   truth: TargetProfile['truth']
   exportPolicy: {
@@ -714,6 +716,8 @@ export function getEpubProfileMetadata(
   return {
     id: profile.id,
     version: profile.version,
+    orientation: profile.orientation,
+    artifact: profile.artifact,
     compositionPolicy: getCompositionPolicy(profile.id),
     truth: profile.truth,
     exportPolicy: {
@@ -3062,7 +3066,15 @@ function parseExportManifest(
     }
     let currentProfile: TargetProfile
     try {
-      currentProfile = getTargetProfile(parsed.profile.id as TargetProfileId)
+      const orientation =
+        isRecord(parsed.profile.orientation) &&
+        typeof parsed.profile.orientation.selected === 'string'
+          ? parsed.profile.orientation.selected
+          : undefined
+      currentProfile = resolveTargetProfile(
+        parsed.profile.id as TargetProfileId,
+        orientation as TargetProfile['orientation']['selected'],
+      )
     } catch {
       throw new Error('EPUB profiled export manifest contract is invalid')
     }
@@ -3103,9 +3115,13 @@ function exportIdentifier(
   paperId: string,
   canonicalContentSha256: string,
   mode: EpubExportMode,
-  profile?: { id: string; version: string },
+  profile?: {
+    id: string
+    version: string
+    orientation?: { selected: string }
+  },
 ) {
-  return `urn:srt:${stableId(paperId)}:${canonicalContentSha256.slice(0, 24)}:${mode}${profile ? `:${profile.id}:${profile.version}:${EPUB_EXPORT_POLICY_VERSION}` : ''}`
+  return `urn:srt:${stableId(paperId)}:${canonicalContentSha256.slice(0, 24)}:${mode}${profile ? `:${profile.id}:${profile.version}:${profile.orientation?.selected ?? 'portrait'}:${EPUB_EXPORT_POLICY_VERSION}` : ''}`
 }
 
 function requireWellFormedXml(value: string, documentName: string) {
@@ -3837,7 +3853,7 @@ export function inspectEpub(
     }
   } else {
     const profileSuffix = manifest.profile
-      ? `:${manifest.profile.id}:${manifest.profile.version}:${EPUB_EXPORT_POLICY_VERSION}`
+      ? `:${manifest.profile.id}:${manifest.profile.version}:${manifest.profile.orientation.selected}:${EPUB_EXPORT_POLICY_VERSION}`
       : ''
     const receiptPattern = new RegExp(
       `^urn:srt:[A-Za-z_][A-Za-z0-9_.:-]*:${manifest.canonicalContentSha256.slice(0, 24)}:${manifest.exportMode}${profileSuffix}$`,
@@ -4160,8 +4176,10 @@ function epubFileName(
   const profileName = slug(
     profile ? profile.id.replace(/([a-z0-9])([A-Z])/g, '$1-$2') : 'reflowable',
   )
+  const orientationSuffix =
+    profile?.orientation.selected === 'landscape' ? '-landscape' : ''
   const modeSuffix = mode === 'readable-fallback' ? '-readable' : ''
-  return `${slug(paper.title)}-${profileName}-${canonicalContentSha256.slice(0, 12)}${modeSuffix}.epub`
+  return `${slug(paper.title)}-${profileName}${orientationSuffix}-${canonicalContentSha256.slice(0, 12)}${modeSuffix}.epub`
 }
 
 async function buildEpubInternal(
@@ -4185,7 +4203,10 @@ async function buildEpubInternal(
     : undefined
   if (
     profile &&
-    JSON.stringify(profile) !== JSON.stringify(getTargetProfile(profile.id))
+    JSON.stringify(profile) !==
+      JSON.stringify(
+        resolveTargetProfile(profile.id, profile.orientation.selected),
+      )
   ) {
     throw new Error(
       `EPUB target profile ${profile.id} must come from src/research/targets.ts`,

--- a/src/research/export-package.ts
+++ b/src/research/export-package.ts
@@ -29,10 +29,7 @@ import {
   type TargetOverride,
 } from './overrides'
 import { canonicalContentHash } from './canonical-hash'
-import {
-  researchPaperSchema,
-  type ResearchPaper,
-} from './schema'
+import { researchPaperSchema, type ResearchPaper } from './schema'
 import {
   getTargetProfile,
   TARGET_PROFILE_IDS,
@@ -108,6 +105,17 @@ const exportManifestSchema = z
               ]),
               profileId: z.enum(['paperPro', 'paperProMove']),
               profileVersion: z.string().min(1),
+              orientation: z.enum(['portrait', 'landscape']),
+              orientationControl: z.enum([
+                'publisher-locked',
+                'reader-controlled',
+              ]),
+              artifactRenderer: z.string().min(1),
+              paginationAuthority: z.enum([
+                'authoritative',
+                'advisory',
+                'reader-controlled',
+              ]),
               compositionPolicy: z
                 .object({
                   id: z.string().min(1),
@@ -187,10 +195,13 @@ function deviceEpubMetadata(epub: EpubExport) {
   const artifact = getTargetProfile(epub.profile.id).epub.fileName
   return {
     artifact: artifact as
-      | 'publication-paperpro.epub'
-      | 'publication-papermove.epub',
+      'publication-paperpro.epub' | 'publication-papermove.epub',
     profileId: epub.profile.id as 'paperPro' | 'paperProMove',
     profileVersion: epub.profile.version,
+    orientation: epub.profile.orientation.selected,
+    orientationControl: epub.profile.orientation.control,
+    artifactRenderer: epub.profile.artifact.renderer,
+    paginationAuthority: epub.profile.truth.pagination,
     compositionPolicy: epub.profile.compositionPolicy,
     exportPolicy: epub.profile.exportPolicy,
   }
@@ -541,6 +552,10 @@ export async function verifyExportPackage(
     artifact: 'publication-paperpro.epub' | 'publication-papermove.epub'
     profileId: 'paperPro' | 'paperProMove'
     profileVersion: string
+    orientation: 'portrait' | 'landscape'
+    orientationControl: 'publisher-locked' | 'reader-controlled'
+    artifactRenderer: string
+    paginationAuthority: TargetProfile['truth']['pagination']
     compositionPolicy: unknown
     exportPolicy: unknown
   }> = []
@@ -554,8 +569,7 @@ export async function verifyExportPackage(
     { path: 'publication.epub' },
     ...DEVICE_EPUB_TARGETS.map((target) => ({
       path: getTargetProfile(target).epub.fileName as
-        | 'publication-paperpro.epub'
-        | 'publication-papermove.epub',
+        'publication-paperpro.epub' | 'publication-papermove.epub',
       profile: getTargetProfile(target),
     })),
   ]
@@ -576,6 +590,9 @@ export async function verifyExportPackage(
           profile?: {
             id: 'paperPro' | 'paperProMove'
             version: string
+            orientation: TargetProfile['orientation']
+            artifact: TargetProfile['artifact']
+            truth: TargetProfile['truth']
             compositionPolicy: unknown
             exportPolicy: unknown
           }
@@ -588,10 +605,13 @@ export async function verifyExportPackage(
         }
         deviceConfigurations.push({
           artifact: artifact.profile.epub.fileName as
-            | 'publication-paperpro.epub'
-            | 'publication-papermove.epub',
+            'publication-paperpro.epub' | 'publication-papermove.epub',
           profileId: embedded.profile.id,
           profileVersion: embedded.profile.version,
+          orientation: embedded.profile.orientation.selected,
+          orientationControl: embedded.profile.orientation.control,
+          artifactRenderer: embedded.profile.artifact.renderer,
+          paginationAuthority: embedded.profile.truth.pagination,
           compositionPolicy: embedded.profile.compositionPolicy,
           exportPolicy: embedded.profile.exportPolicy,
         })

--- a/src/research/pagination.ts
+++ b/src/research/pagination.ts
@@ -2,6 +2,7 @@ import type { ResearchNode, ResearchPaper } from './schema'
 import {
   getPreviewMetrics,
   getTargetProfile,
+  type TargetProfile,
   type TargetProfileId,
 } from './targets'
 
@@ -54,6 +55,7 @@ export type PaginationOverrides = Partial<
   Pick<PaginationConstraints, 'widthCssPx' | 'heightCssPx'>
 > & {
   fontScale?: number
+  profile?: TargetProfile
 }
 
 export type PaginationViolation = {
@@ -308,7 +310,7 @@ export function getPaginationConstraints(
   if (!Number.isFinite(fontScale) || fontScale <= 0) {
     throw new RangeError('Pagination font scale must be a positive number')
   }
-  const profile = getTargetProfile(target)
+  const profile = overrides.profile ?? getTargetProfile(target)
   const preview = getPreviewMetrics(profile)
   const widthCssPx = overrides.widthCssPx ?? preview.widthCssPx
   const heightCssPx =
@@ -328,6 +330,12 @@ export function getPaginationConstraints(
   const columnWidthCssPx =
     (contentWidthCssPx - totalColumnGap) / profile.columns.count
 
+  const estimatedHeaderHeightCssPx = estimateHeaderHeight(
+    paper,
+    contentWidthCssPx,
+    target,
+    fontScale,
+  )
   return {
     widthCssPx,
     heightCssPx,
@@ -336,12 +344,11 @@ export function getPaginationConstraints(
     columnWidthCssPx,
     columns: profile.columns.count,
     columnGapCssPx: profile.columns.gapCssPx,
-    firstPageHeaderHeightCssPx: estimateHeaderHeight(
-      paper,
-      contentWidthCssPx,
-      target,
-      fontScale,
-    ),
+    firstPageHeaderHeightCssPx:
+      profile.orientation.selected === 'landscape' &&
+      contentHeightCssPx !== null
+        ? Math.min(estimatedHeaderHeightCssPx, contentHeightCssPx * 0.9)
+        : estimatedHeaderHeightCssPx,
   }
 }
 

--- a/src/research/target-schema.ts
+++ b/src/research/target-schema.ts
@@ -74,6 +74,31 @@ export const targetProfileSchema = z
         orientation: z.enum(['authoritative', 'advisory', 'reader-controlled']),
       })
       .strict(),
+    orientation: z
+      .object({
+        selected: z.enum(['portrait', 'landscape']),
+        supported: z.array(z.enum(['portrait', 'landscape'])).min(1),
+        control: z.enum(['publisher-locked', 'reader-controlled']),
+      })
+      .strict(),
+    artifact: z.discriminatedUnion('format', [
+      z
+        .object({
+          status: z.literal('generated'),
+          format: z.literal('epub'),
+          renderer: z.literal('local-profiled-epub'),
+          pagination: z.literal('reader-controlled'),
+        })
+        .strict(),
+      z
+        .object({
+          status: z.literal('generated'),
+          format: z.literal('pdf'),
+          renderer: z.literal('local-paginated-pdf'),
+          pagination: z.literal('authoritative'),
+        })
+        .strict(),
+    ]),
     preview: z
       .object({
         widthCssPx: z.number().positive(),
@@ -86,6 +111,46 @@ export const targetProfileSchema = z
   .superRefine((profile, context) => {
     const hasFiniteDimensions = profile.dimensions.height !== null
     const hasFinitePreview = profile.preview.heightCssPx !== null
+
+    if (
+      new Set(profile.orientation.supported).size !==
+        profile.orientation.supported.length ||
+      !profile.orientation.supported.includes(profile.orientation.selected)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['orientation'],
+        message:
+          'Selected orientation must appear exactly once in supported orientations',
+      })
+    }
+    if (
+      profile.orientation.supported.includes('landscape') &&
+      !profile.finiteHeight
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['orientation', 'supported'],
+        message: 'Landscape publisher previews require finite target geometry',
+      })
+    }
+    if (
+      profile.orientation.control === 'publisher-locked' &&
+      profile.truth.orientation !== 'authoritative'
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['truth', 'orientation'],
+        message: 'Publisher-locked orientation must be authoritative',
+      })
+    }
+    if (profile.artifact.pagination !== profile.truth.pagination) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['artifact', 'pagination'],
+        message: 'Artifact pagination must match the declared truth authority',
+      })
+    }
 
     if (profile.finiteHeight !== hasFiniteDimensions) {
       context.addIssue({
@@ -141,7 +206,7 @@ export const targetProfileSchema = z
     }
     if (profile.manufacturerDisplay) {
       if (
-        profile.manufacturerDisplay.logicalOrientation === 'portrait' &&
+        profile.orientation.selected === 'portrait' &&
         profile.dimensions.height !== null &&
         profile.dimensions.width >= profile.dimensions.height
       ) {
@@ -150,6 +215,18 @@ export const targetProfileSchema = z
           path: ['dimensions'],
           message:
             'Portrait manufacturer profiles require a portrait logical viewport',
+        })
+      }
+      if (
+        profile.orientation.selected === 'landscape' &&
+        profile.dimensions.height !== null &&
+        profile.dimensions.width <= profile.dimensions.height
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['dimensions'],
+          message:
+            'Landscape manufacturer profiles require a landscape logical viewport',
         })
       }
       const logicalPixels = [

--- a/src/research/targets.test.ts
+++ b/src/research/targets.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getTargetProfile,
   getPreviewMetrics,
+  resolveTargetProfile,
   TARGET_PROFILES,
   TARGET_PROFILE_IDS,
 } from './targets'
@@ -21,12 +23,10 @@ describe('SRT target profiles', () => {
       expect(profile.finiteHeight).toBe(profile.dimensions.height !== null)
       expect(profile.version).toBe('1.1.0')
       expect(profile.epub.fileName).toMatch(/^publication-[a-z]+\.epub$/)
-      expect(profile.truth).toEqual({
-        geometry: 'authoritative',
-        typography: 'advisory',
-        pagination: 'reader-controlled',
-        orientation: 'reader-controlled',
-      })
+      expect(profile.artifact.status).toBe('generated')
+      expect(profile.orientation.supported).toContain(
+        profile.orientation.selected,
+      )
     }
   })
 
@@ -100,6 +100,37 @@ describe('SRT target profiles', () => {
     expect(pro.preview).toEqual({ widthCssPx: 540, heightCssPx: 720 })
     expect(move.preview.widthCssPx).toBeLessThan(pro.preview.widthCssPx)
     expect(move.preview.heightCssPx!).toBeLessThan(pro.preview.heightCssPx!)
+  })
+
+  it.each(['paperProMove', 'paperPro', 'print'] as const)(
+    'transposes %s geometry, margins, and preview dimensions for landscape',
+    (id) => {
+      const portrait = getTargetProfile(id)
+      const landscape = resolveTargetProfile(id, 'landscape')
+
+      expect(targetProfileSchema.parse(landscape)).toEqual(landscape)
+      expect(landscape.dimensions).toMatchObject({
+        width: portrait.dimensions.height,
+        height: portrait.dimensions.width,
+      })
+      expect(landscape.preview).toMatchObject({
+        widthCssPx: portrait.preview.heightCssPx,
+        heightCssPx: portrait.preview.widthCssPx,
+      })
+      expect(landscape.margins).toMatchObject({
+        top: portrait.margins.left,
+        right: portrait.margins.top,
+        bottom: portrait.margins.right,
+        left: portrait.margins.bottom,
+      })
+      expect(landscape.orientation.selected).toBe('landscape')
+    },
+  )
+
+  it('rejects unsupported continuous-mobile landscape simulation', () => {
+    expect(() => resolveTargetProfile('mobile', 'landscape')).toThrow(
+      /does not support/i,
+    )
   })
 
   it('rejects manufacturer pixels that do not transpose to logical device geometry', () => {

--- a/src/research/targets.ts
+++ b/src/research/targets.ts
@@ -10,9 +10,8 @@ export const TARGET_PROFILE_VERSION = '1.1.0' as const
 export type TargetProfileId = (typeof TARGET_PROFILE_IDS)[number]
 export type TargetLengthUnit = 'css-px' | 'device-px' | 'mm'
 export type TargetTruthAuthority =
-  | 'authoritative'
-  | 'advisory'
-  | 'reader-controlled'
+  'authoritative' | 'advisory' | 'reader-controlled'
+export type TargetOrientation = 'portrait' | 'landscape'
 
 export type TargetProfile = {
   id: TargetProfileId
@@ -62,6 +61,24 @@ export type TargetProfile = {
     pagination: TargetTruthAuthority
     orientation: TargetTruthAuthority
   }
+  orientation: {
+    selected: TargetOrientation
+    supported: TargetOrientation[]
+    control: 'publisher-locked' | 'reader-controlled'
+  }
+  artifact:
+    | {
+        status: 'generated'
+        format: 'epub'
+        renderer: 'local-profiled-epub'
+        pagination: 'reader-controlled'
+      }
+    | {
+        status: 'generated'
+        format: 'pdf'
+        renderer: 'local-paginated-pdf'
+        pagination: 'authoritative'
+      }
   preview: {
     widthCssPx: number
     heightCssPx: number | null
@@ -122,6 +139,17 @@ export const TARGET_PROFILES: Record<TargetProfileId, TargetProfile> = {
       pagination: 'reader-controlled',
       orientation: 'reader-controlled',
     },
+    orientation: {
+      selected: 'portrait',
+      supported: ['portrait'],
+      control: 'reader-controlled',
+    },
+    artifact: {
+      status: 'generated',
+      format: 'epub',
+      renderer: 'local-profiled-epub',
+      pagination: 'reader-controlled',
+    },
     preview: {
       widthCssPx: 390,
       heightCssPx: null,
@@ -169,6 +197,17 @@ export const TARGET_PROFILES: Record<TargetProfileId, TargetProfile> = {
       pagination: 'reader-controlled',
       orientation: 'reader-controlled',
     },
+    orientation: {
+      selected: 'portrait',
+      supported: ['portrait', 'landscape'],
+      control: 'reader-controlled',
+    },
+    artifact: {
+      status: 'generated',
+      format: 'epub',
+      renderer: 'local-profiled-epub',
+      pagination: 'reader-controlled',
+    },
     preview: eInkPreview(954, 1696, 264),
   },
   paperPro: {
@@ -212,6 +251,17 @@ export const TARGET_PROFILES: Record<TargetProfileId, TargetProfile> = {
       pagination: 'reader-controlled',
       orientation: 'reader-controlled',
     },
+    orientation: {
+      selected: 'portrait',
+      supported: ['portrait', 'landscape'],
+      control: 'reader-controlled',
+    },
+    artifact: {
+      status: 'generated',
+      format: 'epub',
+      renderer: 'local-profiled-epub',
+      pagination: 'reader-controlled',
+    },
     preview: eInkPreview(1620, 2160, 229),
   },
   print: {
@@ -247,8 +297,19 @@ export const TARGET_PROFILES: Record<TargetProfileId, TargetProfile> = {
     truth: {
       geometry: 'authoritative',
       typography: 'advisory',
-      pagination: 'reader-controlled',
-      orientation: 'reader-controlled',
+      pagination: 'authoritative',
+      orientation: 'authoritative',
+    },
+    orientation: {
+      selected: 'portrait',
+      supported: ['portrait', 'landscape'],
+      control: 'publisher-locked',
+    },
+    artifact: {
+      status: 'generated',
+      format: 'pdf',
+      renderer: 'local-paginated-pdf',
+      pagination: 'authoritative',
     },
     preview: { widthCssPx: 794, heightCssPx: 1123 },
   },
@@ -256,6 +317,48 @@ export const TARGET_PROFILES: Record<TargetProfileId, TargetProfile> = {
 
 export function getTargetProfile(id: TargetProfileId) {
   return TARGET_PROFILES[id]
+}
+
+export function resolveTargetProfile(
+  id: TargetProfileId,
+  orientation: TargetOrientation = TARGET_PROFILES[id].orientation.selected,
+): TargetProfile {
+  const profile = TARGET_PROFILES[id]
+  if (!profile.orientation.supported.includes(orientation)) {
+    throw new RangeError(
+      `${profile.label} does not support a publisher preview in ${orientation} orientation`,
+    )
+  }
+  if (orientation === profile.orientation.selected) return profile
+  if (
+    profile.dimensions.height === null ||
+    profile.preview.heightCssPx === null
+  ) {
+    throw new RangeError(
+      `${profile.label} has no finite geometry to transpose into ${orientation}`,
+    )
+  }
+  return {
+    ...profile,
+    dimensions: {
+      ...profile.dimensions,
+      width: profile.dimensions.height,
+      height: profile.dimensions.width,
+    },
+    margins: {
+      ...profile.margins,
+      top: profile.margins.left,
+      right: profile.margins.top,
+      bottom: profile.margins.right,
+      left: profile.margins.bottom,
+    },
+    orientation: { ...profile.orientation, selected: orientation },
+    preview: {
+      ...profile.preview,
+      widthCssPx: profile.preview.heightCssPx,
+      heightCssPx: profile.preview.widthCssPx,
+    },
+  }
 }
 
 export function getPreviewMetrics(profile: TargetProfile) {

--- a/tests/e2e/srt-visual.spec.ts
+++ b/tests/e2e/srt-visual.spec.ts
@@ -579,11 +579,13 @@ test('keeps the semantic sentence and annotations through target, width, and fon
     layoutVersions.add(await expectAnchorVisibleAndCached())
   }
 
-  await page.getByRole('button', { name: 'Narrow width' }).click()
+  await page.getByRole('button', { name: 'Simulate narrow reader' }).click()
   await expect(rendition).toHaveAttribute('data-width-scale', '0.86')
   layoutVersions.add(await expectAnchorVisibleAndCached())
 
-  await page.getByRole('button', { name: 'Larger text' }).click()
+  await page
+    .getByRole('button', { name: 'Simulate larger reader text' })
+    .click()
   await expect(rendition).toHaveAttribute('data-font-scale', '1.12')
   layoutVersions.add(await expectAnchorVisibleAndCached())
 
@@ -593,4 +595,49 @@ test('keeps the semantic sentence and annotations through target, width, and fon
     fullPage: true,
     path: testInfo.outputPath('annotation-reflow.png'),
   })
+})
+
+test('recomposes every finite profile in landscape without structural or geometry loss', async ({
+  page,
+  request,
+}) => {
+  const source = await jsonFixture<{ nodes: SourceNode[] }>(
+    request,
+    `/research/${PAPER_ID}/source.json`,
+  )
+  await page.goto(`/research/${PAPER_ID}`)
+  await expectStudioHydrated(page)
+  await page.locator('html').evaluate((element) => {
+    element.classList.add('disable-transitions')
+  })
+  await page.evaluate(() => document.fonts.ready)
+
+  for (const target of ['paperProMove', 'paperPro', 'print'] as const) {
+    const portrait = getTargetProfile(target)
+    await page
+      .getByRole('button', { name: portrait.label, exact: true })
+      .click()
+    await page.getByRole('button', { name: 'Landscape', exact: true }).click()
+
+    const paper = page.locator(
+      `.srt-paper[data-target-profile="${target}"][data-orientation="landscape"]`,
+    )
+    const report = await inspectGeometry(paper, source.nodes)
+    expect(report.missingNodes, `${target}: missing nodes`).toEqual([])
+    expect(report.textLoss, `${target}: text loss`).toEqual([])
+    expect(report.clippedContent, `${target}: clipping`).toEqual([])
+    expect(report.overlaps, `${target}: overlap`).toEqual([])
+    expect(report.horizontalOverflow, `${target}: horizontal overflow`).toEqual(
+      [],
+    )
+    expect(report.orphanedCaptions, `${target}: captions`).toEqual([])
+    expect(report.paper.width, `${target}: landscape width`).toBeCloseTo(
+      portrait.preview.heightCssPx!,
+      1,
+    )
+    for (const renderedPage of report.pages) {
+      expect(renderedPage.width).toBeCloseTo(portrait.preview.heightCssPx!, 1)
+      expect(renderedPage.height).toBeCloseTo(portrait.preview.widthCssPx, 1)
+    }
+  }
 })


### PR DESCRIPTION
Closes #58

## Recovery note

This branch was produced by the `vm-codex` worker on 2026-07-26 and then
stranded: the work was committed as `a091ac1` on the trusted VM but the branch
was never pushed to any remote, so it existed in exactly one place. The
preserved result receipt compounded it by recording `commit_count: 0`,
`dirty: true`, `classification: uncommitted-changes` — all stale, all pointing
an operator toward discarding it. Recovered and pushed manually. Filed as
further evidence on rucksack#253.

## What the worker built

14 files, +654/-80, extending the four surfaces the spec names:

- `src/research/target-schema.ts`, `src/research/targets.ts` — the profile /
  orientation registry and resolver
- `src/components/research/ResearchStudio.tsx`,
  `src/components/research/PublicationImporter.tsx` — controlled profile
  selection shared by preview metadata, download labelling, and manifest
- `src/research/epub.ts`, `src/research/export-package.ts`,
  `src/research/pagination.ts` — artifact and manifest binding
- coverage in `targets.test.ts`, `epub.test.ts`, the importer specs, and
  `tests/e2e/srt-visual.spec.ts`

## Validation, run at this exact head on the trusted VM

```
npx vitest run src/research/targets.test.ts src/research/epub.test.ts \
  src/research/export-package.test.ts src/research/manifest.test.ts
    → 4 files, 142 passed                                    exit 0
npm test
    → 88 files, 1667 passed, 1 skipped                       exit 0
npm run build
    → 131 pages built                                        exit 0
npm run test:e2e -- tests/e2e/publication-importer.spec.ts tests/e2e/srt-visual.spec.ts
    → 15 passed                                              exit 0
scripts/agent-evidence --all
    → passed: .agent/evidence/20260726T130141099Z/manifest.json
```

Manifest binds to this head, and the post-lane worktree is clean:

```
commit = a091ac14002831e53c916ef82f6c9430721b7d5a   (== HEAD)
dirty  = False
result = passed
lanes  = 2 required passed, 1 optional passed
git status --porcelain → empty
```

## What a reviewer should still check

The spec's acceptance list is broad, and passing lanes do not by themselves
prove every clause. The ones worth reading the diff for:

- that every member of `TARGET_PROFILE_IDS` has an honest artifact policy —
  generated and structurally validated, or visibly marked unsupported with a
  reason — rather than only the three-profile issue-032 slice
- that `Narrow width` / `Larger text` are presented as reader simulations and
  do not claim to alter EPUB bytes
- that no copy promises firmware-exact pagination or physical-size parity
- that the registry's `954 × 1696 @ 264 PPI` and `1620 × 2160 @ 229 PPI` values
  derive preview CSS from one common physical scale rather than copied UI
  constants

I verified the lanes and the exact-head evidence, not each acceptance clause
against the rendered UI.
