### PR TITLE
test: make killed-worker PDF scratch cleanup event-driven

### DIFF
--- a/tests/fixtures/pdf-export-scratch-worker.mjs
+++ b/tests/fixtures/pdf-export-scratch-worker.mjs
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { readdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createPdfPipeline } from '../../tools/pdf-corpus-audit-lib.mjs'
 import { installPdfExportWorkerDisconnectGuard } from '../../tools/pdf-export.mjs'
@@ -7,26 +7,33 @@ import { installPdfExportWorkerDisconnectGuard } from '../../tools/pdf-export.mj
 installPdfExportWorkerDisconnectGuard()
 
 process.once('message', async (job) => {
-  const pipeline = await createPdfPipeline({
-    temporaryRoot: job.stagingDirectory,
-  })
-  const cacheName = (await readdir(job.stagingDirectory)).find((name) =>
-    name.startsWith('srt-pdf-vite-'),
+  const cacheDirectory = await mkdtemp(
+    join(job.stagingDirectory, 'srt-pdf-vite-'),
   )
   const grandchild = spawn(
     process.execPath,
     ['-e', 'setInterval(() => {}, 1_000)'],
     { stdio: 'ignore' },
   )
+  const pendingObservationPath = `${job.observationPath}.${process.pid}.tmp`
   await writeFile(
-    job.observationPath,
+    pendingObservationPath,
     JSON.stringify({
       stagingDirectory: job.stagingDirectory,
-      cacheDirectory: join(job.stagingDirectory, cacheName),
+      cacheDirectory,
       workerPid: process.pid,
       grandchildPid: grandchild.pid,
     }),
   )
+  await rename(pendingObservationPath, job.observationPath)
+
+  // The timeout regression holds startup here after scratch readiness. This
+  // models a cold Vite/module load without using a machine-speed delay.
+  if (job.delayPipelineStart) await new Promise(() => {})
+
+  const pipeline = await createPdfPipeline({
+    temporaryRoot: job.stagingDirectory,
+  })
   void pipeline
   setInterval(() => {}, 1_000)
 })

--- a/tools/pdf-export.test.mjs
+++ b/tools/pdf-export.test.mjs
@@ -1,7 +1,7 @@
 import { fork, spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { once } from 'node:events'
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, watch } from 'node:fs'
 import {
   access,
   chmod,
@@ -14,7 +14,7 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { strFromU8, unzipSync } from 'fflate'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import {
@@ -90,6 +90,58 @@ async function waitForJson(path) {
     )
     .toBe(true)
   return value
+}
+
+async function waitForJsonPublication(path) {
+  const deadline = Date.now() + 30_000
+  const watcher = watch(dirname(path), { persistent: false })
+  const publication = new Promise((resolvePublication, rejectPublication) => {
+    watcher.once('error', rejectPublication)
+    watcher.on('change', (_eventType, filename) => {
+      if (!filename || filename.toString() === basename(path)) {
+        resolvePublication()
+      }
+    })
+  })
+  let deadlineImmediate = null
+  try {
+    try {
+      return JSON.parse(await readFile(path, 'utf8'))
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+    }
+
+    await Promise.race([
+      publication,
+      new Promise((_, rejectDeadline) => {
+        const checkDeadline = () => {
+          if (Date.now() >= deadline) {
+            rejectDeadline(
+              new Error(
+                `Worker observation was not published: ${basename(path)}`,
+              ),
+            )
+            return
+          }
+          deadlineImmediate = setImmediate(checkDeadline)
+        }
+        deadlineImmediate = setImmediate(checkDeadline)
+      }),
+    ])
+    return JSON.parse(await readFile(path, 'utf8'))
+  } finally {
+    if (deadlineImmediate) clearImmediate(deadlineImmediate)
+    watcher.close()
+  }
+}
+
+async function waitForProcessExit(pid) {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) return
+    await new Promise((resolveImmediate) => setImmediate(resolveImmediate))
+  }
+  throw new Error(`Worker process did not exit: ${pid}`)
 }
 
 async function waitForParentWatchdogArm(setTimeoutSpy, expectedArmCount) {
@@ -691,8 +743,12 @@ fs.appendFileSync(path, 'epubcheck-' + completed + '-end\\n')
     const directory = await mkdtemp(join(tmpdir(), 'pdf-export-scratch-'))
     const observationPath = join(directory, 'observation.json')
     const outputDirectory = join(directory, 'output')
+    const controller = new AbortController()
+    let pending = null
+    let observation = null
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
     try {
-      const { report } = await processExportDocuments({
+      pending = processExportDocuments({
         paths: [join(directory, 'private paper.pdf')],
         corpusContract: null,
         policy: pipeline.policy,
@@ -702,9 +758,10 @@ fs.appendFileSync(path, 'epubcheck-' + completed + '-end\\n')
         validator: { kind: 'skipped', reason: 'java-unavailable' },
         outputDirectory,
         timeoutMs: 3_000,
+        signal: controller.signal,
         runWorker: (job, options) =>
           runIsolatedPdfExportJob(
-            { ...job, observationPath },
+            { ...job, observationPath, delayPipelineStart: true },
             {
               ...options,
               workerModule: resolve(
@@ -713,7 +770,10 @@ fs.appendFileSync(path, 'epubcheck-' + completed + '-end\\n')
             },
           ),
       })
-      const observation = await waitForJson(observationPath)
+      observation = await waitForJsonPublication(observationPath)
+
+      await vi.advanceTimersByTimeAsync(3_000)
+      const { report } = await pending
 
       expect(report.summary).toMatchObject({
         documents: 1,
@@ -722,7 +782,19 @@ fs.appendFileSync(path, 'epubcheck-' + completed + '-end\\n')
         failed: 1,
         failureReasons: { PDF_DOCUMENT_TIMEOUT: 1 },
       })
-      expect(observation.cacheDirectory).toContain(observation.stagingDirectory)
+      await Promise.all([
+        waitForProcessExit(observation.workerPid),
+        waitForProcessExit(observation.grandchildPid),
+      ])
+      expect(basename(observation.cacheDirectory)).toMatch(
+        /^srt-pdf-vite-/,
+      )
+      expect(observation.cacheDirectory).toBe(
+        join(
+          observation.stagingDirectory,
+          basename(observation.cacheDirectory),
+        ),
+      )
       await expect(access(observation.stagingDirectory)).rejects.toMatchObject({
         code: 'ENOENT',
       })
@@ -731,6 +803,15 @@ fs.appendFileSync(path, 'epubcheck-' + completed + '-end\\n')
       })
       expect(await readdir(outputDirectory)).toEqual(['corpus-audit.json'])
     } finally {
+      controller.abort()
+      await pending?.catch(() => {})
+      vi.useRealTimers()
+      if (
+        observation?.grandchildPid &&
+        processExists(observation.grandchildPid)
+      ) {
+        process.kill(observation.grandchildPid, 'SIGKILL')
+      }
       await rm(directory, { recursive: true, force: true })
     }
   }, 30_000)


### PR DESCRIPTION
Closes #119\n\nPreserves the previously validated implementation at 58b9469b17df2a5c87b8415d080aab034fd237a7.\n\nValidation: three focused passes; PDF export suite 38/38; repository tests 2,452 passed, 1 skipped; unchanged exact-head evidence retry passed.\n\nVisual evidence: not applicable—this is test-only process cleanup with deterministic evidence artifacts.