### PR TITLE
Promote verified mixed-text rectangular tables semantically

### DIFF
--- a/src/research/pdf-table-detection.test.ts
+++ b/src/research/pdf-table-detection.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   detectExplicitHeaderNumericTableWithinProvenScope,
   detectHierarchicalTableWithinProvenScope,
+  detectRectangularTableWithinProvenScope,
   detectTableNearCaption,
   detectTableWithinProvenScope,
   detectWrappedHeaderTableWithinProvenScope,
@@ -772,6 +773,81 @@ describe('bounded table region detection', () => {
       columnSpan: 1,
       rowSpan: 1,
     })
+  })
+
+  it('promotes a proved rectangular table with mixed source text', () => {
+    const lines = [
+      line('header', 0.2, [0.1, 0.35, 0.62]),
+      line('body-1', 0.23, [0.1, 0.35, 0.62]),
+      line('body-2', 0.26, [0.1, 0.35, 0.62]),
+      line('body-3', 0.29, [0.1, 0.35, 0.62]),
+    ]
+    ;['Model', 'Environment', 'Result'].forEach((text, index) => {
+      lines[0].runs[index] = {
+        ...lines[0].runs[index],
+        text,
+        fontName: 'TableSerif-Medium',
+      }
+    })
+    ;[
+      ['BookWorld', 'Castle', 'Characters interact'],
+      ['Baseline', 'Village', 'No interaction'],
+      ['Ablation', 'Harbor', 'Interaction delayed'],
+    ].forEach((texts, rowIndex) => {
+      texts.forEach((text, columnIndex) => {
+        lines[rowIndex + 1].runs[columnIndex] = {
+          ...lines[rowIndex + 1].runs[columnIndex],
+          text,
+          width: columnIndex === 2 ? 0.12 : 0.08,
+        }
+      })
+    })
+    for (const sourceLine of lines) {
+      sourceLine.text = sourceLine.runs.map((run) => run.text).join(' ')
+    }
+    const table = region('mixed-text-table', 'body', 0.2, lines, 'span')
+
+    const detected = detectRectangularTableWithinProvenScope([table], {
+      direction: 'above',
+      sourceRegionIds: [table.id],
+      sourceLineIds: lines.map((sourceLine) => sourceLine.id),
+      evidence: [
+        { code: 'repeated-row-bands' },
+        { code: 'repeated-column-anchors' },
+      ],
+    })
+
+    expect(detected).toMatchObject({
+      columnCount: 3,
+      headerRowCount: 1,
+      evidence: expect.arrayContaining([
+        'complete-bounded-table-scope',
+        'repeated-rectangular-column-geometry',
+        'source-typography-header',
+      ]),
+    })
+    expect(detected?.lines[1].cells[2].run.text).toBe('Characters interact')
+  })
+
+  it('keeps a rectangular text slab as fallback without header proof', () => {
+    const lines = [
+      line('row-1', 0.2, [0.1, 0.35, 0.62]),
+      line('row-2', 0.23, [0.1, 0.35, 0.62]),
+      line('row-3', 0.26, [0.1, 0.35, 0.62]),
+    ]
+    const table = region('unproved-header-table', 'body', 0.2, lines, 'span')
+
+    expect(
+      detectRectangularTableWithinProvenScope([table], {
+        direction: 'above',
+        sourceRegionIds: [table.id],
+        sourceLineIds: lines.map((sourceLine) => sourceLine.id),
+        evidence: [
+          { code: 'repeated-row-bands' },
+          { code: 'repeated-column-anchors' },
+        ],
+      }),
+    ).toBeNull()
   })
 
   it.each([

--- a/src/research/pdf-table-detection.ts
+++ b/src/research/pdf-table-detection.ts
@@ -798,6 +798,13 @@ function tableHeaderCell(text: string) {
   return /\p{L}/u.test(text) && !numericTableBodyCell(text)
 }
 
+function sourceRunHasHeaderFace(run: PdfSourceRun) {
+  return (
+    run.bold === true ||
+    /(?:bold|semi[- ]?bold|demi|medi(?:um)?|black)/iu.test(run.fontName)
+  )
+}
+
 function scopeProvenNumericMatrixBodyCell(text: string) {
   return /^(?:[<>≤≥~≈])?[+\-−]?(?:\d+(?:[.,]\d+)?|\.\d+)(?:(?:[eE][+\-−]?\d+)|(?:[x×]10[+\-−]?\d+))?(?:%|[x×])?$/u.test(
     text.replace(/\s+/gu, ''),
@@ -979,6 +986,146 @@ export function detectExplicitHeaderNumericTableWithinProvenScope(
       'semantic-header-explicit-matrix-geometry',
       'repeated-uniform-numeric-body-rows',
       'variable-width-stub-left-anchor',
+    ],
+  }
+}
+
+// Promote an ordinary rectangular table only after the scope resolver has
+// accounted for every non-empty source line, repeated geometry proves the
+// columns, and either source lineage or typography proves the header. Cell
+// text always comes from the source runs; an unproved grid stays a raster.
+export function detectRectangularTableWithinProvenScope(
+  regions: PdfPageRegion[],
+  scope: {
+    direction: 'above' | 'below'
+    sourceRegionIds: readonly string[]
+    sourceLineIds: readonly string[]
+    evidence: readonly {
+      code: string
+      headerLineIds?: readonly string[]
+    }[]
+  },
+): PdfDetectedTableGrid | null {
+  const hasRowProof = scope.evidence.some(
+    (item) => item.code === 'repeated-row-bands',
+  )
+  const hasColumnProof = scope.evidence.some(
+    (item) =>
+      item.code === 'repeated-column-anchors' ||
+      item.code === 'multi-run-tabular-line-band' ||
+      item.code === 'contiguous-tabular-slab',
+  )
+  if (!hasRowProof || !hasColumnProof) return null
+
+  const sourceRegions = exactScopedSourceRegions(regions, scope)
+  if (!sourceRegions) return null
+  const rows = clusterRows(
+    sourceRegions.flatMap((region) =>
+      region.lines
+        .filter((line) => scope.sourceLineIds.includes(line.id))
+        .map((line) => ({ region, line })),
+    ),
+  )
+  // Require three body rows so a caption-adjacent two-fragment header plus a
+  // pair of prose records cannot become a table merely by sharing anchors.
+  if (rows.length < 4) return null
+
+  const gapThreshold = adaptiveCellGapThreshold(rows)
+  const cellsByRow = rows.map((row) => rowCells(row, gapThreshold))
+  const columnCount = cellsByRow[0]?.length ?? 0
+  if (
+    columnCount < 2 ||
+    columnCount > 12 ||
+    cellsByRow.some(
+      (cells) =>
+        cells.length !== columnCount ||
+        cells.some((cell) => cell.text.trim().length === 0) ||
+        cells.some(
+          (cell, index) =>
+            index < cells.length - 1 &&
+            cell.x + cell.width > cells[index + 1].x + 0.001,
+        ),
+    )
+  ) {
+    return null
+  }
+
+  const sourceHeaderLineIds = new Set(
+    scope.evidence.flatMap((item) => item.headerLineIds ?? []),
+  )
+  const headerByLineage =
+    sourceHeaderLineIds.size > 0 &&
+    rows[0].sourceLineIds.every((lineId) => sourceHeaderLineIds.has(lineId)) &&
+    rows
+      .slice(1)
+      .every((row) =>
+        row.sourceLineIds.every((lineId) => !sourceHeaderLineIds.has(lineId)),
+      )
+  const headerByRegion = rows[0].sourceRegionKinds.every(
+    (kind) => kind === 'header',
+  )
+  const headerByTypography =
+    cellsByRow[0].every(sourceRunHasHeaderFace) &&
+    cellsByRow
+      .slice(1)
+      .some((cells) => cells.some((cell) => !sourceRunHasHeaderFace(cell)))
+  if (!headerByLineage && !headerByRegion && !headerByTypography) return null
+
+  const leftAnchors = Array.from({ length: columnCount }, (_, columnIndex) =>
+    median(cellsByRow.map((cells) => cells[columnIndex].x)),
+  )
+  const centerAnchors = Array.from({ length: columnCount }, (_, columnIndex) =>
+    median(
+      cellsByRow.map((cells) => {
+        const cell = cells[columnIndex]
+        return cell.x + cell.width / 2
+      }),
+    ),
+  )
+  const alignedColumns = Array.from({ length: columnCount }, (_, index) => {
+    const leftDeviation = Math.max(
+      ...cellsByRow.map((cells) =>
+        Math.abs(cells[index].x - leftAnchors[index]),
+      ),
+    )
+    const centerDeviation = Math.max(
+      ...cellsByRow.map((cells) =>
+        Math.abs(
+          cells[index].x + cells[index].width / 2 - centerAnchors[index],
+        ),
+      ),
+    )
+    return Math.min(leftDeviation, centerDeviation) <= COLUMN_ANCHOR_TOLERANCE
+  })
+  if (alignedColumns.some((aligned) => !aligned)) return null
+
+  return {
+    sourceRegions: [...sourceRegions].sort(
+      (left, right) =>
+        left.box.y - right.box.y ||
+        left.box.x - right.box.x ||
+        left.id.localeCompare(right.id),
+    ),
+    sourceLineIds: [...scope.sourceLineIds],
+    lines: rows.map((row, rowIndex) => {
+      const cells = cellsByRow[rowIndex].map((run, columnIndex) => ({
+        run,
+        columnIndex,
+        columnSpan: 1,
+        rowSpan: 1,
+      }))
+      return { ...row, runs: cells.map((cell) => cell.run), cells }
+    }),
+    columnCount,
+    headerRowCount: 1,
+    evidence: [
+      'complete-bounded-table-scope',
+      'repeated-rectangular-column-geometry',
+      headerByLineage
+        ? 'source-lineage-header'
+        : headerByRegion
+          ? 'source-region-header'
+          : 'source-typography-header',
     ],
   }
 }

--- a/src/research/pdf-visuals.ts
+++ b/src/research/pdf-visuals.ts
@@ -28,6 +28,7 @@ import { pdfFontTextRequiresStructuralReconstruction } from './pdf-font-text'
 import {
   detectExplicitHeaderNumericTableWithinProvenScope,
   detectHierarchicalTableWithinProvenScope,
+  detectRectangularTableWithinProvenScope,
   detectTableNearCaption,
   detectTableWithinProvenScope,
   detectWrappedHeaderTableWithinProvenScope,
@@ -9523,6 +9524,10 @@ export async function reconstructPdfVisuals({
               boundedScope.scope,
             ) ??
             detectExplicitHeaderNumericTableWithinProvenScope(
+              availableTableRegions,
+              boundedScope.scope,
+            ) ??
+            detectRectangularTableWithinProvenScope(
               availableTableRegions,
               boundedScope.scope,
             )


### PR DESCRIPTION
## Outcome

Adds a general, deterministic semantic-table promoter for ordinary rectangular tables whose source scope is already proven.

Promotion now requires all of the following:

- every non-empty source line belongs to the exact bounded scope
- repeated row and column geometry
- 2–12 complete, non-overlapping columns
- one independently proved header from source lineage, source region role, or emphasized source font face
- at least three complete body rows

Cell text is copied only from source runs. The promoter creates no cells, spans, headers, or text. If any proof fails, the existing bounded image fallback remains the result.

## Regression coverage

- mixed textual cells promote without numeric-only assumptions
- font-face evidence such as `Medium` proves a header even when the PDF library omits the `bold` flag
- a rectangular text slab without header proof remains a fallback
- a two-fragment caption-adjacent header with only two records remains unresolved and fully source-accounted

## Validation

- focused table/visual suite: 5 files, 355 tests passed
- targeted prior regression: 2 passed
- full suite: 117 files, 2447 passed, 1 skipped
- secret scan: passed

## Measured external paper result

The owner-local BookWorld rerun remains **0/8 semantic tables**. That is expected and recorded rather than hidden: its surviving tables require section-row and wrapped-cell reconstruction, not a flat rectangular grid. This PR advances #83 but does not close it or claim to solve figures, hyperlinks, prose joins, or complex tables.
