### PR TITLE
feat(publication): define universal contracts

### DIFF
--- a/docs/adr/009-universal-publication-contracts.md
+++ b/docs/adr/009-universal-publication-contracts.md
@@ -1,0 +1,90 @@
+# ADR 009: Universal publication and capability contracts
+
+## Status
+
+Accepted for the first source-neutral compiler boundary.
+
+## Context
+
+The research proof has a useful `ResearchPaper` schema and an authoritative
+target-profile registry, but neither is a universal publication source.
+`ResearchPaper` is intentionally scholarly, while rendered pages and recovered
+PDF coordinates are rendition or source evidence. Astro translations, Payload
+locales, DOCX manuscripts, and repaired PDFs need one bounded meaning graph
+without promoting any one source runtime or target geometry into canonical
+content.
+
+## Decision
+
+`PublicationGraph` version `1.0.0` is the source-neutral compiler input. Its
+strict codec admits ordered heading, paragraph, list, quote, code, figure,
+caption, table, equation, aside, note, reference, and media nodes. Stable ids,
+explicit relationships, edition linkage, locale and direction, requirement,
+editorial importance, provenance, accessibility alternatives, authored
+variants, and permitted transformation ids are carried on the graph. Unknown
+versions or fields, duplicate ids, dangling relationships, unsafe URLs,
+unbounded values, invalid ranges, local paths, and secret-shaped source values
+fail closed. Page coordinates are not graph fields.
+
+A `PublicationSourceAdapter` returns `{ graph, assetBundle, diagnostics,
+provenance }`. Asset descriptors are bounded and content-addressed. Bytes remain
+behind an asynchronous resolver and cannot be serialized into graph JSON.
+Source adapters may report unsupported features through diagnostics; they may
+not retain local paths, credentials, source-specific runtime objects, or target
+layout state in the graph.
+
+`CompositionContext` version `1.0.0` describes flow, logical and physical
+dimensions, orientation, color, resolution, refresh, interaction, font
+control, locale and script, accessibility preferences, duplex, binding, bleed,
+offline constraints, reader control, and pagination authority. Named presets
+are derived data. `src/research/targets.ts` remains the only registry for target
+dimensions, margins, orientation, reader assumptions, and pagination
+authority. The adapters in `src/publication/profiles.ts` validate that a context
+still equals its named registry profile before converting it back.
+
+`TransformationPolicy` version `1.0.0` declares representation changes,
+preservation classes, authored-alternative requirements, and hard or soft
+constraints. Omission, summarization, reading-order changes, and
+meaning-changing crops are invalid unless they point to an explicit reviewed
+authored variant.
+
+The first `ResearchPaper` adapter is deliberately thin. It round-trips the two
+existing golden papers' common heading, paragraph, quote, figure, and caption
+subset, including canonical ids, text, inline semantics, figure/caption
+relationships, and asset ids. Annotations and semantic anchors use a separately
+versioned `AnnotationBundle`; cached layout rectangles remain non-canonical
+annotation data. Structured scholarly tables/equations, legacy list context,
+embedded note references, and extended scholarly affiliation/lineage metadata
+produce explicit unsupported errors until a source-neutral mapping is reviewed.
+
+## Versioning and migration
+
+Codecs accept only their declared version. Additive fields still require a new
+contract version because strict decoding would otherwise make producers and
+consumers disagree. A migration must parse the complete old value, explicitly
+map every changed field, validate the new value, and preserve stable ids,
+edition links, relationships, asset hashes, and annotation anchors. Silently
+dropping unknown data is forbidden.
+
+`createPublicationContractReceipt` binds serialized graph and asset-descriptor
+hashes to the graph, asset, composition, policy, profile, and adapter versions,
+plus lockfile/toolchain identity and a caller-proven clean exact commit. The
+repository evidence lane remains responsible for proving that supplied
+environment identity; graph serialization itself is byte-deterministic for a
+validated in-memory value.
+
+## Consequences
+
+Importers and output compilers can evolve independently around a small,
+inspectable boundary. Source and target details remain recoverable at their
+typed edges rather than expanding the graph into an abstract document
+standard. Unsupported input fails visibly instead of being approximated.
+
+## Non-goals
+
+This decision does not add a renderer, optimizer, paged-media engine, general
+document standard, binary asset store, network fetcher, PDF geometry model, or
+source-runtime bridge. It does not migrate the existing SRT runtime, duplicate
+the target registry, promise lossless conversion for unlisted
+`ResearchPaper` extensions, or permit target coordinates in canonical graph
+data.

--- a/src/publication/annotation-bundle.test.ts
+++ b/src/publication/annotation-bundle.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import rawPaper from '../research/papers/semantic-responsive-typesetting.json'
+import { createDemoAnnotations } from '../research/annotations'
+import { researchPaperSchema } from '../research/schema'
+import {
+  annotationBundleSchema,
+  createAnnotationBundle,
+  serializeAnnotationBundle,
+} from './annotation-bundle'
+import { researchPaperToPublicationGraph } from './research-paper-adapter'
+
+describe('AnnotationBundle', () => {
+  it('round-trips typed annotations and semantic anchors beside the graph', () => {
+    const paper = researchPaperSchema.parse(rawPaper)
+    const annotations = createDemoAnnotations(paper)
+    const bundle = createAnnotationBundle(
+      researchPaperToPublicationGraph(paper),
+      annotations,
+    )
+    expect(
+      annotationBundleSchema.parse(
+        JSON.parse(serializeAnnotationBundle(bundle)),
+      ),
+    ).toEqual(bundle)
+    expect(bundle.annotations).toEqual(annotations)
+    expect(serializeAnnotationBundle(bundle)).not.toContain('"graph":')
+  })
+
+  it('rejects anchors to missing graph nodes', () => {
+    const paper = researchPaperSchema.parse(rawPaper)
+    const annotations = createDemoAnnotations(paper)
+    annotations[0].target.nodeId = 'missing'
+    expect(() =>
+      createAnnotationBundle(
+        researchPaperToPublicationGraph(paper),
+        annotations,
+      ),
+    ).toThrow(/missing/)
+  })
+
+  it('rejects stale anchor text even when the graph node still exists', () => {
+    const paper = researchPaperSchema.parse(rawPaper)
+    const annotations = createDemoAnnotations(paper)
+    annotations[0].target.quote.exact = 'x'.repeat(
+      annotations[0].target.quote.exact.length,
+    )
+    expect(() =>
+      createAnnotationBundle(
+        researchPaperToPublicationGraph(paper),
+        annotations,
+      ),
+    ).toThrow(/does not match/)
+  })
+})

--- a/src/publication/annotation-bundle.ts
+++ b/src/publication/annotation-bundle.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+import {
+  semanticTextAnchorSchema,
+  textAnnotationSchema,
+  type SemanticTextAnchor,
+  type TextAnnotation,
+} from '../research/annotations'
+import type { PublicationGraph } from './schema'
+
+export const ANNOTATION_BUNDLE_VERSION = '1.0.0' as const
+
+export const annotationBundleSchema = z
+  .object({
+    version: z.literal(ANNOTATION_BUNDLE_VERSION),
+    graphId: z.string().min(1).max(256),
+    anchors: z
+      .array(
+        z
+          .object({
+            id: z.string().min(1).max(256),
+            anchor: semanticTextAnchorSchema,
+          })
+          .strict(),
+      )
+      .max(100_000),
+    annotations: z.array(textAnnotationSchema).max(100_000),
+  })
+  .strict()
+  .superRefine((bundle, context) => {
+    const anchorIds = new Set<string>()
+    bundle.anchors.forEach((entry, index) => {
+      if (anchorIds.has(entry.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['anchors', index, 'id'],
+          message: `Duplicate anchor id: ${entry.id}`,
+        })
+      }
+      anchorIds.add(entry.id)
+    })
+    const annotationIds = new Set<string>()
+    bundle.annotations.forEach((annotation, index) => {
+      if (annotationIds.has(annotation.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['annotations', index, 'id'],
+          message: `Duplicate annotation id: ${annotation.id}`,
+        })
+      }
+      annotationIds.add(annotation.id)
+    })
+  })
+
+export type AnnotationBundle = z.infer<typeof annotationBundleSchema>
+
+export function createAnnotationBundle(
+  graph: PublicationGraph,
+  annotations: readonly TextAnnotation[],
+  anchors: readonly {
+    id: string
+    anchor: SemanticTextAnchor
+  }[] = annotations.map((annotation) => ({
+    id: `${annotation.id}:target`,
+    anchor: annotation.target,
+  })),
+): AnnotationBundle {
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]))
+  const validateAnchor = (id: string, anchor: SemanticTextAnchor) => {
+    const node = nodesById.get(anchor.nodeId)
+    if (!node) {
+      throw new Error(
+        `Anchor ${id} targets missing graph node ${anchor.nodeId}`,
+      )
+    }
+    const text =
+      'text' in node
+        ? node.text
+        : node.type === 'figure'
+          ? (node.sourceText ?? '')
+          : node.type === 'equation'
+            ? node.source
+            : node.type === 'code'
+              ? node.code
+              : null
+    if (
+      text === null ||
+      text.slice(anchor.position.start, anchor.position.end) !==
+        anchor.quote.exact
+    ) {
+      throw new Error(`Anchor ${id} does not match graph node text`)
+    }
+  }
+  for (const entry of anchors) {
+    validateAnchor(entry.id, entry.anchor)
+  }
+  for (const annotation of annotations) {
+    validateAnchor(annotation.id, annotation.target)
+  }
+  return annotationBundleSchema.parse({
+    version: ANNOTATION_BUNDLE_VERSION,
+    graphId: graph.id,
+    anchors,
+    annotations,
+  })
+}
+
+export function serializeAnnotationBundle(bundle: AnnotationBundle) {
+  return JSON.stringify(annotationBundleSchema.parse(bundle))
+}

