### PR TITLE
Promote source-backed wrapped table cells

### DIFF
--- a/src/research/pdf-table-detection.test.ts
+++ b/src/research/pdf-table-detection.test.ts
@@ -11,6 +11,7 @@ import {
   detectRectangularTableWithinProvenScope,
   detectTableNearCaption,
   detectTableWithinProvenScope,
+  detectWrappedCellTableWithinProvenScope,
   detectWrappedHeaderTableWithinProvenScope,
 } from './pdf-table-detection'
 
@@ -1016,6 +1017,142 @@ describe('bounded table region detection', () => {
     expect(detected?.lines[1].cells.map((cell) => cell.columnIndex)).toEqual([
       1, 2, 3, 4,
     ])
+  })
+
+  it('folds source-backed body continuations into their owning table row', () => {
+    const header = line('wrapped-body-header', 0.2, [0.1, 0.3, 0.5, 0.7])
+    ;['Reference', 'Environment', 'NPC', 'Outcome'].forEach((text, index) => {
+      header.runs[index].text = text
+      header.runs[index].fontName = 'Table-Bold'
+      header.runs[index].bold = true
+    })
+    header.text = header.runs.map((run) => run.text).join(' ')
+
+    const bodyLine = (
+      id: string,
+      y: number,
+      values: string[],
+      xs = [0.1, 0.3, 0.5, 0.7],
+    ) => {
+      const sourceLine = line(id, y, xs)
+      sourceLine.runs.forEach((run, index) => {
+        run.text = values[index]
+      })
+      sourceLine.text = sourceLine.runs.map((run) => run.text).join(' ')
+      return sourceLine
+    }
+    const body1 = bodyLine('wrapped-body-1', 0.24, [
+      'A',
+      'The environment begins',
+      'the NPC waits',
+      'The action resolves',
+    ])
+    const body1Continuation = bodyLine(
+      'wrapped-body-1-continuation',
+      0.26,
+      ['and the light changes', 'before the door opens'],
+      [0.3, 0.5],
+    )
+    const body2 = bodyLine('wrapped-body-2', 0.3, [
+      'B',
+      'A second environment',
+      'a second NPC',
+      'A second outcome',
+    ])
+    const body3 = bodyLine('wrapped-body-3', 0.36, [
+      'C',
+      'A third environment',
+      'a third NPC',
+      'A third outcome',
+    ])
+    const body4 = bodyLine('wrapped-body-4', 0.42, [
+      'D',
+      'A fourth environment',
+      'a fourth NPC',
+      'A fourth outcome',
+    ])
+    const table = region(
+      'wrapped-body-table',
+      'body',
+      0.2,
+      [header, body1, body1Continuation, body2, body3, body4],
+      'span',
+    )
+
+    const detected = detectWrappedCellTableWithinProvenScope([table], {
+      direction: 'below',
+      sourceRegionIds: [table.id],
+      sourceLineIds: table.lines.map((sourceLine) => sourceLine.id),
+      evidence: [
+        { code: 'repeated-row-bands' },
+        { code: 'repeated-column-anchors' },
+      ],
+    })
+
+    expect(detected).toMatchObject({
+      columnCount: 4,
+      headerRowCount: 1,
+      evidence: expect.arrayContaining(['semantic-body-continuation-geometry']),
+    })
+    expect(detected?.lines).toHaveLength(5)
+    expect(detected?.lines[1].sourceLineIds).toEqual([
+      body1.id,
+      body1Continuation.id,
+    ])
+    expect(detected?.lines[1].cells.map((cell) => cell.run.text)).toEqual([
+      'A',
+      'The environment begins and the light changes',
+      'the NPC waits before the door opens',
+      'The action resolves',
+    ])
+  })
+
+  it('rejects a sparse wide section row instead of attaching it to a body cell', () => {
+    const header = line('section-header', 0.2, [0.1, 0.3, 0.5, 0.7])
+    ;['Reference', 'Environment', 'NPC', 'Outcome'].forEach((text, index) => {
+      header.runs[index].text = text
+      header.runs[index].fontName = 'Table-Bold'
+      header.runs[index].bold = true
+    })
+    header.text = header.runs.map((run) => run.text).join(' ')
+    const complete = (id: string, y: number) => {
+      const sourceLine = line(id, y, [0.1, 0.3, 0.5, 0.7])
+      sourceLine.runs.forEach((run, index) => {
+        run.text = `${id}-${index}`
+      })
+      sourceLine.text = sourceLine.runs.map((run) => run.text).join(' ')
+      return sourceLine
+    }
+    const section = line('section-row', 0.27, [0.1])
+    section.runs[0].text = 'Environment and NPC responses'
+    section.runs[0].width = 0.7
+    section.text = section.runs[0].text
+    const table = region(
+      'section-row-table',
+      'body',
+      0.2,
+      [
+        header,
+        complete('section-body-1', 0.24),
+        section,
+        complete('section-body-2', 0.32),
+        complete('section-body-3', 0.38),
+        complete('section-body-4', 0.44),
+      ],
+      'span',
+    )
+
+    expect(
+      detectWrappedCellTableWithinProvenScope([table], {
+        direction: 'below',
+        sourceRegionIds: [table.id],
+        sourceLineIds: table.lines.map((sourceLine) => sourceLine.id),
+        evidence: [
+          { code: 'repeated-row-bands' },
+          { code: 'repeated-column-anchors' },
+        ],
+      }),
+    ).toBeNull()
   })
 
   it('does not split one merged PDF run into invented hierarchical header cells', () => {

--- a/src/research/pdf-table-detection.ts
+++ b/src/research/pdf-table-detection.ts
@@ -33,6 +33,10 @@ type ClusteredTableRow = PdfRegionLine & {
   sourceCellBoxes?: NormalizedSourceBox[]
 }
 
+type DetectedTableCellRun = PdfSourceRun & {
+  sourceLineIds?: string[]
+}
+
 export type PdfDetectedTableGrid = {
   sourceRegions: PdfPageRegion[]
   sourceLineIds: string[]
@@ -366,6 +370,7 @@ function adaptiveCellGapThreshold(lines: PdfRegionLine[]) {
 function rowCells(
   line: PdfRegionLine,
   gapThreshold = FIXED_CELL_GAP_THRESHOLD,
+  sourceRunLineIds?: ReadonlyMap<PdfSourceRun, string>,
 ) {
   const runs = orderedRuns(line)
   const groups: (typeof runs)[] = []
@@ -382,7 +387,22 @@ function rowCells(
       group.push(run)
     }
   }
-  return groups.map(mergedTableCellRuns)
+  return groups.map((group) => {
+    const cell = mergedTableCellRuns(group)
+    const sourceLineIds = sourceRunLineIds
+      ? [
+          ...new Set(
+            group.flatMap((run) => {
+              const sourceLineId = sourceRunLineIds.get(run)
+              return sourceLineId ? [sourceLineId] : []
+            }),
+          ),
+        ].sort()
+      : []
+    return sourceLineIds.length > 0
+      ? ({ ...cell, sourceLineIds } satisfies DetectedTableCellRun)
+      : cell
+  })
 }
 
 function mergedTableCellRuns(group: PdfSourceRun[]) {
@@ -1121,6 +1141,310 @@ export function detectRectangularTableWithinProvenScope(
     evidence: [
       'complete-bounded-table-scope',
       'repeated-rectangular-column-geometry',
+      headerByLineage
+        ? 'source-lineage-header'
+        : headerByRegion
+          ? 'source-region-header'
+          : 'source-typography-header',
+    ],
+  }
+}
+
+function mergeWrappedBodyCellRuns(
+  current: DetectedTableCellRun,
+  continuation: DetectedTableCellRun,
+) {
+  const right = Math.max(
+    current.x + current.width,
+    continuation.x + continuation.width,
+  )
+  const bottom = Math.max(
+    current.y + current.height,
+    continuation.y + continuation.height,
+  )
+  const sourceLineIds = [
+    ...new Set([
+      ...(current.sourceLineIds ?? []),
+      ...(continuation.sourceLineIds ?? []),
+    ]),
+  ].sort()
+  return {
+    ...current,
+    width: right - current.x,
+    height: bottom - current.y,
+    text: `${current.text} ${continuation.text}`,
+    ...(sourceLineIds.length > 0 ? { sourceLineIds } : {}),
+  } satisfies DetectedTableCellRun
+}
+
+function mergeWrappedBodyTableRow(
+  row: ClusteredTableRow,
+  cells: DetectedTableCellRun[],
+  continuation: ClusteredTableRow,
+) {
+  const left = Math.min(row.box.x, continuation.box.x)
+  const top = Math.min(row.box.y, continuation.box.y)
+  const right = Math.max(
+    row.box.x + row.box.width,
+    continuation.box.x + continuation.box.width,
+  )
+  const bottom = Math.max(
+    row.box.y + row.box.height,
+    continuation.box.y + continuation.box.height,
+  )
+  return {
+    ...row,
+    text: cells.map((cell) => cell.text).join(' '),
+    box: {
+      ...row.box,
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+    },
+    runs: cells,
+    sourceLineIds: [
+      ...new Set([...row.sourceLineIds, ...continuation.sourceLineIds]),
+    ].sort(),
+    sourceRegionIds: [
+      ...new Set([...row.sourceRegionIds, ...continuation.sourceRegionIds]),
+    ].sort(),
+    sourceRegionKinds: [
+      ...new Set([...row.sourceRegionKinds, ...continuation.sourceRegionKinds]),
+    ].sort(),
+  }
+}
+
+// Promote a table whose body cells wrap onto source lines below their row. The
+// scope must already account for every non-empty source line; this detector
+// only folds a sparse continuation line into the immediately preceding body
+// row when its cells map uniquely to stable column anchors. Wide/ambiguous
+// rows remain source-preserved fallbacks rather than invented table cells.
+export function detectWrappedCellTableWithinProvenScope(
+  regions: PdfPageRegion[],
+  scope: {
+    direction: 'above' | 'below'
+    sourceRegionIds: readonly string[]
+    sourceLineIds: readonly string[]
+    evidence: readonly {
+      code: string
+      headerLineIds?: readonly string[]
+    }[]
+  },
+): PdfDetectedTableGrid | null {
+  const hasRowProof = scope.evidence.some(
+    (item) =>
+      item.code === 'repeated-row-bands' ||
+      item.code === 'contiguous-tabular-slab' ||
+      item.code === 'contiguous-single-anchor-slab',
+  )
+  const hasColumnProof = scope.evidence.some(
+    (item) =>
+      item.code === 'repeated-column-anchors' ||
+      item.code === 'multi-run-tabular-line-band' ||
+      item.code === 'contiguous-tabular-slab',
+  )
+  if (!hasRowProof || !hasColumnProof) return null
+
+  const sourceRegions = exactScopedSourceRegions(regions, scope)
+  if (!sourceRegions) return null
+  const sourceRunLineIds = new Map<PdfSourceRun, string>()
+  for (const sourceRegion of sourceRegions) {
+    for (const sourceLine of sourceRegion.lines) {
+      for (const run of sourceLine.runs)
+        sourceRunLineIds.set(run, sourceLine.id)
+    }
+  }
+  const rows = clusterRows(
+    sourceRegions.flatMap((region) =>
+      region.lines
+        .filter((line) => scope.sourceLineIds.includes(line.id))
+        .map((line) => ({ region, line })),
+    ),
+  )
+  const gapThreshold = adaptiveCellGapThreshold(rows)
+  const cellsByRow = rows.map((row) =>
+    rowCells(row, gapThreshold, sourceRunLineIds),
+  )
+  const frequency = new Map<number, number>()
+  for (const cells of cellsByRow) {
+    if (cells.length >= 2 && cells.length <= 12) {
+      frequency.set(cells.length, (frequency.get(cells.length) ?? 0) + 1)
+    }
+  }
+  const columnCount = [...frequency.entries()].sort(
+    (left, right) => right[1] - left[1] || right[0] - left[0],
+  )[0]?.[0]
+  if (
+    !columnCount ||
+    rows.length === 0 ||
+    cellsByRow[0].length !== columnCount
+  ) {
+    return null
+  }
+
+  const completeBodyRowIndexes = cellsByRow.flatMap((cells, index) =>
+    index > 0 && cells.length === columnCount ? [index] : [],
+  )
+  if (completeBodyRowIndexes.length < 3) return null
+
+  const bodyRows = completeBodyRowIndexes.map((index) => cellsByRow[index])
+  const leftAnchors = Array.from({ length: columnCount }, (_, columnIndex) =>
+    median(bodyRows.map((cells) => cells[columnIndex].x)),
+  )
+  const centerAnchors = Array.from({ length: columnCount }, (_, columnIndex) =>
+    median(
+      bodyRows.map((cells) => {
+        const cell = cells[columnIndex]
+        return cell.x + cell.width / 2
+      }),
+    ),
+  )
+  const columnWidths = Array.from({ length: columnCount }, (_, columnIndex) =>
+    median(bodyRows.map((cells) => cells[columnIndex].width)),
+  )
+  const alignedColumn = (cell: PdfSourceRun, columnIndex: number) =>
+    Math.min(
+      Math.abs(cell.x - leftAnchors[columnIndex]),
+      Math.abs(cell.x + cell.width / 2 - centerAnchors[columnIndex]),
+    ) <= COLUMN_ANCHOR_TOLERANCE
+  if (
+    bodyRows.some((cells) =>
+      cells.some((cell, columnIndex) => !alignedColumn(cell, columnIndex)),
+    )
+  ) {
+    return null
+  }
+
+  const sourceHeaderLineIds = new Set(
+    scope.evidence.flatMap((item) => item.headerLineIds ?? []),
+  )
+  const headerByLineage =
+    sourceHeaderLineIds.size > 0 &&
+    rows[0].sourceLineIds.every((lineId) => sourceHeaderLineIds.has(lineId)) &&
+    rows
+      .slice(1)
+      .every((row) =>
+        row.sourceLineIds.every((lineId) => !sourceHeaderLineIds.has(lineId)),
+      )
+  const headerByRegion = rows[0].sourceRegionKinds.every(
+    (kind) => kind === 'header',
+  )
+  const headerByTypography = cellsByRow[0].every(sourceRunHasHeaderFace)
+  if (!headerByLineage && !headerByRegion && !headerByTypography) return null
+  if (bodyRows.every((cells) => cells.every(sourceRunHasHeaderFace))) {
+    return null
+  }
+
+  const columnIndexForCell = (cell: PdfSourceRun) => {
+    const candidates = Array.from(
+      { length: columnCount },
+      (_, columnIndex) => ({
+        columnIndex,
+        distance: Math.min(
+          Math.abs(cell.x - leftAnchors[columnIndex]),
+          Math.abs(cell.x + cell.width / 2 - centerAnchors[columnIndex]),
+        ),
+      }),
+    ).sort(
+      (left, right) =>
+        left.distance - right.distance || left.columnIndex - right.columnIndex,
+    )
+    const closest = candidates[0]
+    return closest && closest.distance <= COLUMN_ANCHOR_TOLERANCE
+      ? closest.columnIndex
+      : null
+  }
+
+  const logicalRows: Array<{
+    row: ClusteredTableRow
+    cells: DetectedTableCellRun[]
+  }> = [
+    {
+      row: rows[0],
+      cells: cellsByRow[0],
+    },
+  ]
+  for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex]
+    const cells = cellsByRow[rowIndex]
+    if (cells.length === columnCount) {
+      logicalRows.push({ row, cells })
+      continue
+    }
+    if (
+      cells.length === 0 ||
+      cells.length >= columnCount ||
+      logicalRows.length < 2 ||
+      row.sourceRegionKinds.every((kind) => kind === 'header') ||
+      cells.every(sourceRunHasHeaderFace)
+    ) {
+      return null
+    }
+    const previous = logicalRows.at(-1)!
+    const previousBottom = previous.row.box.y + previous.row.box.height
+    const continuationGap = row.box.y - previousBottom
+    if (
+      continuationGap < -0.003 ||
+      continuationGap > Math.max(0.035, previous.row.box.height * 3)
+    ) {
+      return null
+    }
+    const mappedColumns = cells.map(columnIndexForCell)
+    if (
+      mappedColumns.some((column) => column === null) ||
+      new Set(mappedColumns).size !== mappedColumns.length
+    ) {
+      return null
+    }
+    const mergedCells = [...previous.cells]
+    for (const [cellIndex, column] of mappedColumns.entries()) {
+      const columnIndex = column!
+      if (
+        cells[cellIndex].width > Math.max(0.12, columnWidths[columnIndex] * 1.8)
+      ) {
+        return null
+      }
+      mergedCells[columnIndex] = mergeWrappedBodyCellRuns(
+        mergedCells[columnIndex],
+        cells[cellIndex],
+      )
+    }
+    previous.cells = mergedCells
+    previous.row = mergeWrappedBodyTableRow(previous.row, mergedCells, row)
+  }
+
+  if (logicalRows.length < 4) return null
+  const gridLines: PdfDetectedTableGrid['lines'] = logicalRows.map(
+    ({ row, cells: rowCellsByColumn }) => {
+      const cells = rowCellsByColumn.map((run, columnIndex) => ({
+        run,
+        columnIndex,
+        columnSpan: 1,
+        rowSpan: 1,
+      }))
+      return {
+        ...row,
+        runs: cells.map((cell) => cell.run),
+        cells,
+      }
+    },
+  )
+  return {
+    sourceRegions: [...sourceRegions].sort(
+      (left, right) =>
+        left.box.y - right.box.y ||
+        left.box.x - right.box.x ||
+        left.id.localeCompare(right.id),
+    ),
+    sourceLineIds: [...scope.sourceLineIds],
+    lines: gridLines,
+    columnCount,
+    headerRowCount: 1,
+    evidence: [
+      'complete-bounded-table-scope',
+      'repeated-rectangular-column-geometry',
+      'semantic-body-continuation-geometry',
       headerByLineage
         ? 'source-lineage-header'
         : headerByRegion

--- a/src/research/pdf-visuals.ts
+++ b/src/research/pdf-visuals.ts
@@ -31,6 +31,7 @@ import {
   detectRectangularTableWithinProvenScope,
   detectTableNearCaption,
   detectTableWithinProvenScope,
+  detectWrappedCellTableWithinProvenScope,
   detectWrappedHeaderTableWithinProvenScope,
   type PdfDetectedTableGrid,
 } from './pdf-table-detection'
@@ -9524,6 +9525,10 @@ export async function reconstructPdfVisuals({
               boundedScope.scope,
             ) ??
             detectExplicitHeaderNumericTableWithinProvenScope(
+              availableTableRegions,
+              boundedScope.scope,
+            ) ??
+            detectWrappedCellTableWithinProvenScope(
               availableTableRegions,
               boundedScope.scope,
             ) ??

--- a/src/research/semantic-table-source.test.ts
+++ b/src/research/semantic-table-source.test.ts
@@ -17,6 +17,7 @@ import { assessPdfCompleteness } from './pdf-quality'
 import { isSourceVerifiedSemanticTable } from './semantic-table'
 import {
   detectTableNearCaption,
+  detectWrappedCellTableWithinProvenScope,
   type PdfDetectedTableGrid,
 } from './pdf-table-detection'
 import { canonicalTableFromLines, createTableAsset } from './visual-assets'
@@ -113,6 +114,127 @@ function tableFixture() {
 }
 
 describe('source-verifiable semantic tables', () => {
+  it('keeps wrapped body-cell lineage when a continuation row is canonicalized', () => {
+    const header = line('continuation-header', 0.2, [
+      { text: 'Reference', x: 0.1, bold: true, fontName: 'Table-Bold' },
+      { text: 'Environment', x: 0.3, bold: true, fontName: 'Table-Bold' },
+      { text: 'NPC', x: 0.5, bold: true, fontName: 'Table-Bold' },
+      { text: 'Outcome', x: 0.7, bold: true, fontName: 'Table-Bold' },
+    ])
+    const body = line('continuation-body-1', 0.24, [
+      { text: 'A', x: 0.1 },
+      { text: 'The environment begins', x: 0.3 },
+      { text: 'the NPC waits', x: 0.5 },
+      { text: 'The action resolves', x: 0.7 },
+    ])
+    const continuation = line('continuation-body-1-more', 0.26, [
+      { text: 'and the light changes', x: 0.3 },
+      { text: 'before the door opens', x: 0.5 },
+    ])
+    const completeBody = (id: string, y: number, prefix: string) =>
+      line(id, y, [
+        { text: prefix, x: 0.1 },
+        { text: `${prefix} environment`, x: 0.3 },
+        { text: `${prefix} NPC`, x: 0.5 },
+        { text: `${prefix} outcome`, x: 0.7 },
+      ])
+    const sourceLines = [
+      header,
+      body,
+      continuation,
+      completeBody('continuation-body-2', 0.3, 'B'),
+      completeBody('continuation-body-3', 0.36, 'C'),
+      completeBody('continuation-body-4', 0.42, 'D'),
+    ]
+    const region = {
+      id: 'continuation-table-region',
+      page: 1,
+      kind: 'body',
+      column: 'span',
+      text: sourceLines.map((sourceLine) => sourceLine.text).join(' '),
+      confidence: 1,
+      box: sourceBox(0.1, 0.2, 0.72, 0.24),
+      lines: sourceLines,
+      nativeObjectIds: [],
+      includedInReadingOrder: true,
+    } satisfies PdfPageRegion
+    const detected = detectWrappedCellTableWithinProvenScope([region], {
+      direction: 'below',
+      sourceRegionIds: [region.id],
+      sourceLineIds: sourceLines.map((sourceLine) => sourceLine.id),
+      evidence: [
+        { code: 'repeated-row-bands' },
+        { code: 'repeated-column-anchors' },
+      ],
+    })
+    if (!detected) throw new Error('Expected a wrapped-cell table grid')
+
+    const table = canonicalTableFromLines(detected.lines, {
+      detectedGrid: detected,
+      sourceRegions: [region],
+    })
+    if (!table) throw new Error('Expected a source-verifiable table')
+
+    expect(table.rows).toHaveLength(5)
+    expect(table.rows[1].cells[1]).toMatchObject({
+      text: 'The environment begins and the light changes',
+      sourceRuns: [
+        expect.objectContaining({
+          lineId: body.id,
+          text: 'The environment begins',
+        }),
+        expect.objectContaining({
+          lineId: continuation.id,
+          text: 'and the light changes',
+        }),
+      ],
+    })
+    expect(table.rows[1].cells[2].sourceRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ lineId: body.id, text: 'the NPC waits' }),
+        expect.objectContaining({
+          lineId: continuation.id,
+          text: 'before the door opens',
+        }),
+      ]),
+    )
+    expect(
+      isSourceVerifiedSemanticTable({
+        table,
+        relationship: {
+          id: 'continuation-table-relationship',
+          kind: 'table',
+          label: 'Table 1',
+          captionRegionId: 'continuation-caption',
+          sourceRegionIds: [region.id],
+          sourceLineIds: sourceLines.map((sourceLine) => sourceLine.id),
+          sourceObjectIds: ['continuation-table-object'],
+          assetIds: ['continuation-table-asset'],
+          status: 'matched',
+          confidence: 1,
+          evidence: ['semantic-table'],
+          candidates: [],
+          sourceBoxes: [region.box],
+          sourceText: detected.lines
+            .map((sourceLine) => sourceLine.text)
+            .join(' '),
+          altText: 'Table 1. Wrapped body cells.',
+          altTextSource: 'caption',
+          canonicalNodeId: 'continuation-table-node',
+          captionNodeId: 'continuation-caption-node',
+        },
+        regions: [region],
+        evidence: {
+          confidence: 1,
+          pages: [1],
+          regionIds: [region.id],
+          boxes: [region.box],
+          links: [],
+        },
+      }),
+    ).toBe(true)
+  })
+
   it('preserves exact lineage and associations for a proved two-tier column header', async () => {
     const groupHeader = line('group-header', 0.2, [
       { text: 'Methods', x: 0.1 },

--- a/src/research/semantic-table.ts
+++ b/src/research/semantic-table.ts
@@ -685,6 +685,98 @@ function sameInlineRuns(
   )
 }
 
+function alignVerifiedSourceLineage(
+  table: StrictSemanticTable,
+  sourceRows: VerifiedTableSourceRun[][],
+) {
+  const sourceByKey = new Map(
+    sourceRows.flatMap((row, bandIndex) =>
+      row.map((source) => [source.key, { source, bandIndex }] as const),
+    ),
+  )
+  if (sourceByKey.size !== sourceRows.flat().length) return null
+
+  if (sourceRows.length > table.rows.length) {
+    const bodyRows = table.rows.slice(1)
+    const bodyColumnCount = bodyRows[0]?.cells.length ?? 0
+    const completeBodyGrid =
+      bodyColumnCount >= 2 &&
+      bodyRows.every(
+        (row) =>
+          row.cells.length === bodyColumnCount &&
+          row.cells.every(
+            (cell) => cell.columnSpan === 1 && cell.rowSpan === 1,
+          ),
+      )
+    if (completeBodyGrid) {
+      const bodyColumnAnchors = Array.from(
+        { length: bodyColumnCount },
+        (_, columnIndex) =>
+          median(
+            bodyRows.map((row) =>
+              Math.min(
+                ...(row.cells[columnIndex].sourceRuns ?? []).map(
+                  (source) => source.box.x,
+                ),
+              ),
+            ),
+          ),
+      )
+      if (
+        table.rows.some(
+          (row) =>
+            row.cells.length === bodyColumnCount &&
+            row.cells.some((cell, columnIndex) => {
+              const left = Math.min(
+                ...(cell.sourceRuns ?? []).map((source) => source.box.x),
+              )
+              return Math.abs(left - bodyColumnAnchors[columnIndex]) > 0.045
+            }),
+        )
+      ) {
+        return null
+      }
+    }
+  }
+
+  const claimedKeys = new Set<string>()
+  const alignedRows: VerifiedTableSourceRun[][] = []
+  let previousBandIndex = -1
+  for (const row of table.rows) {
+    const aligned: VerifiedTableSourceRun[] = []
+    const rowBandIndexes: number[] = []
+    for (const cell of row.cells) {
+      if (!cell.sourceRuns || cell.sourceRuns.length === 0) return null
+      for (const claimed of cell.sourceRuns) {
+        const key = sourceRunKey(
+          claimed.regionId,
+          claimed.lineId,
+          claimed.runIndex,
+        )
+        const selected = sourceByKey.get(key)
+        if (
+          !selected ||
+          claimedKeys.has(key) ||
+          claimed.text !== selected.source.run.text ||
+          !sameSourceBox(claimed.box, selected.source.run)
+        ) {
+          return null
+        }
+        claimedKeys.add(key)
+        rowBandIndexes.push(selected.bandIndex)
+        aligned.push(selected.source)
+      }
+    }
+    if (rowBandIndexes.length === 0) return null
+    const firstBandIndex = Math.min(...rowBandIndexes)
+    const lastBandIndex = Math.max(...rowBandIndexes)
+    if (firstBandIndex <= previousBandIndex) return null
+    previousBandIndex = lastBandIndex
+    alignedRows.push(aligned)
+  }
+  return claimedKeys.size === sourceByKey.size ? alignedRows : null
+}
+
 export function isSourceVerifiedSemanticTable({
   table,
   relationship,
@@ -817,7 +909,10 @@ export function isSourceVerifiedSemanticTable({
   ) {
     return false
   }
-  if (sourceRows.length !== table.rows.length) {
+  const alignedSourceRows = alignVerifiedSourceLineage(table, sourceRows)
+  if (alignedSourceRows) {
+    sourceRows = alignedSourceRows
+  } else if (sourceRows.length !== table.rows.length) {
     const closedRows = alignVerifiedWrappedColumnHeaderLineage({
       table,
       sourceRows,
@@ -827,6 +922,8 @@ export function isSourceVerifiedSemanticTable({
     })
     if (!closedRows) return false
     sourceRows = closedRows
+  } else {
+    return false
   }
   const sourceCells = sourceRows.flat()
   if (


### PR DESCRIPTION
## Summary
- promote rectangular tables whose body cells wrap onto later source lines when geometry and source-line ownership prove a unique column mapping
- merge wrapped body continuations into semantic table cells while preserving every source run and line id
- validate physical-to-logical table lineage before accepting the semantic XHTML asset; ambiguous scopes remain source-page image fallbacks

Closes no issue; this is a bounded slice for #83.

## BookWorld evidence
The supplied BookWorld PDF now reports 1/8 semantic tables (Table 6), up from 0/8. Table 6 carries `semantic-table`, `complete-bounded-table-scope`, `repeated-rectangular-column-geometry`, and `semantic-body-continuation-geometry` evidence. Tables whose scope or column mapping is not proven remain image fallbacks.

## Validation
- `npx vitest run src/research/pdf-table-detection.test.ts src/research/semantic-table-source.test.ts src/research/pdf-layout.test.ts` (340 passed)
- `npm run build:astro` (0 errors; pre-existing hints only)
- `scripts/agent-evidence` (build + full npm test passed)
