### PR TITLE
Queue: make STRUCT work resumable and conflict-aware

### DIFF
--- a/docs/issues/040-figure-extraction-and-caption-boundaries.md
+++ b/docs/issues/040-figure-extraction-and-caption-boundaries.md
@@ -1,6 +1,6 @@
 # Stop dropping figures and stop captions absorbing body prose
 
-depends-on: 013,025,033,038
+depends-on: 013,025,033,038,042
 
 ## Provider
 

--- a/docs/issues/043-continuous-prose-reconstruction.md
+++ b/docs/issues/043-continuous-prose-reconstruction.md
@@ -1,6 +1,6 @@
 # Deliver continuous prose across lines, columns, and pages
 
-depends-on: 024,035,038,042
+depends-on: 024,035,038,040,042
 
 ## Provider
 

--- a/docs/issues/047-struct-extraction-typesetting-consolidation.md
+++ b/docs/issues/047-struct-extraction-typesetting-consolidation.md
@@ -1,0 +1,145 @@
+# Consolidate source-agnostic STRUCT extraction and typesetting
+
+depends-on: 034,036,038,039,040,041,042,043,044,045,046
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Deliver one reusable PDF/DOCX extraction-to-typesetting pipeline for unseen
+papers. Every source adapter emits the canonical STRUCT graph; every EPUB or
+HTML renderer consumes only that graph. The implementation must be general,
+deterministic by default, and safe when evidence is insufficient.
+
+## Required behavior
+
+- Reconstruct continuous prose across lines, columns, pages, and spreads while
+  excluding repeated page furniture with an auditable source ledger.
+- Extract figures, diagrams, raster/vector assets, captions, tables, equations,
+  footnotes/endnotes, citations, hyperlinks, cross-references, code, and
+  algorithms. Preserve every obligation exactly once.
+- Prefer semantic table reconstruction only when cell boundaries, spans,
+  headers, links, and complete source lineage are proven. Otherwise keep one
+  bounded source-preserved image/text fallback with caption and provenance.
+- Represent equations as one verified MathML/text object or one bounded source
+  crop. Never emit equation glyph fragments into ordinary prose.
+- Resolve notes, citations, links, and cross-references against verified graph
+  targets. Keep visible source text when a target cannot be proven.
+- Use deterministic extraction and validators first. A Codex/model layout pass
+  may choose only among deterministic candidates supplied in a bounded STRUCT
+  context; it cannot author text, bytes, bounds, or destinations. Persist the
+  proposal and distill successful classes into a fixture and deterministic rule.
+- Compare the rendered output with the source before requesting human help.
+  User-facing recovery contains only actionable pages and exact next steps;
+  safe fallbacks and internal diagnostic counts never become user tasks.
+
+## Validation matrix
+
+BookWorld is the current benchmark. Add held-out born-digital, scanned,
+single-column, two-column, raster/vector, table, equation, note, citation, and
+hyperlink fixtures. Each run must include deterministic rerun hashes, STRUCT
+conservation receipts, EPUB spine smoke, and source-versus-render screenshots.
+
+Fresh evidence supersedes saved screenshots or metrics. The 2026-08-01 clean
+BookWorld rerun produced 0/8 semantic tables; the saved 1/8 report is stale.
+Treat issue 036's provider work as an interface slice until a concrete adapter,
+fallback-candidate path, and real BookWorld-plus-held-out benchmark prove that
+coverage rose.
+
+## Execution partition
+
+- Serialize parser-core issues 042 → 040 → 043 → 044 so page furniture,
+  figures/captions, continuous prose, and notes/citations do not concurrently
+  edit the same layout/visual files.
+- Table candidate work (036) owns table detection/canonicalization until its
+  branch lands. The next table slice is cell-scoped source lineage for shifted
+  wrapped continuations and shared source lines; do not patch the same files in
+  another worker.
+- Source-versus-render evidence (038) and corpus strata (037) may run beside one
+  parser worker only when their declared write paths are disjoint.
+- The umbrella issue (047) integrates completed child receipts; it is not an
+  extra parser worker.
+
+## Acceptance tests
+
+- A source-agnostic fixture in each required document stratum round-trips
+  source → STRUCT → EPUB without dropped text, assets, relationships, or
+  source-preserved fallback regions.
+- The BookWorld benchmark and at least one held-out paper exercise the same
+  extraction path without a paper-title or page-number rule; their receipts
+  reconcile source obligations to rendered obligations.
+- A candidate-constrained model proposal is rejected when it invents text,
+  bytes, bounds, or destinations, and accepted proposals are persisted as
+  provenance plus a deterministic fixture/rule.
+- Source-versus-render evidence runs before recovery UI generation and the UI
+  contains only actionable page/region groups; safe fallbacks do not become
+  user tasks.
+
+## Validation command
+
+```bash
+npx vitest run src/struct/struct.test.ts src/research/pdf-visuals.test.ts src/research/pdf-table-detection.test.ts
+npm test
+npm run build:astro
+scripts/agent-evidence
+```
+
+## Allowed secrets
+
+None for deterministic extraction, tests, local rendering, or source
+comparison. An explicitly enabled model consultation may use the trusted VM's
+provider login, but credentials and source payloads never enter the repository,
+logs, fixtures, or issue comments.
+
+## Artifact outputs
+
+The STRUCT graph and conservation receipt, deterministic extraction/evidence
+manifest, source-versus-EPUB screenshots, local readable fallback, held-out
+metrics, and a plain-language recovery summary containing only exact actions.
+
+## Stop conditions
+
+Stop before inventing text or assets, dropping a source visual, claiming an
+unverified relationship, forcing an ambiguous table/equation into prose,
+asking a human without source comparison, or declaring a pass when a required
+receipt, screenshot, or held-out metric is missing.
+
+## Definition of done
+
+- TDD coverage for every required obligation and a held-out run with no
+  paper-title/page-specific rule.
+- No missing visual/table/equation obligations; ambiguous regions have one
+  bounded source fallback.
+- Continuous prose and relationship ledgers reconcile to source counts.
+- Recovery UI has no raw all-caps/internal diagnostic wall.
+- Small commits link this spec and its relevant sub-issue. Deploy only after
+  the evidence gate is green.
+
+## Human clarification protocol
+
+Do not ask a human until deterministic extraction, candidate-constrained model
+layout (when explicitly enabled), source comparison, and the local fallback
+have all run. If a question remains, name the exact page, source region, and
+single action required.
+
+## Recommended response
+
+Build one conservation-first graph boundary and make each parser issue land a
+reusable fixture plus rule. Keep source-preserved fallbacks automatic so the
+user never has to repair content that the importer can safely retain.
+
+## Trade-offs
+
+Bounded source fallbacks preserve fidelity while semantic proof is incomplete,
+but they defer some reflow quality. Deterministic proof costs more engineering
+than paper-specific heuristics, yet it is the only path that can generalize to
+unseen layouts and produce trustworthy recovery decisions.
+
+## Free-form response
+
+The finished system should turn a new paper into a structured, readable EPUB
+without asking the reader to understand extraction internals; any remaining
+human action is a final, page-specific editorial decision backed by source
+evidence.