--- a/src/publication/asset-bundle.test.ts
+++ b/src/publication/asset-bundle.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assetBundleDescriptorSchema,
+  createAssetBundle,
+  serializeAssetBundle,
+} from './asset-bundle'
+
+const descriptor = {
+  version: '1.0.0',
+  assets: [
+    {
+      id: 'image',
+      sha256:
+        '039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81',
+      byteLength: 3,
+      mediaType: 'image/png',
+      fileName: 'image.png',
+    },
+  ],
+}
+
+describe('AssetBundle', () => {
+  it('keeps content-addressed descriptors separate from byte resolution', async () => {
+    const bundle = createAssetBundle(
+      descriptor,
+      async () => new Uint8Array([1, 2, 3]),
+    )
+    expect(await bundle.resolveBytes(bundle.descriptor.assets[0])).toEqual(
+      new Uint8Array([1, 2, 3]),
+    )
+    expect(serializeAssetBundle(bundle)).not.toContain('[1,2,3]')
+    expect(JSON.parse(serializeAssetBundle(bundle))).toEqual(descriptor)
+  })
+
+  it('rejects embedded bytes, paths, duplicate ids and invalid bounds', () => {
+    expect(
+      assetBundleDescriptorSchema.safeParse({ ...descriptor, bytes: [1] })
+        .success,
+    ).toBe(false)
+    expect(
+      assetBundleDescriptorSchema.safeParse({
+        ...descriptor,
+        assets: [{ ...descriptor.assets[0], fileName: '../image.png' }],
+      }).success,
+    ).toBe(false)
+    expect(
+      assetBundleDescriptorSchema.safeParse({
+        ...descriptor,
+        assets: [descriptor.assets[0], descriptor.assets[0]],
+      }).success,
+    ).toBe(false)
+    expect(
+      assetBundleDescriptorSchema.safeParse({
+        ...descriptor,
+        assets: [{ ...descriptor.assets[0], byteLength: -1 }],
+      }).success,
+    ).toBe(false)
+    expect(
+      assetBundleDescriptorSchema.safeParse({
+        ...descriptor,
+        assets: [{ ...descriptor.assets[0], fileName: '..' }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('verifies resolved bytes against descriptor identity and content', async () => {
+    const wrongLength = createAssetBundle(
+      descriptor,
+      async () => new Uint8Array([1]),
+    )
+    await expect(
+      wrongLength.resolveBytes(wrongLength.descriptor.assets[0]),
+    ).rejects.toThrow(/expected 3/)
+
+    const wrongHash = createAssetBundle(
+      descriptor,
+      async () => new Uint8Array([3, 2, 1]),
+    )
+    await expect(
+      wrongHash.resolveBytes(wrongHash.descriptor.assets[0]),
+    ).rejects.toThrow(/content-address/)
+
+    const valid = createAssetBundle(
+      descriptor,
+      async () => new Uint8Array([1, 2, 3]),
+    )
+    await expect(
+      valid.resolveBytes({
+        ...valid.descriptor.assets[0],
+        mediaType: 'image/jpeg',
+      }),
+    ).rejects.toThrow(/does not match/)
+  })
+})

--- a/src/publication/asset-bundle.ts
+++ b/src/publication/asset-bundle.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod'
+import { createHash } from 'node:crypto'
+
+export const ASSET_BUNDLE_VERSION = '1.0.0' as const
+export const MAX_ASSET_COUNT = 10_000
+export const MAX_ASSET_BYTES = 1_000_000_000
+
+const assetIdSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/)
+
+export const assetDescriptorSchema = z
+  .object({
+    id: assetIdSchema,
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    byteLength: z.number().int().nonnegative().max(MAX_ASSET_BYTES),
+    mediaType: z
+      .string()
+      .min(3)
+      .max(256)
+      .regex(/^[a-z0-9.+-]+\/[a-z0-9.+-]+$/i),
+    fileName: z
+      .string()
+      .min(1)
+      .max(512)
+      .regex(/^[^/\\\u0000-\u001f\u007f]+$/)
+      .refine((value) => value !== '.' && value !== '..', {
+        message: 'Asset file names cannot be path traversal segments',
+      })
+      .optional(),
+    accessibilityLabel: z.string().min(1).max(100_000).optional(),
+  })
+  .strict()
+
+export const assetBundleDescriptorSchema = z
+  .object({
+    version: z.literal(ASSET_BUNDLE_VERSION),
+    assets: z.array(assetDescriptorSchema).max(MAX_ASSET_COUNT),
+  })
+  .strict()
+  .superRefine((bundle, context) => {
+    const ids = new Set<string>()
+    const hashes = new Set<string>()
+    bundle.assets.forEach((asset, index) => {
+      if (ids.has(asset.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['assets', index, 'id'],
+          message: `Duplicate asset id: ${asset.id}`,
+        })
+      }
+      if (hashes.has(asset.sha256)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['assets', index, 'sha256'],
+          message: `Duplicate asset content hash: ${asset.sha256}`,
+        })
+      }
+      ids.add(asset.id)
+      hashes.add(asset.sha256)
+    })
+  })
+
+export type AssetDescriptor = z.infer<typeof assetDescriptorSchema>
+export type AssetBundleDescriptor = z.infer<typeof assetBundleDescriptorSchema>
+export type AssetByteResolver = (
+  descriptor: AssetDescriptor,
+) => Promise<Uint8Array>
+
+export type AssetBundle = {
+  descriptor: AssetBundleDescriptor
+  resolveBytes: AssetByteResolver
+}
+
+export function createAssetBundle(
+  value: unknown,
+  resolveBytes: AssetByteResolver,
+): AssetBundle {
+  if (typeof resolveBytes !== 'function') {
+    throw new TypeError('Asset bundles require a byte resolver')
+  }
+  const descriptor = assetBundleDescriptorSchema.parse(value)
+  const descriptorIds = new Set(descriptor.assets.map((asset) => asset.id))
+  return {
+    descriptor,
+    resolveBytes: async (requested) => {
+      const parsed = assetDescriptorSchema.parse(requested)
+      if (!descriptorIds.has(parsed.id)) {
+        throw new Error(
+          `Asset resolver received unknown descriptor ${parsed.id}`,
+        )
+      }
+      const expected = descriptor.assets.find((asset) => asset.id === parsed.id)
+      if (!expected || JSON.stringify(expected) !== JSON.stringify(parsed)) {
+        throw new Error(
+          `Asset resolver descriptor ${parsed.id} does not match its bundle`,
+        )
+      }
+      const bytes = await resolveBytes(expected)
+      if (!(bytes instanceof Uint8Array)) {
+        throw new TypeError('Asset byte resolvers must return Uint8Array')
+      }
+      if (bytes.byteLength !== expected.byteLength) {
+        throw new Error(
+          `Asset ${expected.id} resolved ${bytes.byteLength} bytes; expected ${expected.byteLength}`,
+        )
+      }
+      const digest = createHash('sha256').update(bytes).digest('hex')
+      if (digest !== expected.sha256) {
+        throw new Error(
+          `Asset ${expected.id} failed content-address verification`,
+        )
+      }
+      return bytes
+    },
+  }
+}
+
+export function serializeAssetBundle(
+  bundle: AssetBundle | AssetBundleDescriptor,
+) {
+  const descriptor = 'descriptor' in bundle ? bundle.descriptor : bundle
+  return JSON.stringify(assetBundleDescriptorSchema.parse(descriptor))
+}

--- a/src/publication/profiles.test.ts
+++ b/src/publication/profiles.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TARGET_PROFILE_IDS,
+  getTargetProfile,
+  resolveTargetProfile,
+} from '../research/targets'
+import {
+  COMPOSITION_CONTEXT_PRESETS,
+  compositionContextSchema,
+  compositionContextToTargetProfile,
+  targetProfileToCompositionContext,
+} from './profiles'
+
+describe('CompositionContext profiles', () => {
+  it('derives every named preset from the one target-profile registry losslessly', () => {
+    expect(Object.keys(COMPOSITION_CONTEXT_PRESETS)).toEqual(TARGET_PROFILE_IDS)
+    for (const id of TARGET_PROFILE_IDS) {
+      const profile = getTargetProfile(id)
+      const context = targetProfileToCompositionContext(profile)
+      expect(compositionContextSchema.parse(context)).toEqual(context)
+      expect(compositionContextToTargetProfile(context)).toEqual(profile)
+    }
+  })
+
+  it('round-trips orientation without a second geometry authority', () => {
+    for (const id of ['paperProMove', 'paperPro', 'print'] as const) {
+      const profile = resolveTargetProfile(id, 'landscape')
+      expect(
+        compositionContextToTargetProfile(
+          targetProfileToCompositionContext(profile),
+        ),
+      ).toEqual(profile)
+    }
+  })
+
+  it('rejects invalid units, ranges and drift from the registry', () => {
+    const invalid: any = structuredClone(COMPOSITION_CONTEXT_PRESETS.print)
+    invalid.logicalDimensions.width += 1
+    expect(() => compositionContextToTargetProfile(invalid)).toThrow(
+      /authoritative/,
+    )
+    invalid.logicalDimensions.unit = 'points'
+    expect(compositionContextSchema.safeParse(invalid).success).toBe(false)
+  })
+})

--- a/src/publication/profiles.ts
+++ b/src/publication/profiles.ts
@@ -1,0 +1,289 @@
+import { z } from 'zod'
+import {
+  getTargetProfile,
+  resolveTargetProfile,
+  TARGET_PROFILE_IDS,
+  TARGET_PROFILE_VERSION,
+  type TargetOrientation,
+  type TargetProfile,
+  type TargetProfileId,
+} from '../research/targets'
+
+export const COMPOSITION_CONTEXT_VERSION = '1.0.0' as const
+
+const dimensionsSchema = z
+  .object({
+    width: z.number().finite().positive(),
+    height: z.number().finite().positive().nullable(),
+    unit: z.enum(['css-px', 'device-px', 'mm', 'in']),
+  })
+  .strict()
+
+export const compositionContextSchema = z
+  .object({
+    version: z.literal(COMPOSITION_CONTEXT_VERSION),
+    presetId: z.enum(TARGET_PROFILE_IDS),
+    sourceProfileVersion: z.literal(TARGET_PROFILE_VERSION),
+    flow: z.enum(['continuous', 'paged']),
+    logicalDimensions: dimensionsSchema,
+    physicalDimensions: dimensionsSchema.nullable(),
+    margins: z
+      .object({
+        top: z.number().finite().nonnegative(),
+        right: z.number().finite().nonnegative(),
+        bottom: z.number().finite().nonnegative(),
+        left: z.number().finite().nonnegative(),
+        unit: z.enum(['css-px', 'device-px', 'mm']),
+      })
+      .strict(),
+    orientation: z.enum(['portrait', 'landscape']),
+    color: z.enum(['full-color', 'monochrome', 'unknown']),
+    resolution: z
+      .object({
+        pixelsPerInch: z.number().finite().positive().nullable(),
+        devicePixels: z
+          .object({
+            width: z.number().int().positive(),
+            height: z.number().int().positive(),
+          })
+          .strict()
+          .nullable(),
+      })
+      .strict(),
+    refresh: z.enum(['dynamic', 'page-refresh', 'static']),
+    interaction: z.enum(['scroll', 'page-turn', 'none']),
+    fontControl: z.enum([
+      'publisher-controlled',
+      'reader-controlled',
+      'advisory',
+    ]),
+    locale: z
+      .string()
+      .min(1)
+      .max(64)
+      .refine((value) => {
+        try {
+          return Intl.getCanonicalLocales(value)[0] === value
+        } catch {
+          return false
+        }
+      }, 'Locale must be a canonical BCP 47 tag'),
+    script: z.string().regex(/^[A-Z][a-z]{3}$/),
+    accessibility: z
+      .object({
+        prefersReducedMotion: z.boolean(),
+        prefersHighContrast: z.boolean(),
+        forcedColors: z.boolean(),
+        screenReaderOptimized: z.boolean(),
+      })
+      .strict(),
+    duplex: z.enum(['none', 'long-edge', 'short-edge', 'unspecified']),
+    binding: z.enum(['none', 'left', 'right', 'top', 'unspecified']),
+    bleed: z
+      .object({
+        top: z.number().finite().nonnegative(),
+        right: z.number().finite().nonnegative(),
+        bottom: z.number().finite().nonnegative(),
+        left: z.number().finite().nonnegative(),
+        unit: z.enum(['mm', 'in']),
+      })
+      .strict(),
+    offline: z
+      .object({
+        required: z.boolean(),
+        externalResourcesAllowed: z.boolean(),
+      })
+      .strict(),
+    readerControl: z
+      .object({
+        orientation: z.boolean(),
+        typography: z.boolean(),
+        pagination: z.boolean(),
+        margins: z.boolean(),
+      })
+      .strict(),
+    paginationAuthority: z.enum([
+      'authoritative',
+      'advisory',
+      'reader-controlled',
+    ]),
+  })
+  .strict()
+  .superRefine((context, refinement) => {
+    if (
+      (context.flow === 'continuous') !==
+      (context.logicalDimensions.height === null)
+    ) {
+      refinement.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['logicalDimensions', 'height'],
+        message: 'Continuous flow requires an unbounded logical height',
+      })
+    }
+    if (
+      context.orientation === 'portrait' &&
+      context.logicalDimensions.height !== null &&
+      context.logicalDimensions.width >= context.logicalDimensions.height
+    ) {
+      refinement.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['logicalDimensions'],
+        message: 'Portrait dimensions must be taller than wide',
+      })
+    }
+    if (
+      context.orientation === 'landscape' &&
+      context.logicalDimensions.height !== null &&
+      context.logicalDimensions.width <= context.logicalDimensions.height
+    ) {
+      refinement.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['logicalDimensions'],
+        message: 'Landscape dimensions must be wider than tall',
+      })
+    }
+  })
+
+export type CompositionContext = z.infer<typeof compositionContextSchema>
+
+const TARGET_COMPOSITION_CAPABILITIES = {
+  mobile: {
+    color: 'full-color',
+    duplex: 'none',
+    binding: 'none',
+  },
+  paperProMove: {
+    color: 'monochrome',
+    duplex: 'none',
+    binding: 'none',
+  },
+  paperPro: {
+    color: 'monochrome',
+    duplex: 'none',
+    binding: 'none',
+  },
+  print: {
+    color: 'monochrome',
+    duplex: 'long-edge',
+    binding: 'left',
+  },
+} as const satisfies Record<
+  TargetProfileId,
+  Pick<CompositionContext, 'color' | 'duplex' | 'binding'>
+>
+
+function physicalDimensions(
+  profile: TargetProfile,
+): CompositionContext['physicalDimensions'] {
+  if (profile.dimensions.height === null) return null
+  if (profile.dimensions.unit === 'mm') return { ...profile.dimensions }
+  if (profile.dimensions.unit === 'device-px' && profile.pixelsPerInch) {
+    return {
+      width: profile.dimensions.width / profile.pixelsPerInch,
+      height: profile.dimensions.height / profile.pixelsPerInch,
+      unit: 'in',
+    }
+  }
+  return null
+}
+
+export function targetProfileToCompositionContext(
+  profile: TargetProfile,
+  locale = 'en',
+  script = 'Latn',
+): CompositionContext {
+  const capabilities = TARGET_COMPOSITION_CAPABILITIES[profile.id]
+  const value: CompositionContext = {
+    version: COMPOSITION_CONTEXT_VERSION,
+    presetId: profile.id,
+    sourceProfileVersion: profile.version,
+    flow: profile.finiteHeight ? 'paged' : 'continuous',
+    logicalDimensions: { ...profile.dimensions },
+    physicalDimensions: physicalDimensions(profile),
+    margins: { ...profile.margins },
+    orientation: profile.orientation.selected,
+    color: capabilities.color,
+    resolution: {
+      pixelsPerInch: profile.pixelsPerInch,
+      devicePixels:
+        profile.dimensions.unit === 'device-px' && profile.dimensions.height
+          ? {
+              width: profile.dimensions.width,
+              height: profile.dimensions.height,
+            }
+          : null,
+    },
+    refresh:
+      profile.interactionMode === 'continuous-scroll'
+        ? 'dynamic'
+        : profile.interactionMode === 'page-turn'
+          ? 'page-refresh'
+          : 'static',
+    interaction:
+      profile.interactionMode === 'continuous-scroll'
+        ? 'scroll'
+        : profile.interactionMode === 'page-turn'
+          ? 'page-turn'
+          : 'none',
+    fontControl:
+      profile.truth.typography === 'reader-controlled'
+        ? 'reader-controlled'
+        : profile.truth.typography === 'authoritative'
+          ? 'publisher-controlled'
+          : 'advisory',
+    locale,
+    script,
+    accessibility: {
+      prefersReducedMotion: false,
+      prefersHighContrast: false,
+      forcedColors: false,
+      screenReaderOptimized: false,
+    },
+    duplex: capabilities.duplex,
+    binding: capabilities.binding,
+    bleed: { top: 0, right: 0, bottom: 0, left: 0, unit: 'mm' },
+    offline: { required: true, externalResourcesAllowed: false },
+    readerControl: {
+      orientation: profile.orientation.control === 'reader-controlled',
+      typography: profile.truth.typography === 'reader-controlled',
+      pagination: profile.truth.pagination === 'reader-controlled',
+      margins: profile.artifact.format === 'epub',
+    },
+    paginationAuthority: profile.truth.pagination,
+  }
+  return compositionContextSchema.parse(value)
+}
+
+export function compositionContextToTargetProfile(
+  context: CompositionContext,
+): TargetProfile {
+  const parsed = compositionContextSchema.parse(context)
+  const profile = resolveTargetProfile(parsed.presetId, parsed.orientation)
+  const expected = targetProfileToCompositionContext(
+    profile,
+    parsed.locale,
+    parsed.script,
+  )
+  if (JSON.stringify(expected) !== JSON.stringify(parsed)) {
+    throw new Error(
+      'Composition context does not match its authoritative target-profile preset',
+    )
+  }
+  return profile
+}
+
+export const COMPOSITION_CONTEXT_PRESETS = Object.fromEntries(
+  TARGET_PROFILE_IDS.map((id) => [
+    id,
+    targetProfileToCompositionContext(getTargetProfile(id)),
+  ]),
+) as Record<TargetProfileId, CompositionContext>
+
+export function getCompositionContextPreset(
+  id: TargetProfileId,
+  orientation: TargetOrientation = 'portrait',
+) {
+  return targetProfileToCompositionContext(
+    resolveTargetProfile(id, orientation),
+  )
+}

