### PR TITLE
feat: add source-reviewed extraction evaluation harness

### DIFF
--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -3,9 +3,10 @@
   "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
-    "fileSha256": "219efcf7f1d75935afa55a34893af4354d599a1140c7c3e808ba7e2e488ba232",
-    "evalSetSha256": "41636518cc8215d3494cde7d3cebc7052874ff6761c83e958d9ca9b117a2a8d0"
+    "fileSha256": "36aed098cd1a6e2a12dbb05737ae667f639ef06021415b5c8c2cb498c784f462",
+    "evalSetSha256": "ae3c64093c71e5d2cc16590f10d44217a8df881457f4cd742b662c6fa70559dd"
   },
+  "evaluationStatus": "reported-only",
   "providers": [
     {
       "id": "deterministic-path",

--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
+  "evalSet": {
+    "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
+    "fileSha256": "219efcf7f1d75935afa55a34893af4354d599a1140c7c3e808ba7e2e488ba232",
+    "evalSetSha256": "41636518cc8215d3494cde7d3cebc7052874ff6761c83e958d9ca9b117a2a8d0"
+  },
+  "providers": [
+    {
+      "id": "deterministic-path",
+      "kind": "deterministic",
+      "version": "source-backed-fixture-path-v1",
+      "mode": "abstain",
+      "sourceIdentitySha256": null,
+      "predictionsPath": null
+    },
+    {
+      "id": "candidate-provider-a",
+      "kind": "candidate",
+      "version": "reported-only-a-v1",
+      "mode": "abstain",
+      "sourceIdentitySha256": null,
+      "predictionsPath": null
+    },
+    {
+      "id": "candidate-provider-b",
+      "kind": "candidate",
+      "version": "reported-only-b-v1",
+      "mode": "abstain",
+      "sourceIdentitySha256": null,
+      "predictionsPath": null
+    }
+  ]
+}

--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -4,7 +4,7 @@
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
     "fileSha256": "36aed098cd1a6e2a12dbb05737ae667f639ef06021415b5c8c2cb498c784f462",
-    "evalSetSha256": "ae3c64093c71e5d2cc16590f10d44217a8df881457f4cd742b662c6fa70559dd"
+    "evalSetSha256": "5d6d6abd1258221e68a39b9bc81724867e69747522a7012443a3cfae1062f3d4"
   },
   "evaluationStatus": "reported-only",
   "providers": [
@@ -14,7 +14,8 @@
       "version": "source-backed-fixture-path-v1",
       "mode": "abstain",
       "sourceIdentitySha256": null,
-      "predictionsPath": null
+      "predictionsPath": null,
+      "predictionsSha256": null
     },
     {
       "id": "candidate-provider-a",
@@ -22,7 +23,8 @@
       "version": "reported-only-a-v1",
       "mode": "abstain",
       "sourceIdentitySha256": null,
-      "predictionsPath": null
+      "predictionsPath": null,
+      "predictionsSha256": null
     },
     {
       "id": "candidate-provider-b",
@@ -30,7 +32,8 @@
       "version": "reported-only-b-v1",
       "mode": "abstain",
       "sourceIdentitySha256": null,
-      "predictionsPath": null
+      "predictionsPath": null,
+      "predictionsSha256": null
     }
   ]
 }

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -29,9 +29,10 @@
       "groundTruthReview": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       }
     },
     {
@@ -44,9 +45,10 @@
       "groundTruthReview": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       }
     },
     {
@@ -59,24 +61,26 @@
       "groundTruthReview": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       }
     },
     {
       "id": "diagnostic-overlays",
       "fixturePath": "tests/fixtures/pdf/diagnostic-overlays.pdf",
-      "sha256": "9495e99cb690b4b5c9873675435294bb8583b006482e7045dc825a9187ebf623",
-      "byteLength": 1143,
+      "sha256": "bdafe1056d6b47d9b59dddcf4585c42c42851e9cd32cecbd912087117b7c2633",
+      "byteLength": 1238,
       "pageCount": 1,
       "layout": "two-column",
       "groundTruthReview": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       }
     }
   ],
@@ -88,9 +92,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "table-structure-f1",
@@ -101,7 +106,7 @@
         "abstentionScore": 0.25,
         "degenerateScore": 0,
         "degenerateAnswerGuardId": "table-structure-degenerate-answer-guard",
-        "authoritativeEvidence": "source-reviewed rows, columns, header scope, spans, and cell text"
+        "authoritativeEvidence": "source-reviewed rows, columns, header scope, spans, cell text, geometry, and line lineage"
       },
       "degenerateAnswerGuard": {
         "id": "table-structure-degenerate-answer-guard",
@@ -123,9 +128,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "heading-sequence-f1",
@@ -158,9 +164,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "display-equation-object-f1",
@@ -193,9 +200,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "figure-diagram-object-f1",
@@ -228,9 +236,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "prose-authoritative-continuity",
@@ -263,9 +272,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "boilerplate-contamination-rate",
@@ -298,9 +308,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "footnote-relationship-f1",
@@ -333,9 +344,10 @@
       "groundTruth": {
         "kind": "source-reviewed",
         "derivedFrom": "source-document",
-        "reviewStatus": "two-reviewer-agreed",
-        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-        "parserOutputConsulted": false
+        "reviewStatus": "review-required",
+        "reviewers": [],
+        "parserOutputConsulted": false,
+        "reviewEvidence": null
       },
       "metric": {
         "id": "column-pairwise-order",
@@ -421,15 +433,30 @@
                   "columnSpan": 1,
                   "text": "12"
                 }
+              ],
+              "box": [
+                0.117647,
+                0.555556,
+                0.24183,
+                0.055556
+              ],
+              "sourceRegionIds": [
+                "pdf-to-epub-fidelity-table-structure-table-1-region"
+              ],
+              "sourceLineIds": [
+                "pdf-to-epub-fidelity-table-structure-table-1-row-1",
+                "pdf-to-epub-fidelity-table-structure-table-1-row-2",
+                "pdf-to-epub-fidelity-table-structure-table-1-row-3"
               ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -478,15 +505,29 @@
                   "columnSpan": 1,
                   "text": "10"
                 }
