### PR TITLE
feat(research): add source/output checkpoint evidence lane

### DIFF
--- a/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
+++ b/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
@@ -1,0 +1,43 @@
+# Source/output checkpoint evidence
+
+SRT visual changes are reviewed as a source page beside the rendition a reader
+receives. The fixture command is:
+
+```bash
+npm run srt:checkpoint-evidence
+```
+
+It reads the repository-owned checkpoint set at
+`tests/fixtures/pdf/source-output-checkpoints.json`, renders the named source
+page with PDF.js, builds the deterministic EPUB through the normal export entry
+point, and captures the resulting rendition at the named target profile width.
+The output is written to `.agent/evidence/srt-checkpoints/`; its `README.md`
+is the review index and `checkpoint-manifest.json` records the artifact hashes and
+fail-closed checkpoint results.
+
+The machine-readable shape is
+`docs/schemas/source-output-checkpoints.schema.json`. Each checkpoint must
+name a document, page, profile, reviewer-visible property, criterion, source
+feature, and rendition feature. The TypeScript validator additionally binds
+each property to its expected rendition feature and rejects duplicate IDs. A
+pair fails when the source page is missing readable/visual evidence, the
+profile is wrong, the rendition is empty, or the named structure is absent. An
+image file by itself never passes a checkpoint.
+
+For an owner-local paper, provide a caller-owned output directory outside the
+repository. Local output is never written to Git or the PR evidence directory:
+
+```bash
+node tools/srt-source-output-evidence.mjs \
+  --document /absolute/local/paper.pdf \
+  --checkpoints /absolute/local/checkpoints.json \
+  --struct /absolute/local/paper.struct.json \
+  --output /absolute/local/source-output-review
+```
+
+The local STRUCT must carry the same source SHA-256, basename, and byte length
+as the selected PDF; this prevents a checkpoint from passing against a
+fabricated or unrelated rendition. The local manifest contains only the input
+basename, digest, dimensions, and checkpoint outcomes. The generated images
+remain in the caller-named local directory. The checked-in fixture flow is the
+required evidence lane for SRT pull requests.

--- a/docs/schemas/source-output-checkpoints.schema.json
+++ b/docs/schemas/source-output-checkpoints.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "source-output-checkpoints.schema.json",
+  "title": "Source/output fidelity checkpoints",
+  "description": "Named, fail-closed claims connecting a source-page property to a rendered output property.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "checkpoints"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "checkpoints": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/checkpoint" }
+    }
+  },
+  "$defs": {
+    "checkpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "document",
+        "page",
+        "profile",
+        "property",
+        "criterion",
+        "source",
+        "output"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "document": { "type": "string", "minLength": 1 },
+        "page": { "type": "integer", "minimum": 1 },
+        "profile": {
+          "enum": ["mobile", "paperProMove", "paperPro", "print"]
+        },
+        "property": {
+          "enum": [
+            "figure-present",
+            "caption-boundary",
+            "prose-continuity",
+            "heading-level",
+            "table-structure",
+            "code-block-structure"
+          ]
+        },
+        "criterion": { "type": "string", "minLength": 1 },
+        "source": { "$ref": "#/$defs/sourceExpectation" },
+        "output": { "$ref": "#/$defs/outputExpectation" }
+      }
+    },
+    "sourceExpectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature"],
+      "properties": {
+        "feature": { "enum": ["visual", "text", "structure"] },
+        "text": { "type": "string", "minLength": 1 }
+      }
+    },
+    "outputExpectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature"],
+      "properties": {
+        "feature": {
+          "enum": ["figure", "caption", "prose", "heading", "table", "code"]
+        },
+        "text": { "type": "string", "minLength": 1 },
+        "level": { "type": "integer", "minimum": 1, "maximum": 6 }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:production": "PUBLIC_RESEARCH_RELEASE=production npm run build:astro && PUBLIC_RESEARCH_RELEASE=production node tools/deployment/apply-release-gate.mjs",
     "build:staging": "PUBLIC_RESEARCH_RELEASE=staging npm run build:astro",
     "srt:export": "PUBLIC_RESEARCH_RELEASE=staging astro check && PUBLIC_RESEARCH_RELEASE=staging astro build --outDir .agent/evidence/srt-export",
-    "srt:checkpoint-evidence": "node tools/srt-source-output-evidence.mjs",
+    "srt:checkpoint-evidence": "playwright install chromium && node tools/srt-source-output-evidence.mjs",
     "preview": "astro preview",
     "srt:evaluate": "node tools/srt/demo-evaluation.mjs",
     "pdf:corpus-audit": "node tools/pdf-corpus-audit.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "pretest": "npm run srt:overlay-evidence",
+    "pretest": "npm run srt:checkpoint-evidence && npm run srt:overlay-evidence",
     "test": "vitest run --exclude 'tests/e2e/**'",
     "test:e2e": "playwright test",
     "build": "npm run build:production",
@@ -18,6 +18,7 @@
     "build:production": "PUBLIC_RESEARCH_RELEASE=production npm run build:astro && PUBLIC_RESEARCH_RELEASE=production node tools/deployment/apply-release-gate.mjs",
     "build:staging": "PUBLIC_RESEARCH_RELEASE=staging npm run build:astro",
     "srt:export": "PUBLIC_RESEARCH_RELEASE=staging astro check && PUBLIC_RESEARCH_RELEASE=staging astro build --outDir .agent/evidence/srt-export",
+    "srt:checkpoint-evidence": "node tools/srt-source-output-evidence.mjs",
     "preview": "astro preview",
     "srt:evaluate": "node tools/srt/demo-evaluation.mjs",
     "pdf:corpus-audit": "node tools/pdf-corpus-audit.mjs",

--- a/src/research/source-output-checkpoints.test.ts
+++ b/src/research/source-output-checkpoints.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateSourceOutputCheckpoint,
+  parseSourceOutputCheckpointSet,
+  validateSourceOutputCheckpointSet,
+} from './source-output-checkpoints'
+
+const base = {
+  id: 'figure-on-page-2',
+  document: 'fixture.pdf',
+  page: 2,
+  profile: 'paperPro' as const,
+  property: 'figure-present' as const,
+  criterion: 'The source figure is present in the generated rendition.',
+  source: { feature: 'visual' as const },
+  output: { feature: 'figure' as const },
+}
+
+describe('source/output checkpoints', () => {
+  it('requires named checkpoints and rejects duplicate ids', () => {
+    const invalid = validateSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [base, base],
+    })
+    expect(invalid).toEqual([expect.objectContaining({ code: 'duplicate-id' })])
+    expect(() =>
+      parseSourceOutputCheckpointSet({
+        schemaVersion: '1.0.0',
+        checkpoints: [{ ...base, id: '' }],
+      }),
+    ).toThrow(/invalid-checkpoint/)
+  })
+
+  it('binds the property to the structure a reviewer must inspect', () => {
+    expect(
+      validateSourceOutputCheckpointSet({
+        schemaVersion: '1.0.0',
+        checkpoints: [
+          {
+            ...base,
+            property: 'code-block-structure',
+            source: { feature: 'structure' },
+          },
+        ],
+      }),
+    ).toEqual([expect.objectContaining({ code: 'property-feature-mismatch' })])
+  })
+
+  it('binds structural claims to structural source evidence', () => {
+    expect(
+      validateSourceOutputCheckpointSet({
+        schemaVersion: '1.0.0',
+        checkpoints: [
+          {
+            ...base,
+            property: 'code-block-structure',
+            output: { feature: 'code' },
+          },
+        ],
+      }),
+    ).toEqual([
+      expect.objectContaining({ code: 'property-source-feature-mismatch' }),
+    ])
+  })
+
+  it('fails when a pair has no source visual or output structure', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [base],
+    }).checkpoints[0]
+    const result = evaluateSourceOutputCheckpoint(checkpoint, {
+      source: { page: 2, text: 'Figure 1', hasVisual: false },
+      rendition: {
+        profile: 'paperPro',
+        width: 540,
+        html: '<p>Figure 1</p>',
+      },
+    })
+    expect(result).toMatchObject({
+      checkpointId: 'figure-on-page-2',
+      status: 'failed',
+    })
+  })
+
+  it('fails when the rendition is captured at a width other than the profile', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [base],
+    }).checkpoints[0]
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source: { page: 2, text: 'Figure 1', hasVisual: true },
+        rendition: {
+          profile: 'paperPro',
+          width: 390,
+          html: '<figure><figcaption>Figure 1</figcaption></figure>',
+        },
+      }),
+    ).toMatchObject({
+      status: 'failed',
+      reason: expect.stringContaining('width'),
+    })
+  })
+
+  it('passes only when the named reviewer-visible property holds', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [base],
+    }).checkpoints[0]
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source: { page: 2, text: 'Figure 1', hasVisual: true },
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<figure><img alt="Figure 1" /><figcaption>Figure 1</figcaption></figure>',
+        },
+      }),
+    ).toEqual({ checkpointId: 'figure-on-page-2', status: 'passed' })
+  })
+
+  it('checks optional output text instead of accepting any matching tag', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          output: { feature: 'figure', text: 'Expected figure' },
+        },
+      ],
+    }).checkpoints[0]
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source: { page: 2, text: 'Figure 1', hasVisual: true },
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<figure><img alt="Other figure" /><figcaption>Other figure</figcaption></figure>',
+        },
+      }),
+    ).toMatchObject({ status: 'failed' })
+  })
+
+  it('rejects a caption that absorbs following prose', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'caption-boundary',
+          property: 'caption-boundary',
+          output: { feature: 'caption', text: 'Figure 1. Source flowchart' },
+        },
+      ],
+    }).checkpoints[0]
+    const observation = {
+      source: { page: 2, text: 'Figure 1', hasVisual: true },
+      rendition: {
+        profile: 'paperPro' as const,
+        width: 540,
+        html: '<figure><img /><figcaption>Figure 1. Source flowchart. The next paragraph was swallowed.</figcaption></figure>',
+      },
+    }
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, observation),
+    ).toMatchObject({
+      checkpointId: 'caption-boundary',
+      status: 'failed',
+    })
+  })
+
+  it('rejects a caption that survives without its figure', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'caption-without-figure',
+          property: 'caption-boundary',
+          output: { feature: 'caption', text: 'Figure 1. Source flowchart' },
+        },
+      ],
+    }).checkpoints[0]
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source: { page: 2, text: 'Figure 1', hasVisual: true },
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<figure><figcaption>Figure 1. Source flowchart</figcaption></figure>',
+        },
+      }),
+    ).toMatchObject({
+      checkpointId: 'caption-without-figure',
+      status: 'failed',
+    })
+  })
+
+  it('rejects prose split across separate paragraph blocks', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'prose-continuity',
+          property: 'prose-continuity',
+          source: { feature: 'text' },
+          output: {
+            feature: 'prose',
+            text: 'The result sentence continues across a column break.',
+          },
+        },
+      ],
+    }).checkpoints[0]
+    const observation = {
+      source: {
+        page: 2,
+        text: 'The result sentence continues across a column break.',
+        hasVisual: false,
+      },
+      rendition: {
+        profile: 'paperPro' as const,
+        width: 540,
+        html: '<p>The result sentence continues</p><p>across a column break.</p>',
+      },
+    }
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, observation),
+    ).toMatchObject({
+      checkpointId: 'prose-continuity',
+      status: 'failed',
+    })
+  })
+
+  it('rejects pseudocode flattened into running prose', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'code-block-structure',
+          property: 'code-block-structure',
+          source: { feature: 'structure', text: 'Pseudocode' },
+          output: { feature: 'code' },
+        },
+      ],
+    }).checkpoints[0]
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source: { page: 2, text: 'Pseudocode', hasVisual: false },
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>for each source line: compare source and rendition</p>',
+        },
+      }),
+    ).toMatchObject({ checkpointId: 'code-block-structure', status: 'failed' })
+  })
+})