--- a/src/publication/research-paper-adapter.test.ts
+++ b/src/publication/research-paper-adapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import rawPaper from '../research/papers/semantic-responsive-typesetting.json'
+import rawLettersPaper from '../research/papers/if-letters-home-could-sing.json'
+import { researchPaperSchema } from '../research/schema'
+import {
+  publicationGraphToResearchPaper,
+  researchPaperToPublicationGraph,
+} from './research-paper-adapter'
+import { serializePublicationGraph } from './schema'
+
+describe('ResearchPaper compatibility adapter', () => {
+  it.each([rawPaper, rawLettersPaper])(
+    'round-trips golden paper $id without changing canonical meaning',
+    (raw) => {
+      const paper = researchPaperSchema.parse(raw)
+      const graph = researchPaperToPublicationGraph(paper)
+      expect(publicationGraphToResearchPaper(graph)).toEqual(paper)
+      expect(graph.nodes.map((node) => node.id)).toEqual(
+        paper.nodes.map((node) => node.id),
+      )
+      expect(serializePublicationGraph(graph)).toBe(
+        serializePublicationGraph(researchPaperToPublicationGraph(paper)),
+      )
+    },
+  )
+
+  it('keeps page geometry out and fails explicitly for unsupported extensions', () => {
+    const paper = researchPaperSchema.parse(rawPaper)
+    expect(
+      serializePublicationGraph(researchPaperToPublicationGraph(paper)),
+    ).not.toMatch(/"page"|"x"|"y"/)
+    expect(() =>
+      researchPaperToPublicationGraph({
+        ...paper,
+        affiliations: ['Example University'],
+      }),
+    ).toThrow(/does not support/)
+  })
+})