+              ],
+              "box": [
+                0.117647,
+                0.689394,
+                0.163399,
+                0.037879
+              ],
+              "sourceRegionIds": [
+                "structured-scientific-table-structure-table-1-region"
+              ],
+              "sourceLineIds": [
+                "structured-scientific-table-structure-table-1-row-1",
+                "structured-scientific-table-structure-table-1-row-2"
               ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -546,9 +587,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -573,9 +615,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -607,9 +650,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -628,15 +672,29 @@
               "sourcePage": 2,
               "kind": "display-equation",
               "bounded": true,
-              "captionRelationship": "caption-of"
+              "captionRelationship": "caption-of",
+              "box": [
+                0.359477,
+                0.719697,
+                0.310458,
+                0.060606
+              ],
+              "sourceRegionIds": [
+                "pdf-to-epub-fidelity-display-equation-equation-1-region"
+              ],
+              "sourceLineIds": [
+                "pdf-to-epub-fidelity-display-equation-equation-1-caption",
+                "pdf-to-epub-fidelity-display-equation-equation-1-body"
+              ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -655,15 +713,29 @@
               "sourcePage": 1,
               "kind": "display-equation",
               "bounded": true,
-              "captionRelationship": "caption-of"
+              "captionRelationship": "caption-of",
+              "box": [
+                0.367647,
+                0.805556,
+                0.269608,
+                0.05303
+              ],
+              "sourceRegionIds": [
+                "structured-scientific-display-equation-equation-1-region"
+              ],
+              "sourceLineIds": [
+                "structured-scientific-display-equation-equation-1-caption",
+                "structured-scientific-display-equation-equation-1-body"
+              ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -682,15 +754,29 @@
               "sourcePage": 2,
               "kind": "figure-or-diagram",
               "bounded": true,
-              "captionRelationship": "caption-of"
+              "captionRelationship": "caption-of",
+              "box": [
+                0.294118,
+                0.166667,
+                0.408497,
+                0.189394
+              ],
+              "sourceRegionIds": [
+                "pdf-to-epub-fidelity-figure-diagram-figure-1-region"
+              ],
+              "sourceLineIds": [
+                "pdf-to-epub-fidelity-figure-diagram-figure-1-caption",
+                "pdf-to-epub-fidelity-figure-diagram-figure-1-body"
+              ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -709,22 +795,49 @@
               "sourcePage": 1,
               "kind": "figure-or-diagram",
               "bounded": true,
-              "captionRelationship": "caption-of"
+              "captionRelationship": "caption-of",
+              "box": [
+                0.359477,
+                0.280303,
+                0.424837,
+                0.138889
+              ],
+              "sourceRegionIds": [
+                "structured-scientific-figure-diagram-figure-1-region"
+              ],
+              "sourceLineIds": [
+                "structured-scientific-figure-diagram-figure-1-caption",
+                "structured-scientific-figure-diagram-figure-1-body"
+              ]
             },
             {
               "id": "figure-2",
               "sourcePage": 1,
               "kind": "figure-or-diagram",
               "bounded": true,
-              "captionRelationship": "caption-of"
+              "captionRelationship": "caption-of",
+              "box": [
+                0.392157,
+                0.494949,
+                0.245098,
+                0.088384
+              ],
+              "sourceRegionIds": [
+                "structured-scientific-figure-diagram-figure-2-region"
+              ],
+              "sourceLineIds": [
+                "structured-scientific-figure-diagram-figure-2-caption",
+                "structured-scientific-figure-diagram-figure-2-body"
+              ]
             }
           ],
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -757,9 +870,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -792,9 +906,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -812,9 +927,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -832,9 +948,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -848,15 +965,25 @@
         "sourcePage": 1,
         "groundTruth": {
           "excluded": [
-            { "id": "page-number-1", "sourcePage": 1, "kind": "page-number" }
+            {
+              "id": "running-head-1",
+              "sourcePage": 1,
+              "kind": "running-head"
+            },
+            {
+              "id": "page-number-1",
+              "sourcePage": 1,
+              "kind": "page-number"
+            }
           ],
           "bodyLineCount": 7,
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -881,9 +1008,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -908,9 +1036,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -929,9 +1058,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -962,9 +1092,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }
@@ -991,9 +1122,10 @@
           "review": {
             "kind": "source-reviewed",
             "derivedFrom": "source-document",
-            "reviewStatus": "two-reviewer-agreed",
-            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
-            "parserOutputConsulted": false
+            "reviewStatus": "review-required",
+            "reviewers": [],
+            "parserOutputConsulted": false,
+            "reviewEvidence": null
           }
         }
       }

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -1,0 +1,1002 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "scholarly-pdf-extraction-strata-2026-08-v1",
+  "privacy": "repository-fixture-identities-source-reviewed-no-private-inputs",
+  "protocol": {
+    "command": "npm run pdf:benchmark:extraction",
+    "reportPrivacy": "identities-hashes-counts-diagnostic-codes-only",
+    "sourceLabelPolicy": "source-review-required-parser-output-never-a-label",
+    "regexProxyPolicy": "authoritative-pipeline-counters-only-regex-never-gates",
+    "abstentionPolicy": {
+      "score": 0.25,
+      "beatsDegenerateAnswer": true,
+      "status": "reported-not-correct"
+    },
+    "corpusBalance": {
+      "layouts": ["one-column", "two-column"],
+      "minimumDocumentsPerLayout": 2,
+      "reportByLayout": true
+    }
+  },
+  "documents": [
+    {
+      "id": "pdf-to-epub-fidelity",
+      "fixturePath": "tests/fixtures/pdf/pdf-to-epub-fidelity.pdf",
+      "sha256": "17921375594e87b1377e86d304f9f151c393255eb94b8e0f523179f6b9e07cea",
+      "byteLength": 16759,
+      "pageCount": 3,
+      "layout": "one-column",
+      "groundTruthReview": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      }
+    },
+    {
+      "id": "structured-scientific",
+      "fixturePath": "tests/fixtures/pdf/structured-scientific.pdf",
+      "sha256": "7a75163906224b0dbf78e28975f6e16ec0e3b7485532995f9a1226b3f1928500",
+      "byteLength": 6075,
+      "pageCount": 1,
+      "layout": "two-column",
+      "groundTruthReview": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      }
+    },
+    {
+      "id": "multilingual-scan",
+      "fixturePath": "tests/fixtures/pdf/multilingual-scan.pdf",
+      "sha256": "514195c541dcf6aa28b5d41a439ac623ccaf9cca2f452e9b4c49411e1c559aec",
+      "byteLength": 6580,
+      "pageCount": 1,
+      "layout": "one-column",
+      "groundTruthReview": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      }
+    },
+    {
+      "id": "diagnostic-overlays",
+      "fixturePath": "tests/fixtures/pdf/diagnostic-overlays.pdf",
+      "sha256": "9495e99cb690b4b5c9873675435294bb8583b006482e7045dc825a9187ebf623",
+      "byteLength": 1143,
+      "pageCount": 1,
+      "layout": "two-column",
+      "groundTruthReview": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      }
+    }
+  ],
+  "strata": [
+    {
+      "id": "table-structure",
+      "task": "table-structure",
+      "description": "Recover bounded rows, columns, header scope, spans, and source cell text.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "table-structure-f1",
+        "name": "table topology and cell F1",
+        "unit": "table-and-cell-f1",
+        "formula": "mean(exact-header-scope-and-topology × cell-text-F1) per reviewed table",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "table-structure-degenerate-answer-guard",
+        "authoritativeEvidence": "source-reviewed rows, columns, header scope, spans, and cell text"
+      },
+      "degenerateAnswerGuard": {
+        "id": "table-structure-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-table-output",
+          "page-wide-grid-that-covers-the-body-measure",
+          "one-grid-fused-across-multiple-reviewed-tables"
+        ],
+        "detection": "A guarded table output scores zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "heading-structure",
+      "task": "heading-structure",
+      "description": "Recover the ordered heading sequence and level, including unnumbered and non-English headings.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "heading-sequence-f1",
+        "name": "heading sequence and level F1",
+        "unit": "ordered-heading-f1",
+        "formula": "F1 over exact (heading text, level) decisions with sequence preserved",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "heading-structure-degenerate-answer-guard",
+        "authoritativeEvidence": "source-reviewed heading sequence, level, numbering flag, and language"
+      },
+      "degenerateAnswerGuard": {
+        "id": "heading-structure-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-heading-output",
+          "every-line-as-a-heading",
+          "heading-count-more-than-two-times-reviewed-sequence"
+        ],
+        "detection": "A broad heading flood scores zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "display-equation",
+      "task": "display-equation",
+      "description": "Recover display-equation grouping and visible equation ownership as bounded objects.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "display-equation-object-f1",
+        "name": "display-equation object F1",
+        "unit": "bounded-equation-object-f1",
+        "formula": "F1 over source-page equation objects after grouping and label ownership",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "display-equation-degenerate-answer-guard",
+        "authoritativeEvidence": "source glyph/raster bounds and reviewed visible equation labels"
+      },
+      "degenerateAnswerGuard": {
+        "id": "display-equation-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-equation-output",
+          "page-wide-equation-box",
+          "each-body-line-emitted-as-an-equation"
+        ],
+        "detection": "Unbounded or absent equation objects score zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "figure-diagram",
+      "task": "figure-diagram",
+      "description": "Recover bounded figure/diagram assets and retain their caption relationship.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "figure-diagram-object-f1",
+        "name": "figure and diagram object F1",
+        "unit": "bounded-visual-object-f1",
+        "formula": "F1 over bounded source objects with a caption-of relationship",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "figure-diagram-degenerate-answer-guard",
+        "authoritativeEvidence": "source raster/component bounds and reviewed caption ownership"
+      },
+      "degenerateAnswerGuard": {
+        "id": "figure-diagram-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-visual-output",
+          "page-wide-asset-fused-with-neighbouring-content",
+          "caption-without-a-bounded-asset"
+        ],
+        "detection": "A dropped or unbounded visual scores zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "prose-continuity",
+      "task": "prose-continuity",
+      "description": "Measure continuous prose with the pipeline's authoritative line-boundary counters.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "prose-authoritative-continuity",
+        "name": "authoritative prose continuity",
+        "unit": "counter-derived-continuity",
+        "formula": "max(0, 1 - unresolvedCorruptingJoinCount / max(1, lineBoundaryCount))",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "prose-continuity-degenerate-answer-guard",
+        "authoritativeEvidence": "unresolvedCorruptingJoinCount and line-boundary decision ledger"
+      },
+      "degenerateAnswerGuard": {
+        "id": "prose-continuity-degenerate-answer-guard",
+        "rejects": [
+          "missing-authoritative-counters",
+          "regex-only-hyphenation-proxy",
+          "line-boundary-counter-arithmetic-inconsistency"
+        ],
+        "detection": "Regex-only or inconsistent evidence scores zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "boilerplate-exclusion",
+      "task": "boilerplate-exclusion",
+      "description": "Exclude running heads and page numbers without deleting body prose.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "boilerplate-contamination-rate",
+        "name": "running-head and page-number contamination",
+        "unit": "zero-contamination-indicator",
+        "formula": "1 iff both contamination counters are zero and excludedCount is bounded; otherwise 0",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "boilerplate-exclusion-degenerate-answer-guard",
+        "authoritativeEvidence": "source-reviewed furniture list and body-line denominator"
+      },
+      "degenerateAnswerGuard": {
+        "id": "boilerplate-exclusion-degenerate-answer-guard",
+        "rejects": [
+          "missing-contamination-counters",
+          "excluding-most-body-lines",
+          "running-head-or-page-number-left-in-body-flow"
+        ],
+        "detection": "Over-exclusion and contamination both score zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "footnote-resolution",
+      "task": "footnote-resolution",
+      "description": "Resolve each note marker to its typed body without collapsing unrelated notes.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "footnote-relationship-f1",
+        "name": "footnote marker/body relationship F1",
+        "unit": "typed-note-relationship-f1",
+        "formula": "F1 over exact marker, reference, and typed-body relationships",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "footnote-resolution-degenerate-answer-guard",
+        "authoritativeEvidence": "source-reviewed marker/body relationships and backlinks"
+      },
+      "degenerateAnswerGuard": {
+        "id": "footnote-resolution-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-note-relationships",
+          "all-note-bodies-assigned-to-one-reference",
+          "dangling-note-body-or-reference"
+        ],
+        "detection": "Missing, dangling, or collapsed note relationships score zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    },
+    {
+      "id": "column-layout",
+      "task": "column-layout",
+      "description": "Recover column assignment and reading order for one- and two-column pages.",
+      "groundTruth": {
+        "kind": "source-reviewed",
+        "derivedFrom": "source-document",
+        "reviewStatus": "two-reviewer-agreed",
+        "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+        "parserOutputConsulted": false
+      },
+      "metric": {
+        "id": "column-pairwise-order",
+        "name": "column assignment and pairwise order",
+        "unit": "mean-column-count-and-order",
+        "formula": "mean(column-count exactness, pairwise reading-order accuracy)",
+        "scoreRange": [0, 1],
+        "abstentionScore": 0.25,
+        "degenerateScore": 0,
+        "degenerateAnswerGuardId": "column-layout-degenerate-answer-guard",
+        "authoritativeEvidence": "source geometry, column lanes, and reviewed reading-order sequence"
+      },
+      "degenerateAnswerGuard": {
+        "id": "column-layout-degenerate-answer-guard",
+        "rejects": [
+          "empty-or-missing-reading-order",
+          "page-wide-single-column-for-two-column-source",
+          "alternating-lines-without-column-lane"
+        ],
+        "detection": "A page-wide or absent layout answer scores zero; an explicit abstention scores 0.25.",
+        "score": 0,
+        "abstentionScore": 0.25,
+        "failClosed": true
+      }
+    }
+  ],
+  "cases": [
+    {
+      "id": "pdf-to-epub-fidelity.table-structure",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "table-structure",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 2,
+        "groundTruth": {
+          "tables": [
+            {
+              "id": "table-1",
+              "sourcePage": 2,
+              "rows": 3,
+              "columns": 2,
+              "headerScope": "row",
+              "cells": [
+                {
+                  "row": 0,
+                  "column": 0,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Profile"
+                },
+                {
+                  "row": 0,
+                  "column": 1,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Nodes"
+                },
+                {
+                  "row": 1,
+                  "column": 0,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Mobile"
+                },
+                {
+                  "row": 1,
+                  "column": 1,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "12"
+                },
+                {
+                  "row": 2,
+                  "column": 0,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "E-ink"
+                },
+                {
+                  "row": 2,
+                  "column": 1,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "12"
+                }
+              ]
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.table-structure",
+      "documentId": "structured-scientific",
+      "stratum": "table-structure",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "tables": [
+            {
+              "id": "table-1",
+              "sourcePage": 1,
+              "rows": 2,
+              "columns": 2,
+              "headerScope": "row",
+              "cells": [
+                {
+                  "row": 0,
+                  "column": 0,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Group"
+                },
+                {
+                  "row": 0,
+                  "column": 1,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Score"
+                },
+                {
+                  "row": 1,
+                  "column": 0,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "Control"
+                },
+                {
+                  "row": 1,
+                  "column": 1,
+                  "rowSpan": 1,
+                  "columnSpan": 1,
+                  "text": "10"
+                }
+              ]
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.heading-structure",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "heading-structure",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "headings": [
+            {
+              "id": "abstract",
+              "text": "Abstract",
+              "level": 1,
+              "numbered": false,
+              "language": "en"
+            },
+            {
+              "id": "methods",
+              "text": "1 Methods",
+              "level": 1,
+              "numbered": true,
+              "language": "en"
+            },
+            {
+              "id": "structure",
+              "text": "1.1 Structure",
+              "level": 2,
+              "numbered": true,
+              "language": "en"
+            },
+            {
+              "id": "results",
+              "text": "2 Results",
+              "level": 1,
+              "numbered": true,
+              "language": "en"
+            },
+            {
+              "id": "discussion",
+              "text": "Discussion",
+              "level": 1,
+              "numbered": false,
+              "language": "en"
+            },
+            {
+              "id": "references",
+              "text": "References",
+              "level": 1,
+              "numbered": false,
+              "language": "en"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.heading-structure",
+      "documentId": "structured-scientific",
+      "stratum": "heading-structure",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "headings": [
+            {
+              "id": "synthetic-title",
+              "text": "Synthetic semantic completeness fixture",
+              "level": 1,
+              "numbered": false,
+              "language": "en"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "multilingual-scan.heading-structure",
+      "documentId": "multilingual-scan",
+      "stratum": "heading-structure",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "headings": [
+            {
+              "id": "multilingual-source",
+              "text": "MULTILINGUAL SOURCE",
+              "level": 1,
+              "numbered": false,
+              "language": "en"
+            },
+            {
+              "id": "local-research",
+              "text": "本地研究",
+              "level": 1,
+              "numbered": false,
+              "language": "zh"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.display-equation",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "display-equation",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 2,
+        "groundTruth": {
+          "objects": [
+            {
+              "id": "equation-1",
+              "sourcePage": 2,
+              "kind": "display-equation",
+              "bounded": true,
+              "captionRelationship": "caption-of"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.display-equation",
+      "documentId": "structured-scientific",
+      "stratum": "display-equation",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "objects": [
+            {
+              "id": "equation-1",
+              "sourcePage": 1,
+              "kind": "display-equation",
+              "bounded": true,
+              "captionRelationship": "caption-of"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.figure-diagram",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "figure-diagram",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 2,
+        "groundTruth": {
+          "objects": [
+            {
+              "id": "figure-1",
+              "sourcePage": 2,
+              "kind": "figure-or-diagram",
+              "bounded": true,
+              "captionRelationship": "caption-of"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.figure-diagram",
+      "documentId": "structured-scientific",
+      "stratum": "figure-diagram",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "objects": [
+            {
+              "id": "figure-1",
+              "sourcePage": 1,
+              "kind": "figure-or-diagram",
+              "bounded": true,
+              "captionRelationship": "caption-of"
+            },
+            {
+              "id": "figure-2",
+              "sourcePage": 1,
+              "kind": "figure-or-diagram",
+              "bounded": true,
+              "captionRelationship": "caption-of"
+            }
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.prose-continuity",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "prose-continuity",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "paragraphs": [
+            {
+              "id": "paragraph-1",
+              "sourcePage": 1,
+              "continuity": "source-proven-continuous"
+            },
+            {
+              "id": "paragraph-2",
+              "sourcePage": 1,
+              "continuity": "source-proven-continuous"
+            }
+          ],
+          "authoritativeCounters": {
+            "lineBoundaryCount": 2,
+            "decidedLineBoundaryCount": 2,
+            "unresolvedCorruptingJoinCount": 0
+          },
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.prose-continuity",
+      "documentId": "structured-scientific",
+      "stratum": "prose-continuity",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "paragraphs": [
+            {
+              "id": "left-prose",
+              "sourcePage": 1,
+              "continuity": "source-proven-continuous"
+            },
+            {
+              "id": "right-prose",
+              "sourcePage": 1,
+              "continuity": "source-proven-continuous"
+            }
+          ],
+          "authoritativeCounters": {
+            "lineBoundaryCount": 3,
+            "decidedLineBoundaryCount": 3,
+            "unresolvedCorruptingJoinCount": 0
+          },
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.boilerplate-exclusion",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "boilerplate-exclusion",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "excluded": [],
+          "bodyLineCount": 16,
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.boilerplate-exclusion",
+      "documentId": "structured-scientific",
+      "stratum": "boilerplate-exclusion",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "excluded": [],
+          "bodyLineCount": 12,
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "diagnostic-overlays.boilerplate-exclusion",
+      "documentId": "diagnostic-overlays",
+      "stratum": "boilerplate-exclusion",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "excluded": [
+            { "id": "page-number-1", "sourcePage": 1, "kind": "page-number" }
+          ],
+          "bodyLineCount": 7,
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.footnote-resolution",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "footnote-resolution",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "references": [
+            {
+              "id": "note-reference-1",
+              "sourcePage": 1,
+              "marker": "1",
+              "bodyId": "footnote-1"
+            }
+          ],
+          "bodies": [{ "id": "footnote-1", "sourcePage": 1, "marker": "1" }],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.footnote-resolution",
+      "documentId": "structured-scientific",
+      "stratum": "footnote-resolution",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "references": [
+            {
+              "id": "note-reference-1",
+              "sourcePage": 1,
+              "marker": "1",
+              "bodyId": "footnote-1"
+            }
+          ],
+          "bodies": [{ "id": "footnote-1", "sourcePage": 1, "marker": "1" }],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "pdf-to-epub-fidelity.column-layout",
+      "documentId": "pdf-to-epub-fidelity",
+      "stratum": "column-layout",
+      "layout": "one-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "columnCount": 1,
+          "columns": [{ "id": "column-0", "index": 0 }],
+          "readingOrder": ["title", "abstract", "methods", "body"],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "structured-scientific.column-layout",
+      "documentId": "structured-scientific",
+      "stratum": "column-layout",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "columnCount": 2,
+          "columns": [
+            { "id": "column-0", "index": 0 },
+            { "id": "column-1", "index": 1 }
+          ],
+          "readingOrder": [
+            "left-line-1",
+            "left-line-2",
+            "left-line-3",
+            "left-line-4",
+            "right-line-1",
+            "right-line-2",
+            "right-line-3",
+            "right-line-4"
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    },
+    {
+      "id": "diagnostic-overlays.column-layout",
+      "documentId": "diagnostic-overlays",
+      "stratum": "column-layout",
+      "layout": "two-column",
+      "source": {
+        "sourcePage": 1,
+        "groundTruth": {
+          "columnCount": 2,
+          "columns": [
+            { "id": "column-0", "index": 0 },
+            { "id": "column-1", "index": 1 }
+          ],
+          "readingOrder": [
+            "left-start",
+            "left-continuation",
+            "right-start",
+            "right-continuation"
+          ],
+          "review": {
+            "kind": "source-reviewed",
+            "derivedFrom": "source-document",
+            "reviewStatus": "two-reviewer-agreed",
+            "reviewers": ["fixture-reviewer-a", "fixture-reviewer-b"],
+            "parserOutputConsulted": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/issues/037-extraction-eval-strata.md
+++ b/docs/issues/037-extraction-eval-strata.md
@@ -28,6 +28,13 @@ A stratum is therefore only admissible with a defined ground truth and a metric 
 - Metrics are stated so a degenerate answer scores zero: emitting a page-wide grid, emitting every line as a heading, or emitting no objects at all must each score worse than abstaining.
 - Prose-continuity metrics use the pipeline's own authoritative counters where they exist rather than text regexes, and any regex proxy is validated against a counter or a rendered page before it may gate anything.
 - The comparator reports the deterministic path and every configured candidate provider on the same corpus, per stratum and per layout, so a change in either direction is visible in one table.
+- A scored table or object prediction carries source-page geometry and source
+  region/line lineage; metadata-only output is a guarded zero rather than a
+  perfect match. Candidate envelopes bind the canonical eval-set hash.
+- Review labels are admissible only with a roster-bound identity artifact and a
+  source-only decision artifact. Until those artifacts and at least one real
+  provider output exist, the command emits a `reported-only` report and does
+  not claim a comparison.
 - Running the benchmark is a single documented command, and its report is privacy-safe: identities, hashes, counts, and diagnostic codes only.
 
 ## TDD sequence

--- a/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
+++ b/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
@@ -22,6 +22,38 @@ inside the repository. The checker rejects document identity collisions, split
 leakage, unverified template-family declarations, and split documents not bound
 by a source.
 
+### Reader-visible extraction strata
+
+The additive extraction benchmark is kept separate from the frozen fidelity
+cases in [`benchmarks/pdf/extraction-eval-strata-v1.json`](../../../benchmarks/pdf/extraction-eval-strata-v1.json).
+It uses repository-owned source fixtures, with two independent source reviews
+per label, and records table cells (including row/column topology and header
+scope) and heading sequences (including unnumbered and non-English headings).
+The corpus has two one-column and two two-column documents. No parser output is
+consulted when labels are made.
+
+Every stratum declares its scoring formula and a fail-closed degenerate-answer
+guard. An explicit abstention is reported at `0.25`; an empty answer, a
+page-wide grid, an every-line heading flood, a caption without a bounded visual,
+or another guarded answer scores `0`. Prose continuity is gated only by the
+pipeline's authoritative line-boundary counters; a regex proxy cannot enter
+the score.
+
+Run the deterministic path and every configured candidate provider in one
+privacy-safe comparison (the default provider manifest is intentionally
+reported-only until a candidate is independently frozen):
+
+```bash
+npm run pdf:benchmark:extraction -- \
+  --eval-set benchmarks/pdf/extraction-eval-strata-v1.json \
+  --providers benchmarks/pdf/extraction-eval-providers-v1.json \
+  --out /tmp/pdf-extraction-eval-report.json
+```
+
+The report contains only provider identities, artifact hashes, counts, scores
+grouped by stratum and layout, and bounded diagnostic codes. Source text,
+local paths, and rendered evidence remain outside the report.
+
 Every frozen split identity covers each document id, exact source-PDF SHA-256,
 verified template-family id, and SHA-256 of the source-only assignment
 evidence. A blind document is acceptable only when every source containing it

--- a/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
+++ b/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
@@ -26,22 +26,26 @@ by a source.
 
 The additive extraction benchmark is kept separate from the frozen fidelity
 cases in [`benchmarks/pdf/extraction-eval-strata-v1.json`](../../../benchmarks/pdf/extraction-eval-strata-v1.json).
-It uses repository-owned source fixtures, with two independent source reviews
-per label, and records table cells (including row/column topology and header
-scope) and heading sequences (including unnumbered and non-English headings).
-The corpus has two one-column and two two-column documents. No parser output is
-consulted when labels are made.
+It uses repository-owned source fixtures and records table cells (including
+row/column topology, header scope, source geometry, and source-line lineage)
+and heading sequences (including unnumbered and non-English headings). The
+corpus has two one-column and two two-column documents. No parser output is
+consulted when labels are made. Labels remain `review-required` until a
+roster-bound reviewer artifact and source-only decision artifact are committed;
+the checked-in fixture slice does not invent reviewer identities.
 
 Every stratum declares its scoring formula and a fail-closed degenerate-answer
 guard. An explicit abstention is reported at `0.25`; an empty answer, a
-page-wide grid, an every-line heading flood, a caption without a bounded visual,
-or another guarded answer scores `0`. Prose continuity is gated only by the
+metadata-only table or object without source geometry and lineage, a page-wide
+grid, an every-line heading flood, a caption without a bounded visual, or
+another guarded answer scores `0`. Prose continuity is gated only by the
 pipeline's authoritative line-boundary counters; a regex proxy cannot enter
-the score.
+the score. Candidate envelopes also bind the canonical eval-set hash.
 
 Run the deterministic path and every configured candidate provider in one
-privacy-safe comparison (the default provider manifest is intentionally
-reported-only until a candidate is independently frozen):
+privacy-safe report. The default provider manifest is explicitly
+`reported-only`: all providers abstain until independently frozen output is
+available, so the command must not be read as a quality comparison.
 
 ```bash
 npm run pdf:benchmark:extraction -- \
@@ -51,8 +55,10 @@ npm run pdf:benchmark:extraction -- \
 ```
 
 The report contains only provider identities, artifact hashes, counts, scores
-grouped by stratum and layout, and bounded diagnostic codes. Source text,
-local paths, and rendered evidence remain outside the report.
+grouped by stratum and layout, a `reported-only`/`comparison` status, and
+bounded diagnostic codes. In `reported-only` mode provider scores are `null`
+and `NO_SCORED_PROVIDER_OUTPUT` is emitted; source text, local paths, and
+rendered evidence remain outside the report.
 
 Every frozen split identity covers each document id, exact source-PDF SHA-256,
 verified template-family id, and SHA-256 of the source-only assignment

--- a/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
+++ b/docs/research/semantic-responsive-typesetting/pdf-benchmark-readiness.md
@@ -60,6 +60,13 @@ bounded diagnostic codes. In `reported-only` mode provider scores are `null`
 and `NO_SCORED_PROVIDER_OUTPUT` is emitted; source text, local paths, and
 rendered evidence remain outside the report.
 
+The canonical eval-set identity preserves source and reviewer-label identity but
+excludes review-evidence file digests, so a source-only decision artifact can
+bind the eval-set hash without creating a digest cycle. File-mode providers must
+also declare `predictionsSha256`; the loader verifies the exact repository bytes
+before accepting the candidate. Abstaining providers declare both prediction
+fields as `null`.
+
 Every frozen split identity covers each document id, exact source-PDF SHA-256,
 verified template-family id, and SHA-256 of the source-only assignment
 evidence. A blind document is acceptable only when every source containing it

--- a/docs/schemas/pdf-extraction-eval-candidate.schema.json
+++ b/docs/schemas/pdf-extraction-eval-candidate.schema.json
@@ -57,7 +57,17 @@
           "type": "array",
           "items": { "$ref": "#/$defs/id" }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "abstain" } }
+          },
+          "then": {
+            "properties": { "prediction": { "type": "null" } }
+          }
+        }
+      ]
     }
   }
 }

--- a/docs/schemas/pdf-extraction-eval-candidate.schema.json
+++ b/docs/schemas/pdf-extraction-eval-candidate.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-candidate-1.0.0.json",
+  "title": "Source-bound PDF extraction evaluation candidate envelope",
+  "description": "A provider output is admissible only when it names the canonical eval-set hash. Predictions are scored only when their stratum-specific geometry and source-lineage bindings are present.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "evalSetId",
+    "evalSetSha256",
+    "provider",
+    "cases"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "evalSetId": { "$ref": "#/$defs/id" },
+    "evalSetSha256": { "$ref": "#/$defs/sha256" },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "version", "sourceIdentitySha256"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": { "enum": ["deterministic", "candidate"] },
+        "version": { "$ref": "#/$defs/id" },
+        "sourceIdentitySha256": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sha256" }]
+        }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["caseId", "status", "prediction", "diagnostics"],
+      "properties": {
+        "caseId": { "$ref": "#/$defs/id" },
+        "status": { "enum": ["scored", "abstain"] },
+        "prediction": {
+          "oneOf": [{ "type": "null" }, { "type": "object" }]
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/id" }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/pdf-extraction-eval-providers.schema.json
+++ b/docs/schemas/pdf-extraction-eval-providers.schema.json
@@ -4,7 +4,13 @@
   "title": "Extraction benchmark provider comparison manifest",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "id", "evalSet", "providers"],
+  "required": [
+    "schemaVersion",
+    "id",
+    "evalSet",
+    "evaluationStatus",
+    "providers"
+  ],
   "properties": {
     "schemaVersion": { "const": "1.0.0" },
     "id": { "$ref": "#/$defs/id" },
@@ -20,6 +26,9 @@
         "fileSha256": { "$ref": "#/$defs/sha256" },
         "evalSetSha256": { "$ref": "#/$defs/sha256" }
       }
+    },
+    "evaluationStatus": {
+      "enum": ["reported-only", "comparison-ready"]
     },
     "providers": {
       "type": "array",

--- a/docs/schemas/pdf-extraction-eval-providers.schema.json
+++ b/docs/schemas/pdf-extraction-eval-providers.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-providers-1.0.0.json",
+  "title": "Extraction benchmark provider comparison manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "id", "evalSet", "providers"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "id": { "$ref": "#/$defs/id" },
+    "evalSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "fileSha256", "evalSetSha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._/-]+$"
+        },
+        "fileSha256": { "$ref": "#/$defs/sha256" },
+        "evalSetSha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "providers": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/provider" }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "version",
+        "mode",
+        "sourceIdentitySha256",
+        "predictionsPath"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": { "enum": ["deterministic", "candidate"] },
+        "version": { "$ref": "#/$defs/id" },
+        "mode": { "enum": ["abstain", "file"] },
+        "sourceIdentitySha256": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sha256" }]
+        },
+        "predictionsPath": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._/-]+$"
+            }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "mode": { "const": "abstain" },
+            "predictionsPath": { "const": null }
+          }
+        },
+        {
+          "properties": {
+            "mode": { "const": "file" },
+            "predictionsPath": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._/-]+$"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/schemas/pdf-extraction-eval-providers.schema.json
+++ b/docs/schemas/pdf-extraction-eval-providers.schema.json
@@ -54,7 +54,8 @@
         "version",
         "mode",
         "sourceIdentitySha256",
-        "predictionsPath"
+        "predictionsPath",
+        "predictionsSha256"
       ],
       "properties": {
         "id": { "$ref": "#/$defs/id" },
@@ -72,13 +73,17 @@
               "pattern": "^[A-Za-z0-9._/-]+$"
             }
           ]
+        },
+        "predictionsSha256": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sha256" }]
         }
       },
       "oneOf": [
         {
           "properties": {
             "mode": { "const": "abstain" },
-            "predictionsPath": { "const": null }
+            "predictionsPath": { "const": null },
+            "predictionsSha256": { "const": null }
           }
         },
         {
@@ -87,7 +92,8 @@
             "predictionsPath": {
               "type": "string",
               "pattern": "^[A-Za-z0-9._/-]+$"
-            }
+            },
+            "predictionsSha256": { "$ref": "#/$defs/sha256" }
           }
         }
       ]

--- a/docs/schemas/pdf-extraction-eval-review.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.0.0.json",
+  "title": "Source-only extraction evaluation review evidence",
+  "description": "Roster and decision artifacts bind reviewer identities and labels without exposing private source content or consulting candidate output.",
+  "oneOf": [
+    { "$ref": "#/$defs/roster" },
+    { "$ref": "#/$defs/decisions" }
+  ],
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "roster": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "kind", "evalSetId", "reviewers"],
+      "properties": {
+        "schemaVersion": { "const": "1.0.0" },
+        "kind": { "const": "pdf-extraction-reviewer-roster" },
+        "evalSetId": { "$ref": "#/$defs/id" },
+        "reviewers": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reviewerId", "identityEvidenceSha256"],
+            "properties": {
+              "reviewerId": { "$ref": "#/$defs/id" },
+              "identityEvidenceSha256": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        }
+      }
+    },
+    "decisions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "evalSetId",
+        "evalSetSha256",
+        "sourceOnly",
+        "candidateOutputConsultedForLabel",
+        "decisions"
+      ],
+      "properties": {
+        "schemaVersion": { "const": "1.0.0" },
+        "kind": { "const": "pdf-extraction-source-only-decisions" },
+        "evalSetId": { "$ref": "#/$defs/id" },
+        "evalSetSha256": { "$ref": "#/$defs/sha256" },
+        "sourceOnly": { "const": true },
+        "candidateOutputConsultedForLabel": { "const": false },
+        "decisions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "caseId",
+              "sourceSha256",
+              "reviewers",
+              "decision",
+              "decisionSha256"
+            ],
+            "properties": {
+              "caseId": { "$ref": "#/$defs/id" },
+              "sourceSha256": { "$ref": "#/$defs/sha256" },
+              "reviewers": {
+                "type": "array",
+                "minItems": 2,
+                "uniqueItems": true,
+                "items": { "$ref": "#/$defs/id" }
+              },
+              "decision": { "const": "agreed" },
+              "decisionSha256": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -1,0 +1,503 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-strata-1.0.0.json",
+  "title": "Source-reviewed scholarly PDF extraction strata benchmark",
+  "description": "Privacy-safe contract for source-reviewed extraction strata. Parser output is never admissible as ground truth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "privacy",
+    "protocol",
+    "documents",
+    "strata",
+    "cases"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "id": { "$ref": "#/$defs/id" },
+    "privacy": {
+      "const": "repository-fixture-identities-source-reviewed-no-private-inputs"
+    },
+    "protocol": { "$ref": "#/$defs/protocol" },
+    "documents": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/document" }
+    },
+    "strata": {
+      "type": "array",
+      "minItems": 8,
+      "items": { "$ref": "#/$defs/stratum" }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "layout": {
+      "enum": ["one-column", "two-column"]
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "derivedFrom",
+        "reviewStatus",
+        "reviewers",
+        "parserOutputConsulted"
+      ],
+      "properties": {
+        "kind": { "const": "source-reviewed" },
+        "derivedFrom": { "const": "source-document" },
+        "reviewStatus": { "const": "two-reviewer-agreed" },
+        "reviewers": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "parserOutputConsulted": { "const": false }
+      }
+    },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "reportPrivacy",
+        "sourceLabelPolicy",
+        "regexProxyPolicy",
+        "abstentionPolicy",
+        "corpusBalance"
+      ],
+      "properties": {
+        "command": { "const": "npm run pdf:benchmark:extraction" },
+        "reportPrivacy": {
+          "const": "identities-hashes-counts-diagnostic-codes-only"
+        },
+        "sourceLabelPolicy": {
+          "const": "source-review-required-parser-output-never-a-label"
+        },
+        "regexProxyPolicy": {
+          "const": "authoritative-pipeline-counters-only-regex-never-gates"
+        },
+        "abstentionPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["score", "beatsDegenerateAnswer", "status"],
+          "properties": {
+            "score": { "const": 0.25 },
+            "beatsDegenerateAnswer": { "const": true },
+            "status": { "const": "reported-not-correct" }
+          }
+        },
+        "corpusBalance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "layouts",
+            "minimumDocumentsPerLayout",
+            "reportByLayout"
+          ],
+          "properties": {
+            "layouts": {
+              "const": ["one-column", "two-column"]
+            },
+            "minimumDocumentsPerLayout": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "reportByLayout": { "const": true }
+          }
+        }
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "fixturePath",
+        "sha256",
+        "byteLength",
+        "pageCount",
+        "layout",
+        "groundTruthReview"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "fixturePath": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._/-]+$"
+        },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "byteLength": { "type": "integer", "minimum": 1 },
+        "pageCount": { "type": "integer", "minimum": 1 },
+        "layout": { "$ref": "#/$defs/layout" },
+        "groundTruthReview": { "$ref": "#/$defs/review" }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "unit",
+        "formula",
+        "scoreRange",
+        "abstentionScore",
+        "degenerateScore",
+        "degenerateAnswerGuardId",
+        "authoritativeEvidence"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string", "minLength": 1 },
+        "unit": { "type": "string", "minLength": 1 },
+        "formula": { "type": "string", "minLength": 1 },
+        "scoreRange": {
+          "type": "array",
+          "prefixItems": [{ "const": 0 }, { "const": 1 }],
+          "items": false
+        },
+        "abstentionScore": { "const": 0.25 },
+        "degenerateScore": { "const": 0 },
+        "degenerateAnswerGuardId": { "$ref": "#/$defs/id" },
+        "authoritativeEvidence": { "type": "string", "minLength": 1 }
+      }
+    },
+    "guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "rejects",
+        "detection",
+        "score",
+        "abstentionScore",
+        "failClosed"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "rejects": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "detection": { "type": "string", "minLength": 1 },
+        "score": { "const": 0 },
+        "abstentionScore": { "const": 0.25 },
+        "failClosed": { "const": true }
+      }
+    },
+    "stratum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "task",
+        "description",
+        "groundTruth",
+        "metric",
+        "degenerateAnswerGuard"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "task": { "$ref": "#/$defs/id" },
+        "description": { "type": "string", "minLength": 1 },
+        "groundTruth": { "$ref": "#/$defs/review" },
+        "metric": { "$ref": "#/$defs/metric" },
+        "degenerateAnswerGuard": { "$ref": "#/$defs/guard" }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "documentId", "stratum", "layout", "source"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "documentId": { "$ref": "#/$defs/id" },
+        "stratum": { "$ref": "#/$defs/id" },
+        "layout": { "$ref": "#/$defs/layout" },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourcePage", "groundTruth"],
+          "properties": {
+            "sourcePage": { "type": "integer", "minimum": 1 },
+            "groundTruth": { "$ref": "#/$defs/caseGroundTruth" }
+          }
+        }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["row", "column", "rowSpan", "columnSpan", "text"],
+      "properties": {
+        "row": { "type": "integer", "minimum": 0 },
+        "column": { "type": "integer", "minimum": 0 },
+        "rowSpan": { "const": 1 },
+        "columnSpan": { "const": 1 },
+        "text": { "type": "string", "minLength": 1 }
+      }
+    },
+    "table": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sourcePage",
+        "rows",
+        "columns",
+        "headerScope",
+        "cells"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "rows": { "type": "integer", "minimum": 1 },
+        "columns": { "type": "integer", "minimum": 1 },
+        "headerScope": {
+          "enum": ["row", "column", "row-and-column", "none"]
+        },
+        "cells": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/cell" }
+        }
+      }
+    },
+    "tableGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tables", "review"],
+      "properties": {
+        "tables": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/table" }
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "heading": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "text", "level", "numbered", "language"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "text": { "type": "string", "minLength": 1 },
+        "level": { "type": "integer", "minimum": 1, "maximum": 6 },
+        "numbered": { "type": "boolean" },
+        "language": { "type": "string", "minLength": 2 }
+      }
+    },
+    "headingGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["headings", "review"],
+      "properties": {
+        "headings": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/heading" }
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sourcePage",
+        "kind",
+        "bounded",
+        "captionRelationship"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "kind": { "enum": ["display-equation", "figure-or-diagram"] },
+        "bounded": { "const": true },
+        "captionRelationship": { "type": "string", "minLength": 1 }
+      }
+    },
+    "objectGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["objects", "review"],
+      "properties": {
+        "objects": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/object" }
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "authoritativeCounters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lineBoundaryCount",
+        "decidedLineBoundaryCount",
+        "unresolvedCorruptingJoinCount"
+      ],
+      "properties": {
+        "lineBoundaryCount": { "type": "integer", "minimum": 0 },
+        "decidedLineBoundaryCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unresolvedCorruptingJoinCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "proseParagraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sourcePage", "continuity"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "continuity": { "const": "source-proven-continuous" }
+      }
+    },
+    "proseGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paragraphs", "authoritativeCounters", "review"],
+      "properties": {
+        "paragraphs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/proseParagraph" }
+        },
+        "authoritativeCounters": {
+          "$ref": "#/$defs/authoritativeCounters"
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "boilerplateItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sourcePage", "kind"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "kind": { "enum": ["running-head", "page-number"] }
+      }
+    },
+    "boilerplateGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["excluded", "bodyLineCount", "review"],
+      "properties": {
+        "excluded": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/boilerplateItem" }
+        },
+        "bodyLineCount": { "type": "integer", "minimum": 1 },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "footnoteReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sourcePage", "marker", "bodyId"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "marker": { "type": "string", "minLength": 1 },
+        "bodyId": { "$ref": "#/$defs/id" }
+      }
+    },
+    "footnoteBody": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sourcePage", "marker"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "sourcePage": { "type": "integer", "minimum": 1 },
+        "marker": { "type": "string", "minLength": 1 }
+      }
+    },
+    "footnoteGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["references", "bodies", "review"],
+      "properties": {
+        "references": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/footnoteReference" }
+        },
+        "bodies": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/footnoteBody" }
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "column": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "index"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "index": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "columnGroundTruth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["columnCount", "columns", "readingOrder", "review"],
+      "properties": {
+        "columnCount": { "type": "integer", "minimum": 1 },
+        "columns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/column" }
+        },
+        "readingOrder": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "review": { "$ref": "#/$defs/review" }
+      }
+    },
+    "caseGroundTruth": {
+      "oneOf": [
+        { "$ref": "#/$defs/tableGroundTruth" },
+        { "$ref": "#/$defs/headingGroundTruth" },
+        { "$ref": "#/$defs/objectGroundTruth" },
+        { "$ref": "#/$defs/proseGroundTruth" },
+        { "$ref": "#/$defs/boilerplateGroundTruth" },
+        { "$ref": "#/$defs/footnoteGroundTruth" },
+        { "$ref": "#/$defs/columnGroundTruth" }
+      ]
+    }
+  }
+}

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -46,6 +46,18 @@
       "type": "string",
       "pattern": "^[a-f0-9]{64}$"
     },