--- a/src/research/source-output-checkpoints.ts
+++ b/src/research/source-output-checkpoints.ts
@@ -1,0 +1,463 @@
+import { z } from 'zod'
+import {
+  getTargetProfile,
+  TARGET_PROFILE_IDS,
+  type TargetProfileId,
+} from './targets'
+
+/**
+ * A checkpoint is the smallest reviewable claim made by source/output
+ * evidence.  Keeping the claim in data (rather than inferring it from the
+ * images) means a generated pair cannot pass merely because two files exist.
+ */
+export const SOURCE_OUTPUT_CHECKPOINT_SCHEMA_VERSION = '1.0.0' as const
+
+export const SOURCE_OUTPUT_CHECKPOINT_PROPERTIES = [
+  'figure-present',
+  'caption-boundary',
+  'prose-continuity',
+  'heading-level',
+  'table-structure',
+  'code-block-structure',
+] as const
+
+export type SourceOutputCheckpointProperty =
+  (typeof SOURCE_OUTPUT_CHECKPOINT_PROPERTIES)[number]
+
+export const SOURCE_OUTPUT_FEATURES = ['visual', 'text', 'structure'] as const
+
+export type SourceOutputFeature = (typeof SOURCE_OUTPUT_FEATURES)[number]
+
+export const SOURCE_OUTPUT_RENDITION_FEATURES = [
+  'figure',
+  'caption',
+  'prose',
+  'heading',
+  'table',
+  'code',
+] as const
+
+export type SourceOutputRenditionFeature =
+  (typeof SOURCE_OUTPUT_RENDITION_FEATURES)[number]
+
+const sourceExpectationSchema = z
+  .object({
+    feature: z.enum(SOURCE_OUTPUT_FEATURES),
+    text: z.string().min(1).optional(),
+  })
+  .strict()
+
+const renditionExpectationSchema = z
+  .object({
+    feature: z.enum(SOURCE_OUTPUT_RENDITION_FEATURES),
+    text: z.string().min(1).optional(),
+    level: z.number().int().min(1).max(6).optional(),
+  })
+  .strict()
+
+export const sourceOutputCheckpointSchema = z
+  .object({
+    id: z.string().min(1),
+    document: z.string().min(1),
+    page: z.number().int().positive(),
+    profile: z.enum(TARGET_PROFILE_IDS),
+    property: z.enum(SOURCE_OUTPUT_CHECKPOINT_PROPERTIES),
+    criterion: z.string().min(1),
+    source: sourceExpectationSchema,
+    output: renditionExpectationSchema,
+  })
+  .strict()
+
+export type SourceOutputCheckpoint = z.infer<
+  typeof sourceOutputCheckpointSchema
+>
+
+export const sourceOutputCheckpointSetSchema = z
+  .object({
+    schemaVersion: z.literal(SOURCE_OUTPUT_CHECKPOINT_SCHEMA_VERSION),
+    checkpoints: z.array(sourceOutputCheckpointSchema).min(1),
+  })
+  .strict()
+
+export type SourceOutputCheckpointSet = z.infer<
+  typeof sourceOutputCheckpointSetSchema
+>
+
+export type CheckpointValidationIssue = {
+  checkpointId: string
+  code:
+    | 'invalid-checkpoint'
+    | 'duplicate-id'
+    | 'property-feature-mismatch'
+    | 'property-source-feature-mismatch'
+  message: string
+}
+
+export class SourceOutputCheckpointValidationError extends Error {
+  constructor(public readonly issues: CheckpointValidationIssue[]) {
+    super(issues.map((issue) => `${issue.code}: ${issue.message}`).join('\n'))
+    this.name = 'SourceOutputCheckpointValidationError'
+  }
+}
+
+function expectedRenditionFeature(
+  property: SourceOutputCheckpointProperty,
+): SourceOutputRenditionFeature {
+  switch (property) {
+    case 'figure-present':
+      return 'figure'
+    case 'caption-boundary':
+      return 'caption'
+    case 'prose-continuity':
+      return 'prose'
+    case 'heading-level':
+      return 'heading'
+    case 'table-structure':
+      return 'table'
+    case 'code-block-structure':
+      return 'code'
+  }
+}
+
+function expectedSourceFeature(
+  property: SourceOutputCheckpointProperty,
+): SourceOutputFeature {
+  switch (property) {
+    case 'figure-present':
+    case 'caption-boundary':
+      return 'visual'
+    case 'prose-continuity':
+      return 'text'
+    case 'heading-level':
+    case 'table-structure':
+    case 'code-block-structure':
+      return 'structure'
+  }
+}
+
+/** Validate the cross-field rules that a plain JSON schema cannot express. */
+export function validateSourceOutputCheckpointSet(
+  input: unknown,
+): CheckpointValidationIssue[] {
+  let parsed: SourceOutputCheckpointSet
+  try {
+    parsed = sourceOutputCheckpointSetSchema.parse(input)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return [
+        {
+          checkpointId: 'checkpoint-set',
+          code: 'invalid-checkpoint',
+          message: error.issues
+            .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+            .join('; '),
+        },
+      ]
+    }
+    return [
+      {
+        checkpointId: 'checkpoint-set',
+        code: 'invalid-checkpoint',
+        message: 'Checkpoint set could not be validated.',
+      },
+    ]
+  }
+
+  const issues: CheckpointValidationIssue[] = []
+  const ids = new Set<string>()
+  for (const checkpoint of parsed.checkpoints) {
+    if (ids.has(checkpoint.id)) {
+      issues.push({
+        checkpointId: checkpoint.id,
+        code: 'duplicate-id',
+        message: `Checkpoint id ${checkpoint.id} is not unique.`,
+      })
+    }
+    ids.add(checkpoint.id)
+
+    const expected = expectedRenditionFeature(checkpoint.property)
+    if (checkpoint.output.feature !== expected) {
+      issues.push({
+        checkpointId: checkpoint.id,
+        code: 'property-feature-mismatch',
+        message: `${checkpoint.property} must inspect rendition feature ${expected}.`,
+      })
+    }
+
+    const expectedSource = expectedSourceFeature(checkpoint.property)
+    if (checkpoint.source.feature !== expectedSource) {
+      issues.push({
+        checkpointId: checkpoint.id,
+        code: 'property-source-feature-mismatch',
+        message: `${checkpoint.property} must inspect source feature ${expectedSource}.`,
+      })
+    }
+  }
+  return issues
+}
+
+export function parseSourceOutputCheckpointSet(
+  input: unknown,
+): SourceOutputCheckpointSet {
+  const issues = validateSourceOutputCheckpointSet(input)
+  if (issues.length > 0) {
+    throw new SourceOutputCheckpointValidationError(issues)
+  }
+  return sourceOutputCheckpointSetSchema.parse(input)
+}
+
+export function assertSourceOutputCheckpoint(
+  input: unknown,
+): SourceOutputCheckpoint {
+  const set = parseSourceOutputCheckpointSet({
+    schemaVersion: SOURCE_OUTPUT_CHECKPOINT_SCHEMA_VERSION,
+    checkpoints: [input],
+  })
+  return set.checkpoints[0]
+}
+
+export function sortSourceOutputCheckpoints(
+  checkpoints: readonly SourceOutputCheckpoint[],
+) {
+  return [...checkpoints].sort(
+    (left, right) =>
+      left.document.localeCompare(right.document) ||
+      left.page - right.page ||
+      left.profile.localeCompare(right.profile) ||
+      left.id.localeCompare(right.id),
+  )
+}
+
+export type SourceCheckpointObservation = {
+  page: number
+  text: string
+  hasVisual: boolean
+}
+
+export type RenditionCheckpointObservation = {
+  profile: TargetProfileId
+  width: number
+  html: string
+}
+
+export type SourceOutputCheckpointObservation = {
+  source: SourceCheckpointObservation
+  rendition: RenditionCheckpointObservation
+}
+
+export type SourceOutputCheckpointResult = {
+  checkpointId: string
+  status: 'passed' | 'failed'
+  reason?: string
+}
+
+function normalizedText(value: string) {
+  return value
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&(?:amp|lt|gt|quot|apos);/g, (entity) => {
+      const values: Record<string, string> = {
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&quot;': '"',
+        '&apos;': "'",
+      }
+      return values[entity] ?? entity
+    })
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function tagContents(html: string, tag: string) {
+  const contents: string[] = []
+  const matcher = new RegExp(
+    '<' + tag + '(?:\\s[^>]*)?>([\\s\\S]*?)</' + tag + '>',
+    'gi',
+  )
+  for (const match of html.matchAll(matcher)) {
+    contents.push(match[1] ?? '')
+  }
+  return contents
+}
+
+function hasHeading(html: string, level?: number) {
+  if (level === undefined) return /<h[1-6](?:\s|>)/i.test(html)
+  return new RegExp(`<h${level}(?:\\s|>)`, 'i').test(html)
+}
+
+function headingContents(html: string, level?: number) {
+  const matcher =
+    level === undefined
+      ? /<h[1-6](?:\s[^>]*)?>([\s\S]*?)<\/h[1-6]>/gi
+      : new RegExp(`<h${level}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/h${level}>`, 'gi')
+  return [...html.matchAll(matcher)].map((match) => match[1] ?? '')
+}
+
+function hasStructuredTable(html: string) {
+  return (
+    /<table(?:\s|>)/i.test(html) &&
+    /<tr(?:\s|>)/i.test(html) &&
+    /<(?:th|td)(?:\s|>)/i.test(html)
+  )
+}
+
+function hasStructuredCode(html: string) {
+  return /<pre(?:\s|>)[\s\S]*?<code(?:\s|>)/i.test(html)
+}
+
+function hasFigure(checkpoint: SourceOutputCheckpoint, html: string) {
+  const figures = tagContents(html, 'figure').filter((figure) =>
+    /<(?:img|svg|canvas)(?:\s|>)/i.test(figure),
+  )
+  if (figures.length === 0) return false
+  if (!checkpoint.output.text) return true
+  const expected = normalizedText(checkpoint.output.text)
+  return figures.some((figure) => normalizedText(figure).includes(expected))
+}
+
+function hasHeadingContent(checkpoint: SourceOutputCheckpoint, html: string) {
+  if (!hasHeading(html, checkpoint.output.level)) return false
+  if (!checkpoint.output.text) return true
+  const expected = normalizedText(checkpoint.output.text)
+  return headingContents(html, checkpoint.output.level).some((heading) =>
+    normalizedText(heading).includes(expected),
+  )
+}
+
+function hasTableContent(checkpoint: SourceOutputCheckpoint, html: string) {
+  if (!hasStructuredTable(html)) return false
+  if (!checkpoint.output.text) return true
+  const expected = normalizedText(checkpoint.output.text)
+  return tagContents(html, 'table').some((table) =>
+    normalizedText(table).includes(expected),
+  )
+}
+
+function hasCodeContent(checkpoint: SourceOutputCheckpoint, html: string) {
+  if (!hasStructuredCode(html)) return false
+  if (!checkpoint.output.text) return true
+  const expected = normalizedText(checkpoint.output.text)
+  return tagContents(html, 'code').some((code) =>
+    normalizedText(code).includes(expected),
+  )
+}
+
+function hasCaption(checkpoint: SourceOutputCheckpoint, html: string) {
+  const figure = tagContents(html, 'figure').find(
+    (content) =>
+      /<(?:img|svg|canvas)(?:\s|>)/i.test(content) &&
+      /<figcaption(?:\s|>)[\s\S]*?<\/figcaption>/i.test(content),
+  )
+  if (!figure) return false
+  if (!checkpoint.output.text) return true
+  const caption = tagContents(figure, 'figcaption')[0]
+  return (
+    caption !== undefined &&
+    normalizedText(caption) === normalizedText(checkpoint.output.text)
+  )
+}
+
+function hasProse(checkpoint: SourceOutputCheckpoint, html: string) {
+  const paragraphs = tagContents(html, 'p')
+  if (!checkpoint.output.text) return paragraphs.length > 0
+  const expected = normalizedText(checkpoint.output.text)
+  return paragraphs.some((paragraph) =>
+    normalizedText(paragraph).includes(expected),
+  )
+}
+
+function outputFeaturePresent(
+  checkpoint: SourceOutputCheckpoint,
+  html: string,
+) {
+  switch (checkpoint.output.feature) {
+    case 'figure':
+      return hasFigure(checkpoint, html)
+    case 'caption':
+      return hasCaption(checkpoint, html)
+    case 'prose':
+      return hasProse(checkpoint, html)
+    case 'heading':
+      return hasHeadingContent(checkpoint, html)
+    case 'table':
+      return hasTableContent(checkpoint, html)
+    case 'code':
+      return hasCodeContent(checkpoint, html)
+  }
+}
+
+/**
+ * Evaluate a named claim against observations made by the paired renderer.
+ * Missing observations, profile mismatches, and absent structure all fail
+ * closed.
+ */
+export function evaluateSourceOutputCheckpoint(
+  checkpoint: SourceOutputCheckpoint,
+  observation: SourceOutputCheckpointObservation,
+): SourceOutputCheckpointResult {
+  if (observation.source.page !== checkpoint.page) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: `Source observation is page ${observation.source.page}, expected page ${checkpoint.page}.`,
+    }
+  }
+  if (observation.rendition.profile !== checkpoint.profile) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: `Rendition uses ${observation.rendition.profile}, expected ${checkpoint.profile}.`,
+    }
+  }
+  const expectedWidth = getTargetProfile(checkpoint.profile).preview.widthCssPx
+  if (observation.rendition.width !== expectedWidth) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: `Rendition width is ${observation.rendition.width}, expected ${expectedWidth} for ${checkpoint.profile}.`,
+    }
+  }
+  if (!observation.source.text.trim()) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: 'The source page has no readable evidence.',
+    }
+  }
+  if (checkpoint.source.feature === 'visual' && !observation.source.hasVisual) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: 'The named source page has no rendered visual object.',
+    }
+  }
+  if (!observation.rendition.html.trim()) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: 'The generated rendition is empty.',
+    }
+  }
+  if (!outputFeaturePresent(checkpoint, observation.rendition.html)) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: `Rendition does not satisfy the ${checkpoint.property} criterion.`,
+    }
+  }
+  if (
+    checkpoint.source.text &&
+    !normalizedText(observation.source.text).includes(
+      normalizedText(checkpoint.source.text),
+    )
+  ) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason: 'The source page does not contain the named source text.',
+    }
+  }
+  return { checkpointId: checkpoint.id, status: 'passed' }
+}