--- a/src/publication/research-paper-adapter.ts
+++ b/src/publication/research-paper-adapter.ts
@@ -1,0 +1,311 @@
+import {
+  researchPaperSchema,
+  type ResearchNode,
+  type ResearchPaper,
+} from '../research/schema'
+import { createAssetBundle, type AssetBundle } from './asset-bundle'
+import {
+  PUBLICATION_GRAPH_VERSION,
+  publicationGraphSchema,
+  type PublicationGraph,
+  type PublicationNode,
+} from './schema'
+import {
+  PUBLICATION_SOURCE_ADAPTER_VERSION,
+  validatePublicationSourceResult,
+  type PublicationSourceAdapter,
+  type PublicationSourceResult,
+} from './source-adapter'
+
+export const RESEARCH_PAPER_ADAPTER_ID = 'research-paper' as const
+
+const emptyAssetBundle = () =>
+  createAssetBundle({ version: '1.0.0', assets: [] }, async () => {
+    throw new Error('The research-paper adapter has no embedded asset bytes')
+  })
+
+function direction(
+  value: ResearchPaper['baseDirection'],
+): 'ltr' | 'rtl' | 'auto' {
+  return value === 'ltr' || value === 'rtl' ? value : 'auto'
+}
+
+function commonNode(
+  paper: ResearchPaper,
+  node: ResearchNode,
+): Omit<PublicationNode, 'type'> {
+  return {
+    id: node.id,
+    locale: paper.language ?? 'und',
+    direction: direction(paper.baseDirection),
+    requirement: 'required',
+    importance:
+      node.type === 'caption' || node.type === 'footnote'
+        ? 'supporting'
+        : 'essential',
+    provenance: {
+      adapterId: RESEARCH_PAPER_ADAPTER_ID,
+      sourceId: node.source,
+      evidence: [],
+    },
+    accessibility: { decorative: false },
+    variants: [],
+    permittedTransformationIds: [],
+    edition: { editionId: `${paper.id}:${paper.language ?? 'und'}` },
+  } as Omit<PublicationNode, 'type'>
+}
+
+function assertSupportedNode(node: ResearchNode) {
+  if ('noteReferences' in node && node.noteReferences?.length) {
+    throw new Error(
+      `Research node ${node.id} uses unsupported embedded note references`,
+    )
+  }
+  if (node.type === 'paragraph' && node.list) {
+    throw new Error(
+      `Research node ${node.id} uses unsupported legacy list context`,
+    )
+  }
+}
+
+export function researchPaperToPublicationGraph(
+  input: ResearchPaper,
+): PublicationGraph {
+  const paper = researchPaperSchema.parse(input)
+  if (
+    paper.authorNotes?.length ||
+    paper.authorAffiliations?.length ||
+    paper.affiliations?.length ||
+    paper.metadataLineage
+  ) {
+    throw new Error(
+      'The first research-paper adapter subset does not support scholarly metadata extensions',
+    )
+  }
+  const captionParents = new Map<string, string>()
+  for (const node of paper.nodes) {
+    if (node.type === 'figure')
+      captionParents.set(node.relationships.caption, node.id)
+  }
+
+  const nodes = paper.nodes.map((node): PublicationNode => {
+    assertSupportedNode(node)
+    const common = commonNode(paper, node)
+    switch (node.type) {
+      case 'heading':
+        return {
+          ...common,
+          type: 'heading',
+          level: node.level,
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+        }
+      case 'paragraph':
+        return {
+          ...common,
+          type: 'paragraph',
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+        }
+      case 'quote':
+        return {
+          ...common,
+          type: 'quote',
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+        }
+      case 'caption': {
+        const parentId = captionParents.get(node.id)
+        if (!parentId)
+          throw new Error(`Caption ${node.id} has no owning research figure`)
+        return {
+          ...common,
+          type: 'caption',
+          parentId,
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+        }
+      }
+      case 'footnote':
+        return {
+          ...common,
+          type: 'note',
+          noteKind: node.kind,
+          label: node.label,
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          backlinkIds: node.relationships.backlinks,
+        }
+      case 'figure':
+        if (
+          node.objectType === 'table' ||
+          node.objectType === 'equation' ||
+          node.table
+        ) {
+          throw new Error(
+            `Research node ${node.id} uses an unsupported structured figure subtype`,
+          )
+        }
+        return {
+          ...common,
+          type: 'figure',
+          title: node.title,
+          sourceText: node.sourceText,
+          inlineRuns: node.inlineRuns,
+          assetIds: node.relationships.assets ?? [],
+          captionId: node.relationships.caption,
+        }
+    }
+  })
+
+  return publicationGraphSchema.parse({
+    version: PUBLICATION_GRAPH_VERSION,
+    id: paper.id,
+    metadata: {
+      title: paper.title,
+      subtitle: paper.subtitle,
+      contributors: paper.authors,
+      abstract: paper.abstract,
+      status: paper.status,
+      sourceDocumentVersion: paper.version,
+      created: paper.publicationDate,
+      modified: paper.updated,
+      artifactModifiedAt: paper.artifactModifiedAt,
+      defaultLocale: paper.language ?? 'und',
+      defaultDirection: direction(paper.baseDirection),
+      keywords: [],
+    },
+    edition: {
+      id: `${paper.id}:${paper.language ?? 'und'}`,
+      locale: paper.language ?? 'und',
+      direction: direction(paper.baseDirection),
+    },
+    nodes,
+  })
+}
+
+export function publicationGraphToResearchPaper(
+  input: PublicationGraph,
+): ResearchPaper {
+  const graph = publicationGraphSchema.parse(input)
+  const nodes = graph.nodes.map((node): ResearchNode => {
+    const source = node.provenance.sourceId
+    switch (node.type) {
+      case 'heading':
+        return {
+          id: node.id,
+          type: 'heading',
+          level: node.level as 1 | 2 | 3,
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          source,
+        }
+      case 'paragraph':
+        return {
+          id: node.id,
+          type: 'paragraph',
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          source,
+        }
+      case 'quote':
+        return {
+          id: node.id,
+          type: 'quote',
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          source,
+        }
+      case 'caption':
+        return {
+          id: node.id,
+          type: 'caption',
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          source,
+        }
+      case 'note':
+        if (node.noteKind === 'author-note')
+          throw new Error('ResearchPaper does not support author-note nodes')
+        return {
+          id: node.id,
+          type: 'footnote',
+          kind: node.noteKind,
+          label: node.label,
+          text: node.text,
+          inlineRuns: node.inlineRuns,
+          relationships: { backlinks: node.backlinkIds },
+          source,
+        }
+      case 'figure':
+        return {
+          id: node.id,
+          type: 'figure',
+          title: node.title,
+          sourceText: node.sourceText,
+          inlineRuns: node.inlineRuns,
+          relationships: {
+            caption:
+              node.captionId ??
+              (() => {
+                throw new Error(`Figure ${node.id} lacks a caption`)
+              })(),
+            ...(node.assetIds.length ? { assets: node.assetIds } : {}),
+          },
+          source,
+        }
+      default:
+        throw new Error(
+          `Publication node ${node.id} (${node.type}) is outside the ResearchPaper subset`,
+        )
+    }
+  })
+
+  return researchPaperSchema.parse({
+    id: graph.id,
+    version: graph.metadata.sourceDocumentVersion,
+    status: graph.metadata.status,
+    title: graph.metadata.title,
+    subtitle: graph.metadata.subtitle,
+    authors: graph.metadata.contributors,
+    language:
+      graph.metadata.defaultLocale === 'und'
+        ? undefined
+        : graph.metadata.defaultLocale,
+    baseDirection:
+      graph.metadata.defaultDirection === 'auto'
+        ? 'unknown'
+        : graph.metadata.defaultDirection,
+    publicationDate: graph.metadata.created,
+    artifactModifiedAt: graph.metadata.artifactModifiedAt,
+    updated: graph.metadata.modified,
+    abstract: graph.metadata.abstract,
+    nodes,
+  })
+}
+
+export function adaptResearchPaper(
+  input: ResearchPaper,
+  assetBundle: AssetBundle = emptyAssetBundle(),
+): PublicationSourceResult {
+  const paper = researchPaperSchema.parse(input)
+  return validatePublicationSourceResult({
+    graph: researchPaperToPublicationGraph(paper),
+    assetBundle,
+    diagnostics: [],
+    provenance: {
+      adapterId: RESEARCH_PAPER_ADAPTER_ID,
+      adapterVersion: PUBLICATION_SOURCE_ADAPTER_VERSION,
+      sourceType: 'research-paper',
+      sourceId: paper.id,
+      sourceRevision: paper.version,
+    },
+  })
+}
+
+export const researchPaperSourceAdapter: PublicationSourceAdapter<ResearchPaper> =
+  {
+    id: RESEARCH_PAPER_ADAPTER_ID,
+    version: PUBLICATION_SOURCE_ADAPTER_VERSION,
+    adapt: adaptResearchPaper,
+  }