+    "box": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
+        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
+        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 }
+      ],
+      "items": false
+    },
     "layout": {
       "enum": ["one-column", "two-column"]
     },
@@ -57,19 +69,54 @@
         "derivedFrom",
         "reviewStatus",
         "reviewers",
-        "parserOutputConsulted"
+        "parserOutputConsulted",
+        "reviewEvidence"
       ],
       "properties": {
         "kind": { "const": "source-reviewed" },
         "derivedFrom": { "const": "source-document" },
-        "reviewStatus": { "const": "two-reviewer-agreed" },
+        "reviewStatus": {
+          "enum": ["review-required", "two-reviewer-agreed"]
+        },
         "reviewers": {
           "type": "array",
-          "minItems": 2,
           "uniqueItems": true,
           "items": { "$ref": "#/$defs/id" }
         },
-        "parserOutputConsulted": { "const": false }
+        "parserOutputConsulted": { "const": false },
+        "reviewEvidence": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/reviewEvidence" }
+          ]
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "reviewStatus": { "const": "review-required" },
+            "reviewers": { "type": "array", "maxItems": 0 },
+            "reviewEvidence": { "type": "null" }
+          }
+        },
+        {
+          "properties": {
+            "reviewStatus": { "const": "two-reviewer-agreed" },
+            "reviewers": { "type": "array", "minItems": 2 },
+            "reviewEvidence": { "$ref": "#/$defs/reviewEvidence" }
+          }
+        }
+      ]
+    },
+    "reviewEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rosterPath", "rosterSha256", "decisionPath", "decisionSha256"],
+      "properties": {
+        "rosterPath": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
+        "rosterSha256": { "$ref": "#/$defs/sha256" },
+        "decisionPath": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
+        "decisionSha256": { "$ref": "#/$defs/sha256" }
       }
     },
     "protocol": {
@@ -171,6 +218,8 @@
         "formula": { "type": "string", "minLength": 1 },
         "scoreRange": {
           "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
           "prefixItems": [{ "const": 0 }, { "const": 1 }],
           "items": false
         },
@@ -265,6 +314,9 @@
         "rows",
         "columns",
         "headerScope",
+        "box",
+        "sourceRegionIds",
+        "sourceLineIds",
         "cells"
       ],
       "properties": {
@@ -274,6 +326,19 @@
         "columns": { "type": "integer", "minimum": 1 },
         "headerScope": {
           "enum": ["row", "column", "row-and-column", "none"]
+        },
+        "box": { "$ref": "#/$defs/box" },
+        "sourceRegionIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "sourceLineIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
         },
         "cells": {
           "type": "array",
@@ -328,14 +393,30 @@
         "sourcePage",
         "kind",
         "bounded",
-        "captionRelationship"
+        "captionRelationship",
+        "box",
+        "sourceRegionIds",
+        "sourceLineIds"
       ],
       "properties": {
         "id": { "$ref": "#/$defs/id" },
         "sourcePage": { "type": "integer", "minimum": 1 },
         "kind": { "enum": ["display-equation", "figure-or-diagram"] },
         "bounded": { "const": true },
-        "captionRelationship": { "type": "string", "minLength": 1 }
+        "captionRelationship": { "type": "string", "minLength": 1 },
+        "box": { "$ref": "#/$defs/box" },
+        "sourceRegionIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "sourceLineIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        }
       }
     },
     "objectGroundTruth": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pdf:export": "node tools/pdf-export.mjs",
     "pdf:local:doctor": "node tools/pdf-local-mac-doctor.mjs",
     "pdf:benchmark:compare": "node tools/pdf-benchmark-compare.mjs",
+    "pdf:benchmark:extraction": "node tools/pdf-extraction-eval.mjs",
     "pdf:ocr:benchmark": "node tools/pdf-ocr-engine-benchmark.mjs",
     "pdf:benchmark:readiness": "node tools/pdf-benchmark-readiness.mjs",
     "pdf:private-decisions:compose": "node tools/pdf-private-decision-compose.mjs",

--- a/tests/fixtures/pdf/README.md
+++ b/tests/fixtures/pdf/README.md
@@ -46,8 +46,9 @@ language-pack and Unicode behavior can be tested without copying a third-party
 document or font.
 
 `diagnostic-overlays.pdf` deliberately retains two plausible column orders and
-two equally scored note bodies. It is the repository-owned visual evidence
-fixture for reading-order and note-relationship overlays.
+two equally scored note bodies, with a running head and page number at the
+page furniture boundaries. It is the repository-owned visual evidence fixture
+for reading-order, note-relationship, and boilerplate-exclusion overlays.
 
 `adjudication-required.pdf` contains two deliberately tied note matches and a
 below-threshold two-column order. It exercises exact-scope human decisions and

--- a/tests/fixtures/pdf/diagnostic-overlays.pdf
+++ b/tests/fixtures/pdf/diagnostic-overlays.pdf
@@ -13,8 +13,13 @@ endobj
 << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]  /Resources << /Font << /F1 3 0 R >>  >> /Contents 5 0 R >>
 endobj
 5 0 obj
-<< /Length 559 >>
+<< /Length 653 >>
 stream
+BT
+/F1 8 Tf
+54 770 Td
+(Diagnostic extraction benchmark) Tj
+ET
 BT
 /F1 11 Tf
 54 690 Td
@@ -50,6 +55,11 @@ BT
 330 70 Td
 (Footnote 1: Right candidate note body.) Tj
 ET
+BT
+/F1 8 Tf
+306 24 Td
+(1) Tj
+ET
 endstream
 endobj
 xref
@@ -63,5 +73,5 @@ xref
 trailer
 << /Size 6 /Root 1 0 R >>
 startxref
-960
+1054
 %%EOF

--- a/tests/fixtures/pdf/generate-fixtures.mjs
+++ b/tests/fixtures/pdf/generate-fixtures.mjs
@@ -950,6 +950,7 @@ const fixtures = {
   'diagnostic-overlays.pdf': [
     {
       lines: [
+        { text: 'Diagnostic extraction benchmark', x: 54, y: 770, size: 8 },
         { text: 'Left candidate order begins here.', x: 54, y: 690 },
         { text: 'Right candidate order begins here.', x: 330, y: 690 },
         { text: 'Indented left order continues here.', x: 100, y: 300 },
@@ -971,6 +972,7 @@ const fixtures = {
           y: 70,
           size: 8,
         },
+        { text: '1', x: 306, y: 24, size: 8 },
       ],
     },
   ],

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -52,6 +52,8 @@ const SAFE_DIAGNOSTIC = /^[A-Z][A-Z0-9_]{2,63}$/
 const MAX_JSON_BYTES = 32 * 1024 * 1024
 const ABSTENTION_SCORE = 0.25
 const DEGENERATE_SCORE = 0
+const REVIEW_STATUSES = Object.freeze(['review-required', 'two-reviewer-agreed'])
+const REVIEW_EVIDENCE_VALIDATED = Symbol('pdfExtractionReviewEvidenceValidated')
 
 function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -151,6 +153,41 @@ function pathIsRepositoryRelative(value) {
   )
 }
 
+function isNormalizedBox(value) {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === 'number' && Number.isFinite(item)) &&
+    value[0] >= 0 &&
+    value[0] < 1 &&
+    value[1] >= 0 &&
+    value[1] < 1 &&
+    value[2] > 0 &&
+    value[2] <= 1 &&
+    value[3] > 0 &&
+    value[3] <= 1 &&
+    value[0] + value[2] <= 1 &&
+    value[1] + value[3] <= 1
+  )
+}
+
+function validateSourceBinding(value, code) {
+  if (
+    !isRecord(value) ||
+    !isNormalizedBox(value.box) ||
+    !Array.isArray(value.sourceRegionIds) ||
+    value.sourceRegionIds.length === 0 ||
+    !uniqueBy(value.sourceRegionIds, (id) => id) ||
+    !value.sourceRegionIds.every((id) => SAFE_ID.test(id ?? '')) ||
+    !Array.isArray(value.sourceLineIds) ||
+    value.sourceLineIds.length === 0 ||
+    !uniqueBy(value.sourceLineIds, (id) => id) ||
+    !value.sourceLineIds.every((id) => SAFE_ID.test(id ?? ''))
+  ) {
+    invalid(code)
+  }
+}
+
 function expectedStratum(value) {
   return (
     isRecord(value) &&
@@ -181,15 +218,37 @@ function validateGroundTruthReview(value, code) {
       'reviewStatus',
       'reviewers',
       'parserOutputConsulted',
+      'reviewEvidence',
     ]) ||
     value.kind !== 'source-reviewed' ||
     value.derivedFrom !== 'source-document' ||
-    value.reviewStatus !== 'two-reviewer-agreed' ||
+    !REVIEW_STATUSES.includes(value.reviewStatus) ||
     !Array.isArray(value.reviewers) ||
-    value.reviewers.length < 2 ||
     !uniqueBy(value.reviewers, (reviewer) => reviewer) ||
     !value.reviewers.every((reviewer) => SAFE_ID.test(reviewer)) ||
     value.parserOutputConsulted !== false
+  ) {
+    invalid(code)
+  }
+  if (value.reviewStatus === 'review-required') {
+    if (value.reviewers.length !== 0 || value.reviewEvidence !== null) {
+      invalid(code)
+    }
+    return
+  }
+  if (
+    value.reviewers.length < 2 ||
+    !isRecord(value.reviewEvidence) ||
+    !exactKeys(value.reviewEvidence, [
+      'rosterPath',
+      'rosterSha256',
+      'decisionPath',
+      'decisionSha256',
+    ]) ||
+    !pathIsRepositoryRelative(value.reviewEvidence.rosterPath) ||
+    !SHA256.test(value.reviewEvidence.rosterSha256 ?? '') ||
+    !pathIsRepositoryRelative(value.reviewEvidence.decisionPath) ||
+    !SHA256.test(value.reviewEvidence.decisionSha256 ?? '')
   ) {
     invalid(code)
   }
@@ -298,6 +357,9 @@ function validateTableGroundTruth(value, code) {
         'rows',
         'columns',
         'headerScope',
+        'box',
+        'sourceRegionIds',
+        'sourceLineIds',
         'cells',
       ]) ||
       !SAFE_ID.test(table.id ?? '') ||
@@ -315,6 +377,7 @@ function validateTableGroundTruth(value, code) {
     ) {
       invalid(code)
     }