--- a/docs/issues/048-vm-drain-persistence-and-checkpoints.md
+++ b/docs/issues/048-vm-drain-persistence-and-checkpoints.md
@@ -1,0 +1,132 @@
+# Keep the trusted VM drain active and make overnight work resumable
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Make unattended development safe and efficient after the laptop closes. A
+successful queue pass must not silently leave the repo timer masked, and every
+pass must leave enough durable state for the next worker or handoff to resume
+without repeating work. This issue supports spec 047 and must be runnable before
+that product umbrella completes.
+
+## Required behavior
+
+- Activate only the selected repository timer after bubblewrap and
+  system-manager network-isolation proofs pass. Keep every other repository
+  drain held.
+- After installation cleanup and after each queue pass, verify the selected
+  timer is loaded, enabled, active, has a future fire, and the service has the
+  repository timeout policy (`30m` start, `5m` stop). A mask or failed state is
+  a queue-health failure, not a successful idle result.
+- Enforce one total live VM issue session for this repository across repeated
+  pulse invocations. `--max-workers 1` is only a per-invocation launch limit;
+  active unexpired leases/sessions consume the global slot before selection.
+  Reconcile GitHub labels and exact issue leases before dispatch; never
+  duplicate a running or human-blocked issue.
+- Keep parser-core work serialized through declared dependencies. Evidence or
+  evaluation work may run in parallel only when its declared path/resource
+  scope is disjoint from the active worker.
+- Record an atomic checkpoint after each pass: issue, branch/PR, source SHA,
+  evidence manifest, tests, visual source/output artifacts, next issue, and
+  failure class. A reconnecting agent must be able to resume from it.
+- Use bounded retries/self-heal. After the configured two attempts, retain the
+  issue's actionable failure and move it to a human gate; do not spin forever.
+- Require source-vs-render comparison and the local readable fallback before
+  exposing human work. User work must name one page/region and one exact
+  action; internal diagnostic counts stay in evidence, not the UI.
+- Keep model/layout calls optional and candidate-constrained. Persist every
+  accepted proposal and distill it into a fixture plus deterministic rule.
+- Install the default-branch `struct-typeset` skill as a pinned, read-only VM
+  skill and record its SHA-256 in each applicable worker receipt. Future layout
+  workers use the configured `gpt-5.6-luna` / `max` VM profile; already-running
+  workers keep their recorded model and are never relabeled retroactively.
+- Resolve the generated drain through an installer-owned stable target alias or
+  validated state file rather than a repository-hard-coded unit version.
+
+## Tests and evidence
+
+- Unit-test timer-state, total active-slot accounting, stable target resolution,
+  skill digest recording, and checkpoint parsing with fake systemd/queue/session
+  responses.
+- Exercise an interrupted worker, a completed worker, and a masked timer; all
+  three must produce an explicit resumable state.
+- Run the full repository evidence command and a held-out STRUCT corpus pass.
+
+## Acceptance tests
+
+- A fake systemd response for a healthy timer is accepted only when it is
+  loaded, enabled, active, and has a future fire; masked, failed, or missing
+  state is reported as queue-health failure.
+- At total capacity one, one live session plus one queued issue launches
+  nothing; a completed/expired session frees exactly one slot. Missing or
+  malformed lease state fails closed for recovery instead of opening a slot.
+- An interrupted worker, completed worker, and provider-blocked worker each
+  leave one atomic checkpoint with a resumable next action and no duplicate
+  lease.
+- Two consecutive pulse passes keep the repo-owned scheduler enabled while the
+  generated drain may be held during a worker pass, and never exceed the total
+  configured session cap.
+- A future applicable worker receipt identifies `gpt-5.6-luna`, `max`, and the
+  exact installed `struct-typeset` skill digest. Stubbed tests do not require a
+  live provider credential.
+
+## Validation command
+
+```bash
+systemd-analyze verify infra/vm/systemd/erniesg-struct-typeset-queue.service infra/vm/systemd/erniesg-struct-typeset-queue.timer
+infra/vm/verify.sh
+scripts/agent-evidence
+```
+
+## Allowed secrets
+
+None in the repository or checkpoints. GitHub/provider credentials remain in
+the trusted VM stores and are minted only by the fixed parent runtime.
+
+## Artifact outputs
+
+The repo-owned pulse units, durable checkpoint, systemd/timer verification,
+queue labels and lease receipts, source-versus-render evidence manifest, and a
+plain-language blocked/resumable status.
+
+## Stop conditions
+
+Stop before automatically clearing an operator hold, dispatching a duplicate
+lease, increasing worker/retry limits, treating a masked timer as idle, or
+claiming unattended completion without a durable checkpoint and future timer
+fire.
+
+## Human clarification protocol
+
+Ask only when the queue reaches a named external gate (provider login, source
+comparison decision, or publication-bundle review). Include the exact issue,
+page/region or gate, the one action required, and the command that resumes it.
+
+## Recommended response
+
+Keep the generated Rucksack drain as the proven execution boundary and add a
+small repo-owned scheduler outside its containment glob. Checkpoint every pass
+so restarting is cheaper and safer than rerunning a whole corpus.
+
+## Trade-offs
+
+The extra pulse unit adds one scheduler to verify, but it prevents a long worker
+or installer cleanup from silently disabling future work. One worker at a time
+reduces throughput while avoiding duplicate edits and makes evidence ordering
+deterministic.
+
+## Free-form response
+
+Overnight development is successful when a disconnected laptop changes nothing:
+the VM keeps one bounded pass moving, records what happened, and leaves the next
+worker an exact command rather than a mystery state.
+
+## Definition of done
+
+Two consecutive unattended queue passes leave the selected timer active and
+produce durable checkpoints. A fresh VM worker can continue the next ready
+issue without conversation context, duplicate dispatch, or an unexplained
+"idle" result.


### PR DESCRIPTION
Closes #116

Adds default-branch ledger provenance for #113 and #115 and serializes the parser-core dependency chain so workers that edit the same layout files do not run concurrently. This PR does not close either implementation tracker or weaken provenance.

After merge, the trusted VM must reconcile with `--adopt --queue-after-activation`: #115 becomes runnable; #113 remains gated on its child specs.

Validation: dry-run reconciliation found exact-title adoptions for specs 047/048; `git diff --check` and staged secret scan passed.