--- a/src/publication/schema.test.ts
+++ b/src/publication/schema.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest'
+import { publicationGraphSchema, serializePublicationGraph } from './schema'
+
+const common = {
+  locale: 'en',
+  direction: 'ltr',
+  requirement: 'required',
+  importance: 'essential',
+  provenance: { adapterId: 'test', sourceId: 'fixture', evidence: [] },
+  accessibility: { decorative: false },
+  variants: [],
+  permittedTransformationIds: [],
+  edition: { editionId: 'edition-en' },
+}
+
+export function graphFixture() {
+  return {
+    version: '1.0.0',
+    id: 'publication',
+    metadata: {
+      title: 'Publication',
+      contributors: ['Author'],
+      defaultLocale: 'en',
+      defaultDirection: 'ltr',
+      keywords: [],
+    },
+    edition: { id: 'edition-en', locale: 'en', direction: 'ltr' },
+    nodes: [
+      { ...common, id: 'heading', type: 'heading', level: 1, text: 'Heading' },
+      { ...common, id: 'paragraph', type: 'paragraph', text: 'Paragraph' },
+      {
+        ...common,
+        id: 'list',
+        type: 'list',
+        ordered: false,
+        itemIds: ['item'],
+      },
+      {
+        ...common,
+        id: 'item',
+        type: 'list-item',
+        parentListId: 'list',
+        text: 'Item',
+      },
+      { ...common, id: 'quote', type: 'quote', text: 'Quote' },
+      {
+        ...common,
+        id: 'code',
+        type: 'code',
+        code: 'const value = 1',
+        language: 'ts',
+      },
+      {
+        ...common,
+        id: 'figure',
+        type: 'figure',
+        title: 'Figure',
+        assetIds: [],
+        captionId: 'figure-caption',
+      },
+      {
+        ...common,
+        id: 'figure-caption',
+        type: 'caption',
+        parentId: 'figure',
+        text: 'Figure caption',
+      },
+      {
+        ...common,
+        id: 'table',
+        type: 'table',
+        captionId: 'table-caption',
+        rows: [
+          {
+            cells: [
+              { text: 'Cell', headerScope: null, columnSpan: 1, rowSpan: 1 },
+            ],
+          },
+        ],
+      },
+      {
+        ...common,
+        id: 'table-caption',
+        type: 'caption',
+        parentId: 'table',
+        text: 'Table caption',
+      },
+      {
+        ...common,
+        id: 'equation',
+        type: 'equation',
+        source: 'x = 1',
+        format: 'latex',
+        captionId: 'equation-caption',
+      },
+      {
+        ...common,
+        id: 'equation-caption',
+        type: 'caption',
+        parentId: 'equation',
+        text: 'Equation caption',
+      },
+      { ...common, id: 'aside', type: 'aside', text: 'Aside' },
+      {
+        ...common,
+        id: 'note',
+        type: 'note',
+        noteKind: 'footnote',
+        label: '1',
+        backlinkIds: ['paragraph'],
+        text: 'Note',
+      },
+      {
+        ...common,
+        id: 'reference',
+        type: 'reference',
+        targetIds: ['paragraph'],
+        href: 'https://example.com',
+        text: 'Reference',
+      },
+      {
+        ...common,
+        id: 'media',
+        type: 'media',
+        mediaKind: 'audio',
+        assetId: 'audio-sha',
+        captionId: 'media-caption',
+      },
+      {
+        ...common,
+        id: 'media-caption',
+        type: 'caption',
+        parentId: 'media',
+        text: 'Transcript',
+      },
+    ],
+  }
+}
+
+describe('PublicationGraph', () => {
+  it('strictly represents the bounded universal node set deterministically', () => {
+    const graph = publicationGraphSchema.parse(graphFixture())
+    expect(graph.nodes.map((node) => node.type)).toEqual([
+      'heading',
+      'paragraph',
+      'list',
+      'list-item',
+      'quote',
+      'code',
+      'figure',
+      'caption',
+      'table',
+      'caption',
+      'equation',
+      'caption',
+      'aside',
+      'note',
+      'reference',
+      'media',
+      'caption',
+    ])
+    expect(serializePublicationGraph(graph)).toBe(
+      serializePublicationGraph(graph),
+    )
+  })
+
+  it.each([
+    [
+      'unknown version',
+      (value: any) => {
+        value.version = '2.0.0'
+      },
+    ],
+    [
+      'extra field',
+      (value: any) => {
+        value.nodes[0].page = 1
+      },
+    ],
+    [
+      'duplicate id',
+      (value: any) => {
+        value.nodes[1].id = value.nodes[0].id
+      },
+    ],
+    [
+      'dangling relationship',
+      (value: any) => {
+        value.nodes[2].itemIds = ['missing']
+      },
+    ],
+    [
+      'unsafe URL',
+      (value: any) => {
+        value.nodes[14].href = 'file:///etc/passwd'
+      },
+    ],
+    [
+      'local source path',
+      (value: any) => {
+        value.nodes[0].provenance.sourceId = '/tmp/source.docx'
+      },
+    ],
+    [
+      'encoded local source path',
+      (value: any) => {
+        value.nodes[0].provenance.sourceId = '%2Ftmp%2Fsource.docx'
+      },
+    ],
+    [
+      'credential-bearing source URL',
+      (value: any) => {
+        value.nodes[0].provenance.sourceId =
+          'https://user:password@example.com/source'
+      },
+    ],
+    [
+      'secret-bearing source evidence',
+      (value: any) => {
+        value.nodes[0].provenance.evidence = ['api_key=do-not-store']
+      },
+    ],
+    [
+      'invalid range',
+      (value: any) => {
+        value.nodes[1].inlineRuns = [{ start: 0, end: 100 }]
+      },
+    ],
+    [
+      'duplicate table cell id',
+      (value: any) => {
+        value.nodes[8].rows[0].cells = [
+          {
+            id: 'cell',
+            text: 'One',
+            headerScope: 'column',
+            columnSpan: 1,
+            rowSpan: 1,
+          },
+          {
+            id: 'cell',
+            text: 'Two',
+            headerScope: null,
+            columnSpan: 1,
+            rowSpan: 1,
+          },
+        ]
+      },
+    ],
+    [
+      'dangling table header relationship',
+      (value: any) => {
+        value.nodes[8].rows[0].cells[0].headerIds = ['missing-header']
+      },
+    ],
+  ])('rejects %s', (_label, mutate) => {
+    const value = graphFixture()
+    mutate(value)
+    expect(publicationGraphSchema.safeParse(value).success).toBe(false)
+  })
+})