+    validateSourceBinding(table, code)
     for (const cell of table.cells) {
       if (
         !exactKeys(cell, ['row', 'column', 'rowSpan', 'columnSpan', 'text']) ||
@@ -386,6 +449,9 @@ function validateObjectGroundTruth(value, code, kind) {
         'kind',
         'bounded',
         'captionRelationship',
+        'box',
+        'sourceRegionIds',
+        'sourceLineIds',
       ]) ||
       !SAFE_ID.test(object.id ?? '') ||
       !Number.isSafeInteger(object.sourcePage) ||
@@ -397,6 +463,7 @@ function validateObjectGroundTruth(value, code, kind) {
     ) {
       invalid(code)
     }
+    validateSourceBinding(object, code)
   }
 }
 
@@ -799,8 +866,146 @@ async function readRepositoryJson(repositoryPath, code) {
   }
 }
 
+async function validateReviewEvidenceFiles(value, identity) {
+  const reviewValues = reviewValuesForEvalSet(value)
+  const agreed = reviewValues.filter(
+    (review) => review.reviewStatus === 'two-reviewer-agreed',
+  )
+  if (agreed.length === 0) return
+  if (reviewValues.some((review) => review.reviewStatus === 'review-required')) {
+    invalid('PDF_EXTRACTION_REVIEW_INCOMPLETE')
+  }
+  const evidence = agreed[0].reviewEvidence
+  if (
+    agreed.some(
+      (review) => canonicalJson(review.reviewEvidence) !== canonicalJson(evidence),
+    )
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_EVIDENCE_BINDING_MISMATCH')
+  }
+  const rosterArtifact = await readRepositoryJson(
+    evidence.rosterPath,
+    'PDF_EXTRACTION_REVIEW_ROSTER_FILE',
+  )
+  if (
+    sha256(rosterArtifact.bytes) !== evidence.rosterSha256 ||
+    !exactKeys(rosterArtifact.value, [
+      'schemaVersion',
+      'kind',
+      'evalSetId',
+      'reviewers',
+    ]) ||
+    rosterArtifact.value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    rosterArtifact.value.kind !== 'pdf-extraction-reviewer-roster' ||
+    rosterArtifact.value.evalSetId !== identity.id ||
+    !Array.isArray(rosterArtifact.value.reviewers) ||
+    rosterArtifact.value.reviewers.length < 2 ||
+    !uniqueBy(rosterArtifact.value.reviewers, (reviewer) => reviewer.reviewerId)
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+  }
+  for (const reviewer of rosterArtifact.value.reviewers) {
+    if (
+      !exactKeys(reviewer, ['reviewerId', 'identityEvidenceSha256']) ||
+      !SAFE_ID.test(reviewer.reviewerId ?? '') ||
+      !SHA256.test(reviewer.identityEvidenceSha256 ?? '')
+    ) {
+      invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+    }
+  }
+  const rosterIds = new Set(
+    rosterArtifact.value.reviewers.map((reviewer) => reviewer.reviewerId),
+  )
+  const decisionArtifact = await readRepositoryJson(
+    evidence.decisionPath,
+    'PDF_EXTRACTION_REVIEW_DECISION_FILE',
+  )
+  if (
+    sha256(decisionArtifact.bytes) !== evidence.decisionSha256 ||
+    !exactKeys(decisionArtifact.value, [
+      'schemaVersion',
+      'kind',
+      'evalSetId',
+      'evalSetSha256',
+      'sourceOnly',
+      'candidateOutputConsultedForLabel',
+      'decisions',
+    ]) ||
+    decisionArtifact.value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    decisionArtifact.value.kind !== 'pdf-extraction-source-only-decisions' ||
+    decisionArtifact.value.evalSetId !== identity.id ||
+    decisionArtifact.value.evalSetSha256 !== identity.evalSetSha256 ||
+    decisionArtifact.value.sourceOnly !== true ||
+    decisionArtifact.value.candidateOutputConsultedForLabel !== false ||
+    !Array.isArray(decisionArtifact.value.decisions) ||
+    !uniqueBy(decisionArtifact.value.decisions, (decision) => decision.caseId)
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
+  }
+  const documentById = new Map(value.documents.map((item) => [item.id, item]))
+  const caseIds = new Set(value.cases.map((item) => item.id))
+  for (const decision of decisionArtifact.value.decisions) {
+    if (
+      !exactKeys(decision, [
+        'caseId',
+        'sourceSha256',
+        'reviewers',
+        'decision',
+        'decisionSha256',
+      ]) ||
+      !caseIds.has(decision.caseId) ||
+      !SHA256.test(decision.sourceSha256 ?? '') ||
+      decision.sourceSha256 !==
+        documentById.get(
+          value.cases.find((item) => item.id === decision.caseId).documentId,
+        ).sha256 ||
+      !Array.isArray(decision.reviewers) ||
+      decision.reviewers.length < 2 ||
+      !uniqueBy(decision.reviewers, (reviewer) => reviewer) ||
+      !decision.reviewers.every((reviewer) => rosterIds.has(reviewer)) ||
+      decision.decision !== 'agreed' ||
+      !SHA256.test(decision.decisionSha256 ?? '')
+    ) {
+      invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
+    }
+  }
+  const agreedCaseIds = new Set(
+    decisionArtifact.value.decisions.map((decision) => decision.caseId),
+  )
+  if ([...caseIds].some((caseId) => !agreedCaseIds.has(caseId))) {
+    invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
+  }
+  const decisionReviewerIds = new Set(
+    decisionArtifact.value.decisions.flatMap((decision) => decision.reviewers),
+  )
+  for (const review of agreed) {
+    if (
+      review.reviewers.some(
+        (reviewer) =>
+          !rosterIds.has(reviewer) || !decisionReviewerIds.has(reviewer),
+      )
+    ) {
+      invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+    }
+  }
+  Object.defineProperty(value, REVIEW_EVIDENCE_VALIDATED, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  })
+}
+
+function reviewValuesForEvalSet(value) {
+  return [
+    ...value.documents.map((item) => item.groundTruthReview),
+    ...value.strata.map((item) => item.groundTruth),
+    ...value.cases.map((item) => item.source.groundTruth.review),
+  ]
+}
+
 export async function validatePdfExtractionEvalSetFiles(value) {
   const identity = validatePdfExtractionEvalSet(value)
+  await validateReviewEvidenceFiles(value, identity)
   for (const document of value.documents) {
     if (!pathIsRepositoryRelative(document.fixturePath)) {
       invalid('INVALID_PDF_EXTRACTION_FIXTURE_PATH')
@@ -834,9 +1039,16 @@ export async function validatePdfExtractionEvalSetFiles(value) {
 function validateCandidateProvider(value, evalIdentity, code) {
   if (
     !isRecord(value) ||
-    !exactKeys(value, ['schemaVersion', 'evalSetId', 'provider', 'cases']) ||
+    !exactKeys(value, [
+      'schemaVersion',
+      'evalSetId',
+      'evalSetSha256',
+      'provider',
+      'cases',
+    ]) ||
     value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
     value.evalSetId !== evalIdentity.id ||
+    value.evalSetSha256 !== evalIdentity.evalSetSha256 ||
     !isRecord(value.provider) ||
     !exactKeys(value.provider, [
       'id',
@@ -909,11 +1121,44 @@ function predictionArray(prediction, key) {
   return Array.isArray(prediction?.[key]) ? prediction[key] : null
 }
 
+function sourceBindingMatches(expected, candidate) {
+  return (
+    hasValidSourceBinding(candidate) &&
+    canonicalJson(candidate.box) === canonicalJson(expected.box) &&
+    canonicalJson(candidate.sourceRegionIds) ===
+      canonicalJson(expected.sourceRegionIds) &&
+    canonicalJson(candidate.sourceLineIds) ===
+      canonicalJson(expected.sourceLineIds)
+  )
+}
+
+function hasValidSourceBinding(value) {
+  return (
+    isRecord(value) &&
+    isNormalizedBox(value.box) &&
+    Array.isArray(value.sourceRegionIds) &&
+    value.sourceRegionIds.length > 0 &&
+    uniqueBy(value.sourceRegionIds, (id) => id) &&
+    value.sourceRegionIds.every((id) => SAFE_ID.test(id ?? '')) &&
+    Array.isArray(value.sourceLineIds) &&
+    value.sourceLineIds.length > 0 &&
+    uniqueBy(value.sourceLineIds, (id) => id) &&
+    value.sourceLineIds.every((id) => SAFE_ID.test(id ?? ''))
+  )
+}
+
+function missingSourceBinding(predictions) {
+  return predictions.some((prediction) => !hasValidSourceBinding(prediction))
+}
+
 function tableScore(expected, prediction) {
   const expectedTables = expected.tables
   const predictedTables = predictionArray(prediction, 'tables')
   if (!predictedTables) return degenerateResult()
   if (predictedTables.length === 0) return degenerateResult()
+  if (missingSourceBinding(predictedTables)) {
+    return degenerateResult('MISSING_TABLE_GEOMETRY_OR_LINEAGE')
+  }
   if (
     predictedTables.some(
       (table) =>
@@ -930,8 +1175,10 @@ function tableScore(expected, prediction) {
       candidate.rows !== table.rows ||
       candidate.columns !== table.columns ||
       candidate.headerScope !== table.headerScope ||
+      candidate.sourcePage !== table.sourcePage ||
       !Array.isArray(candidate.cells) ||
-      !candidate.cells.every(isRecord)
+      !candidate.cells.every(isRecord) ||
+      !sourceBindingMatches(table, candidate)
     ) {
       return count
     }
@@ -994,6 +1241,9 @@ function objectScore(expected, prediction, key, degenerateCode) {
   const objects = predictionArray(prediction, key)
   if (!objects) return degenerateResult()
   if (objects.length === 0) return degenerateResult()
+  if (missingSourceBinding(objects)) {
+    return degenerateResult('MISSING_OBJECT_GEOMETRY_OR_LINEAGE')
+  }
   if (
     objects.some(
       (object) =>
@@ -1011,7 +1261,8 @@ function objectScore(expected, prediction, key, degenerateCode) {
       candidate.kind === item.kind &&
       candidate.sourcePage === item.sourcePage &&
       candidate.captionRelationship === item.captionRelationship &&
-      candidate.bounded === true
+      candidate.bounded === true &&
+      sourceBindingMatches(item, candidate)
     )
   }).length
   return diagnosticResult(
@@ -1098,7 +1349,15 @@ function relationshipScore(expected, prediction) {
   const relationships = predictionArray(prediction, 'relationships')
   if (!relationships) return degenerateResult()
   if (relationships.length === 0) return degenerateResult()
+  const relationshipKeys = relationships.map(
+    (relationship) =>
+      `${relationship?.referenceId}\0${relationship?.bodyId}\0${relationship?.marker}`,
+  )
+  if (!uniqueBy(relationshipKeys, (key) => key)) {
+    return degenerateResult('DEGENERATE_DUPLICATE_FOOTNOTE_RELATIONSHIP')
+  }
   if (
+    new Set(expected.references.map((reference) => reference.bodyId)).size > 1 &&
     relationships.length > 1 &&
     new Set(relationships.map((item) => item?.bodyId)).size === 1
   ) {
@@ -1203,6 +1462,7 @@ function noGroundTruthOutput(evalSet, provider) {
   return {
     schemaVersion: PDF_EXTRACTION_EVAL_SCHEMA_VERSION,
     evalSetId: evalSet.id,
+    evalSetSha256: canonicalHash(evalSet),
     provider: {
       id: provider.id,
       kind: provider.kind,
@@ -1245,6 +1505,14 @@ export function createAbstainingPdfExtractionCandidate(evalSet, provider) {
  */
 export function comparePdfExtractionProviders(evalSet, providers) {
   const identity = validatePdfExtractionEvalSet(evalSet)
+  if (
+    reviewValuesForEvalSet(evalSet).some(
+      (review) => review.reviewStatus === 'two-reviewer-agreed',
+    ) &&
+    evalSet[REVIEW_EVIDENCE_VALIDATED] !== true
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED')
+  }
   if (!Array.isArray(providers) || providers.length === 0) {
     invalid('PDF_EXTRACTION_NO_PROVIDERS')
   }
@@ -1310,23 +1578,30 @@ export function comparePdfExtractionProviders(evalSet, providers) {
         providerRows.push(row)
       }
     }
-    const scoredRows = providerRows.filter((row) => row.score !== null)
+    const scoredOutputRows = providerRows.filter(
+      (row) => row.scoredCaseCount > 0,
+    )
     providerSummaries.push({
       providerId: candidate.provider.id,
       providerKind: candidate.provider.kind,
       providerVersion: candidate.provider.version,
       caseCount: candidate.cases.length,
-      score: scoredRows.length
-        ? average(scoredRows.map((row) => row.score))
+      score: scoredOutputRows.length
+        ? average(scoredOutputRows.map((row) => row.score))
         : null,
       diagnosticCodes: [
         ...new Set(providerRows.flatMap((row) => row.diagnostics)),
       ].sort(),
     })
   }
+  const hasScoredOutput = providerSummaries.some(
+    (provider) => provider.score !== null,
+  )
   const reportWithoutHash = {
     schemaVersion: PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION,
     privacy: PDF_EXTRACTION_EVAL_REPORT_PRIVACY,
+    status: hasScoredOutput ? 'comparison' : 'reported-only',
+    diagnosticCodes: hasScoredOutput ? [] : ['NO_SCORED_PROVIDER_OUTPUT'],
     evalSet: {
       id: identity.id,
       schemaVersion: identity.schemaVersion,
@@ -1343,6 +1618,9 @@ export function comparePdfExtractionProviders(evalSet, providers) {
     summary: {
       providerCount: providerSummaries.length,
       rowCount: rows.length,
+      scoredProviderCount: providerSummaries.filter(
+        (provider) => provider.score !== null,
+      ).length,
       strata: [...EXTRACTION_STRATA],
       layouts: [...EXTRACTION_LAYOUTS],
       reportByLayout: true,
@@ -1382,7 +1660,13 @@ function parseArgs(argv) {
 async function loadProviderManifest(value, evalIdentity, evalSet) {
   if (
     !isRecord(value) ||
-    !exactKeys(value, ['schemaVersion', 'id', 'evalSet', 'providers']) ||
+    !exactKeys(value, [
+      'schemaVersion',
+      'id',
+      'evalSet',
+      'evaluationStatus',
+      'providers',
+    ]) ||
     value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
     !SAFE_ID.test(value.id ?? '') ||
     !isRecord(value.evalSet) ||
@@ -1390,11 +1674,28 @@ async function loadProviderManifest(value, evalIdentity, evalSet) {
     !pathIsRepositoryRelative(value.evalSet.path) ||
     !SHA256.test(value.evalSet.fileSha256 ?? '') ||
     value.evalSet.evalSetSha256 !== evalIdentity.evalSetSha256 ||
+    !['reported-only', 'comparison-ready'].includes(value.evaluationStatus) ||
     !Array.isArray(value.providers) ||
     value.providers.length === 0 ||
     !uniqueBy(value.providers, ({ id }) => id)
   ) {
     invalid('INVALID_PDF_EXTRACTION_PROVIDER_MANIFEST')
+  }
+  const expectedEvaluationStatus = value.providers.some(
+    (provider) => provider.mode === 'file',
+  )
+    ? 'comparison-ready'
+    : 'reported-only'
+  if (value.evaluationStatus !== expectedEvaluationStatus) {
+    invalid('PDF_EXTRACTION_PROVIDER_STATUS_MISMATCH')
+  }
+  if (
+    expectedEvaluationStatus === 'comparison-ready' &&
+    reviewValuesForEvalSet(evalSet).some(
+      (review) => review.reviewStatus === 'review-required',
+    )
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_REQUIRED')
   }
   if (!value.providers.some((provider) => provider.kind === 'deterministic')) {
     invalid('PDF_EXTRACTION_NO_DETERMINISTIC_PROVIDER')

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -1,0 +1,1488 @@
+#!/usr/bin/env node
+
+/**
+ * Source-reviewed extraction benchmark.
+ *
+ * This evaluator deliberately lives beside (rather than inside) the frozen
+ * fidelity benchmark.  The fidelity benchmark measures bounded page cases;
+ * this contract measures the reader-visible extraction strata that a parser
+ * can otherwise hide behind aggregate text coverage.
+ */
+
+import { createHash } from 'node:crypto'
+import { lstat, readFile, realpath, writeFile } from 'node:fs/promises'
+import { resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const PDF_EXTRACTION_EVAL_SCHEMA_VERSION = '1.0.0'
+export const PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION = '1.0.0'
+export const PDF_EXTRACTION_EVAL_PRIVACY =
+  'repository-fixture-identities-source-reviewed-no-private-inputs'
+export const PDF_EXTRACTION_EVAL_REPORT_PRIVACY =
+  'identities-hashes-counts-diagnostic-codes-only'
+
+export const PDF_EXTRACTION_EVAL_SCHEMA_PATH =
+  'docs/schemas/pdf-extraction-eval-strata.schema.json'
+export const PDF_EXTRACTION_EVAL_SET_PATH =
+  'benchmarks/pdf/extraction-eval-strata-v1.json'
+export const PDF_EXTRACTION_EVAL_PROVIDER_PATH =
+  'benchmarks/pdf/extraction-eval-providers-v1.json'
+
+export const EXTRACTION_LAYOUTS = Object.freeze(['one-column', 'two-column'])
+export const EXTRACTION_STRATA = Object.freeze([
+  'table-structure',
+  'heading-structure',
+  'display-equation',
+  'figure-diagram',
+  'prose-continuity',
+  'boilerplate-exclusion',
+  'footnote-resolution',
+  'column-layout',
+])
+export const EXTRACTION_PROVIDER_KINDS = Object.freeze([
+  'deterministic',
+  'candidate',
+])
+
+const REPOSITORY_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
+const SAFE_PATH = /^[A-Za-z0-9._/-]+$/
+const SHA256 = /^[a-f0-9]{64}$/
+const SAFE_DIAGNOSTIC = /^[A-Z][A-Z0-9_]{2,63}$/
+const MAX_JSON_BYTES = 32 * 1024 * 1024
+const ABSTENTION_SCORE = 0.25
+const DEGENERATE_SCORE = 0
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(value, expected) {
+  if (!isRecord(value)) return false
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return (
+    actual.length === wanted.length &&
+    actual.every((key, index) => key === wanted[index])
+  )
+}
+
+function uniqueBy(values, selector) {
+  return new Set(values.map(selector)).size === values.length
+}
+
+function invalid(code = 'INVALID_PDF_EXTRACTION_EVAL') {
+  throw new Error(code)
+}
+
+function nonNegativeInteger(value) {
+  return Number.isSafeInteger(value) && value >= 0
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export { canonicalJson }
+
+export function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function canonicalHash(value) {
+  return sha256(canonicalJson(value))
+}
+
+function rounded(value) {
+  return Math.round(value * 100000) / 100000
+}
+
+function average(values, fallback = 0) {
+  return values.length
+    ? rounded(values.reduce((sum, value) => sum + value, 0) / values.length)
+    : fallback
+}
+
+function f1(truePositive, expected, predicted) {
+  const precision = predicted > 0 ? truePositive / predicted : 0
+  const recall = expected > 0 ? truePositive / expected : 0
+  return precision + recall === 0
+    ? 0
+    : rounded((2 * precision * recall) / (precision + recall))
+}
+
+function orderedMatchCount(expected, predicted) {
+  const rows = expected.length + 1
+  const columns = predicted.length + 1
+  const matrix = Array.from({ length: rows }, () => new Uint32Array(columns))
+  for (let row = 1; row < rows; row += 1) {
+    for (let column = 1; column < columns; column += 1) {
+      matrix[row][column] =
+        expected[row - 1] === predicted[column - 1]
+          ? matrix[row - 1][column - 1] + 1
+          : Math.max(matrix[row - 1][column], matrix[row][column - 1])
+    }
+  }
+  return matrix[rows - 1][columns - 1]
+}
+
+function safeDiagnostic(code) {
+  return SAFE_DIAGNOSTIC.test(code) ? code : 'INVALID_DIAGNOSTIC_CODE'
+}
+
+function pathIsRepositoryRelative(value) {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 255 &&
+    !value.startsWith('/') &&
+    !value.includes('\\') &&
+    !value.split('/').includes('..') &&
+    SAFE_PATH.test(value)
+  )
+}
+
+function expectedStratum(value) {
+  return (
+    isRecord(value) &&
+    exactKeys(value, [
+      'id',
+      'task',
+      'description',
+      'groundTruth',
+      'metric',
+      'degenerateAnswerGuard',
+    ]) &&
+    SAFE_ID.test(value.id ?? '') &&
+    EXTRACTION_STRATA.includes(value.id) &&
+    typeof value.task === 'string' &&
+    value.description.length > 0 &&
+    isRecord(value.groundTruth) &&
+    isRecord(value.metric) &&
+    isRecord(value.degenerateAnswerGuard)
+  )
+}
+
+function validateGroundTruthReview(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, [
+      'kind',
+      'derivedFrom',
+      'reviewStatus',
+      'reviewers',
+      'parserOutputConsulted',
+    ]) ||
+    value.kind !== 'source-reviewed' ||
+    value.derivedFrom !== 'source-document' ||
+    value.reviewStatus !== 'two-reviewer-agreed' ||
+    !Array.isArray(value.reviewers) ||
+    value.reviewers.length < 2 ||
+    !uniqueBy(value.reviewers, (reviewer) => reviewer) ||
+    !value.reviewers.every((reviewer) => SAFE_ID.test(reviewer)) ||
+    value.parserOutputConsulted !== false
+  ) {
+    invalid(code)
+  }
+}
+
+function validateMetric(value, guardId, code) {
+  if (
+    !exactKeys(value, [
+      'id',
+      'name',
+      'unit',
+      'formula',
+      'scoreRange',
+      'abstentionScore',
+      'degenerateScore',
+      'degenerateAnswerGuardId',
+      'authoritativeEvidence',
+    ]) ||
+    !SAFE_ID.test(value.id ?? '') ||
+    typeof value.name !== 'string' ||
+    value.name.length === 0 ||
+    typeof value.unit !== 'string' ||
+    typeof value.formula !== 'string' ||
+    !Array.isArray(value.scoreRange) ||
+    value.scoreRange.length !== 2 ||
+    value.scoreRange[0] !== 0 ||
+    value.scoreRange[1] !== 1 ||
+    value.abstentionScore !== ABSTENTION_SCORE ||
+    value.degenerateScore !== DEGENERATE_SCORE ||
+    value.degenerateAnswerGuardId !== guardId ||
+    typeof value.authoritativeEvidence !== 'string' ||
+    value.authoritativeEvidence.length === 0
+  ) {
+    invalid(code)
+  }
+}
+
+function validateGuard(value, stratumId, code) {
+  if (
+    !exactKeys(value, [
+      'id',
+      'rejects',
+      'detection',
+      'score',
+      'abstentionScore',
+      'failClosed',
+    ]) ||
+    !SAFE_ID.test(value.id ?? '') ||
+    !Array.isArray(value.rejects) ||
+    value.rejects.length === 0 ||
+    !value.rejects.every(
+      (item) => typeof item === 'string' && item.length > 0,
+    ) ||
+    typeof value.detection !== 'string' ||
+    value.detection.length === 0 ||
+    value.score !== 0 ||
+    value.abstentionScore !== ABSTENTION_SCORE ||
+    value.failClosed !== true ||
+    value.id !== `${stratumId}-degenerate-answer-guard`
+  ) {
+    invalid(code)
+  }
+}
+
+function validateDocument(value, code) {
+  if (
+    !exactKeys(value, [
+      'id',
+      'fixturePath',
+      'sha256',
+      'byteLength',
+      'pageCount',
+      'layout',
+      'groundTruthReview',
+    ]) ||
+    !SAFE_ID.test(value.id ?? '') ||
+    !pathIsRepositoryRelative(value.fixturePath) ||
+    !SHA256.test(value.sha256 ?? '') ||
+    !nonNegativeInteger(value.byteLength) ||
+    value.byteLength <= 0 ||
+    !Number.isSafeInteger(value.pageCount) ||
+    value.pageCount <= 0 ||
+    !EXTRACTION_LAYOUTS.includes(value.layout)
+  ) {
+    invalid(code)
+  }
+  validateGroundTruthReview(value.groundTruthReview, code)
+}
+
+function validateTableGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['tables', 'review']) ||
+    !Array.isArray(value.tables) ||
+    value.tables.length === 0
+  ) {
+    invalid(code)
+  }
+  if (!uniqueBy(value.tables, (table) => table.id)) invalid(code)
+  validateGroundTruthReview(value.review, code)
+  for (const table of value.tables) {
+    if (
+      !exactKeys(table, [
+        'id',
+        'sourcePage',
+        'rows',
+        'columns',
+        'headerScope',
+        'cells',
+      ]) ||
+      !SAFE_ID.test(table.id ?? '') ||
+      !Number.isSafeInteger(table.sourcePage) ||
+      table.sourcePage < 1 ||
+      !Number.isSafeInteger(table.rows) ||
+      table.rows < 1 ||
+      !Number.isSafeInteger(table.columns) ||
+      table.columns < 1 ||
+      !['row', 'column', 'row-and-column', 'none'].includes(
+        table.headerScope,
+      ) ||
+      !Array.isArray(table.cells) ||
+      table.cells.length !== table.rows * table.columns
+    ) {
+      invalid(code)
+    }
+    for (const cell of table.cells) {
+      if (
+        !exactKeys(cell, ['row', 'column', 'rowSpan', 'columnSpan', 'text']) ||
+        !Number.isSafeInteger(cell.row) ||
+        cell.row < 0 ||
+        cell.row >= table.rows ||
+        !Number.isSafeInteger(cell.column) ||
+        cell.column < 0 ||
+        cell.column >= table.columns ||
+        cell.rowSpan !== 1 ||
+        cell.columnSpan !== 1 ||
+        typeof cell.text !== 'string' ||
+        cell.text.trim().length === 0
+      ) {
+        invalid(code)
+      }
+    }
+    if (!uniqueBy(table.cells, (cell) => `${cell.row}:${cell.column}`)) {
+      invalid(code)
+    }
+  }
+}
+
+function validateHeadingGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['headings', 'review']) ||
+    !Array.isArray(value.headings) ||
+    value.headings.length === 0
+  ) {
+    invalid(code)
+  }
+  if (!uniqueBy(value.headings, (heading) => heading.id)) invalid(code)
+  validateGroundTruthReview(value.review, code)
+  for (const heading of value.headings) {
+    if (
+      !exactKeys(heading, ['id', 'text', 'level', 'numbered', 'language']) ||
+      !SAFE_ID.test(heading.id ?? '') ||
+      typeof heading.text !== 'string' ||
+      heading.text.trim().length === 0 ||
+      !Number.isSafeInteger(heading.level) ||
+      heading.level < 1 ||
+      heading.level > 6 ||
+      typeof heading.numbered !== 'boolean' ||
+      typeof heading.language !== 'string' ||
+      heading.language.length < 2
+    ) {
+      invalid(code)
+    }
+  }
+}
+
+function validateObjectGroundTruth(value, code, kind) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['objects', 'review']) ||
+    !Array.isArray(value.objects) ||
+    value.objects.length === 0
+  ) {
+    invalid(code)
+  }
+  if (!uniqueBy(value.objects, (object) => object.id)) invalid(code)
+  validateGroundTruthReview(value.review, code)
+  for (const object of value.objects) {
+    if (
+      !exactKeys(object, [
+        'id',
+        'sourcePage',
+        'kind',
+        'bounded',
+        'captionRelationship',
+      ]) ||
+      !SAFE_ID.test(object.id ?? '') ||
+      !Number.isSafeInteger(object.sourcePage) ||
+      object.sourcePage < 1 ||
+      object.kind !== kind ||
+      object.bounded !== true ||
+      typeof object.captionRelationship !== 'string' ||
+      object.captionRelationship.length === 0
+    ) {
+      invalid(code)
+    }
+  }
+}
+
+function validateProseGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['paragraphs', 'authoritativeCounters', 'review']) ||
+    !Array.isArray(value.paragraphs) ||
+    value.paragraphs.length === 0 ||
+    !exactKeys(value.authoritativeCounters, [
+      'lineBoundaryCount',
+      'decidedLineBoundaryCount',
+      'unresolvedCorruptingJoinCount',
+    ]) ||
+    !Object.values(value.authoritativeCounters).every(nonNegativeInteger)
+  ) {
+    invalid(code)
+  }
+  if (
+    value.authoritativeCounters.decidedLineBoundaryCount >
+      value.authoritativeCounters.lineBoundaryCount ||
+    value.authoritativeCounters.unresolvedCorruptingJoinCount >
+      value.authoritativeCounters.decidedLineBoundaryCount ||
+    !uniqueBy(value.paragraphs, (paragraph) => paragraph.id)
+  ) {
+    invalid(code)
+  }
+  validateGroundTruthReview(value.review, code)
+  for (const paragraph of value.paragraphs) {
+    if (
+      !exactKeys(paragraph, ['id', 'sourcePage', 'continuity']) ||
+      !SAFE_ID.test(paragraph.id ?? '') ||
+      !Number.isSafeInteger(paragraph.sourcePage) ||
+      paragraph.sourcePage < 1 ||
+      paragraph.continuity !== 'source-proven-continuous'
+    ) {
+      invalid(code)
+    }
+  }
+}
+
+function validateBoilerplateGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['excluded', 'bodyLineCount', 'review']) ||
+    !Array.isArray(value.excluded) ||
+    !Number.isSafeInteger(value.bodyLineCount) ||
+    value.bodyLineCount <= 0
+  ) {
+    invalid(code)
+  }
+  if (!uniqueBy(value.excluded, (item) => item.id)) invalid(code)
+  validateGroundTruthReview(value.review, code)
+  for (const item of value.excluded) {
+    if (
+      !exactKeys(item, ['id', 'sourcePage', 'kind']) ||
+      !SAFE_ID.test(item.id ?? '') ||
+      !Number.isSafeInteger(item.sourcePage) ||
+      item.sourcePage < 1 ||
+      !['running-head', 'page-number'].includes(item.kind)
+    ) {
+      invalid(code)
+    }
+  }
+}
+
+function validateFootnoteGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['references', 'bodies', 'review']) ||
+    !Array.isArray(value.references) ||
+    !Array.isArray(value.bodies) ||
+    value.references.length === 0 ||
+    value.bodies.length === 0
+  ) {
+    invalid(code)
+  }
+  validateGroundTruthReview(value.review, code)
+  const bodyIds = new Set()
+  for (const body of value.bodies) {
+    if (
+      !exactKeys(body, ['id', 'sourcePage', 'marker']) ||
+      !SAFE_ID.test(body.id ?? '') ||
+      !Number.isSafeInteger(body.sourcePage) ||
+      body.sourcePage < 1 ||
+      typeof body.marker !== 'string' ||
+      body.marker.length === 0
+    ) {
+      invalid(code)
+    }
+    bodyIds.add(body.id)
+  }
+  if (bodyIds.size !== value.bodies.length) invalid(code)
+  if (!uniqueBy(value.references, (reference) => reference.id)) {
+    invalid(code)
+  }
+  for (const reference of value.references) {
+    if (
+      !exactKeys(reference, ['id', 'sourcePage', 'marker', 'bodyId']) ||
+      !SAFE_ID.test(reference.id ?? '') ||
+      !Number.isSafeInteger(reference.sourcePage) ||
+      reference.sourcePage < 1 ||
+      typeof reference.marker !== 'string' ||
+      !bodyIds.has(reference.bodyId)
+    ) {
+      invalid(code)
+    }
+  }
+}
+
+function validateColumnGroundTruth(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['columnCount', 'columns', 'readingOrder', 'review']) ||
+    !Number.isSafeInteger(value.columnCount) ||
+    value.columnCount < 1 ||
+    !Array.isArray(value.columns) ||
+    value.columns.length !== value.columnCount ||
+    !Array.isArray(value.readingOrder) ||
+    value.readingOrder.length < 2
+  ) {
+    invalid(code)
+  }
+  validateGroundTruthReview(value.review, code)
+  for (const column of value.columns) {
+    if (
+      !exactKeys(column, ['id', 'index']) ||
+      !SAFE_ID.test(column.id ?? '') ||
+      !Number.isSafeInteger(column.index) ||
+      column.index < 0 ||
+      column.index >= value.columnCount
+    ) {
+      invalid(code)
+    }
+  }
+  if (
+    !uniqueBy(value.columns, (column) => column.index) ||
+    !uniqueBy(value.columns, (column) => column.id) ||
+    !uniqueBy(value.readingOrder, (id) => id) ||
+    !value.readingOrder.every((id) => SAFE_ID.test(id))
+  ) {
+    invalid(code)
+  }
+}
+
+function validateCaseGroundTruth(value, stratum, code) {
+  if (!isRecord(value) || !exactKeys(value, ['sourcePage', 'groundTruth'])) {
+    invalid(code)
+  }
+  if (!Number.isSafeInteger(value.sourcePage) || value.sourcePage < 1) {
+    invalid(code)
+  }
+  const groundTruth = value.groundTruth
+  if (stratum === 'table-structure') {
+    validateTableGroundTruth(groundTruth, code)
+  } else if (stratum === 'heading-structure') {
+    validateHeadingGroundTruth(groundTruth, code)
+  } else if (stratum === 'display-equation') {
+    validateObjectGroundTruth(groundTruth, code, 'display-equation')
+  } else if (stratum === 'figure-diagram') {
+    validateObjectGroundTruth(groundTruth, code, 'figure-or-diagram')
+  } else if (stratum === 'prose-continuity') {
+    validateProseGroundTruth(groundTruth, code)
+  } else if (stratum === 'boilerplate-exclusion') {
+    validateBoilerplateGroundTruth(groundTruth, code)
+  } else if (stratum === 'footnote-resolution') {
+    validateFootnoteGroundTruth(groundTruth, code)
+  } else if (stratum === 'column-layout') {
+    validateColumnGroundTruth(groundTruth, code)
+  } else {
+    invalid(code)
+  }
+}
+
+function validateGroundTruthSourcePages(value, pageCount, code) {
+  const pending = [value]
+  while (pending.length > 0) {
+    const current = pending.pop()
+    if (Array.isArray(current)) {
+      pending.push(...current)
+      continue
+    }
+    if (!isRecord(current)) continue
+    for (const [key, child] of Object.entries(current)) {
+      if (
+        key === 'sourcePage' &&
+        (!Number.isSafeInteger(child) || child < 1 || child > pageCount)
+      ) {
+        invalid(code)
+      }
+      if (isRecord(child) || Array.isArray(child)) pending.push(child)
+    }
+  }
+}
+
+function validateStratum(value, code) {
+  if (!expectedStratum(value)) invalid(code)
+  validateGroundTruthReview(value.groundTruth, code)
+  validateGuard(value.degenerateAnswerGuard, value.id, code)
+  validateMetric(value.metric, value.degenerateAnswerGuard.id, code)
+}
+
+function validateProtocol(value, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, [
+      'command',
+      'reportPrivacy',
+      'sourceLabelPolicy',
+      'regexProxyPolicy',
+      'abstentionPolicy',
+      'corpusBalance',
+    ]) ||
+    value.command !== 'npm run pdf:benchmark:extraction' ||
+    value.reportPrivacy !== PDF_EXTRACTION_EVAL_REPORT_PRIVACY ||
+    value.sourceLabelPolicy !==
+      'source-review-required-parser-output-never-a-label' ||
+    value.regexProxyPolicy !==
+      'authoritative-pipeline-counters-only-regex-never-gates' ||
+    !isRecord(value.abstentionPolicy) ||
+    !exactKeys(value.abstentionPolicy, [
+      'score',
+      'beatsDegenerateAnswer',
+      'status',
+    ]) ||
+    value.abstentionPolicy.score !== ABSTENTION_SCORE ||
+    value.abstentionPolicy.beatsDegenerateAnswer !== true ||
+    value.abstentionPolicy.status !== 'reported-not-correct' ||
+    !isRecord(value.corpusBalance) ||
+    !exactKeys(value.corpusBalance, [
+      'layouts',
+      'minimumDocumentsPerLayout',
+      'reportByLayout',
+    ]) ||
+    canonicalJson(value.corpusBalance.layouts) !==
+      canonicalJson(EXTRACTION_LAYOUTS) ||
+    !Number.isSafeInteger(value.corpusBalance.minimumDocumentsPerLayout) ||
+    value.corpusBalance.minimumDocumentsPerLayout < 1 ||
+    value.corpusBalance.reportByLayout !== true
+  ) {
+    invalid(code)
+  }
+}
+
+/**
+ * Validate the source-reviewed strata artifact without consulting any parser
+ * output.  The returned identity is suitable for binding provider reports.
+ */
+export function validatePdfExtractionEvalSet(value) {
+  try {
+    if (
+      !isRecord(value) ||
+      !exactKeys(value, [
+        'schemaVersion',
+        'id',
+        'privacy',
+        'protocol',
+        'documents',
+        'strata',
+        'cases',
+      ]) ||
+      value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+      !SAFE_ID.test(value.id ?? '') ||
+      value.privacy !== PDF_EXTRACTION_EVAL_PRIVACY ||
+      !Array.isArray(value.documents) ||
+      !Array.isArray(value.strata) ||
+      !Array.isArray(value.cases) ||
+      value.documents.length < 2 ||
+      value.strata.length !== EXTRACTION_STRATA.length ||
+      value.cases.length === 0 ||
+      !uniqueBy(value.documents, ({ id }) => id) ||
+      !uniqueBy(value.strata, ({ id }) => id) ||
+      !uniqueBy(value.cases, ({ id }) => id)
+    ) {
+      invalid('INVALID_PDF_EXTRACTION_EVAL_SET')
+    }
+    validateProtocol(value.protocol, 'INVALID_PDF_EXTRACTION_EVAL_SET')
+    for (const document of value.documents) {
+      validateDocument(document, 'INVALID_PDF_EXTRACTION_EVAL_SET')
+    }
+    for (const stratum of value.strata) {
+      validateStratum(stratum, 'INVALID_PDF_EXTRACTION_EVAL_SET')
+    }
+    const documents = new Map(value.documents.map((item) => [item.id, item]))
+    const strata = new Map(value.strata.map((item) => [item.id, item]))
+    for (const item of value.cases) {
+      if (
+        !isRecord(item) ||
+        !exactKeys(item, ['id', 'documentId', 'stratum', 'layout', 'source']) ||
+        !SAFE_ID.test(item.id ?? '') ||
+        !documents.has(item.documentId) ||
+        !strata.has(item.stratum) ||
+        item.layout !== documents.get(item.documentId).layout ||
+        !EXTRACTION_LAYOUTS.includes(item.layout) ||
+        item.source?.sourcePage > documents.get(item.documentId).pageCount
+      ) {
+        invalid('INVALID_PDF_EXTRACTION_EVAL_SET')
+      }
+      validateCaseGroundTruth(
+        item.source,
+        item.stratum,
+        'INVALID_PDF_EXTRACTION_EVAL_SET',
+      )
+      validateGroundTruthSourcePages(
+        item.source,
+        documents.get(item.documentId).pageCount,
+        'INVALID_PDF_EXTRACTION_EVAL_SET',
+      )
+    }
+    const usedStrata = new Set(value.cases.map(({ stratum }) => stratum))
+    if (EXTRACTION_STRATA.some((id) => !usedStrata.has(id))) {
+      invalid('PDF_EXTRACTION_EVAL_MISSING_STRATUM')
+    }
+    for (const stratumId of EXTRACTION_STRATA) {
+      for (const layout of EXTRACTION_LAYOUTS) {
+        if (
+          !value.cases.some(
+            (item) => item.stratum === stratumId && item.layout === layout,
+          )
+        ) {
+          invalid('PDF_EXTRACTION_EVAL_LAYOUT_IMBALANCED')
+        }
+      }
+    }
+    const layoutCounts = Object.fromEntries(
+      EXTRACTION_LAYOUTS.map((layout) => [
+        layout,
+        value.documents.filter((document) => document.layout === layout).length,
+      ]),
+    )
+    if (
+      Object.values(layoutCounts).some(
+        (count) =>
+          count < value.protocol.corpusBalance.minimumDocumentsPerLayout,
+      )
+    ) {
+      invalid('PDF_EXTRACTION_EVAL_LAYOUT_IMBALANCED')
+    }
+    const hasNonEnglishHeading = value.cases.some(
+      (item) =>
+        item.stratum === 'heading-structure' &&
+        item.source.groundTruth.headings.some(
+          (heading) => !/^en(?:[-_]|$)/i.test(heading.language),
+        ),
+    )
+    if (!hasNonEnglishHeading) {
+      invalid('PDF_EXTRACTION_EVAL_MISSING_NON_ENGLISH_HEADING')
+    }
+    return {
+      valid: true,
+      id: value.id,
+      schemaVersion: value.schemaVersion,
+      evalSetSha256: canonicalHash(value),
+      documentIdentitySha256: canonicalHash(
+        value.documents.map(({ id, sha256: sourceSha256, layout }) => ({
+          id,
+          sourceSha256,
+          layout,
+        })),
+      ),
+      caseIdentitySha256: canonicalHash(value.cases),
+      documentCount: value.documents.length,
+      caseCount: value.cases.length,
+      stratumCount: value.strata.length,
+      layoutCounts,
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /^PDF_EXTRACTION|^INVALID_PDF_EXTRACTION/.test(error.message)
+    ) {
+      throw error
+    }
+    invalid('INVALID_PDF_EXTRACTION_EVAL_SET')
+  }
+}
+
+async function readRepositoryJson(repositoryPath, code) {
+  if (!pathIsRepositoryRelative(repositoryPath)) invalid(code)
+  const root = await realpath(REPOSITORY_ROOT)
+  const absolute = resolve(root, repositoryPath)
+  if (absolute !== root && !absolute.startsWith(`${root}${sep}`)) invalid(code)
+  try {
+    const details = await lstat(absolute)
+    const canonical = await realpath(absolute)
+    if (
+      !details.isFile() ||
+      details.isSymbolicLink() ||
+      (canonical !== root && !canonical.startsWith(`${root}${sep}`)) ||
+      details.size <= 0 ||
+      details.size > MAX_JSON_BYTES
+    ) {
+      invalid(code)
+    }
+    const bytes = await readFile(canonical)
+    if (bytes.byteLength !== details.size) invalid(code)
+    return { value: JSON.parse(bytes.toString('utf8')), bytes }
+  } catch {
+    invalid(code)
+  }
+}
+
+export async function validatePdfExtractionEvalSetFiles(value) {
+  const identity = validatePdfExtractionEvalSet(value)
+  for (const document of value.documents) {
+    if (!pathIsRepositoryRelative(document.fixturePath)) {
+      invalid('INVALID_PDF_EXTRACTION_FIXTURE_PATH')
+    }
+    try {
+      const absolute = resolve(REPOSITORY_ROOT, document.fixturePath)
+      const details = await lstat(absolute)
+      const canonical = await realpath(absolute)
+      if (
+        !details.isFile() ||
+        details.isSymbolicLink() ||
+        (canonical !== REPOSITORY_ROOT &&
+          !canonical.startsWith(`${REPOSITORY_ROOT}${sep}`))
+      ) {
+        invalid('INVALID_PDF_EXTRACTION_FIXTURE')
+      }
+      const bytes = await readFile(canonical)
+      if (
+        bytes.byteLength !== document.byteLength ||
+        sha256(bytes) !== document.sha256
+      ) {
+        invalid('PDF_EXTRACTION_FIXTURE_IDENTITY_MISMATCH')
+      }
+    } catch {
+      invalid('INVALID_PDF_EXTRACTION_FIXTURE')
+    }
+  }
+  return identity
+}
+
+function validateCandidateProvider(value, evalIdentity, code) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['schemaVersion', 'evalSetId', 'provider', 'cases']) ||
+    value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    value.evalSetId !== evalIdentity.id ||
+    !isRecord(value.provider) ||
+    !exactKeys(value.provider, [
+      'id',
+      'kind',
+      'version',
+      'sourceIdentitySha256',
+    ]) ||
+    !SAFE_ID.test(value.provider.id ?? '') ||
+    !EXTRACTION_PROVIDER_KINDS.includes(value.provider.kind) ||
+    !SAFE_ID.test(value.provider.version ?? '') ||
+    (value.provider.sourceIdentitySha256 !== null &&
+      !SHA256.test(value.provider.sourceIdentitySha256 ?? '')) ||
+    !Array.isArray(value.cases) ||
+    !uniqueBy(value.cases, ({ caseId }) => caseId)
+  ) {
+    invalid(code)
+  }
+  for (const item of value.cases) {
+    if (
+      !exactKeys(item, ['caseId', 'status', 'prediction', 'diagnostics']) ||
+      !SAFE_ID.test(item.caseId ?? '') ||
+      !['scored', 'abstain'].includes(item.status) ||
+      (item.status === 'abstain' && item.prediction !== null) ||
+      !Array.isArray(item.diagnostics) ||
+      !item.diagnostics.every((diagnostic) => SAFE_DIAGNOSTIC.test(diagnostic))
+    ) {
+      invalid(code)
+    }
+  }
+  return value
+}
+
+export function validatePdfExtractionCandidate(value, evalSetOrIdentity) {
+  const identity = evalSetOrIdentity?.evalSetSha256
+    ? evalSetOrIdentity
+    : validatePdfExtractionEvalSet(evalSetOrIdentity)
+  return validateCandidateProvider(
+    value,
+    identity,
+    'INVALID_PDF_EXTRACTION_CANDIDATE',
+  )
+}
+
+function indexCases(evalSet) {
+  return new Map(evalSet.cases.map((item) => [item.id, item]))
+}
+
+function stratumById(evalSet) {
+  return new Map(evalSet.strata.map((item) => [item.id, item]))
+}
+
+function diagnosticResult(score, status, diagnostics, extra = {}) {
+  return {
+    score: rounded(Math.max(0, Math.min(1, score))),
+    status,
+    diagnostics: [...new Set(diagnostics.map(safeDiagnostic))].sort(),
+    ...extra,
+  }
+}
+
+function abstainedResult(code = 'CANDIDATE_ABSTAINED') {
+  return diagnosticResult(ABSTENTION_SCORE, 'abstained', [code])
+}
+
+function degenerateResult(code = 'DEGENERATE_EMPTY_OUTPUT') {
+  return diagnosticResult(DEGENERATE_SCORE, 'degenerate', [code])
+}
+
+function predictionArray(prediction, key) {
+  return Array.isArray(prediction?.[key]) ? prediction[key] : null
+}
+
+function tableScore(expected, prediction) {
+  const expectedTables = expected.tables
+  const predictedTables = predictionArray(prediction, 'tables')
+  if (!predictedTables) return degenerateResult()
+  if (predictedTables.length === 0) return degenerateResult()
+  if (
+    predictedTables.some(
+      (table) =>
+        table?.pageWide === true ||
+        (Array.isArray(table?.box) && table.box[2] * table.box[3] > 0.8),
+    )
+  ) {
+    return degenerateResult('DEGENERATE_PAGE_WIDE_GRID')
+  }
+  const matched = expectedTables.reduce((count, table, index) => {
+    const candidate = predictedTables[index]
+    if (
+      !candidate ||
+      candidate.rows !== table.rows ||
+      candidate.columns !== table.columns ||
+      candidate.headerScope !== table.headerScope ||
+      !Array.isArray(candidate.cells) ||
+      !candidate.cells.every(isRecord)
+    ) {
+      return count
+    }
+    const cells = new Map(
+      candidate.cells.map((cell) => [`${cell.row}:${cell.column}`, cell]),
+    )
+    return (
+      count +
+      table.cells.filter((cell) => {
+        const predictedCell = cells.get(`${cell.row}:${cell.column}`)
+        return (
+          predictedCell?.text === cell.text &&
+          predictedCell.rowSpan === cell.rowSpan &&
+          predictedCell.columnSpan === cell.columnSpan
+        )
+      }).length /
+        table.cells.length
+    )
+  }, 0)
+  const topologyScore = matched / expectedTables.length
+  const extraPenalty =
+    predictedTables.length > expectedTables.length
+      ? expectedTables.length / predictedTables.length
+      : 1
+  return diagnosticResult(topologyScore * extraPenalty, 'scored', [], {
+    expected: expectedTables.length,
+    predicted: predictedTables.length,
+  })
+}
+
+function headingScore(expected, prediction) {
+  const headings = predictionArray(prediction, 'headings')
+  if (!headings) return degenerateResult()
+  if (headings.length === 0) return degenerateResult()
+  if (!headings.every(isRecord)) {
+    return degenerateResult('INVALID_HEADING_OUTPUT')
+  }
+  if (
+    prediction.everyLineIsHeading === true ||
+    headings.length > expected.headings.length * 2
+  ) {
+    return degenerateResult('DEGENERATE_EVERY_LINE_HEADING')
+  }
+  const expectedKeys = expected.headings.map(
+    (heading) => `${heading.text}\0${heading.level}`,
+  )
+  const predictedKeys = headings.map(
+    (heading) => `${heading.text}\0${heading.level}`,
+  )
+  const matched = orderedMatchCount(expectedKeys, predictedKeys)
+  return diagnosticResult(
+    f1(matched, expected.headings.length, headings.length),
+    'scored',
+    [],
+    { expected: expected.headings.length, predicted: headings.length },
+  )
+}
+
+function objectScore(expected, prediction, key, degenerateCode) {
+  const objects = predictionArray(prediction, key)
+  if (!objects) return degenerateResult()
+  if (objects.length === 0) return degenerateResult()
+  if (
+    objects.some(
+      (object) =>
+        object?.pageWide === true ||
+        (Array.isArray(object?.box) && object.box[2] * object.box[3] > 0.9),
+    )
+  ) {
+    return degenerateResult(degenerateCode)
+  }
+  const expectedObjects = expected.objects
+  const matched = expectedObjects.filter((item, index) => {
+    const candidate = objects[index]
+    return (
+      candidate &&
+      candidate.kind === item.kind &&
+      candidate.sourcePage === item.sourcePage &&
+      candidate.captionRelationship === item.captionRelationship &&
+      candidate.bounded === true
+    )
+  }).length
+  return diagnosticResult(
+    f1(matched, expectedObjects.length, objects.length),
+    'scored',
+    [],
+    { expected: expectedObjects.length, predicted: objects.length },
+  )
+}
+
+function proseScore(expected, prediction) {
+  if (!isRecord(prediction)) return degenerateResult()
+  if (Object.hasOwn(prediction, 'regexBrokenJoinCount')) {
+    invalid('PDF_EXTRACTION_REGEX_PROXY_NOT_AUTHORITATIVE')
+  }
+  const counters = prediction.authoritativeCounters
+  if (
+    !isRecord(counters) ||
+    !exactKeys(counters, [
+      'lineBoundaryCount',
+      'decidedLineBoundaryCount',
+      'unresolvedCorruptingJoinCount',
+    ]) ||
+    !Object.values(counters).every(nonNegativeInteger)
+  ) {
+    return degenerateResult('MISSING_AUTHORITATIVE_PROSE_COUNTERS')
+  }
+  const expectedCount = Math.max(
+    1,
+    expected.authoritativeCounters.lineBoundaryCount,
+  )
+  if (
+    counters.lineBoundaryCount !==
+      expected.authoritativeCounters.lineBoundaryCount ||
+    counters.decidedLineBoundaryCount !== counters.lineBoundaryCount ||
+    counters.decidedLineBoundaryCount > counters.lineBoundaryCount ||
+    counters.unresolvedCorruptingJoinCount > counters.decidedLineBoundaryCount
+  ) {
+    return degenerateResult('INVALID_PROSE_COUNTERS')
+  }
+  const score = Math.max(
+    0,
+    1 - counters.unresolvedCorruptingJoinCount / expectedCount,
+  )
+  return diagnosticResult(score, 'scored', [], {
+    unresolvedCorruptingJoinCount: counters.unresolvedCorruptingJoinCount,
+  })
+}
+
+function boilerplateScore(expected, prediction) {
+  if (!isRecord(prediction)) return degenerateResult()
+  const counters = prediction.contamination
+  if (
+    !isRecord(counters) ||
+    !exactKeys(counters, [
+      'runningHeadContaminationCount',
+      'pageNumberContaminationCount',
+      'excludedCount',
+    ]) ||
+    !Object.values(counters).every(nonNegativeInteger)
+  ) {
+    return degenerateResult('MISSING_BOILERPLATE_COUNTERS')
+  }
+  if (
+    counters.excludedCount > expected.bodyLineCount ||
+    counters.excludedCount > expected.bodyLineCount * 0.75
+  ) {
+    return degenerateResult('DEGENERATE_EXCLUDING_EVERY_LINE')
+  }
+  if (counters.excludedCount !== expected.excluded.length) {
+    return diagnosticResult(0, 'scored', ['INCOMPLETE_BOILERPLATE_EXCLUSION'], {
+      expectedExcluded: expected.excluded.length,
+      predictedExcluded: counters.excludedCount,
+    })
+  }
+  const contamination =
+    counters.runningHeadContaminationCount +
+    counters.pageNumberContaminationCount
+  const score = contamination === 0 ? 1 : 0
+  return diagnosticResult(score, 'scored', [], { contamination })
+}
+
+function relationshipScore(expected, prediction) {
+  const relationships = predictionArray(prediction, 'relationships')
+  if (!relationships) return degenerateResult()
+  if (relationships.length === 0) return degenerateResult()
+  if (
+    relationships.length > 1 &&
+    new Set(relationships.map((item) => item?.bodyId)).size === 1
+  ) {
+    return degenerateResult('DEGENERATE_SINGLE_FOOTNOTE_OWNER')
+  }
+  const expectedKeys = new Set(
+    expected.references.map(
+      (reference) =>
+        `${reference.id}\0${reference.bodyId}\0${reference.marker}`,
+    ),
+  )
+  const matched = relationships.filter((relationship) =>
+    expectedKeys.has(
+      `${relationship?.referenceId}\0${relationship?.bodyId}\0${relationship?.marker}`,
+    ),
+  ).length
+  return diagnosticResult(
+    f1(matched, expected.references.length, relationships.length),
+    'scored',
+    [],
+    { expected: expected.references.length, predicted: relationships.length },
+  )
+}
+
+function columnScore(expected, prediction) {
+  if (!isRecord(prediction)) return degenerateResult()
+  if (!Array.isArray(prediction.order) || prediction.order.length === 0) {
+    return degenerateResult()
+  }
+  if (prediction.pageWideSingleColumn === true) {
+    return degenerateResult('DEGENERATE_PAGE_WIDE_SINGLE_COLUMN')
+  }
+  const expectedOrder = expected.readingOrder
+  const order = prediction.order
+  if (expected.columnCount > 1 && prediction.columnCount === 1) {
+    return degenerateResult('DEGENERATE_PAGE_WIDE_SINGLE_COLUMN')
+  }
+  if (
+    !Number.isSafeInteger(prediction.columnCount) ||
+    prediction.columnCount < 1 ||
+    !order.every((id) => expectedOrder.includes(id)) ||
+    !uniqueBy(order, (id) => id)
+  ) {
+    return degenerateResult('INVALID_COLUMN_ORDER')
+  }
+  const pairs = []
+  for (let index = 0; index < expectedOrder.length; index += 1) {
+    for (let next = index + 1; next < expectedOrder.length; next += 1) {
+      pairs.push([expectedOrder[index], expectedOrder[next]])
+    }
+  }
+  const indexes = new Map(order.map((id, index) => [id, index]))
+  const matched = pairs.filter(
+    ([left, right]) =>
+      indexes.has(left) &&
+      indexes.has(right) &&
+      indexes.get(left) < indexes.get(right),
+  ).length
+  const pairScore = pairs.length === 0 ? 0 : matched / pairs.length
+  const countScore = prediction.columnCount === expected.columnCount ? 1 : 0
+  return diagnosticResult(average([pairScore, countScore]), 'scored', [], {
+    expected: expected.columnCount,
+    predicted: prediction.columnCount ?? null,
+  })
+}
+
+function scoreCase(item, stratum, output) {
+  if (!output || output.status === 'abstain') return abstainedResult()
+  const prediction = output.prediction
+  const expected = item.source.groundTruth
+  if (stratum.id === 'table-structure') return tableScore(expected, prediction)
+  if (stratum.id === 'heading-structure')
+    return headingScore(expected, prediction)
+  if (stratum.id === 'display-equation') {
+    return objectScore(
+      expected,
+      prediction,
+      'objects',
+      'DEGENERATE_PAGE_WIDE_EQUATION',
+    )
+  }
+  if (stratum.id === 'figure-diagram') {
+    return objectScore(
+      expected,
+      prediction,
+      'objects',
+      'DEGENERATE_PAGE_WIDE_FIGURE',
+    )
+  }
+  if (stratum.id === 'prose-continuity') return proseScore(expected, prediction)
+  if (stratum.id === 'boilerplate-exclusion') {
+    return boilerplateScore(expected, prediction)
+  }
+  if (stratum.id === 'footnote-resolution') {
+    return relationshipScore(expected, prediction)
+  }
+  if (stratum.id === 'column-layout') return columnScore(expected, prediction)
+  invalid('INVALID_PDF_EXTRACTION_STRATUM')
+}
+
+function noGroundTruthOutput(evalSet, provider) {
+  return {
+    schemaVersion: PDF_EXTRACTION_EVAL_SCHEMA_VERSION,
+    evalSetId: evalSet.id,
+    provider: {
+      id: provider.id,
+      kind: provider.kind,
+      version: provider.version,
+      sourceIdentitySha256: provider.sourceIdentitySha256 ?? null,
+    },
+    cases: [],
+  }
+}
+
+export function createAbstainingPdfExtractionCandidate(evalSet, provider) {
+  const identity = validatePdfExtractionEvalSet(evalSet)
+  if (
+    !isRecord(provider) ||
+    !SAFE_ID.test(provider.id ?? '') ||
+    !EXTRACTION_PROVIDER_KINDS.includes(provider.kind) ||
+    !SAFE_ID.test(provider.version ?? '')
+  ) {
+    invalid('INVALID_PDF_EXTRACTION_PROVIDER')
+  }
+  const candidate = noGroundTruthOutput(evalSet, provider)
+  candidate.cases = evalSet.cases.map((item) => ({
+    caseId: item.id,
+    status: 'abstain',
+    prediction: null,
+    diagnostics: ['CANDIDATE_ABSTAINED'],
+  }))
+  validateCandidateProvider(
+    candidate,
+    identity,
+    'INVALID_PDF_EXTRACTION_CANDIDATE',
+  )
+  return candidate
+}
+
+/**
+ * Compare every provider against the same source-reviewed corpus.  Rows are
+ * emitted for every provider × stratum × layout combination, including empty
+ * combinations, so a layout disappearing cannot be hidden by an aggregate.
+ */
+export function comparePdfExtractionProviders(evalSet, providers) {
+  const identity = validatePdfExtractionEvalSet(evalSet)
+  if (!Array.isArray(providers) || providers.length === 0) {
+    invalid('PDF_EXTRACTION_NO_PROVIDERS')
+  }
+  if (!uniqueBy(providers, (candidate) => candidate?.provider?.id)) {
+    invalid('PDF_EXTRACTION_DUPLICATE_PROVIDER')
+  }
+  const caseMap = indexCases(evalSet)
+  const strata = stratumById(evalSet)
+  const rows = []
+  const providerSummaries = []
+  for (const candidate of providers) {
+    validateCandidateProvider(
+      candidate,
+      identity,
+      'INVALID_PDF_EXTRACTION_CANDIDATE',
+    )
+    const outputMap = new Map(
+      candidate.cases.map((item) => [item.caseId, item]),
+    )
+    if ([...outputMap.keys()].some((caseId) => !caseMap.has(caseId))) {
+      invalid('PDF_EXTRACTION_PROVIDER_UNKNOWN_CASE')
+    }
+    const providerRows = []
+    for (const stratumId of EXTRACTION_STRATA) {
+      for (const layout of EXTRACTION_LAYOUTS) {
+        const matchingCases = evalSet.cases.filter(
+          (item) => item.stratum === stratumId && item.layout === layout,
+        )
+        const scores = []
+        const diagnostics = []
+        for (const item of matchingCases) {
+          const output = outputMap.get(item.id)
+          let result
+          if (!output) {
+            result = abstainedResult('MISSING_PROVIDER_CASE')
+          } else {
+            result = scoreCase(item, strata.get(stratumId), output)
+          }
+          scores.push(result)
+          diagnostics.push(...result.diagnostics)
+        }
+        const row = {
+          providerId: candidate.provider.id,
+          providerKind: candidate.provider.kind,
+          providerVersion: candidate.provider.version,
+          stratum: stratumId,
+          layout,
+          caseCount: matchingCases.length,
+          scoredCaseCount: scores.filter((item) => item.status === 'scored')
+            .length,
+          abstainedCaseCount: scores.filter(
+            (item) => item.status === 'abstained',
+          ).length,
+          degenerateCaseCount: scores.filter(
+            (item) => item.status === 'degenerate',
+          ).length,
+          score: scores.length
+            ? average(scores.map((item) => item.score))
+            : null,
+          diagnostics: [...new Set(diagnostics)].sort(),
+        }
+        rows.push(row)
+        providerRows.push(row)
+      }
+    }
+    const scoredRows = providerRows.filter((row) => row.score !== null)
+    providerSummaries.push({
+      providerId: candidate.provider.id,
+      providerKind: candidate.provider.kind,
+      providerVersion: candidate.provider.version,
+      caseCount: candidate.cases.length,
+      score: scoredRows.length
+        ? average(scoredRows.map((row) => row.score))
+        : null,
+      diagnosticCodes: [
+        ...new Set(providerRows.flatMap((row) => row.diagnostics)),
+      ].sort(),
+    })
+  }
+  const reportWithoutHash = {
+    schemaVersion: PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION,
+    privacy: PDF_EXTRACTION_EVAL_REPORT_PRIVACY,
+    evalSet: {
+      id: identity.id,
+      schemaVersion: identity.schemaVersion,
+      evalSetSha256: identity.evalSetSha256,
+      documentIdentitySha256: identity.documentIdentitySha256,
+      caseIdentitySha256: identity.caseIdentitySha256,
+      documentCount: identity.documentCount,
+      caseCount: identity.caseCount,
+      stratumCount: identity.stratumCount,
+      layoutCounts: identity.layoutCounts,
+    },
+    providers: providerSummaries,
+    rows,
+    summary: {
+      providerCount: providerSummaries.length,
+      rowCount: rows.length,
+      strata: [...EXTRACTION_STRATA],
+      layouts: [...EXTRACTION_LAYOUTS],
+      reportByLayout: true,
+    },
+  }
+  return {
+    ...reportWithoutHash,
+    reportSha256: canonicalHash(reportWithoutHash),
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    evalSet: PDF_EXTRACTION_EVAL_SET_PATH,
+    providers: PDF_EXTRACTION_EVAL_PROVIDER_PATH,
+    out: null,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === 'run') continue
+    if (arg === '--eval-set' || arg === '--providers' || arg === '--out') {
+      const value = argv[++index]
+      if (!value) invalid('INVALID_PDF_EXTRACTION_CLI_ARGUMENTS')
+      if (arg === '--eval-set') options.evalSet = value
+      else if (arg === '--providers') options.providers = value
+      else options.out = value
+      continue
+    }
+    if (arg.startsWith('--eval-set=')) options.evalSet = arg.slice(11)
+    else if (arg.startsWith('--providers=')) options.providers = arg.slice(12)
+    else if (arg.startsWith('--out=')) options.out = arg.slice(6)
+    else invalid('INVALID_PDF_EXTRACTION_CLI_ARGUMENTS')
+  }
+  return options
+}
+
+async function loadProviderManifest(value, evalIdentity, evalSet) {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, ['schemaVersion', 'id', 'evalSet', 'providers']) ||
+    value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    !SAFE_ID.test(value.id ?? '') ||
+    !isRecord(value.evalSet) ||
+    !exactKeys(value.evalSet, ['path', 'fileSha256', 'evalSetSha256']) ||
+    !pathIsRepositoryRelative(value.evalSet.path) ||
+    !SHA256.test(value.evalSet.fileSha256 ?? '') ||
+    value.evalSet.evalSetSha256 !== evalIdentity.evalSetSha256 ||
+    !Array.isArray(value.providers) ||
+    value.providers.length === 0 ||
+    !uniqueBy(value.providers, ({ id }) => id)
+  ) {
+    invalid('INVALID_PDF_EXTRACTION_PROVIDER_MANIFEST')
+  }
+  if (!value.providers.some((provider) => provider.kind === 'deterministic')) {
+    invalid('PDF_EXTRACTION_NO_DETERMINISTIC_PROVIDER')
+  }
+  const providers = []
+  for (const item of value.providers) {
+    if (
+      !exactKeys(item, [
+        'id',
+        'kind',
+        'version',
+        'mode',
+        'sourceIdentitySha256',
+        'predictionsPath',
+      ]) ||
+      !SAFE_ID.test(item.id ?? '') ||
+      !EXTRACTION_PROVIDER_KINDS.includes(item.kind) ||
+      !SAFE_ID.test(item.version ?? '') ||
+      !['abstain', 'file'].includes(item.mode) ||
+      (item.sourceIdentitySha256 !== null &&
+        !SHA256.test(item.sourceIdentitySha256 ?? '')) ||
+      (item.mode === 'abstain' && item.predictionsPath !== null) ||
+      (item.mode === 'file' && !pathIsRepositoryRelative(item.predictionsPath))
+    ) {
+      invalid('INVALID_PDF_EXTRACTION_PROVIDER_MANIFEST')
+    }
+    if (item.mode === 'abstain') {
+      providers.push(createAbstainingPdfExtractionCandidate(evalSet, item))
+    } else {
+      const artifact = await readRepositoryJson(
+        item.predictionsPath,
+        'INVALID_PDF_EXTRACTION_PROVIDER_OUTPUT',
+      )
+      const candidate = artifact.value
+      validateCandidateProvider(
+        candidate,
+        evalIdentity,
+        'INVALID_PDF_EXTRACTION_CANDIDATE',
+      )
+      if (candidate.provider.id !== item.id) {
+        invalid('PDF_EXTRACTION_PROVIDER_ID_MISMATCH')
+      }
+      if (
+        candidate.provider.kind !== item.kind ||
+        candidate.provider.version !== item.version ||
+        candidate.provider.sourceIdentitySha256 !== item.sourceIdentitySha256
+      ) {
+        invalid('PDF_EXTRACTION_PROVIDER_BINDING_MISMATCH')
+      }
+      providers.push(candidate)
+    }
+  }
+  return providers
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const evalArtifact = await readRepositoryJson(
+    options.evalSet,
+    'INVALID_PDF_EXTRACTION_EVAL_SET_FILE',
+  )
+  const evalSet = evalArtifact.value
+  const identity = await validatePdfExtractionEvalSetFiles(evalSet)
+  const providerArtifact = await readRepositoryJson(
+    options.providers,
+    'INVALID_PDF_EXTRACTION_PROVIDER_MANIFEST_FILE',
+  )
+  if (
+    providerArtifact.value.evalSet.path !== options.evalSet ||
+    sha256(evalArtifact.bytes) !== providerArtifact.value.evalSet.fileSha256
+  ) {
+    invalid('PDF_EXTRACTION_PROVIDER_EVAL_SET_BINDING_MISMATCH')
+  }
+  const providers = await loadProviderManifest(
+    providerArtifact.value,
+    identity,
+    evalSet,
+  )
+  const report = comparePdfExtractionProviders(evalSet, providers)
+  if (options.out) {
+    await writeFile(options.out, `${JSON.stringify(report, null, 2)}\n`)
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`)
+    process.exitCode = 1
+  })
+}

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -104,6 +104,36 @@ function canonicalHash(value) {
   return sha256(canonicalJson(value))
 }
 
+function reviewIdentityProjection(review) {
+  if (!isRecord(review)) return review
+  const { reviewEvidence: _reviewEvidence, ...identity } = review
+  return identity
+}
+
+function evalSetIdentityProjection(value) {
+  return {
+    ...value,
+    documents: value.documents.map((document) => ({
+      ...document,
+      groundTruthReview: reviewIdentityProjection(document.groundTruthReview),
+    })),
+    strata: value.strata.map((stratum) => ({
+      ...stratum,
+      groundTruth: reviewIdentityProjection(stratum.groundTruth),
+    })),
+    cases: value.cases.map((item) => ({
+      ...item,
+      source: {
+        ...item.source,
+        groundTruth: {
+          ...item.source.groundTruth,
+          review: reviewIdentityProjection(item.source.groundTruth.review),
+        },
+      },
+    })),
+  }
+}
+
 function rounded(value) {
   return Math.round(value * 100000) / 100000
 }
@@ -812,11 +842,12 @@ export function validatePdfExtractionEvalSet(value) {
     if (!hasNonEnglishHeading) {
       invalid('PDF_EXTRACTION_EVAL_MISSING_NON_ENGLISH_HEADING')
     }
+    const identityProjection = evalSetIdentityProjection(value)
     return {
       valid: true,
       id: value.id,
       schemaVersion: value.schemaVersion,
-      evalSetSha256: canonicalHash(value),
+      evalSetSha256: canonicalHash(identityProjection),
       documentIdentitySha256: canonicalHash(
         value.documents.map(({ id, sha256: sourceSha256, layout }) => ({
           id,
@@ -824,7 +855,7 @@ export function validatePdfExtractionEvalSet(value) {
           layout,
         })),
       ),
-      caseIdentitySha256: canonicalHash(value.cases),
+      caseIdentitySha256: canonicalHash(identityProjection.cases),
       documentCount: value.documents.length,
       caseCount: value.cases.length,
       stratumCount: value.strata.length,
@@ -975,17 +1006,26 @@ async function validateReviewEvidenceFiles(value, identity) {
   if ([...caseIds].some((caseId) => !agreedCaseIds.has(caseId))) {
     invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
   }
-  const decisionReviewerIds = new Set(
-    decisionArtifact.value.decisions.flatMap((decision) => decision.reviewers),
+  const decisionByCaseId = new Map(
+    decisionArtifact.value.decisions.map((decision) => [
+      decision.caseId,
+      decision,
+    ]),
   )
   for (const review of agreed) {
-    if (
-      review.reviewers.some(
-        (reviewer) =>
-          !rosterIds.has(reviewer) || !decisionReviewerIds.has(reviewer),
-      )
-    ) {
+    if (review.reviewers.some((reviewer) => !rosterIds.has(reviewer))) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+    }
+  }
+  for (const item of value.cases) {
+    const decision = decisionByCaseId.get(item.id)
+    const caseReview = item.source.groundTruth.review
+    if (
+      !decision ||
+      canonicalJson([...caseReview.reviewers].sort()) !==
+        canonicalJson([...decision.reviewers].sort())
+    ) {
+      invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
     }
   }
   Object.defineProperty(value, REVIEW_EVIDENCE_VALIDATED, {
@@ -1151,6 +1191,37 @@ function missingSourceBinding(predictions) {
   return predictions.some((prediction) => !hasValidSourceBinding(prediction))
 }
 
+function hasValidPredictedTableCells(table) {
+  if (
+    !isRecord(table) ||
+    !Number.isSafeInteger(table.rows) ||
+    table.rows < 1 ||
+    !Number.isSafeInteger(table.columns) ||
+    table.columns < 1 ||
+    !Array.isArray(table.cells) ||
+    table.cells.length === 0
+  ) {
+    return false
+  }
+  const coordinates = new Set()
+  return table.cells.every(
+    (cell) =>
+      exactKeys(cell, ['row', 'column', 'rowSpan', 'columnSpan', 'text']) &&
+      Number.isSafeInteger(cell.row) &&
+      cell.row >= 0 &&
+      cell.row < table.rows &&
+      Number.isSafeInteger(cell.column) &&
+      cell.column >= 0 &&
+      cell.column < table.columns &&
+      cell.rowSpan === 1 &&
+      cell.columnSpan === 1 &&
+      typeof cell.text === 'string' &&
+      cell.text.trim().length > 0 &&
+      !coordinates.has(`${cell.row}:${cell.column}`) &&
+      coordinates.add(`${cell.row}:${cell.column}`),
+  )
+}
+
 function tableScore(expected, prediction) {
   const expectedTables = expected.tables
   const predictedTables = predictionArray(prediction, 'tables')
@@ -1168,37 +1239,37 @@ function tableScore(expected, prediction) {
   ) {
     return degenerateResult('DEGENERATE_PAGE_WIDE_GRID')
   }
-  const matched = expectedTables.reduce((count, table, index) => {
-    const candidate = predictedTables[index]
-    if (
-      !candidate ||
-      candidate.rows !== table.rows ||
-      candidate.columns !== table.columns ||
-      candidate.headerScope !== table.headerScope ||
-      candidate.sourcePage !== table.sourcePage ||
-      !Array.isArray(candidate.cells) ||
-      !candidate.cells.every(isRecord) ||
-      !sourceBindingMatches(table, candidate)
-    ) {
-      return count
-    }
+  if (predictedTables.some((table) => !hasValidPredictedTableCells(table))) {
+    return degenerateResult('INVALID_TABLE_CELLS')
+  }
+  const matchedPredictions = new Set()
+  const tableScores = expectedTables.map((table) => {
+    const candidateIndex = predictedTables.findIndex(
+      (candidate, index) =>
+        !matchedPredictions.has(index) &&
+        candidate.rows === table.rows &&
+        candidate.columns === table.columns &&
+        candidate.headerScope === table.headerScope &&
+        candidate.sourcePage === table.sourcePage &&
+        sourceBindingMatches(table, candidate),
+    )
+    if (candidateIndex < 0) return 0
+    matchedPredictions.add(candidateIndex)
+    const candidate = predictedTables[candidateIndex]
     const cells = new Map(
       candidate.cells.map((cell) => [`${cell.row}:${cell.column}`, cell]),
     )
-    return (
-      count +
-      table.cells.filter((cell) => {
-        const predictedCell = cells.get(`${cell.row}:${cell.column}`)
-        return (
-          predictedCell?.text === cell.text &&
-          predictedCell.rowSpan === cell.rowSpan &&
-          predictedCell.columnSpan === cell.columnSpan
-        )
-      }).length /
-        table.cells.length
-    )
-  }, 0)
-  const topologyScore = matched / expectedTables.length
+    const matchedCells = table.cells.filter((cell) => {
+      const predictedCell = cells.get(`${cell.row}:${cell.column}`)
+      return (
+        predictedCell?.text === cell.text &&
+        predictedCell.rowSpan === cell.rowSpan &&
+        predictedCell.columnSpan === cell.columnSpan
+      )
+    }).length
+    return f1(matchedCells, table.cells.length, candidate.cells.length)
+  })
+  const topologyScore = average(tableScores)
   const extraPenalty =
     predictedTables.length > expectedTables.length
       ? expectedTables.length / predictedTables.length
@@ -1254,17 +1325,21 @@ function objectScore(expected, prediction, key, degenerateCode) {
     return degenerateResult(degenerateCode)
   }
   const expectedObjects = expected.objects
-  const matched = expectedObjects.filter((item, index) => {
-    const candidate = objects[index]
-    return (
-      candidate &&
-      candidate.kind === item.kind &&
-      candidate.sourcePage === item.sourcePage &&
-      candidate.captionRelationship === item.captionRelationship &&
-      candidate.bounded === true &&
-      sourceBindingMatches(item, candidate)
+  const matchedObjects = new Set()
+  const matched = expectedObjects.reduce((count, item) => {
+    const candidateIndex = objects.findIndex(
+      (candidate, index) =>
+        !matchedObjects.has(index) &&
+        candidate.kind === item.kind &&
+        candidate.sourcePage === item.sourcePage &&
+        candidate.captionRelationship === item.captionRelationship &&
+        candidate.bounded === true &&
+        sourceBindingMatches(item, candidate),
     )
-  }).length
+    if (candidateIndex < 0) return count
+    matchedObjects.add(candidateIndex)
+    return count + 1
+  }, 0)
   return diagnosticResult(
     f1(matched, expectedObjects.length, objects.length),
     'scored',
@@ -1458,11 +1533,11 @@ function scoreCase(item, stratum, output) {
   invalid('INVALID_PDF_EXTRACTION_STRATUM')
 }
 
-function noGroundTruthOutput(evalSet, provider) {
+function noGroundTruthOutput(evalSet, identity, provider) {
   return {
     schemaVersion: PDF_EXTRACTION_EVAL_SCHEMA_VERSION,
     evalSetId: evalSet.id,
-    evalSetSha256: canonicalHash(evalSet),
+    evalSetSha256: identity.evalSetSha256,
     provider: {
       id: provider.id,
       kind: provider.kind,
@@ -1483,7 +1558,7 @@ export function createAbstainingPdfExtractionCandidate(evalSet, provider) {
   ) {
     invalid('INVALID_PDF_EXTRACTION_PROVIDER')
   }
-  const candidate = noGroundTruthOutput(evalSet, provider)
+  const candidate = noGroundTruthOutput(evalSet, identity, provider)
   candidate.cases = evalSet.cases.map((item) => ({
     caseId: item.id,
     status: 'abstain',
@@ -1578,7 +1653,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
         providerRows.push(row)
       }
     }
-    const scoredOutputRows = providerRows.filter(
+    const hasScoredOutput = providerRows.some(
       (row) => row.scoredCaseCount > 0,
     )
     providerSummaries.push({
@@ -1586,8 +1661,8 @@ export function comparePdfExtractionProviders(evalSet, providers) {
       providerKind: candidate.provider.kind,
       providerVersion: candidate.provider.version,
       caseCount: candidate.cases.length,
-      score: scoredOutputRows.length
-        ? average(scoredOutputRows.map((row) => row.score))
+      score: hasScoredOutput
+        ? average(providerRows.map((row) => row.score))
         : null,
       diagnosticCodes: [
         ...new Set(providerRows.flatMap((row) => row.diagnostics)),
@@ -1657,7 +1732,7 @@ function parseArgs(argv) {
   return options
 }
 
-async function loadProviderManifest(value, evalIdentity, evalSet) {
+export async function loadProviderManifest(value, evalIdentity, evalSet) {
   if (
     !isRecord(value) ||
     !exactKeys(value, [
@@ -1710,6 +1785,7 @@ async function loadProviderManifest(value, evalIdentity, evalSet) {
         'mode',
         'sourceIdentitySha256',
         'predictionsPath',
+        'predictionsSha256',
       ]) ||
       !SAFE_ID.test(item.id ?? '') ||
       !EXTRACTION_PROVIDER_KINDS.includes(item.kind) ||
@@ -1718,7 +1794,10 @@ async function loadProviderManifest(value, evalIdentity, evalSet) {
       (item.sourceIdentitySha256 !== null &&
         !SHA256.test(item.sourceIdentitySha256 ?? '')) ||
       (item.mode === 'abstain' && item.predictionsPath !== null) ||
-      (item.mode === 'file' && !pathIsRepositoryRelative(item.predictionsPath))
+      (item.mode === 'abstain' && item.predictionsSha256 !== null) ||
+      (item.mode === 'file' &&
+        (!pathIsRepositoryRelative(item.predictionsPath) ||
+          !SHA256.test(item.predictionsSha256 ?? '')))
     ) {
       invalid('INVALID_PDF_EXTRACTION_PROVIDER_MANIFEST')
     }
@@ -1729,6 +1808,9 @@ async function loadProviderManifest(value, evalIdentity, evalSet) {
         item.predictionsPath,
         'INVALID_PDF_EXTRACTION_PROVIDER_OUTPUT',
       )
+      if (sha256(artifact.bytes) !== item.predictionsSha256) {
+        invalid('PDF_EXTRACTION_PROVIDER_PREDICTIONS_HASH_MISMATCH')
+      }
       const candidate = artifact.value
       validateCandidateProvider(
         candidate,

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -1,0 +1,149 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+import {
+  EXTRACTION_LAYOUTS,
+  EXTRACTION_STRATA,
+  comparePdfExtractionProviders,
+  createAbstainingPdfExtractionCandidate,
+  validatePdfExtractionEvalSet,
+  validatePdfExtractionEvalSetFiles,
+} from './pdf-extraction-eval.mjs'
+
+const evalPath = 'benchmarks/pdf/extraction-eval-strata-v1.json'
+
+async function readEvalSet() {
+  return JSON.parse(await readFile(evalPath, 'utf8'))
+}
+
+describe('source-reviewed PDF extraction strata benchmark', () => {
+  it('validates the reviewed table/structure slice and both layout lanes', async () => {
+    const evalSet = await readEvalSet()
+    const identity = await validatePdfExtractionEvalSetFiles(evalSet)
+
+    expect(identity).toMatchObject({
+      valid: true,
+      documentCount: 4,
+      caseCount: 19,
+      stratumCount: 8,
+      layoutCounts: { 'one-column': 2, 'two-column': 2 },
+    })
+    expect(EXTRACTION_LAYOUTS).toEqual(['one-column', 'two-column'])
+    expect(EXTRACTION_STRATA).toEqual([
+      'table-structure',
+      'heading-structure',
+      'display-equation',
+      'figure-diagram',
+      'prose-continuity',
+      'boilerplate-exclusion',
+      'footnote-resolution',
+      'column-layout',
+    ])
+    expect(
+      evalSet.cases
+        .filter(({ stratum }) => stratum === 'table-structure')
+        .every(({ source }) =>
+          source.groundTruth.tables.every(
+            (table) =>
+              table.rows * table.columns === table.cells.length &&
+              table.cells.every((cell) => typeof cell.text === 'string'),
+          ),
+        ),
+    ).toBe(true)
+    expect(
+      evalSet.cases.some(
+        ({ stratum, source }) =>
+          stratum === 'heading-structure' &&
+          source.groundTruth.headings.some(({ language }) => language === 'zh'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects parser output being relabeled as source ground truth', async () => {
+    const evalSet = await readEvalSet()
+    evalSet.cases[0].source.groundTruth.review.parserOutputConsulted = true
+    expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
+      'INVALID_PDF_EXTRACTION_EVAL_SET',
+    )
+  })
+
+  it('reports deterministic and every configured candidate by stratum and layout', async () => {
+    const evalSet = await readEvalSet()
+    const providers = [
+      createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'deterministic-path',
+        kind: 'deterministic',
+        version: 'fixture-baseline-v1',
+      }),
+      createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-a',
+        kind: 'candidate',
+        version: 'candidate-a-v1',
+      }),
+      createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-b',
+        kind: 'candidate',
+        version: 'candidate-b-v1',
+      }),
+    ]
+    const report = comparePdfExtractionProviders(evalSet, providers)
+
+    expect(report.privacy).toBe(
+      'identities-hashes-counts-diagnostic-codes-only',
+    )
+    expect(report.providers).toHaveLength(3)
+    expect(report.rows).toHaveLength(3 * 8 * 2)
+    expect(report.rows.every((row) => row.score === 0.25)).toBe(true)
+    expect(new Set(report.rows.map(({ stratum }) => stratum))).toEqual(
+      new Set(EXTRACTION_STRATA),
+    )
+    expect(new Set(report.rows.map(({ layout }) => layout))).toEqual(
+      new Set(EXTRACTION_LAYOUTS),
+    )
+  })
+
+  it('scores abstention above guarded degenerate answers', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    tableCase.status = 'scored'
+    tableCase.prediction = {
+      tables: [
+        { pageWide: true, rows: 1, columns: 1, headerScope: 'none', cells: [] },
+      ],
+    }
+    tableCase.diagnostics = []
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    const tableRow = report.rows.find(
+      (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+    )
+    const abstainedRows = report.rows.filter(
+      (row) => row.stratum !== 'table-structure',
+    )
+    expect(tableRow).toMatchObject({ degenerateCaseCount: 1, score: 0 })
+    expect(abstainedRows.every((row) => row.score === 0.25)).toBe(true)
+  })
+
+  it('refuses regex-only prose continuity evidence', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const proseCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.prose-continuity'),
+    )
+    proseCase.status = 'scored'
+    proseCase.prediction = { regexBrokenJoinCount: 204 }
+    proseCase.diagnostics = []
+    expect(() => comparePdfExtractionProviders(evalSet, [candidate])).toThrow(
+      'PDF_EXTRACTION_REGEX_PROXY_NOT_AUTHORITATIVE',
+    )
+  })
+})

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -90,7 +90,11 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(report.privacy).toBe(
       'identities-hashes-counts-diagnostic-codes-only',
     )
+    expect(report.status).toBe('reported-only')
     expect(report.providers).toHaveLength(3)
+    expect(report.providers.every((provider) => provider.score === null)).toBe(
+      true,
+    )
     expect(report.rows).toHaveLength(3 * 8 * 2)
     expect(report.rows.every((row) => row.score === 0.25)).toBe(true)
     expect(new Set(report.rows.map(({ stratum }) => stratum))).toEqual(
@@ -127,6 +131,176 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     )
     expect(tableRow).toMatchObject({ degenerateCaseCount: 1, score: 0 })
     expect(abstainedRows.every((row) => row.score === 0.25)).toBe(true)
+  })
+
+  it('does not give metadata-only table or object predictions a perfect score', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    tableCase.status = 'scored'
+    tableCase.prediction = {
+      tables: [
+        {
+          rows: 3,
+          columns: 2,
+          headerScope: 'row',
+          cells: [
+            { row: 0, column: 0, rowSpan: 1, columnSpan: 1, text: 'Profile' },
+            { row: 0, column: 1, rowSpan: 1, columnSpan: 1, text: 'Nodes' },
+            { row: 1, column: 0, rowSpan: 1, columnSpan: 1, text: 'Mobile' },
+            { row: 1, column: 1, rowSpan: 1, columnSpan: 1, text: '12' },
+            { row: 2, column: 0, rowSpan: 1, columnSpan: 1, text: 'E-ink' },
+            { row: 2, column: 1, rowSpan: 1, columnSpan: 1, text: '12' },
+          ],
+        },
+      ],
+    }
+    const objectCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.figure-diagram'),
+    )
+    objectCase.status = 'scored'
+    objectCase.prediction = {
+      objects: [
+        {
+          kind: 'figure-or-diagram',
+          sourcePage: 2,
+          captionRelationship: 'caption-of',
+          bounded: true,
+        },
+      ],
+    }
+    tableCase.diagnostics = []
+    objectCase.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+      ),
+    ).toMatchObject({ score: 0, degenerateCaseCount: 1 })
+    expect(
+      report.rows.find(
+        (row) => row.stratum === 'figure-diagram' && row.layout === 'one-column',
+      ),
+    ).toMatchObject({ score: 0, degenerateCaseCount: 1 })
+  })
+
+  it('accepts a prediction only when its source geometry and lineage match', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    const expectedTable = evalSet.cases.find((item) =>
+      item.id.endsWith('.table-structure'),
+    ).source.groundTruth.tables[0]
+    tableCase.status = 'scored'
+    tableCase.prediction = {
+      tables: [{ ...expectedTable }],
+    }
+    tableCase.diagnostics = []
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+      ),
+    ).toMatchObject({ score: 1, scoredCaseCount: 1, degenerateCaseCount: 0 })
+  })
+
+  it('requires a canonical eval-set hash in every candidate envelope', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const identity = validatePdfExtractionEvalSet(evalSet)
+    expect(candidate.evalSetSha256).toBe(identity.evalSetSha256)
+
+    delete candidate.evalSetSha256
+    expect(() =>
+      comparePdfExtractionProviders(evalSet, [candidate]),
+    ).toThrow('INVALID_PDF_EXTRACTION_CANDIDATE')
+  })
+
+  it('rejects two-reviewer labels without roster-bound source-only evidence', async () => {
+    const evalSet = await readEvalSet()
+    evalSet.documents[0].groundTruthReview.reviewStatus = 'two-reviewer-agreed'
+    evalSet.documents[0].groundTruthReview.reviewers = [
+      'fixture-reviewer-a',
+      'fixture-reviewer-b',
+    ]
+    evalSet.documents[0].groundTruthReview.reviewEvidence = null
+    expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
+      'INVALID_PDF_EXTRACTION_EVAL_SET',
+    )
+  })
+
+  it('keeps the diagnostic furniture label tied to a real running-head and page-number case', async () => {
+    const evalSet = await readEvalSet()
+    const furnitureCase = evalSet.cases.find(
+      (item) => item.id === 'diagnostic-overlays.boilerplate-exclusion',
+    )
+    expect(furnitureCase.source.groundTruth.excluded).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'running-head' }),
+        expect.objectContaining({ kind: 'page-number' }),
+      ]),
+    )
+  })
+
+  it('scores valid many-to-one footnote references instead of treating them as degenerate', async () => {
+    const evalSet = await readEvalSet()
+    const footnoteCase = evalSet.cases.find((item) =>
+      item.id.endsWith('.footnote-resolution'),
+    )
+    footnoteCase.source.groundTruth.references.push({
+      id: 'note-reference-2',
+      sourcePage: footnoteCase.source.sourcePage,
+      marker: '1',
+      bodyId: 'footnote-1',
+    })
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find(
+      (item) => item.caseId === footnoteCase.id,
+    )
+    output.status = 'scored'
+    output.prediction = {
+      relationships: [
+        {
+          referenceId: 'note-reference-1',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+        {
+          referenceId: 'note-reference-2',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+      ],
+    }
+    output.diagnostics = []
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'footnote-resolution' && row.layout === footnoteCase.layout,
+      ),
+    ).toMatchObject({ score: 1, degenerateCaseCount: 0, scoredCaseCount: 1 })
   })
 
   it('refuses regex-only prose continuity evidence', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -1,10 +1,14 @@
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import Ajv2020 from 'ajv/dist/2020.js'
 import { describe, expect, it } from 'vitest'
 import {
   EXTRACTION_LAYOUTS,
   EXTRACTION_STRATA,
   comparePdfExtractionProviders,
   createAbstainingPdfExtractionCandidate,
+  loadProviderManifest,
+  sha256,
   validatePdfExtractionEvalSet,
   validatePdfExtractionEvalSetFiles,
 } from './pdf-extraction-eval.mjs'
@@ -301,6 +305,291 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
           row.stratum === 'footnote-resolution' && row.layout === footnoteCase.layout,
       ),
     ).toMatchObject({ score: 1, degenerateCaseCount: 0, scoredCaseCount: 1 })
+  })
+
+  it('includes abstained rows in sparse provider aggregates', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    const expectedTable = evalSet.cases.find((item) =>
+      item.id.endsWith('.table-structure'),
+    ).source.groundTruth.tables[0]
+    tableCase.status = 'scored'
+    tableCase.prediction = { tables: [{ ...expectedTable }] }
+    tableCase.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    const provider = report.providers[0]
+    const expectedAggregate = Number(
+      (
+        report.rows.reduce((sum, row) => sum + row.score, 0) /
+        report.rows.length
+      ).toFixed(5),
+    )
+    expect(provider.score).toBe(expectedAggregate)
+    expect(provider.score).toBeLessThan(1)
+    expect(provider.score).toBeGreaterThan(0.25)
+  })
+
+  it('matches bounded objects by source binding rather than array order', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const objectCase = evalSet.cases.find(
+      (item) => item.id === 'structured-scientific.figure-diagram',
+    )
+    const output = candidate.cases.find((item) => item.caseId === objectCase.id)
+    output.status = 'scored'
+    output.prediction = {
+      objects: [...objectCase.source.groundTruth.objects].reverse(),
+    }
+    output.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'figure-diagram' && row.layout === 'two-column',
+      ),
+    ).toMatchObject({ score: 1, scoredCaseCount: 1, degenerateCaseCount: 0 })
+  })
+
+  it('fails closed on extra or invalid table cells', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    const expectedTable = evalSet.cases.find((item) =>
+      item.id.endsWith('.table-structure'),
+    ).source.groundTruth.tables[0]
+    tableCase.status = 'scored'
+    tableCase.prediction = {
+      tables: [
+        {
+          ...expectedTable,
+          cells: [
+            ...expectedTable.cells,
+            { row: 999, column: 999, rowSpan: 1, columnSpan: 1, text: 'noise' },
+          ],
+        },
+      ],
+    }
+    tableCase.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+      ),
+    ).toMatchObject({ score: 0, scoredCaseCount: 0, degenerateCaseCount: 1 })
+  })
+
+  it('keeps eval-set identity stable when review evidence files change', async () => {
+    const evalSet = await readEvalSet()
+    const reviews = [
+      ...evalSet.documents.map((item) => item.groundTruthReview),
+      ...evalSet.strata.map((item) => item.groundTruth),
+      ...evalSet.cases.map((item) => item.source.groundTruth.review),
+    ]
+    for (const review of reviews) {
+      review.reviewStatus = 'two-reviewer-agreed'
+      review.reviewers = ['fixture-reviewer-a', 'fixture-reviewer-b']
+      review.reviewEvidence = {
+        rosterPath: 'docs/reviews/roster.json',
+        rosterSha256: 'a'.repeat(64),
+        decisionPath: 'docs/reviews/decisions.json',
+        decisionSha256: 'b'.repeat(64),
+      }
+    }
+    const changed = JSON.parse(JSON.stringify(evalSet))
+    for (const review of [
+      ...changed.documents.map((item) => item.groundTruthReview),
+      ...changed.strata.map((item) => item.groundTruth),
+      ...changed.cases.map((item) => item.source.groundTruth.review),
+    ]) {
+      review.reviewEvidence.decisionSha256 = 'c'.repeat(64)
+    }
+
+    expect(validatePdfExtractionEvalSet(evalSet).evalSetSha256).toBe(
+      validatePdfExtractionEvalSet(changed).evalSetSha256,
+    )
+  })
+
+  it('binds each case reviewer list to its corresponding decision', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-')
+    const rosterPath = join(directory, 'roster.json')
+    const decisionPath = join(directory, 'decisions.json')
+    const reviewerA = 'fixture-reviewer-a'
+    const reviewerB = 'fixture-reviewer-b'
+    const reviewerC = 'fixture-reviewer-c'
+    try {
+      const reviews = [
+        ...evalSet.documents.map((item) => item.groundTruthReview),
+        ...evalSet.strata.map((item) => item.groundTruth),
+        ...evalSet.cases.map((item) => item.source.groundTruth.review),
+      ]
+      for (const review of reviews) {
+        review.reviewStatus = 'two-reviewer-agreed'
+        review.reviewers = [reviewerA, reviewerB]
+        review.reviewEvidence = {
+          rosterPath,
+          rosterSha256: '0'.repeat(64),
+          decisionPath,
+          decisionSha256: '0'.repeat(64),
+        }
+      }
+      evalSet.cases.forEach((item, index) => {
+        item.source.groundTruth.review.reviewers =
+          index % 2 === 0 ? [reviewerA, reviewerB] : [reviewerB, reviewerC]
+      })
+
+      const roster = {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-extraction-reviewer-roster',
+        evalSetId: evalSet.id,
+        reviewers: [
+          { reviewerId: reviewerA, identityEvidenceSha256: 'a'.repeat(64) },
+          { reviewerId: reviewerB, identityEvidenceSha256: 'b'.repeat(64) },
+          { reviewerId: reviewerC, identityEvidenceSha256: 'c'.repeat(64) },
+        ],
+      }
+      const identity = validatePdfExtractionEvalSet(evalSet)
+      const documentById = new Map(
+        evalSet.documents.map((item) => [item.id, item]),
+      )
+      const decisions = evalSet.cases.map((item) => ({
+        caseId: item.id,
+        sourceSha256: documentById.get(item.documentId).sha256,
+        reviewers: [...item.source.groundTruth.review.reviewers],
+        decision: 'agreed',
+        decisionSha256: 'd'.repeat(64),
+      }))
+      const decisionArtifact = {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-extraction-source-only-decisions',
+        evalSetId: evalSet.id,
+        evalSetSha256: identity.evalSetSha256,
+        sourceOnly: true,
+        candidateOutputConsultedForLabel: false,
+        decisions,
+      }
+      const rosterBytes = Buffer.from(`${JSON.stringify(roster)}\n`)
+      const decisionBytes = Buffer.from(`${JSON.stringify(decisionArtifact)}\n`)
+      await writeFile(rosterPath, rosterBytes)
+      await writeFile(decisionPath, decisionBytes)
+      const evidence = {
+        rosterPath,
+        rosterSha256: sha256(rosterBytes),
+        decisionPath,
+        decisionSha256: sha256(decisionBytes),
+      }
+      for (const review of reviews) review.reviewEvidence = evidence
+
+      await expect(validatePdfExtractionEvalSetFiles(evalSet)).resolves.toMatchObject(
+        { evalSetSha256: identity.evalSetSha256 },
+      )
+
+      evalSet.cases[0].source.groundTruth.review.reviewers = [
+        ...evalSet.cases[1].source.groundTruth.review.reviewers,
+      ]
+      await expect(validatePdfExtractionEvalSetFiles(evalSet)).rejects.toThrow(
+        'PDF_EXTRACTION_REVIEW_DECISION_MISMATCH',
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('requires the manifest hash to match exact file-mode prediction bytes', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-provider-')
+    const predictionsPath = join(directory, 'predictions.json')
+    try {
+      for (const review of [
+        ...evalSet.documents.map((item) => item.groundTruthReview),
+        ...evalSet.strata.map((item) => item.groundTruth),
+        ...evalSet.cases.map((item) => item.source.groundTruth.review),
+      ]) {
+        review.reviewStatus = 'two-reviewer-agreed'
+        review.reviewers = ['fixture-reviewer-a', 'fixture-reviewer-b']
+        review.reviewEvidence = {
+          rosterPath: 'docs/reviews/roster.json',
+          rosterSha256: 'a'.repeat(64),
+          decisionPath: 'docs/reviews/decisions.json',
+          decisionSha256: 'b'.repeat(64),
+        }
+      }
+      const identity = validatePdfExtractionEvalSet(evalSet)
+      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-file',
+        kind: 'deterministic',
+        version: 'candidate-file-v1',
+      })
+      const predictionBytes = Buffer.from(`${JSON.stringify(candidate)}\n`)
+      await writeFile(predictionsPath, predictionBytes)
+      const manifest = JSON.parse(
+        await readFile('benchmarks/pdf/extraction-eval-providers-v1.json', 'utf8'),
+      )
+      manifest.evalSet.evalSetSha256 = identity.evalSetSha256
+      manifest.evaluationStatus = 'comparison-ready'
+      manifest.providers = [
+        {
+          id: candidate.provider.id,
+          kind: candidate.provider.kind,
+          version: candidate.provider.version,
+          mode: 'file',
+          sourceIdentitySha256: null,
+          predictionsPath,
+          predictionsSha256: sha256(predictionBytes),
+        },
+      ]
+      await expect(
+        loadProviderManifest(manifest, identity, evalSet),
+      ).resolves.toHaveLength(1)
+
+      await writeFile(predictionsPath, `${predictionBytes} `)
+      await expect(loadProviderManifest(manifest, identity, evalSet)).rejects.toThrow(
+        'PDF_EXTRACTION_PROVIDER_PREDICTIONS_HASH_MISMATCH',
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('publishes the runtime abstention constraint in the candidate schema', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const schema = JSON.parse(
+      await readFile('docs/schemas/pdf-extraction-eval-candidate.schema.json', 'utf8'),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    expect(validate(candidate)).toBe(true)
+
+    candidate.cases[0].prediction = {}
+    expect(validate(candidate)).toBe(false)
+
+    candidate.cases[0].status = 'scored'
+    candidate.cases[0].prediction = null
+    expect(validate(candidate)).toBe(true)
   })
 
   it('refuses regex-only prose continuity evidence', async () => {


### PR DESCRIPTION
Refs #89.

This draft preserves the VM worker's bounded extraction-evaluation slice for review.

What changed:
- Adds eight reader-visible strata: tables, headings, display equations, figures/diagrams, prose continuity, boilerplate exclusion, footnote resolution, and column layout.
- Adds four repository-owned fixture identities with one-/two-column balance and source-ground-truth metadata.
- Adds fail-closed degenerate-answer guards and authoritative-counter rules for prose.
- Adds a provider manifest and one-command, privacy-safe deterministic/candidate comparison report.
- Keeps the default provider lanes abstaining/report-only until independently frozen predictions are available; no parser output is used as a label.

VM validation:
- Extraction evaluator: 5/5 tests passed.
- CLI: 48 rows across 3 configured providers, 8 strata, and 2 layouts.
- All four declared fixture byte lengths and SHA-256 identities matched.
- Build: 0 errors; existing repository hints remain.
- `git diff --check`: passed.

The full repository evidence lane is not being claimed as clean here: the unchanged MinerU fidelity test exceeded Vitest's 5-second default timeout, and the VM baseline verifier reports the expected inactive/systemd environment.