--- a/tests/fixtures/pdf/README.md
+++ b/tests/fixtures/pdf/README.md
@@ -33,6 +33,12 @@ source-glyph equation raster, and bibliography entries. Its
 text and visual content were written for this repository and do not reduce or
 copy any external paper.
 
+`source-output-checkpoints.pdf` is the small source/output review fixture. It
+contains a source flowchart, a caption, a sentence explicitly labelled as
+continuing across a column break, and a pseudocode listing. The paired evidence
+command uses this page only; it never renders owner-local papers into the
+repository.
+
 `sparse-embedded-text.pdf` is a title/divider page with no image content. It
 proves that high-confidence OCR which only confirms the embedded text completes
 the OCR attempt without duplicating runs, while the no-OCR path stays blocked.

--- a/tests/fixtures/pdf/generate-source-output-checkpoints.mjs
+++ b/tests/fixtures/pdf/generate-source-output-checkpoints.mjs
@@ -1,0 +1,58 @@
+import { deflateSync } from 'node:zlib'
+import { writeFileSync } from 'node:fs'
+
+function escaped(value) {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('(', '\\(')
+    .replaceAll(')', '\\)')
+}
+
+function textLine(text, x, y, size = 12, font = 'F1') {
+  return `BT\n/${font} ${size} Tf\n${x} ${y} Td\n(${escaped(text)}) Tj\nET`
+}
+
+function imageObject() {
+  const pixels = Uint8Array.from([
+    235, 235, 235, 235, 235, 35, 35, 235, 235, 35, 35, 235, 235, 235, 235, 235,
+  ])
+  const encoded = `${Buffer.from(deflateSync(pixels)).toString('hex').toUpperCase()}>`
+  return `<< /Type /XObject /Subtype /Image /Width 4 /Height 4 /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter [/ASCIIHexDecode /FlateDecode] /Length ${encoded.length} >>\nstream\n${encoded}\nendstream`
+}
+
+const content = [
+  textLine('Source/output checkpoint fixture', 72, 730, 20, 'F2'),
+  textLine('Figure 1. Source flowchart', 72, 680),
+  textLine('The result sentence continues across a column break.', 72, 640),
+  textLine('Pseudocode', 72, 580, 14, 'F2'),
+  textLine('for each source line:', 90, 550),
+  textLine('compare source and rendition', 108, 528),
+  textLine('keep the named property visible', 108, 506),
+  'q\n360 0 0 160 126 300 cm\n/Im1 Do\nQ',
+  textLine('Figure 1 caption stays below the source flowchart.', 72, 250, 10),
+].join('\n')
+
+const objects = [
+  '<< /Type /Catalog /Pages 2 0 R >>',
+  '<< /Type /Pages /Kids [5 0 R] /Count 1 >>',
+  '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  imageObject(),
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> /XObject << /Im1 4 0 R >> >> /Contents 6 0 R >>',
+  `<< /Length ${Buffer.byteLength(content)} >>\nstream\n${content}\nendstream`,
+]
+
+let pdf = '%PDF-1.4\n% synthetic fixture owned by erniesg\n'
+const offsets = [0]
+for (const [index, object] of objects.entries()) {
+  offsets.push(Buffer.byteLength(pdf))
+  pdf += `${index + 1} 0 obj\n${object}\nendobj\n`
+}
+const xref = Buffer.byteLength(pdf)
+pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`
+pdf += offsets
+  .slice(1)
+  .map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`)
+  .join('')
+pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`
+
+writeFileSync(new URL('./source-output-checkpoints.pdf', import.meta.url), pdf)

--- a/tests/fixtures/pdf/manifest.json
+++ b/tests/fixtures/pdf/manifest.json
@@ -80,6 +80,17 @@
       ]
     },
     {
+      "file": "source-output-checkpoints.pdf",
+      "sha256": "2265f0d49304011feb8c972bf24bf5b93db099180d4fa270826e19df23c2de30",
+      "features": [
+        "source-output-checkpoints",
+        "source-flowchart",
+        "caption-boundary",
+        "prose-continuity",
+        "pseudocode-block"
+      ]
+    },
+    {
       "file": "diagnostic-overlays.pdf",
       "features": [
         "ambiguous-reading-order",

--- a/tests/fixtures/pdf/source-output-checkpoints.json
+++ b/tests/fixtures/pdf/source-output-checkpoints.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": "1.0.0",
+  "checkpoints": [
+    {
+      "id": "fidelity-page-1-figure-present",
+      "document": "source-output-checkpoints.pdf",
+      "page": 1,
+      "profile": "paperPro",
+      "property": "figure-present",
+      "criterion": "Figure 1 is visible in the source page and remains a figure in the rendition.",
+      "source": { "feature": "visual", "text": "Figure 1" },
+      "output": { "feature": "figure" }
+    },
+    {
+      "id": "fidelity-page-1-caption-boundary",
+      "document": "source-output-checkpoints.pdf",
+      "page": 1,
+      "profile": "paperPro",
+      "property": "caption-boundary",
+      "criterion": "The Figure 1 caption stays attached to its figure and does not absorb following prose.",
+      "source": { "feature": "visual", "text": "Figure 1" },
+      "output": { "feature": "caption", "text": "Figure 1. Source flowchart" }
+    },
+    {
+      "id": "fidelity-page-1-prose-continuity",
+      "document": "source-output-checkpoints.pdf",
+      "page": 1,
+      "profile": "paperPro",
+      "property": "prose-continuity",
+      "criterion": "The result sentence remains one continuous prose block in the rendition.",
+      "source": { "feature": "text" },
+      "output": {
+        "feature": "prose",
+        "text": "The result sentence continues across a column break."
+      }
+    },
+    {
+      "id": "fidelity-page-1-code-block-structure",
+      "document": "source-output-checkpoints.pdf",
+      "page": 1,
+      "profile": "paperPro",
+      "property": "code-block-structure",
+      "criterion": "The pseudocode checkpoint is emitted as a preformatted code block, not running prose.",
+      "source": { "feature": "structure", "text": "Pseudocode" },
+      "output": { "feature": "code" }
+    }
+  ]
+}

--- a/tests/fixtures/pdf/source-output-checkpoints.pdf
+++ b/tests/fixtures/pdf/source-output-checkpoints.pdf
@@ -1,0 +1,83 @@
+%PDF-1.4
+% synthetic fixture owned by erniesg
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [5 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Type /XObject /Subtype /Image /Width 4 /Height 4 /ColorSpace /DeviceGray /BitsPerComponent 8 /Filter [/ASCIIHexDecode /FlateDecode] /Length 41 >>
+stream
+789C7BFDFAF5EBD7CACA10FCFAF56B0062580B91>
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> /XObject << /Im1 4 0 R >> >> /Contents 6 0 R >>
+endobj
+6 0 obj
+<< /Length 542 >>
+stream
+BT
+/F2 20 Tf
+72 730 Td
+(Source/output checkpoint fixture) Tj
+ET
+BT
+/F1 12 Tf
+72 680 Td
+(Figure 1. Source flowchart) Tj
+ET
+BT
+/F1 12 Tf
+72 640 Td
+(The result sentence continues across a column break.) Tj
+ET
+BT
+/F2 14 Tf
+72 580 Td
+(Pseudocode) Tj
+ET
+BT
+/F1 12 Tf
+90 550 Td
+(for each source line:) Tj
+ET
+BT
+/F1 12 Tf
+108 528 Td
+(compare source and rendition) Tj
+ET
+BT
+/F1 12 Tf
+108 506 Td
+(keep the named property visible) Tj
+ET
+q
+360 0 0 160 126 300 cm
+/Im1 Do
+Q
+BT
+/F1 10 Tf
+72 250 Td
+(Figure 1 caption stays below the source flowchart.) Tj
+ET
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000046 00000 n 
+0000000095 00000 n 
+0000000152 00000 n 
+0000000222 00000 n 
+0000000446 00000 n 
+0000000608 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+1201
+%%EOF

--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -1,0 +1,983 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { createServer } from 'vite'
+import { chromium } from '@playwright/test'
+import { unzipSync } from 'fflate'
+import { createCanvas, loadImage } from '@napi-rs/canvas'
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs'
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const DEFAULT_DOCUMENT = resolve(
+  REPOSITORY_ROOT,
+  'tests/fixtures/pdf/source-output-checkpoints.pdf',
+)
+const DEFAULT_CHECKPOINTS = resolve(
+  REPOSITORY_ROOT,
+  'tests/fixtures/pdf/source-output-checkpoints.json',
+)
+const DEFAULT_OUTPUT = resolve(
+  REPOSITORY_ROOT,
+  '.agent/evidence/srt-checkpoints',
+)
+const TOOL_VERSION = '1.0.0'
+
+const IMAGE_OPERATORS = new Set([
+  pdfjs.OPS.paintImageMaskXObject,
+  pdfjs.OPS.paintImageMaskXObjectGroup,
+  pdfjs.OPS.paintImageMaskXObjectRepeat,
+  pdfjs.OPS.paintImageXObject,
+  pdfjs.OPS.paintImageXObjectRepeat,
+  pdfjs.OPS.paintInlineImageXObject,
+  pdfjs.OPS.paintInlineImageXObjectGroup,
+  pdfjs.OPS.paintSolidColorImageMask,
+])
+
+const VECTOR_VISUAL_OPERATORS = new Set([
+  pdfjs.OPS.constructPath,
+  pdfjs.OPS.rectangle,
+  pdfjs.OPS.stroke,
+  pdfjs.OPS.closeStroke,
+  pdfjs.OPS.fill,
+  pdfjs.OPS.eoFill,
+  pdfjs.OPS.fillStroke,
+  pdfjs.OPS.eoFillStroke,
+  pdfjs.OPS.closeFillStroke,
+  pdfjs.OPS.closeEOFillStroke,
+  pdfjs.OPS.shadingFill,
+  pdfjs.OPS.rawFillPath,
+])
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function jsonBytes(value) {
+  return new TextEncoder().encode(`${JSON.stringify(value, null, 2)}\n`)
+}
+
+function safeStem(value) {
+  return (
+    basename(value, extname(value))
+      .normalize('NFKD')
+      .replace(/[^A-Za-z0-9._-]+/g, '-')
+      .replace(/^-|-$/g, '') || 'document'
+  )
+}
+
+function parseList(value, label) {
+  const values = String(value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+  if (values.length === 0) throw new Error(`INVALID_${label.toUpperCase()}`)
+  return values
+}
+
+export function parseArguments(arguments_) {
+  let document = DEFAULT_DOCUMENT
+  let checkpoints = DEFAULT_CHECKPOINTS
+  let output = DEFAULT_OUTPUT
+  let explicitDocument = false
+  let explicitOutput = false
+  let profiles = null
+  let pages = null
+  let struct = null
+
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index]
+    const nextValue = () => {
+      const value = arguments_[index + 1]
+      if (!value || value.startsWith('--')) throw new Error('INVALID_USAGE')
+      index += 1
+      return value
+    }
+    if (argument === '--document') {
+      document = resolve(nextValue())
+      explicitDocument = true
+    } else if (argument.startsWith('--document=')) {
+      document = resolve(argument.slice('--document='.length))
+      explicitDocument = true
+    } else if (argument === '--checkpoints') {
+      checkpoints = resolve(nextValue())
+    } else if (argument.startsWith('--checkpoints=')) {
+      checkpoints = resolve(argument.slice('--checkpoints='.length))
+    } else if (argument === '--output') {
+      output = resolve(nextValue())
+      explicitOutput = true
+    } else if (argument.startsWith('--output=')) {
+      output = resolve(argument.slice('--output='.length))
+      explicitOutput = true
+    } else if (argument === '--profile') {
+      profiles = parseList(nextValue(), 'profile')
+    } else if (argument.startsWith('--profile=')) {
+      profiles = parseList(argument.slice('--profile='.length), 'profile')
+    } else if (argument === '--pages') {
+      pages = parseList(nextValue(), 'pages').map((value) => {
+        if (!/^[1-9][0-9]*$/u.test(value)) throw new Error('INVALID_PAGES')
+        return Number(value)
+      })
+    } else if (argument.startsWith('--pages=')) {
+      pages = parseList(argument.slice('--pages='.length), 'pages').map(
+        (value) => {
+          if (!/^[1-9][0-9]*$/u.test(value)) throw new Error('INVALID_PAGES')
+          return Number(value)
+        },
+      )
+    } else if (argument === '--struct') {
+      struct = resolve(nextValue())
+    } else if (argument.startsWith('--struct=')) {
+      struct = resolve(argument.slice('--struct='.length))
+    } else {
+      throw new Error('INVALID_USAGE')
+    }
+  }
+
+  return {
+    document,
+    checkpoints,
+    output,
+    explicitDocument,
+    explicitOutput,
+    profiles,
+    pages,
+    struct,
+  }
+}
+
+function pathWithin(root, candidate) {
+  const value = relative(root, candidate)
+  return (
+    value === '' ||
+    (value !== '..' && !value.startsWith(`..${'/'}`) && !isAbsolute(value))
+  )
+}
+
+async function policyPath(candidate) {
+  const resolved = resolve(candidate)
+  const missingSegments = []
+  let current = resolved
+  while (true) {
+    try {
+      const existing = await realpath(current)
+      return join(existing, ...missingSegments.reverse())
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+      const parent = dirname(current)
+      if (parent === current) return resolved
+      missingSegments.push(basename(current))
+      current = parent
+    }
+  }
+}
+
+async function enforceOutputPrivacy(options) {
+  const [repositoryRoot, documentPath, outputPath] = await Promise.all([
+    realpath(REPOSITORY_ROOT),
+    policyPath(options.document),
+    policyPath(options.output),
+  ])
+  const fixtureDocument = pathWithin(repositoryRoot, documentPath)
+  const defaultFixture = documentPath === (await policyPath(DEFAULT_DOCUMENT))
+  const callerOutputPath = resolve(options.output)
+  if (
+    !fixtureDocument &&
+    (pathWithin(repositoryRoot, callerOutputPath) ||
+      pathWithin(repositoryRoot, outputPath))
+  ) {
+    throw new Error(
+      'PRIVATE_OUTPUT_MUST_BE_OUTSIDE_REPOSITORY: owner-local documents require a caller-named local output directory',
+    )
+  }
+  if (!defaultFixture && !options.struct) {
+    throw new Error(
+      'PRIVATE_STRUCT_REQUIRED: documents other than the repository fixture require a caller-provided STRUCT JSON document',
+    )
+  }
+  if (options.explicitDocument && !options.explicitOutput) {
+    throw new Error(
+      'PRIVATE_OUTPUT_REQUIRED: custom documents require an explicit --output directory',
+    )
+  }
+  return { defaultFixture }
+}
+
+async function renderSourcePage(pdfDocument, pageNumber, width) {
+  if (
+    !Number.isInteger(pageNumber) ||
+    pageNumber < 1 ||
+    pageNumber > pdfDocument.numPages
+  ) {
+    throw new Error(`SOURCE_PAGE_OUT_OF_RANGE: ${pageNumber}`)
+  }
+  const page = await pdfDocument.getPage(pageNumber)
+  try {
+    const base = page.getViewport({ scale: 1 })
+    const scale = width / base.width
+    const viewport = page.getViewport({ scale })
+    const canvas = createCanvas(
+      Math.max(1, Math.ceil(viewport.width)),
+      Math.max(1, Math.ceil(viewport.height)),
+    )
+    const context = canvas.getContext('2d')
+    context.save()
+    context.fillStyle = '#ffffff'
+    context.fillRect(0, 0, canvas.width, canvas.height)
+    context.restore()
+    await page.render({
+      canvas,
+      canvasContext: context,
+      viewport,
+      background: 'white',
+    }).promise
+    const operatorList = await page.getOperatorList()
+    const textContent = await page.getTextContent()
+    const text = textContent.items
+      .map((item) => ('str' in item ? item.str : ''))
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    return {
+      bytes: new Uint8Array(await canvas.encode('png')),
+      width: canvas.width,
+      height: canvas.height,
+      text,
+      hasVisual: operatorList.fnArray.some(
+        (operator) =>
+          IMAGE_OPERATORS.has(operator) ||
+          VECTOR_VISUAL_OPERATORS.has(operator),
+      ),
+    }
+  } finally {
+    page.cleanup()
+  }
+}
+
+function evidence(page, sourceHash, byteLength, width, height) {
+  return {
+    confidence: 1,
+    pages: [page],
+    boxes: [
+      {
+        page,
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        rotation: 0,
+      },
+    ],
+    sourceIds: [
+      `source-page-${page}-${sourceHash.slice(0, 12)}-${byteLength}-${width}x${height}`,
+    ],
+  }
+}
+
+async function cropFixtureFigure(asset) {
+  const image = await loadImage(Buffer.from(asset.bytes))
+  const xScale = asset.width / 612
+  const yScale = asset.height / 792
+  const crop = {
+    x: Math.round(126 * xScale),
+    y: Math.round((792 - 460) * yScale),
+    width: Math.round(360 * xScale),
+    height: Math.round(160 * yScale),
+  }
+  const canvas = createCanvas(crop.width, crop.height)
+  const context = canvas.getContext('2d')
+  context.drawImage(
+    image,
+    crop.x,
+    crop.y,
+    crop.width,
+    crop.height,
+    0,
+    0,
+    crop.width,
+    crop.height,
+  )
+  return {
+    bytes: new Uint8Array(await canvas.encode('png')),
+    width: crop.width,
+    height: crop.height,
+  }
+}
+
+async function createFixtureStructDocument({
+  sourceHash,
+  byteLength,
+  pageCount,
+  fileName,
+  page,
+  asset,
+}) {
+  const figureAsset = await cropFixtureFigure(asset)
+  const sourceEvidence = evidence(
+    page,
+    sourceHash,
+    byteLength,
+    asset.width,
+    asset.height,
+  )
+  const blockEvidence = {
+    ...sourceEvidence,
+    sourceIds: [`source-page-${page}`],
+  }
+  const cells = [
+    {
+      id: 'checkpoint-table-profile',
+      text: 'Profile',
+      row: 0,
+      column: 0,
+      rowSpan: 1,
+      columnSpan: 1,
+      headerScope: 'column',
+      inline: [],
+      evidence: blockEvidence,
+    },
+    {
+      id: 'checkpoint-table-nodes',
+      text: 'Nodes',
+      row: 0,
+      column: 1,
+      rowSpan: 1,
+      columnSpan: 1,
+      headerScope: 'column',
+      inline: [],
+      evidence: blockEvidence,
+    },
+    {
+      id: 'checkpoint-table-paper',
+      text: 'Paper Pro',
+      row: 1,
+      column: 0,
+      rowSpan: 1,
+      columnSpan: 1,
+      headerScope: null,
+      inline: [],
+      evidence: blockEvidence,
+    },
+    {
+      id: 'checkpoint-table-value',
+      text: '4',
+      row: 1,
+      column: 1,
+      rowSpan: 1,
+      columnSpan: 1,
+      headerScope: null,
+      inline: [],
+      evidence: blockEvidence,
+    },
+  ]
+  const textCharacterCount = [
+    'Checkpoint paper',
+    'The result sentence continues across a column break.',
+    'Figure 1. Source flowchart',
+    'Table 1. Validated checkpoint values remain structured.',
+    'for each source line:\n  compare source and rendition\n  keep the named property visible',
+    ...cells.map(({ text }) => text),
+  ].reduce((total, value) => total + value.length, 0)
+  const figureEvidence = {
+    ...sourceEvidence,
+    boxes: [
+      {
+        page,
+        x: 126 / 612,
+        y: 300 / 792,
+        width: 360 / 612,
+        height: 160 / 792,
+        rotation: 0,
+      },
+    ],
+    sourceIds: [`source-figure-${page}`],
+  }
+  return {
+    schemaVersion: '0.1.0',
+    source: {
+      format: 'pdf',
+      fileName,
+      sha256: sourceHash,
+      byteLength,
+      pageCount,
+      localOnly: true,
+    },
+    metadata: {
+      title: 'A source/output checkpoint fixture',
+      subtitle: 'The reader-visible rendition is the evidence.',
+      authors: ['Ernie Fixture'],
+      abstract: 'A deterministic fixture for source-versus-output review.',
+      language: 'en',
+      baseDirection: 'ltr',
+      updated: '2026-01-01',
+      artifactModifiedAt: '2026-01-01T00:00:00Z',
+    },
+    blocks: [
+      {
+        id: 'checkpoint-heading',
+        kind: 'heading',
+        text: 'Checkpoint paper',
+        page,
+        order: 0,
+        column: 'single',
+        inline: [],
+        attributes: { level: 1 },
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-prose',
+        kind: 'paragraph',
+        text: 'The result sentence continues across a column break.',
+        page,
+        order: 1,
+        column: 'single',
+        inline: [],
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-figure',
+        kind: 'figure',
+        label: 'Figure 1',
+        text: 'Figure 1. Source flowchart',
+        page,
+        order: 2,
+        column: 'single',
+        inline: [],
+        fallbackAssetIds: ['checkpoint-source-flowchart'],
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-table',
+        kind: 'table',
+        text: 'Table 1. Validated checkpoint values remain structured.',
+        page,
+        order: 3,
+        column: 'single',
+        inline: [],
+        table: { rows: 2, columns: 2, cells, semantic: 'verified' },
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-code',
+        kind: 'code',
+        text: 'for each source line:\n  compare source and rendition\n  keep the named property visible',
+        page,
+        order: 4,
+        column: 'single',
+        inline: [],
+        evidence: blockEvidence,
+      },
+    ],
+    assets: [
+      {
+        id: 'checkpoint-source-flowchart',
+        kind: 'figure',
+        href: 'assets/source-flowchart.png',
+        mediaType: 'image/png',
+        sha256: sha256(figureAsset.bytes),
+        width: figureAsset.width,
+        height: figureAsset.height,
+        bytes: figureAsset.bytes,
+        sourceObjectIds: [`source-figure-${page}`],
+        evidence: figureEvidence,
+        fallback: 'asset',
+      },
+    ],
+    relationships: [],
+    pages: [
+      {
+        page,
+        width: asset.width,
+        height: asset.height,
+        rotation: 0,
+        blocks: [
+          'checkpoint-heading',
+          'checkpoint-prose',
+          'checkpoint-figure',
+          'checkpoint-table',
+          'checkpoint-code',
+        ],
+        columns: [
+          {
+            id: 'column-single',
+            side: 'single',
+            blockIds: [
+              'checkpoint-heading',
+              'checkpoint-prose',
+              'checkpoint-figure',
+              'checkpoint-table',
+              'checkpoint-code',
+            ],
+          },
+        ],
+      },
+    ],
+    diagnostics: [],
+    recovery: {
+      status: 'ready',
+      title: 'Checkpoint fixture is ready.',
+      summary: 'All named source/output properties are available for review.',
+      issues: [],
+    },
+    receipt: {
+      schemaVersion: '0.1.0',
+      sourceSha256: sourceHash,
+      blockCount: 5,
+      assetCount: 1,
+      relationshipCount: 0,
+      diagnosticCount: 0,
+      textCharacterCount,
+      conservation: {
+        sourceNodeCount: 5,
+        accountedSourceNodeCount: 5,
+        sourceRegionCount: 1,
+        accountedSourceRegionCount: 1,
+        sourceAnnotationCount: 0,
+        accountedSourceAnnotationCount: 0,
+        sourceAssetCount: 1,
+        accountedSourceAssetCount: 1,
+        sourceRelationshipCount: 0,
+        accountedSourceRelationshipCount: 0,
+        sourceDiagnosticCount: 0,
+        accountedSourceDiagnosticCount: 0,
+        sourceTextCharacterCount: textCharacterCount,
+        structBlockCount: 5,
+        structAssetCount: 1,
+        structRelationshipCount: 0,
+        structDiagnosticCount: 0,
+        structTextCharacterCount: textCharacterCount,
+      },
+      generatedSha256: sourceHash,
+    },
+  }
+}
+
+async function loadStructDocument(path, fallback) {
+  if (!path) return fallback
+  const parsed = JSON.parse(await readFile(path, 'utf8'))
+  return {
+    ...parsed,
+    assets: Array.isArray(parsed.assets)
+      ? parsed.assets.map((asset) => ({
+          ...asset,
+          bytes: decodeAssetBytes(asset.bytes),
+        }))
+      : parsed.assets,
+  }
+}
+
+function decodeAssetBytes(value) {
+  if (value === undefined || value instanceof Uint8Array) return value
+  if (typeof value === 'string') {
+    return new Uint8Array(Buffer.from(value, 'base64'))
+  }
+  if (Array.isArray(value)) return Uint8Array.from(value)
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([key]) => /^[0-9]+$/u.test(key))
+      .sort(([left], [right]) => Number(left) - Number(right))
+      .map(([, entry]) => entry)
+    if (entries.length > 0) return Uint8Array.from(entries)
+  }
+  return value
+}
+
+async function writeArchive(archive, root) {
+  for (const [name, bytes] of Object.entries(archive)) {
+    const destination = join(root, ...name.split('/'))
+    if (!pathWithin(root, destination)) {
+      throw new Error(`EPUB_ARCHIVE_PATH_ESCAPE: ${name}`)
+    }
+    await mkdir(dirname(destination), { recursive: true })
+    await writeFile(destination, bytes)
+  }
+}
+
+async function renderRendition({
+  buildEpub,
+  profile,
+  document,
+  browser,
+  root,
+}) {
+  const epub = await buildEpub(document)
+  const archive = unzipSync(epub.bytes)
+  const unpacked = await mkdtemp(join(root, 'rendition-'))
+  await writeArchive(archive, unpacked)
+  const page = await browser.newPage({
+    viewport: {
+      width: Math.max(1, Math.round(profile.preview.widthCssPx)),
+      height: Math.max(
+        1,
+        Math.round(
+          profile.preview.heightCssPx ??
+            profile.preview.continuousWindowHeightCssPx ??
+            900,
+        ),
+      ),
+    },
+    deviceScaleFactor: 1,
+    locale: 'en-US',
+    timezoneId: 'UTC',
+  })
+  await page.route('**/*', async (route) => {
+    const url = route.request().url()
+    if (/^(?:file|data|about):/u.test(url)) await route.continue()
+    else await route.abort('blockedbyclient')
+  })
+  try {
+    await page.goto(pathToFileURL(join(unpacked, 'EPUB/content.xhtml')).href, {
+      waitUntil: 'load',
+      timeout: 30_000,
+    })
+    const html = await page.evaluate(() => document.documentElement.outerHTML)
+    const bytes = new Uint8Array(
+      await page.screenshot({ type: 'png', fullPage: true }),
+    )
+    const renderedHeight = await page.evaluate(() =>
+      Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight,
+      ),
+    )
+    return {
+      html,
+      bytes,
+      width: Math.max(1, Math.round(profile.preview.widthCssPx)),
+      height: Math.max(1, renderedHeight),
+    }
+  } finally {
+    await page.close()
+    await rm(unpacked, { recursive: true, force: true })
+  }
+}
+
+async function createViteModules() {
+  const vite = await createServer({
+    appType: 'custom',
+    logLevel: 'silent',
+    root: REPOSITORY_ROOT,
+    server: { middlewareMode: true, watch: null },
+  })
+  try {
+    const [checkpoints, struct, targets] = await Promise.all([
+      vite.ssrLoadModule('/src/research/source-output-checkpoints.ts'),
+      vite.ssrLoadModule('/src/research/epub.ts'),
+      vite.ssrLoadModule('/src/research/targets.ts'),
+    ])
+    return { vite, checkpoints, struct, targets }
+  } catch (error) {
+    await vite.close()
+    throw error
+  }
+}
+
+function artifactName(checkpoint, kind) {
+  return `${safeStem(checkpoint.id)}.${kind}.png`
+}
+
+function reviewerConclusion(checkpoint, result) {
+  return result.status === 'passed'
+    ? `Pass: inspect the ${checkpoint.property} claim in this source/after pair.`
+    : `Fail: ${result.reason ?? 'the named property is not proven'}`
+}
+
+function assertStructMatchesSource(
+  document,
+  sourceHash,
+  sourceBytes,
+  fileName,
+) {
+  if (!document || typeof document !== 'object') {
+    throw new Error('STRUCT_DOCUMENT_INVALID: expected a JSON object')
+  }
+  if (document.source?.sha256 !== sourceHash) {
+    throw new Error(
+      'STRUCT_SOURCE_MISMATCH: STRUCT source.sha256 must match the selected PDF',
+    )
+  }
+  if (document.source?.fileName && document.source.fileName !== fileName) {
+    throw new Error(
+      'STRUCT_SOURCE_MISMATCH: STRUCT source.fileName must match the selected PDF basename',
+    )
+  }
+  if (document.source?.byteLength !== sourceBytes.byteLength) {
+    throw new Error(
+      'STRUCT_SOURCE_MISMATCH: STRUCT source.byteLength must match the selected PDF',
+    )
+  }
+}
+
+async function run(options) {
+  const privacy = await enforceOutputPrivacy(options)
+  const [sourceBytes, checkpointInput] = await Promise.all([
+    readFile(options.document),
+    readFile(options.checkpoints, 'utf8'),
+  ])
+  const sourceHash = sha256(sourceBytes)
+  const modules = await createViteModules()
+  let browser
+  let pdfDocument
+  try {
+    const checkpointSet = modules.checkpoints.parseSourceOutputCheckpointSet(
+      JSON.parse(checkpointInput),
+    )
+    let checkpoints = checkpointSet.checkpoints.filter(
+      (checkpoint) => checkpoint.document === basename(options.document),
+    )
+    if (checkpoints.length === 0) {
+      throw new Error(
+        `NO_CHECKPOINTS_FOR_DOCUMENT: ${basename(options.document)}`,
+      )
+    }
+    if (options.profiles) {
+      checkpoints = checkpoints.filter((checkpoint) =>
+        options.profiles.includes(checkpoint.profile),
+      )
+    }
+    if (options.pages) {
+      checkpoints = checkpoints.filter((checkpoint) =>
+        options.pages.includes(checkpoint.page),
+      )
+    }
+    if (checkpoints.length === 0) throw new Error('NO_CHECKPOINTS_SELECTED')
+    checkpoints = modules.checkpoints.sortSourceOutputCheckpoints(checkpoints)
+
+    pdfDocument = await pdfjs.getDocument({
+      data: new Uint8Array(sourceBytes),
+      isEvalSupported: false,
+      useSystemFonts: true,
+    }).promise
+    const sourceAsset = await renderSourcePage(
+      pdfDocument,
+      checkpoints[0].page,
+      1200,
+    )
+    const fallback = privacy.defaultFixture
+      ? await createFixtureStructDocument({
+          sourceHash,
+          byteLength: sourceBytes.byteLength,
+          pageCount: pdfDocument.numPages,
+          fileName: basename(options.document),
+          page: checkpoints[0].page,
+          asset: sourceAsset,
+        })
+      : null
+    const document = await loadStructDocument(options.struct, fallback)
+    assertStructMatchesSource(
+      document,
+      sourceHash,
+      sourceBytes,
+      basename(options.document),
+    )
+    browser = await chromium.launch({ headless: true })
+    const browserRoot = await mkdtemp(join(tmpdir(), 'srt-source-output-'))
+    const byPair = new Map()
+    const results = []
+    const artifacts = []
+    const artifactPaths = new Set()
+    try {
+      await mkdir(join(options.output, 'pairs'), { recursive: true })
+      for (const checkpoint of checkpoints) {
+        const profile = modules.targets.getTargetProfile(checkpoint.profile)
+        const pairKey = `${checkpoint.page}\0${checkpoint.profile}`
+        let pair = byPair.get(pairKey)
+        if (!pair) {
+          const source = await renderSourcePage(
+            pdfDocument,
+            checkpoint.page,
+            Math.max(1, Math.round(profile.preview.widthCssPx)),
+          )
+          const rendition = await renderRendition({
+            buildEpub: modules.struct.buildEpub,
+            profile,
+            document,
+            browser,
+            root: browserRoot,
+          })
+          pair = { source, rendition }
+          byPair.set(pairKey, pair)
+        }
+        const result = modules.checkpoints.evaluateSourceOutputCheckpoint(
+          checkpoint,
+          {
+            source: {
+              page: checkpoint.page,
+              text: pair.source.text,
+              hasVisual: pair.source.hasVisual,
+            },
+            rendition: {
+              profile: checkpoint.profile,
+              width: pair.rendition.width,
+              html: pair.rendition.html,
+            },
+          },
+        )
+        const sourceName = artifactName(checkpoint, 'source')
+        const outputName = artifactName(checkpoint, 'after')
+        for (const artifactPath of [sourceName, outputName]) {
+          if (artifactPaths.has(artifactPath)) {
+            throw new Error(
+              `CHECKPOINT_ARTIFACT_COLLISION: ${artifactPath} is not unique`,
+            )
+          }
+          artifactPaths.add(artifactPath)
+        }
+        await writeFile(
+          join(options.output, 'pairs', sourceName),
+          pair.source.bytes,
+        )
+        await writeFile(
+          join(options.output, 'pairs', outputName),
+          pair.rendition.bytes,
+        )
+        artifacts.push(
+          {
+            checkpointId: checkpoint.id,
+            kind: 'source-page',
+            path: `pairs/${sourceName}`,
+            sha256: sha256(pair.source.bytes),
+            byteLength: pair.source.bytes.byteLength,
+            width: pair.source.width,
+            height: pair.source.height,
+          },
+          {
+            checkpointId: checkpoint.id,
+            kind: 'rendered-output',
+            path: `pairs/${outputName}`,
+            sha256: sha256(pair.rendition.bytes),
+            byteLength: pair.rendition.bytes.byteLength,
+            width: pair.rendition.width,
+            height: pair.rendition.height,
+          },
+        )
+        results.push({
+          ...result,
+          document: checkpoint.document,
+          page: checkpoint.page,
+          profile: checkpoint.profile,
+          property: checkpoint.property,
+          criterion: checkpoint.criterion,
+          sourceExpectation: checkpoint.source,
+          outputExpectation: checkpoint.output,
+          sourceArtifact: `pairs/${sourceName}`,
+          outputArtifact: `pairs/${outputName}`,
+          conclusion: reviewerConclusion(checkpoint, result),
+        })
+      }
+    } finally {
+      await rm(browserRoot, { recursive: true, force: true })
+    }
+
+    const manifest = {
+      schemaVersion: TOOL_VERSION,
+      kind: 'srt-source-output-checkpoint-evidence',
+      source: {
+        document: basename(options.document),
+        sha256: sourceHash,
+        byteLength: sourceBytes.byteLength,
+        pageCount: pdfDocument.numPages,
+      },
+      profiles: [
+        ...new Set(checkpoints.map((checkpoint) => checkpoint.profile)),
+      ].map((id) => {
+        const profile = modules.targets.getTargetProfile(id)
+        return {
+          id,
+          version: profile.version,
+          width: profile.preview.widthCssPx,
+          height:
+            profile.preview.heightCssPx ??
+            profile.preview.continuousWindowHeightCssPx ??
+            null,
+        }
+      }),
+      checkpoints: results,
+      artifacts,
+      result: results.every((result) => result.status === 'passed')
+        ? 'passed'
+        : 'failed',
+      determinism: {
+        volatileFields: [],
+        guarantee:
+          'Fixed source bytes, checkpoint set, target profile, export implementation, and compatible browser/toolchain produce byte-stable artifacts.',
+      },
+    }
+    await writeFile(
+      join(options.output, 'checkpoint-manifest.json'),
+      jsonBytes(manifest),
+    )
+    const rows = results
+      .map(
+        (result) =>
+          `| ${result.checkpointId} | ${result.document} | ${result.page} | ${result.profile} | ${result.property} | [source](./${result.sourceArtifact}) | [after](./${result.outputArtifact}) | ${result.status} | ${result.conclusion} |`,
+      )
+      .join('\n')
+    const readme = `# Source/output checkpoint evidence
+
+Generated by \`npm run srt:checkpoint-evidence\`. Each row names the source
+page, the target profile width, the property under test, and the conclusion a
+reviewer should draw from the paired images. The \"after\" image is captured
+from the deterministic EPUB produced by the same export entry point used by
+the reader; it is not a studio approximation or a raw canonical-text render.
+
+Private documents may use this tool with a caller-named output directory
+outside the repository. Only repository-owned fixture inputs are eligible for
+the checked-in evidence flow.
+
+| Checkpoint | Document | Page | Profile | Property | Source | After | Result | Reviewer conclusion |
+|---|---|---:|---|---|---|---|---|---|
+${rows}
+
+The JSON checkpoint manifest records SHA-256 digests, dimensions, and the exact named
+criteria. No timestamp, absolute path, or local document text is emitted.
+`
+    await writeFile(join(options.output, 'README.md'), readme)
+    if (manifest.result !== 'passed') {
+      throw new Error('SOURCE_OUTPUT_CHECKPOINT_FAILED')
+    }
+    return manifest
+  } finally {
+    await pdfDocument?.destroy().catch(() => undefined)
+    await browser?.close()
+    await modules.vite.close()
+  }
+}
+
+async function main() {
+  let options
+  try {
+    options = parseArguments(process.argv.slice(2))
+    await run(options)
+    process.stdout.write('Source/output checkpoint evidence passed.\n')
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = /INVALID_USAGE|INVALID_PAGES/u.test(String(error))
+      ? 2
+      : 1
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  await main()
+}

--- a/tools/srt-source-output-evidence.test.mjs
+++ b/tools/srt-source-output-evidence.test.mjs
@@ -1,0 +1,72 @@
+import {
+  copyFileSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const tool = fileURLToPath(
+  new URL('./srt-source-output-evidence.mjs', import.meta.url),
+)
+const fixturePdf = join(
+  root,
+  'tests/fixtures/pdf/source-output-checkpoints.pdf',
+)
+const fixtureCheckpoints = join(
+  root,
+  'tests/fixtures/pdf/source-output-checkpoints.json',
+)
+const temporaryDirectories = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+function privateFixture() {
+  const directory = mkdtempSync(join(tmpdir(), 'srt-checkpoint-test-'))
+  temporaryDirectories.push(directory)
+  const document = join(directory, 'owner-paper.pdf')
+  const checkpoints = join(directory, 'owner-checkpoints.json')
+  const output = join(directory, 'evidence')
+  copyFileSync(fixturePdf, document)
+  const checkpointSet = JSON.parse(readFileSync(fixtureCheckpoints, 'utf8'))
+  checkpointSet.checkpoints = checkpointSet.checkpoints.map((checkpoint) => ({
+    ...checkpoint,
+    document: basename(document),
+  }))
+  writeFileSync(checkpoints, `${JSON.stringify(checkpointSet)}\n`)
+  return { document, checkpoints, output }
+}
+
+describe('source/output evidence privacy boundary', () => {
+  it('does not fabricate a private rendition without caller-provided STRUCT', () => {
+    const paths = privateFixture()
+    const result = spawnSync(
+      process.execPath,
+      [
+        tool,
+        '--document',
+        paths.document,
+        '--checkpoints',
+        paths.checkpoints,
+        '--output',
+        paths.output,
+      ],
+      { cwd: root, encoding: 'utf8' },
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'PRIVATE_STRUCT_REQUIRED',
+    )
+  })
+})


### PR DESCRIPTION
Closes #91

## Summary
- Add a source-page versus rendered-output checkpoint contract for SRT pull requests.
- Bind checkpoint properties to the expected source feature and rendered feature.
- Require caller-provided STRUCT for private documents and verify source hash, basename, and byte length.
- Produce deterministic, collision-safe source/output artifacts and regression coverage.
- Provision the pinned Playwright Chromium runtime before browser-backed checkpoint evidence runs, so clean GitHub runners do not fail before the evidence check.

## Validation
- Focused checkpoint validation and deterministic reruns passed in the trusted VM.
- Exact-head required manifest for `8ad1bfb3a220c91edb27fb6cae3ce2f5ac3960a6`: build passed; test passed (121 files, 2,500 tests, 1 skipped); dirty=false.
- The all-lane manifest also passed its required build/test lanes.
- Optional E2E lane: 13 passed, 1 skipped, 7 failed in existing publication-importer/review-viewer UI expectations; no new E2E changes are included in this PR.
- No protected policy, workflow, deploy, auth, or live-resource paths changed.