--- a/src/publication/schema.ts
+++ b/src/publication/schema.ts
@@ -1,0 +1,522 @@
+import { z } from 'zod'
+
+export const PUBLICATION_GRAPH_VERSION = '1.0.0' as const
+export const MAX_PUBLICATION_NODES = 10_000
+export const MAX_TEXT_LENGTH = 1_000_000
+
+const idSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/)
+const textSchema = z.string().max(MAX_TEXT_LENGTH)
+const nonEmptyTextSchema = textSchema.min(1)
+function safeSourceValue(value: string) {
+  let decoded = value
+  try {
+    decoded = decodeURIComponent(value)
+  } catch {
+    return false
+  }
+  if (
+    /^(?:file:|[A-Za-z]:[\\/]|\/|\\\\)/i.test(decoded) ||
+    /(?:token|secret|password|credential|api[_-]?key)\s*[=:]/i.test(decoded)
+  ) {
+    return false
+  }
+  try {
+    const url = new URL(decoded)
+    return !url.username && !url.password && url.protocol !== 'file:'
+  } catch {
+    return true
+  }
+}
+const safeSourceValueSchema = nonEmptyTextSchema
+  .max(2_048)
+  .refine(
+    safeSourceValue,
+    'Source values cannot contain local paths or secret material',
+  )
+const localeSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .refine((value) => {
+    try {
+      return Intl.getCanonicalLocales(value)[0] === value
+    } catch {
+      return false
+    }
+  }, 'Locale must be a canonical BCP 47 language tag')
+const safeUrlSchema = z
+  .string()
+  .min(1)
+  .max(2_048)
+  .superRefine((value, context) => {
+    if (/^#[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(value)) return
+    try {
+      const url = new URL(value)
+      if (!['https:', 'http:', 'mailto:'].includes(url.protocol))
+        throw new Error()
+      if (url.username || url.password) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'URL credentials are forbidden',
+        })
+      }
+    } catch {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Only safe internal fragments and absolute http, https, or mailto URLs are permitted',
+      })
+    }
+  })
+
+export const publicationInlineRunSchema = z
+  .object({
+    start: z.number().int().nonnegative(),
+    end: z.number().int().positive(),
+    bold: z.boolean().optional(),
+    italic: z.boolean().optional(),
+    href: safeUrlSchema.optional(),
+    annotationId: idSchema.optional(),
+    verticalAlign: z.enum(['superscript', 'subscript']).optional(),
+    compactMathAtom: z.boolean().optional(),
+    relationshipId: idSchema.optional(),
+    semanticRole: z
+      .enum([
+        'citation',
+        'cross-reference',
+        'affiliation-marker',
+        'bibliography-entry',
+      ])
+      .optional(),
+    targetIds: z.array(idSchema).max(256).optional(),
+  })
+  .strict()
+
+const provenanceSchema = z
+  .object({
+    adapterId: idSchema,
+    sourceId: safeSourceValueSchema,
+    sourceRevision: safeSourceValueSchema.pipe(z.string().max(256)).optional(),
+    evidence: z.array(safeSourceValueSchema).max(256).default([]),
+  })
+  .strict()
+
+const accessibilitySchema = z
+  .object({
+    alternativeText: textSchema.optional(),
+    longDescription: textSchema.optional(),
+    transcript: textSchema.optional(),
+    decorative: z.boolean().default(false),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.decorative && (value.alternativeText || value.longDescription)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Decorative content cannot also declare textual alternatives',
+      })
+    }
+  })
+
+const variantSchema = z
+  .object({
+    kind: z.enum(['compact', 'monochrome', 'static']),
+    assetId: idSchema.optional(),
+    text: textSchema.optional(),
+    reviewed: z.boolean(),
+  })
+  .strict()
+  .refine((value) => value.assetId !== undefined || value.text !== undefined, {
+    message: 'An authored variant must contain text or an asset reference',
+  })
+
+const nodeBase = z.object({
+  id: idSchema,
+  locale: localeSchema,
+  direction: z.enum(['ltr', 'rtl', 'auto']),
+  requirement: z.enum(['required', 'optional']),
+  importance: z.enum(['essential', 'supporting', 'supplemental']),
+  provenance: provenanceSchema,
+  accessibility: accessibilitySchema,
+  variants: z.array(variantSchema).max(3).default([]),
+  permittedTransformationIds: z.array(idSchema).max(256),
+  edition: z
+    .object({
+      editionId: idSchema,
+      equivalentNodeId: idSchema.optional(),
+      sourceLocaleKey: nonEmptyTextSchema.max(256).optional(),
+    })
+    .strict(),
+})
+
+const textContent = {
+  text: nonEmptyTextSchema,
+  inlineRuns: z.array(publicationInlineRunSchema).max(100_000).optional(),
+}
+
+const relationshipArray = z.array(idSchema).max(10_000)
+const headingNode = nodeBase
+  .extend({
+    type: z.literal('heading'),
+    level: z.number().int().min(1).max(6),
+    ...textContent,
+  })
+  .strict()
+const paragraphNode = nodeBase
+  .extend({ type: z.literal('paragraph'), ...textContent })
+  .strict()
+const listNode = nodeBase
+  .extend({
+    type: z.literal('list'),
+    ordered: z.boolean(),
+    start: z.number().int().positive().optional(),
+    itemIds: relationshipArray.min(1),
+  })
+  .strict()
+const listItemNode = nodeBase
+  .extend({
+    type: z.literal('list-item'),
+    parentListId: idSchema,
+    ...textContent,
+  })
+  .strict()
+const quoteNode = nodeBase
+  .extend({
+    type: z.literal('quote'),
+    attribution: textSchema.optional(),
+    ...textContent,
+  })
+  .strict()
+const codeNode = nodeBase
+  .extend({
+    type: z.literal('code'),
+    code: nonEmptyTextSchema,
+    language: z.string().max(128).optional(),
+  })
+  .strict()
+const figureNode = nodeBase
+  .extend({
+    type: z.literal('figure'),
+    title: nonEmptyTextSchema,
+    assetIds: relationshipArray,
+    captionId: idSchema.optional(),
+    sourceText: textSchema.optional(),
+    inlineRuns: z.array(publicationInlineRunSchema).max(100_000).optional(),
+  })
+  .strict()
+const captionNode = nodeBase
+  .extend({ type: z.literal('caption'), parentId: idSchema, ...textContent })
+  .strict()
+const tableNode = nodeBase
+  .extend({
+    type: z.literal('table'),
+    captionId: idSchema.optional(),
+    rows: z
+      .array(
+        z
+          .object({
+            cells: z
+              .array(
+                z
+                  .object({
+                    id: idSchema.optional(),
+                    text: textSchema,
+                    headerScope: z.enum(['column', 'row']).nullable(),
+                    columnSpan: z.number().int().min(1).max(1_000),
+                    rowSpan: z.number().int().min(1).max(1_000),
+                    headerIds: z.array(idSchema).max(1_000).optional(),
+                  })
+                  .strict(),
+              )
+              .min(1)
+              .max(1_000),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(10_000),
+  })
+  .strict()
+const equationNode = nodeBase
+  .extend({
+    type: z.literal('equation'),
+    source: nonEmptyTextSchema,
+    format: z.enum(['mathml', 'latex', 'plain-text']),
+    label: textSchema.optional(),
+    captionId: idSchema.optional(),
+  })
+  .strict()
+const asideNode = nodeBase
+  .extend({ type: z.literal('aside'), ...textContent })
+  .strict()
+const noteNode = nodeBase
+  .extend({
+    type: z.literal('note'),
+    noteKind: z.enum(['footnote', 'endnote', 'author-note']),
+    label: nonEmptyTextSchema,
+    backlinkIds: relationshipArray,
+    ...textContent,
+  })
+  .strict()
+const referenceNode = nodeBase
+  .extend({
+    type: z.literal('reference'),
+    targetIds: relationshipArray,
+    href: safeUrlSchema.optional(),
+    ...textContent,
+  })
+  .strict()
+const mediaNode = nodeBase
+  .extend({
+    type: z.literal('media'),
+    mediaKind: z.enum(['image', 'audio', 'video', 'interactive']),
+    assetId: idSchema,
+    captionId: idSchema.optional(),
+  })
+  .strict()
+
+export const publicationNodeSchema = z.discriminatedUnion('type', [
+  headingNode,
+  paragraphNode,
+  listNode,
+  listItemNode,
+  quoteNode,
+  codeNode,
+  figureNode,
+  captionNode,
+  tableNode,
+  equationNode,
+  asideNode,
+  noteNode,
+  referenceNode,
+  mediaNode,
+])
+
+const metadataSchema = z
+  .object({
+    title: nonEmptyTextSchema,
+    subtitle: textSchema.optional(),
+    contributors: z.array(nonEmptyTextSchema.max(1_024)).max(1_000),
+    abstract: textSchema.optional(),
+    status: z.enum(['working', 'review', 'published']).optional(),
+    sourceDocumentVersion: nonEmptyTextSchema.max(256).optional(),
+    created: z.string().date().optional(),
+    modified: z.string().date().optional(),
+    artifactModifiedAt: z.string().datetime({ offset: true }).optional(),
+    defaultLocale: localeSchema,
+    defaultDirection: z.enum(['ltr', 'rtl', 'auto']),
+    keywords: z.array(nonEmptyTextSchema.max(256)).max(1_000).default([]),
+  })
+  .strict()
+
+function relationshipTargets(node: z.infer<typeof publicationNodeSchema>) {
+  switch (node.type) {
+    case 'list':
+      return node.itemIds
+    case 'list-item':
+      return [node.parentListId]
+    case 'figure':
+      return node.captionId ? [node.captionId] : []
+    case 'caption':
+      return [node.parentId]
+    case 'table':
+    case 'equation':
+    case 'media':
+      return node.captionId ? [node.captionId] : []
+    case 'note':
+      return node.backlinkIds
+    case 'reference':
+      return node.targetIds
+    default:
+      return []
+  }
+}
+
+export const publicationGraphSchema = z
+  .object({
+    version: z.literal(PUBLICATION_GRAPH_VERSION),
+    id: idSchema,
+    metadata: metadataSchema,
+    edition: z
+      .object({
+        id: idSchema,
+        locale: localeSchema,
+        direction: z.enum(['ltr', 'rtl', 'auto']),
+      })
+      .strict(),
+    nodes: z.array(publicationNodeSchema).min(1).max(MAX_PUBLICATION_NODES),
+  })
+  .strict()
+  .superRefine((graph, context) => {
+    const ids = new Set<string>()
+    const nodesById = new Map<string, z.infer<typeof publicationNodeSchema>>()
+    graph.nodes.forEach((node, index) => {
+      if (ids.has(node.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', index, 'id'],
+          message: `Duplicate node id: ${node.id}`,
+        })
+      }
+      ids.add(node.id)
+      nodesById.set(node.id, node)
+      if (node.edition.editionId !== graph.edition.id) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', index, 'edition', 'editionId'],
+          message: 'Node edition must link to the graph edition',
+        })
+      }
+      if ('inlineRuns' in node && node.inlineRuns) {
+        const content = 'text' in node ? node.text : (node.sourceText ?? '')
+        node.inlineRuns.forEach((run, runIndex) => {
+          if (run.start >= run.end || run.end > content.length) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['nodes', index, 'inlineRuns', runIndex],
+              message: 'Inline range lies outside node text',
+            })
+          }
+          run.targetIds?.forEach((target, targetIndex) => {
+            if (!graph.nodes.some((candidate) => candidate.id === target)) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [
+                  'nodes',
+                  index,
+                  'inlineRuns',
+                  runIndex,
+                  'targetIds',
+                  targetIndex,
+                ],
+                message: `Dangling inline target: ${target}`,
+              })
+            }
+          })
+        })
+      }
+      if (node.type === 'table') {
+        const cellIds = new Set<string>()
+        node.rows.forEach((row, rowIndex) => {
+          row.cells.forEach((cell, cellIndex) => {
+            if (cell.id && cellIds.has(cell.id)) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [
+                  'nodes',
+                  index,
+                  'rows',
+                  rowIndex,
+                  'cells',
+                  cellIndex,
+                  'id',
+                ],
+                message: `Duplicate table cell id: ${cell.id}`,
+              })
+            }
+            if (cell.id) cellIds.add(cell.id)
+          })
+        })
+        node.rows.forEach((row, rowIndex) => {
+          row.cells.forEach((cell, cellIndex) => {
+            cell.headerIds?.forEach((headerId, headerIndex) => {
+              if (!cellIds.has(headerId)) {
+                context.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  path: [
+                    'nodes',
+                    index,
+                    'rows',
+                    rowIndex,
+                    'cells',
+                    cellIndex,
+                    'headerIds',
+                    headerIndex,
+                  ],
+                  message: `Dangling table header relationship: ${headerId}`,
+                })
+              }
+            })
+          })
+        })
+      }
+    })
+    graph.nodes.forEach((node, index) => {
+      relationshipTargets(node).forEach((target, relationshipIndex) => {
+        if (!ids.has(target)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['nodes', index, 'relationships', relationshipIndex],
+            message: `Dangling relationship: ${target}`,
+          })
+        }
+      })
+      if (node.type === 'list') {
+        node.itemIds.forEach((id, relationshipIndex) => {
+          const item = nodesById.get(id)
+          if (
+            item &&
+            (item.type !== 'list-item' || item.parentListId !== node.id)
+          ) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['nodes', index, 'itemIds', relationshipIndex],
+              message: 'List items must link reciprocally to their owning list',
+            })
+          }
+        })
+      }
+      if (
+        node.type === 'list-item' &&
+        nodesById.get(node.parentListId)?.type !== 'list'
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', index, 'parentListId'],
+          message: 'List-item parent must be a list',
+        })
+      }
+      if (node.type === 'caption') {
+        const parent = nodesById.get(node.parentId)
+        if (
+          parent &&
+          !['figure', 'table', 'equation', 'media'].includes(parent.type)
+        ) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['nodes', index, 'parentId'],
+            message:
+              'Caption parent must be a figure, table, equation, or media node',
+          })
+        }
+      }
+      if ('captionId' in node && node.captionId) {
+        const caption = nodesById.get(node.captionId)
+        if (
+          caption &&
+          (caption.type !== 'caption' || caption.parentId !== node.id)
+        ) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['nodes', index, 'captionId'],
+            message: 'Caption relationships must be reciprocal',
+          })
+        }
+      }
+    })
+  })
+
+export type PublicationGraph = z.infer<typeof publicationGraphSchema>
+export type PublicationNode = z.infer<typeof publicationNodeSchema>
+
+export function parsePublicationGraph(value: unknown): PublicationGraph {
+  return publicationGraphSchema.parse(value)
+}
+
+export function serializePublicationGraph(value: PublicationGraph) {
+  return JSON.stringify(publicationGraphSchema.parse(value))
+}

--- a/src/publication/source-adapter.test.ts
+++ b/src/publication/source-adapter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import rawPaper from '../research/papers/semantic-responsive-typesetting.json'
+import { researchPaperSchema } from '../research/schema'
+import { createAssetBundle } from './asset-bundle'
+import {
+  adaptResearchPaper,
+  researchPaperToPublicationGraph,
+} from './research-paper-adapter'
+import {
+  adapterProvenanceSchema,
+  createPublicationContractReceipt,
+  validatePublicationSourceResult,
+} from './source-adapter'
+
+describe('PublicationSourceAdapter', () => {
+  it('returns the versioned graph, asset, diagnostics and provenance boundary', () => {
+    const result = adaptResearchPaper(researchPaperSchema.parse(rawPaper))
+    const validated = validatePublicationSourceResult(result)
+    expect({
+      ...validated,
+      assetBundle: { descriptor: validated.assetBundle.descriptor },
+    }).toEqual({
+      ...result,
+      assetBundle: { descriptor: result.assetBundle.descriptor },
+    })
+    expect(validated.assetBundle.resolveBytes).toBeTypeOf('function')
+    expect(result).toMatchObject({
+      graph: { version: '1.0.0' },
+      assetBundle: { descriptor: { version: '1.0.0' } },
+      diagnostics: [],
+      provenance: { adapterVersion: '1.0.0', sourceType: 'research-paper' },
+    })
+  })
+
+  it.each([
+    '/tmp/manuscript.docx',
+    'file:///tmp/input.pdf',
+    'source?token=abc',
+    '%2Ftmp%2Finput.pdf',
+    'https://user:password@example.com/source',
+  ])('rejects unsafe source id %s', (sourceId) => {
+    expect(
+      adapterProvenanceSchema.safeParse({
+        adapterId: 'docx',
+        adapterVersion: '1.0.0',
+        sourceType: 'docx',
+        sourceId,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects malformed bundles and dangling graph asset references', () => {
+    const paper = researchPaperSchema.parse(rawPaper)
+    const graph = researchPaperToPublicationGraph(paper)
+    graph.nodes[0].variants.push({
+      kind: 'compact',
+      assetId: 'missing',
+      reviewed: true,
+    })
+    expect(() =>
+      validatePublicationSourceResult({
+        graph,
+        assetBundle: createAssetBundle(
+          { version: '1.0.0', assets: [] },
+          async () => new Uint8Array(),
+        ),
+        diagnostics: [],
+        provenance: {
+          adapterId: 'test',
+          adapterVersion: '1.0.0',
+          sourceType: 'research-paper',
+          sourceId: 'fixture',
+        },
+      }),
+    ).toThrow(/missing asset/)
+  })
+
+  it('creates deterministic exact-head contract receipts', () => {
+    const result = adaptResearchPaper(researchPaperSchema.parse(rawPaper))
+    const environment = {
+      toolchain: {
+        node: 'v24.0.0',
+        packageLockSha256: 'a'.repeat(64),
+      },
+      repository: { commit: 'b'.repeat(40), dirty: false as const },
+    }
+    const receipt = createPublicationContractReceipt(result, environment)
+    expect(createPublicationContractReceipt(result, environment)).toEqual(
+      receipt,
+    )
+    expect(receipt).toMatchObject({
+      contracts: {
+        publicationGraph: '1.0.0',
+        assetBundle: '1.0.0',
+        compositionContext: '1.0.0',
+        transformationPolicy: '1.0.0',
+        sourceAdapter: '1.0.0',
+        targetProfile: '1.1.0',
+      },
+      repository: environment.repository,
+    })
+    expect(() =>
+      createPublicationContractReceipt(result, {
+        ...environment,
+        repository: { ...environment.repository, dirty: true },
+      } as any),
+    ).toThrow()
+  })
+})

--- a/src/publication/source-adapter.ts
+++ b/src/publication/source-adapter.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto'
+import { z } from 'zod'
+import {
+  ASSET_BUNDLE_VERSION,
+  assetBundleDescriptorSchema,
+  createAssetBundle,
+  serializeAssetBundle,
+  type AssetBundle,
+} from './asset-bundle'
+import { COMPOSITION_CONTEXT_VERSION } from './profiles'
+import {
+  PUBLICATION_GRAPH_VERSION,
+  publicationGraphSchema,
+  serializePublicationGraph,
+  type PublicationGraph,
+} from './schema'
+import { TRANSFORMATION_POLICY_VERSION } from './transformation-policy'
+import { TARGET_PROFILE_VERSION } from '../research/targets'
+
+export const PUBLICATION_SOURCE_ADAPTER_VERSION = '1.0.0' as const
+export const PUBLICATION_CONTRACT_RECEIPT_VERSION = '1.0.0' as const
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/)
+
+export const publicationContractReceiptSchema = z
+  .object({
+    version: z.literal(PUBLICATION_CONTRACT_RECEIPT_VERSION),
+    graphSha256: sha256Schema,
+    assetBundleSha256: sha256Schema,
+    contracts: z
+      .object({
+        publicationGraph: z.literal(PUBLICATION_GRAPH_VERSION),
+        assetBundle: z.literal(ASSET_BUNDLE_VERSION),
+        compositionContext: z.literal(COMPOSITION_CONTEXT_VERSION),
+        transformationPolicy: z.literal(TRANSFORMATION_POLICY_VERSION),
+        sourceAdapter: z.literal(PUBLICATION_SOURCE_ADAPTER_VERSION),
+        targetProfile: z.literal(TARGET_PROFILE_VERSION),
+      })
+      .strict(),
+    toolchain: z
+      .object({
+        node: z.string().min(1).max(256),
+        packageLockSha256: sha256Schema,
+      })
+      .strict(),
+    repository: z
+      .object({
+        commit: z.string().regex(/^[a-f0-9]{40}$/),
+        dirty: z.literal(false),
+      })
+      .strict(),
+  })
+  .strict()
+
+export type PublicationContractReceipt = z.infer<
+  typeof publicationContractReceiptSchema
+>
+
+function safeSourceId(value: string) {
+  let decoded = value
+  try {
+    decoded = decodeURIComponent(value)
+  } catch {
+    return false
+  }
+  if (
+    /^(?:file:|[A-Za-z]:[\\/]|\/|\\\\)/i.test(decoded) ||
+    /(?:token|secret|password|credential|api[_-]?key)\s*[=:]/i.test(decoded)
+  ) {
+    return false
+  }
+  try {
+    const url = new URL(decoded)
+    return !url.username && !url.password && url.protocol !== 'file:'
+  } catch {
+    return true
+  }
+}
+
+const safeSourceIdSchema = z
+  .string()
+  .min(1)
+  .max(2_048)
+  .refine(
+    safeSourceId,
+    'Source ids cannot contain local paths or secret material',
+  )
+
+export const adapterDiagnosticSchema = z
+  .object({
+    severity: z.enum(['info', 'warning', 'error']),
+    code: z
+      .string()
+      .min(1)
+      .max(128)
+      .regex(/^[a-z0-9-]+$/),
+    message: z.string().min(1).max(100_000),
+    sourceId: safeSourceIdSchema.optional(),
+    nodeId: z.string().min(1).max(256).optional(),
+  })
+  .strict()
+
+export const adapterProvenanceSchema = z
+  .object({
+    adapterId: z
+      .string()
+      .min(1)
+      .max(256)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/),
+    adapterVersion: z.literal(PUBLICATION_SOURCE_ADAPTER_VERSION),
+    sourceType: z.enum(['astro', 'payload', 'docx', 'pdf', 'research-paper']),
+    sourceId: safeSourceIdSchema,
+    sourceRevision: safeSourceIdSchema.pipe(z.string().max(256)).optional(),
+  })
+  .strict()
+
+export type AdapterDiagnostic = z.infer<typeof adapterDiagnosticSchema>
+export type AdapterProvenance = z.infer<typeof adapterProvenanceSchema>
+
+export type PublicationSourceResult = {
+  graph: PublicationGraph
+  assetBundle: AssetBundle
+  diagnostics: AdapterDiagnostic[]
+  provenance: AdapterProvenance
+}
+
+export interface PublicationSourceAdapter<Input = unknown> {
+  readonly id: string
+  readonly version: typeof PUBLICATION_SOURCE_ADAPTER_VERSION
+  adapt(
+    input: Input,
+  ): Promise<PublicationSourceResult> | PublicationSourceResult
+}
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+export function createPublicationContractReceipt(
+  value: PublicationSourceResult,
+  environment: Pick<PublicationContractReceipt, 'toolchain' | 'repository'>,
+): PublicationContractReceipt {
+  const result = validatePublicationSourceResult(value)
+  return publicationContractReceiptSchema.parse({
+    version: PUBLICATION_CONTRACT_RECEIPT_VERSION,
+    graphSha256: sha256(serializePublicationGraph(result.graph)),
+    assetBundleSha256: sha256(serializeAssetBundle(result.assetBundle)),
+    contracts: {
+      publicationGraph: PUBLICATION_GRAPH_VERSION,
+      assetBundle: ASSET_BUNDLE_VERSION,
+      compositionContext: COMPOSITION_CONTEXT_VERSION,
+      transformationPolicy: TRANSFORMATION_POLICY_VERSION,
+      sourceAdapter: PUBLICATION_SOURCE_ADAPTER_VERSION,
+      targetProfile: TARGET_PROFILE_VERSION,
+    },
+    toolchain: environment.toolchain,
+    repository: environment.repository,
+  })
+}
+
+export function validatePublicationSourceResult(
+  value: PublicationSourceResult,
+): PublicationSourceResult {
+  const graph = publicationGraphSchema.parse(value.graph)
+  const descriptor = assetBundleDescriptorSchema.parse(
+    value.assetBundle.descriptor,
+  )
+  if (typeof value.assetBundle.resolveBytes !== 'function') {
+    throw new TypeError(
+      'Publication source results require an asset byte resolver',
+    )
+  }
+  const assetIds = new Set(descriptor.assets.map((asset) => asset.id))
+  graph.nodes.forEach((node) => {
+    const referenced =
+      node.type === 'figure'
+        ? node.assetIds
+        : node.type === 'media'
+          ? [node.assetId]
+          : node.variants.flatMap((variant) =>
+              variant.assetId ? [variant.assetId] : [],
+            )
+    referenced.forEach((assetId) => {
+      if (!assetIds.has(assetId)) {
+        throw new Error(
+          `Publication node ${node.id} references missing asset ${assetId}`,
+        )
+      }
+    })
+  })
+  return {
+    graph,
+    assetBundle: createAssetBundle(descriptor, value.assetBundle.resolveBytes),
+    diagnostics: z
+      .array(adapterDiagnosticSchema)
+      .max(10_000)
+      .parse(value.diagnostics),
+    provenance: adapterProvenanceSchema.parse(value.provenance),
+  }
+}

--- a/src/publication/transformation-policy.test.ts
+++ b/src/publication/transformation-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { transformationPolicySchema } from './transformation-policy'
+
+const base = {
+  version: '1.0.0',
+  id: 'accessible-reflow',
+  transformations: [
+    {
+      id: 'reflow-text',
+      from: 'text',
+      to: 'text',
+      operation: 'reflow',
+      preservationClass: 'identity',
+      requiredAuthoredAlternative: 'none',
+    },
+  ],
+  constraints: [
+    {
+      id: 'preserve-reading-order',
+      strength: 'hard',
+      subject: 'reading-order',
+      operator: 'preserve',
+      value: true,
+      rationale: 'Reading order carries meaning.',
+    },
+  ],
+}
+
+describe('TransformationPolicy', () => {
+  it('declares legal representation changes and hard/soft constraints', () => {
+    expect(transformationPolicySchema.parse(base)).toEqual(base)
+  })
+
+  it.each([
+    'omit',
+    'summarize',
+    'reorder-reading-order',
+    'crop-meaning-changing',
+  ])('rejects unreviewed %s', (operation) => {
+    const value: any = structuredClone(base)
+    value.transformations[0].operation = operation
+    expect(transformationPolicySchema.safeParse(value).success).toBe(false)
+    value.transformations[0] = {
+      ...value.transformations[0],
+      preservationClass: 'reviewed-meaning-change',
+      requiredAuthoredAlternative: 'compact',
+      reviewedVariantId: 'reviewed-compact',
+    }
+    expect(transformationPolicySchema.safeParse(value).success).toBe(true)
+  })
+})

--- a/src/publication/transformation-policy.ts
+++ b/src/publication/transformation-policy.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod'
+
+export const TRANSFORMATION_POLICY_VERSION = '1.0.0' as const
+
+const idSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/)
+const representationChangeSchema = z
+  .object({
+    id: idSchema,
+    from: z.enum([
+      'text',
+      'list',
+      'figure',
+      'table',
+      'equation',
+      'media',
+      'interactive',
+    ]),
+    to: z.enum([
+      'text',
+      'list',
+      'figure',
+      'table',
+      'equation',
+      'media',
+      'interactive',
+    ]),
+    operation: z.enum([
+      'reformat',
+      'reflow',
+      'scale',
+      'color-convert',
+      'substitute-authored-variant',
+      'omit',
+      'summarize',
+      'reorder-reading-order',
+      'crop-meaning-changing',
+    ]),
+    preservationClass: z.enum([
+      'identity',
+      'semantic-equivalence',
+      'reviewed-meaning-change',
+    ]),
+    requiredAuthoredAlternative: z.enum([
+      'none',
+      'compact',
+      'monochrome',
+      'static',
+    ]),
+    reviewedVariantId: idSchema.optional(),
+  })
+  .strict()
+  .superRefine((change, context) => {
+    const meaningChanging = [
+      'omit',
+      'summarize',
+      'reorder-reading-order',
+      'crop-meaning-changing',
+    ].includes(change.operation)
+    if (
+      meaningChanging &&
+      (change.preservationClass !== 'reviewed-meaning-change' ||
+        !change.reviewedVariantId ||
+        change.requiredAuthoredAlternative === 'none')
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Meaning-changing operations require an explicit reviewed authored variant',
+      })
+    }
+    if (
+      change.operation === 'substitute-authored-variant' &&
+      (change.requiredAuthoredAlternative === 'none' ||
+        !change.reviewedVariantId)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Authored substitutions must identify the required reviewed variant',
+      })
+    }
+  })
+
+const constraintSchema = z
+  .object({
+    id: idSchema,
+    strength: z.enum(['hard', 'soft']),
+    subject: z.enum([
+      'content',
+      'reading-order',
+      'accessibility',
+      'dimensions',
+      'color',
+      'resolution',
+      'offline',
+    ]),
+    operator: z.enum(['preserve', 'require', 'forbid', 'prefer', 'limit']),
+    value: z.union([z.string().max(10_000), z.number().finite(), z.boolean()]),
+    rationale: z.string().min(1).max(100_000),
+  })
+  .strict()
+
+export const transformationPolicySchema = z
+  .object({
+    version: z.literal(TRANSFORMATION_POLICY_VERSION),
+    id: idSchema,
+    transformations: z.array(representationChangeSchema).max(1_000),
+    constraints: z.array(constraintSchema).max(1_000),
+  })
+  .strict()
+  .superRefine((policy, context) => {
+    for (const [key, values] of [
+      ['transformations', policy.transformations],
+      ['constraints', policy.constraints],
+    ] as const) {
+      const seen = new Set<string>()
+      values.forEach((value, index) => {
+        if (seen.has(value.id)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [key, index, 'id'],
+            message: `Duplicate policy id: ${value.id}`,
+          })
+        }
+        seen.add(value.id)
+      })
+    }
+  })
+
+export type TransformationPolicy = z.infer<typeof transformationPolicySchema>
+
+export function parseTransformationPolicy(
+  value: unknown,
+): TransformationPolicy {
+  return transformationPolicySchema.parse(value)
+}
+
+export function serializeTransformationPolicy(value: TransformationPolicy) {
+  return JSON.stringify(transformationPolicySchema.parse(value))
+}


### PR DESCRIPTION
Closes #59.

Introduces the versioned, source-neutral publication compiler boundary:

- strict `PublicationGraph`, source-adapter, asset-bundle, composition-context, transformation-policy, and annotation contracts;
- lossless adapters for both existing golden `ResearchPaper` fixtures and the authoritative target-profile registry;
- content-addressed byte verification, cross-boundary asset checks, safe source provenance, relationship/range validation, and deterministic exact-head contract receipts;
- ADR 009 documenting versioning, migration, unsupported features, source/asset separation, and non-goals.

The recovered VM implementation was reviewed and tightened before publication. In particular, the final patch closes gaps around dangling table headers/assets, stale annotation anchors, unverified resolver bytes, encoded local paths/credential-bearing source IDs, data-driven target capabilities, the second golden paper, and receipt identity.

Validation at exact head `d2211f976b6b7b3f65bf50d5522c3963cab2e51a`:

- focused publication suite: 38/38 passed;
- full unit suite: 1,711 passed, 1 skipped;
- production build/type check: passed;
- canonical `scripts/agent-evidence --all`: build, test, and e2e passed; clean manifest with no caveats.
