### PR TITLE
fix: harden extraction bakeoff evidence boundaries

### DIFF
--- a/benchmarks/pdf/extraction-bakeoff-corpus-v1.json
+++ b/benchmarks/pdf/extraction-bakeoff-corpus-v1.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "synthetic-extraction-bakeoff-v1",
+  "privacy": "synthetic-identities-hashes-metrics-only",
+  "sourcePolicy": "owner-local-papers-must-be-bound-by-sha256-before-run",
+  "splits": {
+    "development": {
+      "status": "fixture",
+      "documentIds": ["development-one"]
+    },
+    "held-out": {
+      "status": "fixture",
+      "documentIds": ["heldout-one", "heldout-two"]
+    }
+  },
+  "layouts": ["one-column", "two-column"],
+  "strata": [
+    "sectioning",
+    "prose-continuity",
+    "boilerplate-exclusion",
+    "code-listings",
+    "tables",
+    "figures-diagrams",
+    "equations",
+    "footnotes-citations"
+  ],
+  "groundTruthPolicy": "independent-source-reviewed-labels-never-candidate-output",
+  "heldOutPolicy": "score-once-per-candidate-identity-no-tuning",
+  "runner": "tools/pdf-extraction-bakeoff.mjs",
+  "reportSchema": "docs/schemas/extraction-bakeoff-report.schema.json"
+}

--- a/benchmarks/pdf/extraction-bakeoff-report-v1.json
+++ b/benchmarks/pdf/extraction-bakeoff-report-v1.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
   "corpusId": "synthetic-extraction-bakeoff-v1",
-  "heldOutIdentitySha256": "d6f59400f1c093dc5c82125444ce6cf92fe6fb46f906428fd4dc957f1edcb9d6",
+  "heldOutIdentitySha256": "b95c199887b1a35bdae8558e660c0e6fddaf41b09c655d57dfd64ee29505c545",
   "candidateIdentities": {
     "geometric-baseline": {
       "providerId": "geometric-baseline",
@@ -362,11 +362,13 @@
           "documentId": "heldout-one",
           "split": "held-out",
           "layout": "one-column",
-          "status": "disqualified",
+          "status": "failed",
           "verification": {
             "status": "failed",
-            "issueCodes": ["source-text-mismatch", "byte-instability"],
-            "issueCount": 2
+            "issueCodes": [
+              "source-text-mismatch"
+            ],
+            "issueCount": 1
           },
           "outputHash": null,
           "byteStable": false,
@@ -386,8 +388,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -403,8 +407,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -420,8 +426,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -437,8 +445,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -454,8 +464,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -471,8 +483,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -488,8 +502,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -505,8 +521,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             }
           ]
@@ -515,11 +533,13 @@
           "documentId": "heldout-two",
           "split": "held-out",
           "layout": "two-column",
-          "status": "disqualified",
+          "status": "failed",
           "verification": {
             "status": "failed",
-            "issueCodes": ["source-text-mismatch", "byte-instability"],
-            "issueCount": 2
+            "issueCodes": [
+              "source-text-mismatch"
+            ],
+            "issueCount": 1
           },
           "outputHash": null,
           "byteStable": false,
@@ -539,8 +559,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -556,8 +578,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -573,8 +597,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -590,8 +616,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -607,8 +635,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -624,8 +654,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -641,8 +673,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -658,8 +692,10 @@
               "boilerplateContamination": 0,
               "verification": {
                 "status": "failed",
-                "issueCodes": ["source-text-mismatch", "byte-instability"],
-                "issueCount": 2
+                "issueCodes": [
+                  "source-text-mismatch"
+                ],
+                "issueCount": 1
               }
             }
           ]
@@ -683,7 +719,7 @@
         "tables/one-column": 0,
         "tables/two-column": 0
       },
-      "disqualified": true
+      "disqualified": false
     },
     "llm-grounded": {
       "documents": [
@@ -1025,7 +1061,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "boilerplate-exclusion",
@@ -1036,7 +1074,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "code-listings",
@@ -1047,7 +1087,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "code-listings",
@@ -1058,7 +1100,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "equations",
@@ -1069,7 +1113,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "equations",
@@ -1080,7 +1126,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "figures-diagrams",
@@ -1091,7 +1139,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "figures-diagrams",
@@ -1102,7 +1152,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "footnotes-citations",
@@ -1113,7 +1165,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "footnotes-citations",
@@ -1124,7 +1178,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "prose-continuity",
@@ -1135,7 +1191,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "prose-continuity",
@@ -1146,7 +1204,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "sectioning",
@@ -1157,7 +1217,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "sectioning",
@@ -1168,7 +1230,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     },
     {
       "stratum": "tables",
@@ -1179,7 +1243,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-one"]
+      "disagreementDocumentIds": [
+        "heldout-one"
+      ]
     },
     {
       "stratum": "tables",
@@ -1190,7 +1256,9 @@
         "llm-grounded": 1
       },
       "winner": "llm-grounded",
-      "disagreementDocumentIds": ["heldout-two"]
+      "disagreementDocumentIds": [
+        "heldout-two"
+      ]
     }
   ],
   "disagreements": [
@@ -1198,114 +1266,178 @@
       "documentId": "heldout-one",
       "stratum": "boilerplate-exclusion",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "boilerplate-exclusion",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "code-listings",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "code-listings",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "equations",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "equations",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "figures-diagrams",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "figures-diagrams",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "footnotes-citations",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "footnotes-citations",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "prose-continuity",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "prose-continuity",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "sectioning",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "sectioning",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-one",
       "stratum": "tables",
       "layout": "one-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     },
     {
       "documentId": "heldout-two",
       "stratum": "tables",
       "layout": "two-column",
-      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "arms": [
+        "geometric-baseline",
+        "llm-authored",
+        "llm-grounded"
+      ],
       "reason": "verification"
     }
   ],
-  "reportSha256": "f7c9f73c6a8ac216c5887e6f24f30076e3ffa1e6751fabf4cf4090a578501d76"
+  "reportSha256": "e6c606e68fc42dde1778953bc8ca99ebcdcc3e24efe2064f6f24841ad3398269"
 }

--- a/benchmarks/pdf/extraction-bakeoff-report-v1.json
+++ b/benchmarks/pdf/extraction-bakeoff-report-v1.json
@@ -1,0 +1,1311 @@
+{
+  "schemaVersion": "1.0.0",
+  "corpusId": "synthetic-extraction-bakeoff-v1",
+  "heldOutIdentitySha256": "d6f59400f1c093dc5c82125444ce6cf92fe6fb46f906428fd4dc957f1edcb9d6",
+  "candidateIdentities": {
+    "geometric-baseline": {
+      "providerId": "geometric-baseline",
+      "modelId": "geometric-baseline-model",
+      "modelVersion": "fixture-1.0.0",
+      "modelDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "promptHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "llm-authored": {
+      "providerId": "llm-authored",
+      "modelId": "llm-authored-model",
+      "modelVersion": "fixture-1.0.0",
+      "modelDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "promptHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "llm-grounded": {
+      "providerId": "llm-grounded",
+      "modelId": "llm-grounded-model",
+      "modelVersion": "fixture-1.0.0",
+      "modelDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "promptHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+  },
+  "heldOutScoredOnce": true,
+  "arms": {
+    "geometric-baseline": {
+      "documents": [
+        {
+          "documentId": "heldout-one",
+          "split": "held-out",
+          "layout": "one-column",
+          "status": "passed",
+          "verification": {
+            "status": "passed",
+            "issueCodes": [],
+            "issueCount": 0
+          },
+          "outputHash": "f74fa39356ad082e442413559cacfecfe06a60969ff9145829cc3ba7dfb2f45d",
+          "byteStable": true,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-one-sectioning",
+              "documentId": "heldout-one",
+              "stratum": "sectioning",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-prose-continuity",
+              "documentId": "heldout-one",
+              "stratum": "prose-continuity",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-boilerplate-exclusion",
+              "documentId": "heldout-one",
+              "stratum": "boilerplate-exclusion",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-code-listings",
+              "documentId": "heldout-one",
+              "stratum": "code-listings",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-tables",
+              "documentId": "heldout-one",
+              "stratum": "tables",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-figures-diagrams",
+              "documentId": "heldout-one",
+              "stratum": "figures-diagrams",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-equations",
+              "documentId": "heldout-one",
+              "stratum": "equations",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-footnotes-citations",
+              "documentId": "heldout-one",
+              "stratum": "footnotes-citations",
+              "layout": "one-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            }
+          ]
+        },
+        {
+          "documentId": "heldout-two",
+          "split": "held-out",
+          "layout": "two-column",
+          "status": "passed",
+          "verification": {
+            "status": "passed",
+            "issueCodes": [],
+            "issueCount": 0
+          },
+          "outputHash": "56f0eca85a79cbdb5456b76202f99698141f0915981b881db2519d81163c3422",
+          "byteStable": true,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-two-sectioning",
+              "documentId": "heldout-two",
+              "stratum": "sectioning",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-prose-continuity",
+              "documentId": "heldout-two",
+              "stratum": "prose-continuity",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-boilerplate-exclusion",
+              "documentId": "heldout-two",
+              "stratum": "boilerplate-exclusion",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-code-listings",
+              "documentId": "heldout-two",
+              "stratum": "code-listings",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-tables",
+              "documentId": "heldout-two",
+              "stratum": "tables",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-figures-diagrams",
+              "documentId": "heldout-two",
+              "stratum": "figures-diagrams",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-equations",
+              "documentId": "heldout-two",
+              "stratum": "equations",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-footnotes-citations",
+              "documentId": "heldout-two",
+              "stratum": "footnotes-citations",
+              "layout": "two-column",
+              "score": 0.8,
+              "typePrecision": 1,
+              "typeRecall": 0.5,
+              "sourceRecall": 0.5,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            }
+          ]
+        }
+      ],
+      "byStratumAndLayout": {
+        "boilerplate-exclusion/one-column": 0.8,
+        "boilerplate-exclusion/two-column": 0.8,
+        "code-listings/one-column": 0.8,
+        "code-listings/two-column": 0.8,
+        "equations/one-column": 0.8,
+        "equations/two-column": 0.8,
+        "figures-diagrams/one-column": 0.8,
+        "figures-diagrams/two-column": 0.8,
+        "footnotes-citations/one-column": 0.8,
+        "footnotes-citations/two-column": 0.8,
+        "prose-continuity/one-column": 0.8,
+        "prose-continuity/two-column": 0.8,
+        "sectioning/one-column": 0.8,
+        "sectioning/two-column": 0.8,
+        "tables/one-column": 0.8,
+        "tables/two-column": 0.8
+      },
+      "disqualified": false
+    },
+    "llm-authored": {
+      "documents": [
+        {
+          "documentId": "heldout-one",
+          "split": "held-out",
+          "layout": "one-column",
+          "status": "disqualified",
+          "verification": {
+            "status": "failed",
+            "issueCodes": ["source-text-mismatch", "byte-instability"],
+            "issueCount": 2
+          },
+          "outputHash": null,
+          "byteStable": false,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-one-sectioning",
+              "documentId": "heldout-one",
+              "stratum": "sectioning",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-prose-continuity",
+              "documentId": "heldout-one",
+              "stratum": "prose-continuity",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-boilerplate-exclusion",
+              "documentId": "heldout-one",
+              "stratum": "boilerplate-exclusion",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-code-listings",
+              "documentId": "heldout-one",
+              "stratum": "code-listings",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-tables",
+              "documentId": "heldout-one",
+              "stratum": "tables",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-figures-diagrams",
+              "documentId": "heldout-one",
+              "stratum": "figures-diagrams",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-equations",
+              "documentId": "heldout-one",
+              "stratum": "equations",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-one-footnotes-citations",
+              "documentId": "heldout-one",
+              "stratum": "footnotes-citations",
+              "layout": "one-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            }
+          ]
+        },
+        {
+          "documentId": "heldout-two",
+          "split": "held-out",
+          "layout": "two-column",
+          "status": "disqualified",
+          "verification": {
+            "status": "failed",
+            "issueCodes": ["source-text-mismatch", "byte-instability"],
+            "issueCount": 2
+          },
+          "outputHash": null,
+          "byteStable": false,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-two-sectioning",
+              "documentId": "heldout-two",
+              "stratum": "sectioning",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-prose-continuity",
+              "documentId": "heldout-two",
+              "stratum": "prose-continuity",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-boilerplate-exclusion",
+              "documentId": "heldout-two",
+              "stratum": "boilerplate-exclusion",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-code-listings",
+              "documentId": "heldout-two",
+              "stratum": "code-listings",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-tables",
+              "documentId": "heldout-two",
+              "stratum": "tables",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-figures-diagrams",
+              "documentId": "heldout-two",
+              "stratum": "figures-diagrams",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-equations",
+              "documentId": "heldout-two",
+              "stratum": "equations",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            },
+            {
+              "caseId": "heldout-two-footnotes-citations",
+              "documentId": "heldout-two",
+              "stratum": "footnotes-citations",
+              "layout": "two-column",
+              "score": 0,
+              "typePrecision": 1,
+              "typeRecall": 0,
+              "sourceRecall": 0,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "failed",
+                "issueCodes": ["source-text-mismatch", "byte-instability"],
+                "issueCount": 2
+              }
+            }
+          ]
+        }
+      ],
+      "byStratumAndLayout": {
+        "boilerplate-exclusion/one-column": 0,
+        "boilerplate-exclusion/two-column": 0,
+        "code-listings/one-column": 0,
+        "code-listings/two-column": 0,
+        "equations/one-column": 0,
+        "equations/two-column": 0,
+        "figures-diagrams/one-column": 0,
+        "figures-diagrams/two-column": 0,
+        "footnotes-citations/one-column": 0,
+        "footnotes-citations/two-column": 0,
+        "prose-continuity/one-column": 0,
+        "prose-continuity/two-column": 0,
+        "sectioning/one-column": 0,
+        "sectioning/two-column": 0,
+        "tables/one-column": 0,
+        "tables/two-column": 0
+      },
+      "disqualified": true
+    },
+    "llm-grounded": {
+      "documents": [
+        {
+          "documentId": "heldout-one",
+          "split": "held-out",
+          "layout": "one-column",
+          "status": "passed",
+          "verification": {
+            "status": "passed",
+            "issueCodes": [],
+            "issueCount": 0
+          },
+          "outputHash": "06ad4f63c333174d3d855db815ca91d05a46f47f043b9c914645995099d2635e",
+          "byteStable": true,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-one-sectioning",
+              "documentId": "heldout-one",
+              "stratum": "sectioning",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-prose-continuity",
+              "documentId": "heldout-one",
+              "stratum": "prose-continuity",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-boilerplate-exclusion",
+              "documentId": "heldout-one",
+              "stratum": "boilerplate-exclusion",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-code-listings",
+              "documentId": "heldout-one",
+              "stratum": "code-listings",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-tables",
+              "documentId": "heldout-one",
+              "stratum": "tables",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-figures-diagrams",
+              "documentId": "heldout-one",
+              "stratum": "figures-diagrams",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-equations",
+              "documentId": "heldout-one",
+              "stratum": "equations",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-one-footnotes-citations",
+              "documentId": "heldout-one",
+              "stratum": "footnotes-citations",
+              "layout": "one-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            }
+          ]
+        },
+        {
+          "documentId": "heldout-two",
+          "split": "held-out",
+          "layout": "two-column",
+          "status": "passed",
+          "verification": {
+            "status": "passed",
+            "issueCodes": [],
+            "issueCount": 0
+          },
+          "outputHash": "36c1634902376d92e27c994b90865a517a1d1c95a58bd0189f147a4943257f6e",
+          "byteStable": true,
+          "latencyMsPerPage": 1,
+          "costUsdPerPage": 0,
+          "caseScores": [
+            {
+              "caseId": "heldout-two-sectioning",
+              "documentId": "heldout-two",
+              "stratum": "sectioning",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-prose-continuity",
+              "documentId": "heldout-two",
+              "stratum": "prose-continuity",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-boilerplate-exclusion",
+              "documentId": "heldout-two",
+              "stratum": "boilerplate-exclusion",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-code-listings",
+              "documentId": "heldout-two",
+              "stratum": "code-listings",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-tables",
+              "documentId": "heldout-two",
+              "stratum": "tables",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-figures-diagrams",
+              "documentId": "heldout-two",
+              "stratum": "figures-diagrams",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-equations",
+              "documentId": "heldout-two",
+              "stratum": "equations",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            },
+            {
+              "caseId": "heldout-two-footnotes-citations",
+              "documentId": "heldout-two",
+              "stratum": "footnotes-citations",
+              "layout": "two-column",
+              "score": 1,
+              "typePrecision": 1,
+              "typeRecall": 1,
+              "sourceRecall": 1,
+              "assetRecall": 1,
+              "boilerplateContamination": 0,
+              "verification": {
+                "status": "passed",
+                "issueCodes": [],
+                "issueCount": 0
+              }
+            }
+          ]
+        }
+      ],
+      "byStratumAndLayout": {
+        "boilerplate-exclusion/one-column": 1,
+        "boilerplate-exclusion/two-column": 1,
+        "code-listings/one-column": 1,
+        "code-listings/two-column": 1,
+        "equations/one-column": 1,
+        "equations/two-column": 1,
+        "figures-diagrams/one-column": 1,
+        "figures-diagrams/two-column": 1,
+        "footnotes-citations/one-column": 1,
+        "footnotes-citations/two-column": 1,
+        "prose-continuity/one-column": 1,
+        "prose-continuity/two-column": 1,
+        "sectioning/one-column": 1,
+        "sectioning/two-column": 1,
+        "tables/one-column": 1,
+        "tables/two-column": 1
+      },
+      "disqualified": false
+    }
+  },
+  "comparison": [
+    {
+      "stratum": "boilerplate-exclusion",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "boilerplate-exclusion",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "code-listings",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "code-listings",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "equations",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "equations",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "figures-diagrams",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "figures-diagrams",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "footnotes-citations",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "footnotes-citations",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "prose-continuity",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "prose-continuity",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "sectioning",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "sectioning",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    },
+    {
+      "stratum": "tables",
+      "layout": "one-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-one"]
+    },
+    {
+      "stratum": "tables",
+      "layout": "two-column",
+      "scores": {
+        "geometric-baseline": 0.8,
+        "llm-authored": 0,
+        "llm-grounded": 1
+      },
+      "winner": "llm-grounded",
+      "disagreementDocumentIds": ["heldout-two"]
+    }
+  ],
+  "disagreements": [
+    {
+      "documentId": "heldout-one",
+      "stratum": "boilerplate-exclusion",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "boilerplate-exclusion",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "code-listings",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "code-listings",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "equations",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "equations",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "figures-diagrams",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "figures-diagrams",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "footnotes-citations",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "footnotes-citations",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "prose-continuity",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "prose-continuity",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "sectioning",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "sectioning",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-one",
+      "stratum": "tables",
+      "layout": "one-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    },
+    {
+      "documentId": "heldout-two",
+      "stratum": "tables",
+      "layout": "two-column",
+      "arms": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "reason": "verification"
+    }
+  ],
+  "reportSha256": "f7c9f73c6a8ac216c5887e6f24f30076e3ffa1e6751fabf4cf4090a578501d76"
+}

--- a/docs/research/semantic-responsive-typesetting/extraction-architecture-bakeoff.md
+++ b/docs/research/semantic-responsive-typesetting/extraction-architecture-bakeoff.md
@@ -1,0 +1,62 @@
+# Extraction architecture bake-off
+
+Issue 95 defines two candidate owners for semantic extraction:
+
+- **LLM-authored** receives source runs and a page rendition and proposes the
+  whole structure.
+- **LLM-grounded** receives the same source plus only deterministic artifacts
+  that have already been proved (region lanes, table scopes, line boundaries,
+  note/citation relationships, and source-run provenance).
+
+Both candidates use the shared verifier in
+[`src/research/structured-extraction.ts`](../../../src/research/structured-extraction.ts).
+The verifier is the authority for text, source spans, assets, and alt text:
+
+- every emitted node is rebuilt from source-run IDs;
+- a mismatch, unknown run, duplicate span, or unaccounted boilerplate run
+  rejects the complete candidate and invokes the deterministic fallback;
+- figures and diagrams can reference only deterministic asset IDs; bytes and
+  bounds are never candidate fields;
+- figure alt text is rebuilt from the source-backed caption and is never read
+  from image content or a model string.
+
+## Reproduction
+
+The runner takes a development/held-out corpus binding and three adapters
+behind one interface. It reports per-stratum and per-layout scores, verifier
+failures, disagreements, latency/page, cost/page, model identity, model digest,
+and prompt hash:
+
+```bash
+npm run pdf:extraction:bakeoff
+```
+
+The checked-in self-test is synthetic and contains no paper bytes. An owner-
+local run should supply the same source-run context and hash-pinned held-out
+split from issue 037, plus the named source/output checkpoints from issue 038.
+The report schema is
+[`docs/schemas/extraction-bakeoff-report.schema.json`](../../../docs/schemas/extraction-bakeoff-report.schema.json).
+
+The runner passes no ground-truth labels to an adapter, permits tuning only on
+`development`, scores each held-out candidate identity once, and rejects a
+proposal carrying `gold`, `expected`, reviewer labels, or equivalent fields.
+The second invocation for a fixed source, identity, and prompt is compared to
+the first; a byte-unstable candidate is disqualified.
+
+## Decision record
+
+The deterministic geometric path remains the verifier and fail-closed fallback
+in every arm. The grounded interface is the repository's safe model-assisted
+owner: it can propose structure only where source artifacts leave a decision
+open, while the verifier owns every emitted span and asset association. The
+authored interface remains an experimental comparison arm and cannot become an
+authority merely by scoring higher.
+
+This is a safety/ownership decision, not a claim that the synthetic self-test
+has evaluated private papers. A promotion or reversal requires a new
+hash-pinned held-out split scored once per candidate version. The winning arm
+must improve the affected stratum and layout without regressing another
+stratum, and any unverified span, model-authored alt text, or model-authored
+asset geometry disqualifies it regardless of aggregate score. If arms win
+different strata, the report is presented for an explicit hybrid decision
+instead of silently selecting a global winner.

--- a/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
+++ b/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
@@ -19,6 +19,6 @@
     "A proposed winner must improve the affected stratum and layout without lowering any other held-out stratum below the recorded baseline.",
     "Any unverified span, model-authored alt text, or model-authored asset bounds disqualifies the candidate regardless of score."
   ],
-  "heldOutIdentitySha256": "d6f59400f1c093dc5c82125444ce6cf92fe6fb46f906428fd4dc957f1edcb9d6",
-  "reportSha256": "f7c9f73c6a8ac216c5887e6f24f30076e3ffa1e6751fabf4cf4090a578501d76"
+  "heldOutIdentitySha256": "b95c199887b1a35bdae8558e660c0e6fddaf41b09c655d57dfd64ee29505c545",
+  "reportSha256": "e6c606e68fc42dde1778953bc8ca99ebcdcc3e24efe2064f6f24841ad3398269"
 }

--- a/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
+++ b/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "1.0.0",
+  "decisionId": "extraction-architecture-v1",
+  "owner": "llm-grounded",
+  "humanDecisionRequired": false,
+  "perStratum": {
+    "boilerplate-exclusion": "llm-grounded",
+    "code-listings": "llm-grounded",
+    "equations": "llm-grounded",
+    "figures-diagrams": "llm-grounded",
+    "footnotes-citations": "llm-grounded",
+    "prose-continuity": "llm-grounded",
+    "sectioning": "llm-grounded",
+    "tables": "llm-grounded"
+  },
+  "geometricRole": "Remain the source-run, asset-bound, and publication verifier in every arm; it may provide the fail-closed fallback.",
+  "reversalCriteria": [
+    "Reverse only after a new hash-pinned held-out split is scored once per candidate version.",
+    "A proposed winner must improve the affected stratum and layout without lowering any other held-out stratum below the recorded baseline.",
+    "Any unverified span, model-authored alt text, or model-authored asset bounds disqualifies the candidate regardless of score."
+  ],
+  "heldOutIdentitySha256": "d6f59400f1c093dc5c82125444ce6cf92fe6fb46f906428fd4dc957f1edcb9d6",
+  "reportSha256": "f7c9f73c6a8ac216c5887e6f24f30076e3ffa1e6751fabf4cf4090a578501d76"
+}

--- a/docs/schemas/extraction-bakeoff-corpus.schema.json
+++ b/docs/schemas/extraction-bakeoff-corpus.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/extraction-bakeoff-corpus-1.0.0.json",
+  "title": "Extraction architecture bake-off corpus binding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "privacy",
+    "sourcePolicy",
+    "splits",
+    "layouts",
+    "strata",
+    "groundTruthPolicy",
+    "heldOutPolicy",
+    "runner",
+    "reportSchema"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "id": { "$ref": "#/$defs/id" },
+    "privacy": { "const": "synthetic-identities-hashes-metrics-only" },
+    "sourcePolicy": { "type": "string", "minLength": 1 },
+    "splits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["development", "held-out"],
+      "properties": {
+        "development": { "$ref": "#/$defs/split" },
+        "held-out": { "$ref": "#/$defs/split" }
+      }
+    },
+    "layouts": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": { "enum": ["one-column", "two-column"] }
+    },
+    "strata": {
+      "type": "array",
+      "minItems": 8,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/id" }
+    },
+    "groundTruthPolicy": { "type": "string", "minLength": 1 },
+    "heldOutPolicy": { "type": "string", "minLength": 1 },
+    "runner": { "type": "string", "minLength": 1 },
+    "reportSchema": { "type": "string", "minLength": 1 }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 192,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "split": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "documentIds"],
+      "properties": {
+        "status": { "enum": ["fixture", "owner-local"] },
+        "documentIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/extraction-bakeoff-report.schema.json
+++ b/docs/schemas/extraction-bakeoff-report.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/extraction-bakeoff-report-1.0.0.json",
+  "title": "LLM extraction architecture bake-off report",
+  "description": "Privacy-safe, held-out-scored comparison of the geometric baseline and the two candidate extraction arms.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "corpusId",
+    "heldOutIdentitySha256",
+    "candidateIdentities",
+    "heldOutScoredOnce",
+    "arms",
+    "comparison",
+    "disagreements",
+    "reportSha256"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "corpusId": { "$ref": "#/$defs/id" },
+    "heldOutIdentitySha256": { "$ref": "#/$defs/sha256" },
+    "heldOutScoredOnce": { "const": true },
+    "candidateIdentities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "properties": {
+        "geometric-baseline": { "$ref": "#/$defs/identity" },
+        "llm-authored": { "$ref": "#/$defs/identity" },
+        "llm-grounded": { "$ref": "#/$defs/identity" }
+      }
+    },
+    "arms": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["geometric-baseline", "llm-authored", "llm-grounded"],
+      "properties": {
+        "geometric-baseline": { "$ref": "#/$defs/arm" },
+        "llm-authored": { "$ref": "#/$defs/arm" },
+        "llm-grounded": { "$ref": "#/$defs/arm" }
+      }
+    },
+    "comparison": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/comparison" }
+    },
+    "disagreements": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/disagreement" }
+    },
+    "reportSha256": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 192,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
+    },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "providerId",
+        "modelId",
+        "modelVersion",
+        "modelDigest",
+        "promptHash"
+      ],
+      "properties": {
+        "providerId": { "$ref": "#/$defs/id" },
+        "modelId": { "$ref": "#/$defs/id" },
+        "modelVersion": { "$ref": "#/$defs/id" },
+        "modelDigest": { "$ref": "#/$defs/sha256" },
+        "promptHash": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "issueCodes", "issueCount"],
+      "properties": {
+        "status": { "enum": ["passed", "failed"] },
+        "issueCodes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "issueCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "caseScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "caseId",
+        "documentId",
+        "stratum",
+        "layout",
+        "score",
+        "typePrecision",
+        "typeRecall",
+        "sourceRecall",
+        "assetRecall",
+        "boilerplateContamination",
+        "verification"
+      ],
+      "properties": {
+        "caseId": { "$ref": "#/$defs/id" },
+        "documentId": { "$ref": "#/$defs/id" },
+        "stratum": { "$ref": "#/$defs/id" },
+        "layout": { "enum": ["one-column", "two-column"] },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "typePrecision": { "type": "number", "minimum": 0, "maximum": 1 },
+        "typeRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "sourceRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "assetRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "boilerplateContamination": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "verification": { "$ref": "#/$defs/verification" }
+      }
+    },
+    "document": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "documentId",
+        "split",
+        "layout",
+        "status",
+        "verification",
+        "outputHash",
+        "byteStable",
+        "latencyMsPerPage",
+        "costUsdPerPage",
+        "caseScores"
+      ],
+      "properties": {
+        "documentId": { "$ref": "#/$defs/id" },
+        "split": { "enum": ["development", "held-out"] },
+        "layout": { "enum": ["one-column", "two-column"] },
+        "status": { "enum": ["passed", "failed", "disqualified"] },
+        "verification": { "$ref": "#/$defs/verification" },
+        "outputHash": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sha256" }]
+        },
+        "byteStable": { "type": "boolean" },
+        "latencyMsPerPage": {
+          "oneOf": [{ "type": "null" }, { "type": "number", "minimum": 0 }]
+        },
+        "costUsdPerPage": {
+          "oneOf": [{ "type": "null" }, { "type": "number", "minimum": 0 }]
+        },
+        "caseScores": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/caseScore" }
+        }
+      }
+    },
+    "arm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documents", "byStratumAndLayout", "disqualified"],
+      "properties": {
+        "documents": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/document" }
+        },
+        "byStratumAndLayout": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          }
+        },
+        "disqualified": { "type": "boolean" }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stratum",
+        "layout",
+        "scores",
+        "winner",
+        "disagreementDocumentIds"
+      ],
+      "properties": {
+        "stratum": { "$ref": "#/$defs/id" },
+        "layout": { "enum": ["one-column", "two-column"] },
+        "scores": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              { "type": "null" },
+              { "type": "number", "minimum": 0, "maximum": 1 }
+            ]
+          }
+        },
+        "winner": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "enum": [
+                "geometric-baseline",
+                "llm-authored",
+                "llm-grounded",
+                "tie"
+              ]
+            }
+          ]
+        },
+        "disagreementDocumentIds": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        }
+      }
+    },
+    "disagreement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["documentId", "stratum", "layout", "arms", "reason"],
+      "properties": {
+        "documentId": { "$ref": "#/$defs/id" },
+        "stratum": { "$ref": "#/$defs/id" },
+        "layout": { "enum": ["one-column", "two-column"] },
+        "arms": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["geometric-baseline", "llm-authored", "llm-grounded"]
+          }
+        },
+        "reason": { "enum": ["verification", "structure", "score"] }
+      }
+    }
+  }
+}

--- a/docs/schemas/structured-extraction-output.schema.json
+++ b/docs/schemas/structured-extraction-output.schema.json
@@ -18,7 +18,11 @@
     "schemaVersion": { "const": "1.0.0" },
     "documentId": { "$ref": "#/$defs/id" },
     "sourceSha256": { "$ref": "#/$defs/sha256" },
-    "nodes": { "type": "array", "items": { "$ref": "#/$defs/node" } },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/node" }
+    },
     "assetIds": {
       "type": "array",
       "uniqueItems": true,

--- a/docs/schemas/structured-extraction-output.schema.json
+++ b/docs/schemas/structured-extraction-output.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ernie.sg/schemas/structured-extraction-output-1.0.0.json",
+  "title": "Source-backed structured extraction output",
+  "description": "Candidate structure may reference source runs and deterministic assets; all emitted text is materialized by the verifier.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "documentId",
+    "sourceSha256",
+    "nodes",
+    "assetIds",
+    "excludedBoilerplateRunIds",
+    "accountedSourceRunIds"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "documentId": { "$ref": "#/$defs/id" },
+    "sourceSha256": { "$ref": "#/$defs/sha256" },
+    "nodes": { "type": "array", "items": { "$ref": "#/$defs/node" } },
+    "assetIds": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/id" }
+    },
+    "excludedBoilerplateRunIds": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/id" }
+    },
+    "accountedSourceRunIds": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/id" }
+    }
+  },
+  "$defs": {
+    "id": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "sourceRunIds", "text", "provenance"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "type": {
+          "enum": [
+            "title",
+            "author",
+            "affiliation",
+            "abstract",
+            "heading",
+            "paragraph",
+            "code",
+            "table",
+            "figure",
+            "equation",
+            "footnote",
+            "reference"
+          ]
+        },
+        "sourceRunIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "text": { "type": "string" },
+        "level": { "type": "integer", "minimum": 1, "maximum": 6 },
+        "assetId": { "$ref": "#/$defs/id" },
+        "captionNodeId": { "$ref": "#/$defs/id" },
+        "altText": { "type": "string" },
+        "altTextSource": { "const": "caption" },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceRunIds"],
+          "properties": {
+            "sourceRunIds": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "$ref": "#/$defs/id" }
+            }
+          }
+        },
+        "table": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["rows"],
+          "properties": {
+            "rows": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["cells"],
+                "properties": {
+                  "cells": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["text", "sourceRunIds", "headerScope"],
+                      "properties": {
+                        "text": { "type": "string" },
+                        "sourceRunIds": {
+                          "type": "array",
+                          "minItems": 1,
+                          "uniqueItems": true,
+                          "items": { "$ref": "#/$defs/id" }
+                        },
+                        "headerScope": {
+                          "enum": [
+                            "row",
+                            "column",
+                            "rowgroup",
+                            "colgroup",
+                            "none"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pdf:benchmark:compare": "node tools/pdf-benchmark-compare.mjs",
     "pdf:ocr:benchmark": "node tools/pdf-ocr-engine-benchmark.mjs",
     "pdf:benchmark:readiness": "node tools/pdf-benchmark-readiness.mjs",
+    "pdf:extraction:bakeoff": "node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test",
     "pdf:private-decisions:compose": "node tools/pdf-private-decision-compose.mjs",
     "pdf:private-fidelity": "node tools/pdf-private-fidelity.mjs",
     "pdf:review-sink": "node tools/pdf-review-langfuse-bridge.mjs",

--- a/src/research/extraction-architecture-bakeoff.ts
+++ b/src/research/extraction-architecture-bakeoff.ts
@@ -1,0 +1,1 @@
+export * from './extraction-bakeoff.ts'

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -201,5 +201,135 @@ describe('extraction architecture bake-off', () => {
     expect(() =>
       assertNoHeldOutContamination(clean, withLabel, 'held-out'),
     ).toThrow('HELD_OUT_CONTAMINATION')
+
+    for (const key of [
+      'goldLabel',
+      'ground_truth',
+      'reviewer-label',
+      'target_box',
+    ]) {
+      expect(() =>
+        assertNoHeldOutContamination(
+          clean,
+          {
+            ...proposal(context('heldout-one', 'held-out', 'one-column')),
+            [key]: true,
+          },
+          'held-out',
+        ),
+      ).toThrow('HELD_OUT_CONTAMINATION')
+    }
+  })
+
+  it('disqualifies a contaminated arm without aborting the other arms', async () => {
+    const contaminated = arm('llm-authored')
+    contaminated.usedHeldOutForTuning = true
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), contaminated, arm('llm-grounded')],
+    })
+
+    expect(report.arms['llm-authored'].disqualified).toBe(true)
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status, outputHash }) =>
+          status === 'disqualified' && outputHash === null,
+      ),
+    ).toBe(true)
+    expect(
+      report.arms['geometric-baseline'].documents.every(
+        ({ status }) => status === 'passed',
+      ),
+    ).toBe(true)
+    expect(
+      report.arms['llm-grounded'].documents.every(
+        ({ status }) => status === 'passed',
+      ),
+    ).toBe(true)
+  })
+
+  it('reports deterministic verifier failures as failed, not byte instability', async () => {
+    const invalid = arm('llm-authored', (input) => {
+      const output = proposal(input)
+      output.nodes[0]!.text = 'not source-backed'
+      return output
+    })
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), invalid, arm('llm-grounded')],
+    })
+    const result = report.arms['llm-authored'].documents[0]!
+
+    expect(result.status).toBe('failed')
+    expect(result.byteStable).toBe(false)
+    expect(result.verification.status).toBe('failed')
+    expect(result.verification.issueCodes).toContain('source-text-mismatch')
+    expect(result.verification.issueCodes).not.toContain('byte-instability')
+    expect(result.outputHash).toBeNull()
+  })
+
+  it('keeps development-only rows out of held-out comparisons', async () => {
+    const developmentWeak = arm('geometric-baseline', (input) =>
+      input.split === 'development'
+        ? {
+            schemaVersion: '1.0.0',
+            nodes: [],
+          }
+        : proposal(input),
+    )
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [developmentWeak, arm('llm-authored'), arm('llm-grounded')],
+      includeDevelopment: true,
+    })
+    const row = report.comparison.find(
+      ({ stratum, layout }) =>
+        stratum === 'sectioning' && layout === 'one-column',
+    )!
+
+    expect(row.scores['geometric-baseline']).toBe(1)
+  })
+
+  it('binds the held-out identity to its labels as well as its documents', async () => {
+    const original = corpus()
+    const changed = corpus()
+    changed.heldOut[0]!.cases[0]!.expectedNodeTypes = ['paragraph']
+
+    const arms = [
+      arm('geometric-baseline'),
+      arm('llm-authored'),
+      arm('llm-grounded'),
+    ]
+    const first = await runExtractionBakeoff({ corpus: original, arms })
+    const second = await runExtractionBakeoff({
+      corpus: changed,
+      arms: [
+        arm('geometric-baseline'),
+        arm('llm-authored'),
+        arm('llm-grounded'),
+      ],
+    })
+
+    expect(second.heldOutIdentitySha256).not.toBe(first.heldOutIdentitySha256)
+  })
+
+  it('requires a human decision when any stratum is unresolved', async () => {
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [
+        arm('geometric-baseline'),
+        arm('llm-authored'),
+        arm('llm-grounded'),
+      ],
+    })
+    const mixed = structuredClone(report)
+    mixed.comparison[0]!.winner = 'tie'
+
+    const decision = createExtractionArchitectureDecision({ report: mixed })
+
+    expect(decision.owner).toBe('pending')
+    expect(decision.humanDecisionRequired).toBe(true)
   })
 })

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertNoHeldOutContamination,
+  createExtractionArchitectureDecision,
+  EXTRACTION_BAKEOFF_STRATA,
+  runExtractionBakeoff,
+  type ExtractionBakeoffArm,
+  type ExtractionBakeoffCorpus,
+} from './extraction-bakeoff'
+import type {
+  StructuredExtractionContext,
+  StructuredExtractionNodeType,
+  StructuredExtractionProposal,
+} from './structured-extraction'
+
+const hashA = 'a'.repeat(64)
+const hashB = 'b'.repeat(64)
+
+function context(
+  id: string,
+  split: 'development' | 'held-out',
+  layout: 'one-column' | 'two-column',
+): StructuredExtractionContext {
+  return {
+    documentId: id,
+    sourceSha256: id === 'dev-paper' ? hashA : hashB,
+    split,
+    layout,
+    sourceRuns: [
+      { id: `${id}-title`, text: 'Title', page: 1, order: 1 },
+      { id: `${id}-body`, text: 'Body text.', page: 1, order: 2 },
+    ],
+    sourceAssets: [],
+  }
+}
+
+function proposal(
+  input: StructuredExtractionContext,
+): StructuredExtractionProposal {
+  return {
+    schemaVersion: '1.0.0',
+    nodes: [
+      {
+        id: `${input.documentId}-title`,
+        type: 'title',
+        sourceRunIds: [`${input.documentId}-title`],
+        text: 'Title',
+      },
+      {
+        id: `${input.documentId}-body`,
+        type: 'paragraph',
+        sourceRunIds: [`${input.documentId}-body`],
+        text: 'Body text.',
+      },
+    ],
+  }
+}
+
+function corpus(): ExtractionBakeoffCorpus {
+  const developmentContext = context('dev-paper', 'development', 'one-column')
+  const heldOutOneColumn = context('heldout-one', 'held-out', 'one-column')
+  const heldOutTwoColumn = context('heldout-two', 'held-out', 'two-column')
+  const cases = (input: StructuredExtractionContext) =>
+    EXTRACTION_BAKEOFF_STRATA.map((stratum) => ({
+      id: `${input.documentId}-${stratum}`,
+      documentId: input.documentId,
+      stratum,
+      layout: input.layout,
+      expectedNodeTypes: [
+        'title',
+        'paragraph',
+      ] as StructuredExtractionNodeType[],
+      expectedSourceRunIds: [
+        `${input.documentId}-title`,
+        `${input.documentId}-body`,
+      ],
+    }))
+  return {
+    id: 'synthetic-bakeoff',
+    development: [
+      {
+        id: 'dev-paper',
+        split: 'development',
+        layout: 'one-column',
+        context: developmentContext,
+        cases: cases(developmentContext),
+      },
+    ],
+    heldOut: [
+      {
+        id: 'heldout-one',
+        split: 'held-out',
+        layout: 'one-column',
+        context: heldOutOneColumn,
+        cases: cases(heldOutOneColumn),
+      },
+      {
+        id: 'heldout-two',
+        split: 'held-out',
+        layout: 'two-column',
+        context: heldOutTwoColumn,
+        cases: cases(heldOutTwoColumn),
+      },
+    ],
+  }
+}
+
+function arm(
+  id: ExtractionBakeoffArm['id'],
+  run = (input: StructuredExtractionContext) => proposal(input),
+): ExtractionBakeoffArm {
+  return {
+    id,
+    identity: {
+      providerId: id,
+      modelId: `${id}-model`,
+      modelVersion: '1.0.0',
+      modelDigest: hashA,
+      promptHash: hashB,
+    },
+    tunedOn: ['development'],
+    run: (input) => ({
+      proposal: run(input),
+      metrics: { latencyMs: 12, costUsd: 0.02 },
+    }),
+  }
+}
+
+describe('extraction architecture bake-off', () => {
+  it('scores both arms and the geometric baseline once on a layout-balanced held-out split', async () => {
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [
+        arm('geometric-baseline'),
+        arm('llm-authored'),
+        arm('llm-grounded'),
+      ],
+    })
+
+    expect(report.heldOutScoredOnce).toBe(true)
+    expect(report.arms['llm-grounded'].documents).toHaveLength(2)
+    expect(report.arms['llm-grounded'].documents[0]!.latencyMsPerPage).toBe(12)
+    expect(report.comparison).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stratum: 'sectioning',
+          layout: 'one-column',
+        }),
+        expect.objectContaining({
+          stratum: 'sectioning',
+          layout: 'two-column',
+        }),
+      ]),
+    )
+    expect(report.reportSha256).toMatch(/^[a-f0-9]{64}$/u)
+    expect(createExtractionArchitectureDecision({ report }).reportSha256).toBe(
+      report.reportSha256,
+    )
+  })
+
+  it('disqualifies a byte-unstable candidate rather than publishing the first result', async () => {
+    let invocation = 0
+    const unstable = arm('llm-authored', (input) => {
+      invocation += 1
+      const output = proposal(input)
+      if (invocation % 2 === 0) output.nodes.reverse()
+      return output
+    })
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), unstable, arm('llm-grounded')],
+    })
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status }) => status === 'disqualified',
+      ),
+    ).toBe(true)
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ outputHash }) => outputHash === null,
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects held-out tuning and candidate payloads that carry labels', () => {
+    const contaminated = arm('llm-grounded')
+    contaminated.usedHeldOutForTuning = true
+    expect(() =>
+      assertNoHeldOutContamination(
+        contaminated,
+        proposal(context('heldout-one', 'held-out', 'one-column')),
+        'held-out',
+      ),
+    ).toThrow('HELD_OUT_CONTAMINATION')
+
+    const withLabel = {
+      ...proposal(context('heldout-one', 'held-out', 'one-column')),
+      expected: ['title'],
+    }
+    const clean = arm('llm-authored')
+    expect(() =>
+      assertNoHeldOutContamination(clean, withLabel, 'held-out'),
+    ).toThrow('HELD_OUT_CONTAMINATION')
+  })
+})

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -181,12 +181,13 @@ const SHA256 = /^[a-f0-9]{64}$/u
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u
 const FORBIDDEN_GROUND_TRUTH_KEYS = new Set([
   'gold',
-  'groundTruth',
+  'goldlabel',
   'groundtruth',
   'expected',
   'labels',
-  'reviewerAnnotation',
-  'targetBox',
+  'reviewerannotation',
+  'reviewerlabel',
+  'targetbox',
 ])
 
 function finiteNonNegative(value: unknown): value is number {
@@ -217,7 +218,17 @@ function hasForbiddenGroundTruth(value: unknown, path = ''): string | null {
   }
   if (!value || typeof value !== 'object') return null
   for (const [key, child] of Object.entries(value)) {
-    if (FORBIDDEN_GROUND_TRUTH_KEYS.has(key)) return `${path}.${key}`
+    const normalizedKey = key
+      .normalize('NFKC')
+      .replace(/[^A-Za-z0-9]/gu, '')
+      .toLowerCase()
+    if (
+      FORBIDDEN_GROUND_TRUTH_KEYS.has(normalizedKey) ||
+      /^(?:gold|groundtruth|expected|labels?|reviewer|targetbox)/u.test(
+        normalizedKey,
+      )
+    )
+      return `${path}.${key}`
     const found = hasForbiddenGroundTruth(child, `${path}.${key}`)
     if (found) return found
   }
@@ -305,14 +316,9 @@ export function validateExtractionBakeoffCorpus(
     corpusId: corpus.id,
     developmentCount: corpus.development.length,
     heldOutCount: corpus.heldOut.length,
-    heldOutIdentitySha256: structuredExtractionHash(
-      corpus.heldOut.map(({ id, split, layout, context }) => ({
-        id,
-        split,
-        layout,
-        sourceSha256: context.sourceSha256,
-      })),
-    ),
+    // Bind the receipt to the complete held-out binding, including its
+    // independent labels.  The digest is published, never the source text.
+    heldOutIdentitySha256: structuredExtractionHash(corpus.heldOut),
   }
 }
 
@@ -434,6 +440,63 @@ function verificationSummary(
       }
 }
 
+function combinedVerification(
+  first: ReturnType<typeof verifyStructuredExtraction>,
+  second: ReturnType<typeof verifyStructuredExtraction>,
+  byteStable: boolean,
+): ExtractionBakeoffVerification {
+  const firstSummary = verificationSummary(first)
+  const secondSummary = verificationSummary(second)
+  const issueCodes = [
+    ...new Set([...firstSummary.issueCodes, ...secondSummary.issueCodes]),
+  ]
+  const byteInstability =
+    first.status === 'passed' && second.status === 'passed' && !byteStable
+  if (byteInstability) issueCodes.push('byte-instability')
+  return {
+    status:
+      first.status === 'passed' && second.status === 'passed' && byteStable
+        ? 'passed'
+        : 'failed',
+    issueCodes: [...new Set(issueCodes)],
+    issueCount:
+      Math.max(firstSummary.issueCount, secondSummary.issueCount) +
+      (byteInstability ? 1 : 0),
+  }
+}
+
+function disqualifiedDocumentResult(
+  document: ExtractionBakeoffDocument,
+  issueCode: string,
+): ExtractionBakeoffDocumentResult {
+  const verification: ExtractionBakeoffVerification = {
+    status: 'failed',
+    issueCodes: [issueCode],
+    issueCount: 1,
+  }
+  return {
+    documentId: document.id,
+    split: document.split,
+    layout: document.layout,
+    status: 'disqualified',
+    verification,
+    outputHash: null,
+    byteStable: false,
+    latencyMsPerPage: null,
+    costUsdPerPage: null,
+    caseScores: document.cases.map((caseInput) =>
+      scoreCase(caseInput, null, verification),
+    ),
+  }
+}
+
+function heldOutContaminationCode(error: unknown) {
+  return error instanceof Error &&
+    error.message.startsWith('HELD_OUT_CONTAMINATION')
+    ? 'held-out-contamination'
+    : null
+}
+
 function pageCount(context: StructuredExtractionContext) {
   return Math.max(
     1,
@@ -493,13 +556,15 @@ function comparisons(
     ]
     const scores = Object.fromEntries(
       EXTRACTION_BAKEOFF_ARMS.map((arm) => {
-        const values = results[arm].flatMap((result) =>
-          result.caseScores
-            .filter(
-              (score) => score.stratum === stratum && score.layout === layout,
-            )
-            .map((score) => score.score),
-        )
+        const values = results[arm]
+          .filter(({ split }) => split === 'held-out')
+          .flatMap((result) =>
+            result.caseScores
+              .filter(
+                (score) => score.stratum === stratum && score.layout === layout,
+              )
+              .map((score) => score.score),
+          )
         return [
           arm,
           values.length === 0
@@ -509,11 +574,13 @@ function comparisons(
       }),
     ) as Record<ExtractionBakeoffArmId, number | null>
     const relevant = EXTRACTION_BAKEOFF_ARMS.map((arm) =>
-      results[arm].filter((result) =>
-        result.caseScores.some(
-          (score) => score.stratum === stratum && score.layout === layout,
+      results[arm]
+        .filter(({ split }) => split === 'held-out')
+        .filter((result) =>
+          result.caseScores.some(
+            (score) => score.stratum === stratum && score.layout === layout,
+          ),
         ),
-      ),
     )
     const documentIds = [
       ...new Set(
@@ -588,6 +655,20 @@ export async function runExtractionBakeoff({
         )
       const inputArm =
         arm.id === 'geometric-baseline' ? 'geometric-baseline' : arm.id
+      if (document.split === 'held-out') {
+        if (!identityValid(arm.identity))
+          throw new Error(`INVALID_EXTRACTION_MODEL_IDENTITY:${arm.id}`)
+        const staticContamination =
+          !arm.tunedOn.every((value) => value === 'development') ||
+          Boolean(arm.usedHeldOutForTuning)
+        if (staticContamination) {
+          resultByArm[arm.id].push(
+            disqualifiedDocumentResult(document, 'held-out-contamination'),
+          )
+          identityRunKeys.add(runKey)
+          continue
+        }
+      }
       const firstInput = modelInputForStructuredExtraction(
         document.context,
         inputArm,
@@ -595,8 +676,19 @@ export async function runExtractionBakeoff({
       const first = await arm.run(firstInput)
       if (!first || typeof first !== 'object')
         throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
-      if (document.split === 'held-out')
-        assertNoHeldOutContamination(arm, first.proposal, document.split)
+      if (document.split === 'held-out') {
+        try {
+          assertNoHeldOutContamination(arm, first.proposal, document.split)
+        } catch (error) {
+          const issueCode = heldOutContaminationCode(error)
+          if (!issueCode) throw error
+          resultByArm[arm.id].push(
+            disqualifiedDocumentResult(document, issueCode),
+          )
+          identityRunKeys.add(runKey)
+          continue
+        }
+      }
       const firstVerification = verifyStructuredExtraction(
         document.context,
         first.proposal,
@@ -608,8 +700,19 @@ export async function runExtractionBakeoff({
       const second = await arm.run(secondInput)
       if (!second || typeof second !== 'object')
         throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
-      if (document.split === 'held-out')
-        assertNoHeldOutContamination(arm, second.proposal, document.split)
+      if (document.split === 'held-out') {
+        try {
+          assertNoHeldOutContamination(arm, second.proposal, document.split)
+        } catch (error) {
+          const issueCode = heldOutContaminationCode(error)
+          if (!issueCode) throw error
+          resultByArm[arm.id].push(
+            disqualifiedDocumentResult(document, issueCode),
+          )
+          identityRunKeys.add(runKey)
+          continue
+        }
+      }
       const secondVerification = verifyStructuredExtraction(
         document.context,
         second.proposal,
@@ -619,7 +722,11 @@ export async function runExtractionBakeoff({
         secondVerification.status === 'passed' &&
         structuredExtractionStableJson(firstVerification.output) ===
           structuredExtractionStableJson(secondVerification.output)
-      const verification = verificationSummary(firstVerification)
+      const verification = combinedVerification(
+        firstVerification,
+        secondVerification,
+        byteStable,
+      )
       const metrics = first.metrics
       if (!metrics) throw new Error(`MISSING_EXTRACTION_RUN_METRICS:${arm.id}`)
       if (
@@ -631,42 +738,27 @@ export async function runExtractionBakeoff({
         throw new Error(`INVALID_EXTRACTION_RUN_METRICS:${arm.id}`)
       const pages = metrics.pageCount ?? pageCount(document.context)
       const output =
-        firstVerification.status === 'passed' && byteStable
+        firstVerification.status === 'passed' &&
+        secondVerification.status === 'passed' &&
+        byteStable
           ? firstVerification.output
           : null
       const caseScores = document.cases.map((caseInput) =>
-        scoreCase(
-          caseInput,
-          output,
-          byteStable
-            ? verification
-            : {
-                status: 'failed',
-                issueCodes: [
-                  ...verification.issueCodes,
-                  ...(byteStable ? [] : ['byte-instability']),
-                ],
-                issueCount: verification.issueCount + (byteStable ? 0 : 1),
-              },
-        ),
+        scoreCase(caseInput, output, verification),
       )
-      const status: ExtractionBakeoffDocumentResult['status'] = !byteStable
-        ? 'disqualified'
-        : firstVerification.status === 'passed'
-          ? 'passed'
+      const status: ExtractionBakeoffDocumentResult['status'] =
+        firstVerification.status === 'passed' &&
+        secondVerification.status === 'passed'
+          ? byteStable
+            ? 'passed'
+            : 'disqualified'
           : 'failed'
       resultByArm[arm.id].push({
         documentId: document.id,
         split: document.split,
         layout: document.layout,
         status,
-        verification: byteStable
-          ? verification
-          : {
-              status: 'failed',
-              issueCodes: [...verification.issueCodes, 'byte-instability'],
-              issueCount: verification.issueCount + 1,
-            },
+        verification,
         outputHash: output ? structuredExtractionHash(output) : null,
         byteStable,
         latencyMsPerPage: metrics.latencyMs / pages,
@@ -680,12 +772,14 @@ export async function runExtractionBakeoff({
   const comparison = comparisons(corpus, resultByArm)
   const disagreements = comparison.flatMap((row) => {
     const armResults = EXTRACTION_BAKEOFF_ARMS.map((arm) =>
-      resultByArm[arm].filter((result) =>
-        result.caseScores.some(
-          (score) =>
-            score.stratum === row.stratum && score.layout === row.layout,
+      resultByArm[arm]
+        .filter(({ split }) => split === 'held-out')
+        .filter((result) =>
+          result.caseScores.some(
+            (score) =>
+              score.stratum === row.stratum && score.layout === row.layout,
+          ),
         ),
-      ),
     )
     const ids = [
       ...new Set(
@@ -697,7 +791,7 @@ export async function runExtractionBakeoff({
     return ids.flatMap((documentId) => {
       const states = EXTRACTION_BAKEOFF_ARMS.map((arm) => {
         const result = resultByArm[arm].find(
-          (item) => item.documentId === documentId,
+          (item) => item.documentId === documentId && item.split === 'held-out',
         )
         return {
           arm,
@@ -766,28 +860,30 @@ export function createExtractionArchitectureDecision({
   const perStratum: Record<string, ExtractionBakeoffArmId | 'tie' | 'pending'> =
     {}
   for (const row of report.comparison) {
+    const winner = row.winner ?? 'pending'
     const previous = perStratum[row.stratum]
-    if (previous === undefined)
-      perStratum[row.stratum] = row.winner ?? 'pending'
-    else if (previous !== row.winner && row.winner !== null)
-      perStratum[row.stratum] = 'tie'
+    if (previous === undefined) perStratum[row.stratum] = winner
+    else if (previous !== winner)
+      perStratum[row.stratum] =
+        previous === 'pending' || winner === 'pending' ? 'pending' : 'tie'
   }
   const winners = Object.values(perStratum).filter(
     (value): value is ExtractionBakeoffArmId =>
       EXTRACTION_BAKEOFF_ARMS.includes(value as ExtractionBakeoffArmId),
   )
   const uniqueWinners = [...new Set(winners)]
-  const owner: ExtractionArchitectureDecision['owner'] =
-    uniqueWinners.length === 0
-      ? 'pending'
-      : uniqueWinners.length > 1
-        ? 'pending'
-        : uniqueWinners[0]!
+  const unresolved = Object.values(perStratum).some(
+    (value) => value === 'tie' || value === 'pending',
+  )
+  const humanDecisionRequired = unresolved || uniqueWinners.length !== 1
+  const owner: ExtractionArchitectureDecision['owner'] = humanDecisionRequired
+    ? 'pending'
+    : uniqueWinners[0]!
   return {
     schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
     decisionId,
     owner,
-    humanDecisionRequired: uniqueWinners.length > 1,
+    humanDecisionRequired,
     perStratum,
     geometricRole:
       'Remain the source-run, asset-bound, and publication verifier in every arm; it may provide the fail-closed fallback.',

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -1,0 +1,808 @@
+import {
+  STRUCTURED_EXTRACTION_NODE_TYPES,
+  type StructuredExtractionContext,
+  type StructuredExtractionLayout,
+  type StructuredExtractionNodeType,
+  type StructuredExtractionProposal,
+  type StructuredExtractionSplit,
+  structuredExtractionHash,
+  structuredExtractionStableJson,
+  verifyStructuredExtraction,
+  modelInputForStructuredExtraction,
+  type VerifiedStructuredExtraction,
+} from './structured-extraction.ts'
+
+export const EXTRACTION_BAKEOFF_SCHEMA_VERSION = '1.0.0' as const
+export const EXTRACTION_BAKEOFF_ARMS = [
+  'geometric-baseline',
+  'llm-authored',
+  'llm-grounded',
+] as const
+export type ExtractionBakeoffArmId = (typeof EXTRACTION_BAKEOFF_ARMS)[number]
+
+export const EXTRACTION_BAKEOFF_STRATA = [
+  'sectioning',
+  'prose-continuity',
+  'boilerplate-exclusion',
+  'code-listings',
+  'tables',
+  'figures-diagrams',
+  'equations',
+  'footnotes-citations',
+] as const
+export type ExtractionBakeoffStratum =
+  (typeof EXTRACTION_BAKEOFF_STRATA)[number]
+
+export type ExtractionBakeoffDocument = {
+  id: string
+  split: StructuredExtractionSplit
+  layout: StructuredExtractionLayout
+  context: StructuredExtractionContext
+  cases: ExtractionBakeoffCase[]
+}
+
+export type ExtractionBakeoffCase = {
+  id: string
+  documentId: string
+  stratum: string
+  layout: StructuredExtractionLayout
+  /** Independent labels; never supplied to a candidate arm. */
+  expectedNodeTypes: StructuredExtractionNodeType[]
+  expectedHeadingLevels?: number[]
+  expectedAssetIds?: string[]
+  expectedSourceRunIds?: string[]
+  expectedExcludedBoilerplateRunIds?: string[]
+}
+
+export type ExtractionBakeoffCorpus = {
+  id: string
+  development: ExtractionBakeoffDocument[]
+  heldOut: ExtractionBakeoffDocument[]
+}
+
+export type ExtractionBakeoffModelIdentity = {
+  providerId: string
+  modelId: string
+  modelVersion: string
+  modelDigest: string
+  promptHash: string
+}
+
+export type ExtractionBakeoffRunMetrics = {
+  latencyMs: number
+  costUsd: number
+  pageCount?: number
+}
+
+export type ExtractionBakeoffArmResult = {
+  proposal: StructuredExtractionProposal
+  metrics?: ExtractionBakeoffRunMetrics
+}
+
+export type ExtractionBakeoffArm = {
+  id: ExtractionBakeoffArmId
+  identity: ExtractionBakeoffModelIdentity
+  /** Candidate tuning may only use development labels. */
+  tunedOn: readonly StructuredExtractionSplit[]
+  /** Set this when the adapter knows it consulted held-out labels. */
+  usedHeldOutForTuning?: boolean
+  run: (
+    input: StructuredExtractionContext,
+  ) => ExtractionBakeoffArmResult | Promise<ExtractionBakeoffArmResult>
+}
+
+export type ExtractionBakeoffVerification = {
+  status: 'passed' | 'failed'
+  issueCodes: string[]
+  issueCount: number
+}
+
+export type ExtractionBakeoffCaseScore = {
+  caseId: string
+  documentId: string
+  stratum: string
+  layout: StructuredExtractionLayout
+  score: number
+  typePrecision: number
+  typeRecall: number
+  sourceRecall: number
+  assetRecall: number
+  boilerplateContamination: number
+  verification: ExtractionBakeoffVerification
+}
+
+export type ExtractionBakeoffDocumentResult = {
+  documentId: string
+  split: StructuredExtractionSplit
+  layout: StructuredExtractionLayout
+  status: 'passed' | 'failed' | 'disqualified'
+  verification: ExtractionBakeoffVerification
+  outputHash: string | null
+  byteStable: boolean
+  latencyMsPerPage: number | null
+  costUsdPerPage: number | null
+  caseScores: ExtractionBakeoffCaseScore[]
+}
+
+export type ExtractionBakeoffComparisonRow = {
+  stratum: string
+  layout: StructuredExtractionLayout
+  scores: Record<ExtractionBakeoffArmId, number | null>
+  winner: ExtractionBakeoffArmId | 'tie' | null
+  disagreementDocumentIds: string[]
+}
+
+export type ExtractionBakeoffReport = {
+  schemaVersion: typeof EXTRACTION_BAKEOFF_SCHEMA_VERSION
+  corpusId: string
+  heldOutIdentitySha256: string
+  candidateIdentities: Record<
+    ExtractionBakeoffArmId,
+    ExtractionBakeoffModelIdentity
+  >
+  heldOutScoredOnce: true
+  arms: Record<
+    ExtractionBakeoffArmId,
+    {
+      documents: ExtractionBakeoffDocumentResult[]
+      byStratumAndLayout: Record<string, number>
+      disqualified: boolean
+    }
+  >
+  comparison: ExtractionBakeoffComparisonRow[]
+  disagreements: Array<{
+    documentId: string
+    stratum: string
+    layout: StructuredExtractionLayout
+    arms: ExtractionBakeoffArmId[]
+    reason: 'verification' | 'structure' | 'score'
+  }>
+  reportSha256: string
+}
+
+export type ExtractionArchitectureDecision = {
+  schemaVersion: typeof EXTRACTION_BAKEOFF_SCHEMA_VERSION
+  decisionId: string
+  owner:
+    | 'llm-authored'
+    | 'llm-grounded'
+    | 'geometric-baseline'
+    | 'hybrid'
+    | 'pending'
+  humanDecisionRequired: boolean
+  perStratum: Record<string, ExtractionBakeoffArmId | 'tie' | 'pending'>
+  geometricRole: string
+  reversalCriteria: string[]
+  heldOutIdentitySha256: string
+  reportSha256: string
+}
+
+const SHA256 = /^[a-f0-9]{64}$/u
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u
+const FORBIDDEN_GROUND_TRUTH_KEYS = new Set([
+  'gold',
+  'groundTruth',
+  'groundtruth',
+  'expected',
+  'labels',
+  'reviewerAnnotation',
+  'targetBox',
+])
+
+function finiteNonNegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function stableJson(value: unknown) {
+  return structuredExtractionStableJson(value)
+}
+
+function identityValid(identity: ExtractionBakeoffModelIdentity) {
+  return (
+    SAFE_ID.test(identity.providerId) &&
+    SAFE_ID.test(identity.modelId) &&
+    SAFE_ID.test(identity.modelVersion) &&
+    SHA256.test(identity.modelDigest) &&
+    SHA256.test(identity.promptHash)
+  )
+}
+
+function hasForbiddenGroundTruth(value: unknown, path = ''): string | null {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const found = hasForbiddenGroundTruth(item, `${path}[${index}]`)
+      if (found) return found
+    }
+    return null
+  }
+  if (!value || typeof value !== 'object') return null
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_GROUND_TRUTH_KEYS.has(key)) return `${path}.${key}`
+    const found = hasForbiddenGroundTruth(child, `${path}.${key}`)
+    if (found) return found
+  }
+  return null
+}
+
+function unique(values: readonly string[]) {
+  return new Set(values).size === values.length
+}
+
+function validateCase(
+  caseInput: ExtractionBakeoffCase,
+  document: ExtractionBakeoffDocument,
+) {
+  if (
+    !SAFE_ID.test(caseInput.id) ||
+    caseInput.documentId !== document.id ||
+    caseInput.layout !== document.layout ||
+    !caseInput.stratum ||
+    caseInput.expectedNodeTypes.length === 0 ||
+    !caseInput.expectedNodeTypes.every((type) =>
+      (STRUCTURED_EXTRACTION_NODE_TYPES as readonly string[]).includes(type),
+    ) ||
+    !unique(caseInput.expectedAssetIds ?? []) ||
+    !unique(caseInput.expectedSourceRunIds ?? []) ||
+    !unique(caseInput.expectedExcludedBoilerplateRunIds ?? [])
+  ) {
+    throw new Error(`INVALID_EXTRACTION_BAKEOFF_CASE:${caseInput.id}`)
+  }
+}
+
+export function validateExtractionBakeoffCorpus(
+  corpus: ExtractionBakeoffCorpus,
+) {
+  if (!SAFE_ID.test(corpus.id))
+    throw new Error('INVALID_EXTRACTION_BAKEOFF_CORPUS')
+  if (corpus.development.length === 0 || corpus.heldOut.length === 0) {
+    throw new Error('EXTRACTION_BAKEOFF_REQUIRES_DEVELOPMENT_AND_HELD_OUT')
+  }
+  const documents = [...corpus.development, ...corpus.heldOut]
+  if (!unique(documents.map(({ id }) => id)))
+    throw new Error('DUPLICATE_EXTRACTION_BAKEOFF_DOCUMENT')
+  for (const document of documents) {
+    if (
+      !SAFE_ID.test(document.id) ||
+      document.context.documentId !== document.id ||
+      document.context.split !== document.split ||
+      document.context.layout !== document.layout
+    ) {
+      throw new Error(`INVALID_EXTRACTION_BAKEOFF_DOCUMENT:${document.id}`)
+    }
+    if (
+      !SHA256.test(document.context.sourceSha256) ||
+      document.cases.length === 0
+    ) {
+      throw new Error(`INVALID_EXTRACTION_BAKEOFF_DOCUMENT:${document.id}`)
+    }
+    const caseIds = document.cases.map(({ id }) => id)
+    if (!unique(caseIds))
+      throw new Error(`DUPLICATE_EXTRACTION_BAKEOFF_CASE:${document.id}`)
+    for (const caseInput of document.cases) validateCase(caseInput, document)
+  }
+  const layouts = new Set(corpus.heldOut.map(({ layout }) => layout))
+  if (layouts.size < 2)
+    throw new Error('EXTRACTION_BAKEOFF_HELD_OUT_MUST_BALANCE_LAYOUTS')
+  const heldOutStrata = new Map<string, Set<StructuredExtractionLayout>>()
+  for (const document of corpus.heldOut) {
+    for (const caseInput of document.cases) {
+      const layoutsForStratum =
+        heldOutStrata.get(caseInput.stratum) ??
+        new Set<StructuredExtractionLayout>()
+      layoutsForStratum.add(caseInput.layout)
+      heldOutStrata.set(caseInput.stratum, layoutsForStratum)
+    }
+  }
+  for (const stratum of EXTRACTION_BAKEOFF_STRATA) {
+    const stratumLayouts = heldOutStrata.get(stratum)
+    if (!stratumLayouts || stratumLayouts.size < 2) {
+      throw new Error(
+        `EXTRACTION_BAKEOFF_HELD_OUT_MISSING_STRATUM_OR_LAYOUT:${stratum}`,
+      )
+    }
+  }
+  return {
+    corpusId: corpus.id,
+    developmentCount: corpus.development.length,
+    heldOutCount: corpus.heldOut.length,
+    heldOutIdentitySha256: structuredExtractionHash(
+      corpus.heldOut.map(({ id, split, layout, context }) => ({
+        id,
+        split,
+        layout,
+        sourceSha256: context.sourceSha256,
+      })),
+    ),
+  }
+}
+
+export function assertNoHeldOutContamination(
+  arm: ExtractionBakeoffArm,
+  proposal: unknown,
+  split: StructuredExtractionSplit,
+) {
+  if (!identityValid(arm.identity))
+    throw new Error(`INVALID_EXTRACTION_MODEL_IDENTITY:${arm.id}`)
+  if (!arm.tunedOn.every((value) => value === 'development')) {
+    throw new Error(`HELD_OUT_CONTAMINATION:${arm.id}:tunedOn`)
+  }
+  if (arm.usedHeldOutForTuning)
+    throw new Error(`HELD_OUT_CONTAMINATION:${arm.id}:adapter-flag`)
+  const forbidden = hasForbiddenGroundTruth(proposal)
+  if (forbidden)
+    throw new Error(`HELD_OUT_CONTAMINATION:${arm.id}:${forbidden}`)
+  if (
+    split === 'held-out' &&
+    arm.tunedOn.some((tuningSplit) => tuningSplit !== 'development')
+  ) {
+    throw new Error(`HELD_OUT_CONTAMINATION:${arm.id}:held-out-tuning`)
+  }
+  // The `every` check above deliberately narrows the tuning declaration to
+  // development-only; a held-out entry can therefore never pass this point.
+}
+
+function ratio(numerator: number, denominator: number) {
+  return denominator === 0
+    ? 1
+    : Math.max(0, Math.min(1, numerator / denominator))
+}
+
+function scoreCase(
+  caseInput: ExtractionBakeoffCase,
+  output: VerifiedStructuredExtraction | null,
+  verification: ExtractionBakeoffVerification,
+): ExtractionBakeoffCaseScore {
+  const nodes = output?.nodes ?? []
+  const actualTypes = nodes.map(({ type }) => type)
+  const expectedTypes = [...caseInput.expectedNodeTypes]
+  const matchedTypes = expectedTypes.filter(
+    (type, index) => actualTypes[index] === type,
+  ).length
+  const expectedCounts = new Map<string, number>()
+  const actualCounts = new Map<string, number>()
+  expectedTypes.forEach((type) =>
+    expectedCounts.set(type, (expectedCounts.get(type) ?? 0) + 1),
+  )
+  actualTypes.forEach((type) =>
+    actualCounts.set(type, (actualCounts.get(type) ?? 0) + 1),
+  )
+  const typePrecision = ratio(
+    [...actualCounts.entries()].reduce(
+      (sum, [type, count]) =>
+        sum + Math.min(count, expectedCounts.get(type) ?? 0),
+      0,
+    ),
+    actualTypes.length,
+  )
+  const typeRecall = ratio(matchedTypes, expectedTypes.length)
+  const expectedRuns = new Set(caseInput.expectedSourceRunIds ?? [])
+  const actualRuns = new Set(nodes.flatMap(({ sourceRunIds }) => sourceRunIds))
+  const sourceRecall = ratio(
+    [...expectedRuns].filter((id) => actualRuns.has(id)).length,
+    expectedRuns.size,
+  )
+  const expectedAssets = new Set(caseInput.expectedAssetIds ?? [])
+  const actualAssets = new Set(output?.assetIds ?? [])
+  const assetRecall = ratio(
+    [...expectedAssets].filter((id) => actualAssets.has(id)).length,
+    expectedAssets.size,
+  )
+  const boilerplate = new Set(caseInput.expectedExcludedBoilerplateRunIds ?? [])
+  const bodyRuns = [...actualRuns].filter((id) => boilerplate.has(id)).length
+  const boilerplateContamination =
+    boilerplate.size === 0 ? 0 : ratio(bodyRuns, boilerplate.size)
+  // A failed verifier and a degenerate/no-object answer are both zero. The
+  // precision term keeps "every line is a heading" below a useful answer.
+  const score =
+    verification.status === 'passed' && nodes.length > 0
+      ? (typePrecision +
+          typeRecall +
+          sourceRecall +
+          assetRecall +
+          (1 - boilerplateContamination)) /
+        5
+      : 0
+  return {
+    caseId: caseInput.id,
+    documentId: caseInput.documentId,
+    stratum: caseInput.stratum,
+    layout: caseInput.layout,
+    score,
+    typePrecision,
+    typeRecall,
+    sourceRecall,
+    assetRecall,
+    boilerplateContamination,
+    verification,
+  }
+}
+
+function aggregateCaseScores(cases: readonly ExtractionBakeoffCaseScore[]) {
+  if (cases.length === 0) return 0
+  return cases.reduce((sum, item) => sum + item.score, 0) / cases.length
+}
+
+function verificationSummary(
+  result: ReturnType<typeof verifyStructuredExtraction>,
+): ExtractionBakeoffVerification {
+  return result.status === 'passed'
+    ? { status: 'passed', issueCodes: [], issueCount: 0 }
+    : {
+        status: 'failed',
+        issueCodes: [...new Set(result.issues.map(({ code }) => code))],
+        issueCount: result.issues.length,
+      }
+}
+
+function pageCount(context: StructuredExtractionContext) {
+  return Math.max(
+    1,
+    ...context.sourceRuns.map(({ page }) => page),
+    ...context.sourceAssets.map(({ page }) => page),
+  )
+}
+
+function scoreByStratumAndLayout(
+  documents: readonly ExtractionBakeoffDocumentResult[],
+) {
+  const grouped = new Map<string, number[]>()
+  for (const document of documents) {
+    for (const score of document.caseScores) {
+      const key = `${score.stratum}\u0000${score.layout}`
+      const values = grouped.get(key) ?? []
+      values.push(score.score)
+      grouped.set(key, values)
+    }
+  }
+  return Object.fromEntries(
+    [...grouped.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, values]) => [
+        key.replace('\u0000', '/'),
+        aggregateCaseScores(
+          values.map((score) => ({ score }) as ExtractionBakeoffCaseScore),
+        ),
+      ]),
+  )
+}
+
+function winner(
+  scores: Record<ExtractionBakeoffArmId, number | null>,
+): ExtractionBakeoffArmId | 'tie' | null {
+  const present = EXTRACTION_BAKEOFF_ARMS.filter((arm) => scores[arm] !== null)
+  if (present.length === 0) return null
+  const max = Math.max(...present.map((arm) => scores[arm]!))
+  const winners = present.filter((arm) => Math.abs(scores[arm]! - max) < 1e-12)
+  return winners.length === 1 ? winners[0] : 'tie'
+}
+
+function comparisons(
+  corpus: ExtractionBakeoffCorpus,
+  results: Record<ExtractionBakeoffArmId, ExtractionBakeoffDocumentResult[]>,
+) {
+  const heldOutCases = corpus.heldOut.flatMap(({ cases }) => cases)
+  const keys = [
+    ...new Set(
+      heldOutCases.map(({ stratum, layout }) => `${stratum}\u0000${layout}`),
+    ),
+  ].sort()
+  return keys.map((key) => {
+    const [stratum, layout] = key.split('\u0000') as [
+      string,
+      StructuredExtractionLayout,
+    ]
+    const scores = Object.fromEntries(
+      EXTRACTION_BAKEOFF_ARMS.map((arm) => {
+        const values = results[arm].flatMap((result) =>
+          result.caseScores
+            .filter(
+              (score) => score.stratum === stratum && score.layout === layout,
+            )
+            .map((score) => score.score),
+        )
+        return [
+          arm,
+          values.length === 0
+            ? null
+            : values.reduce((sum, value) => sum + value, 0) / values.length,
+        ]
+      }),
+    ) as Record<ExtractionBakeoffArmId, number | null>
+    const relevant = EXTRACTION_BAKEOFF_ARMS.map((arm) =>
+      results[arm].filter((result) =>
+        result.caseScores.some(
+          (score) => score.stratum === stratum && score.layout === layout,
+        ),
+      ),
+    )
+    const documentIds = [
+      ...new Set(
+        relevant.flatMap((items) => items.map(({ documentId }) => documentId)),
+      ),
+    ].sort()
+    const disagreementDocumentIds = documentIds.filter((documentId) => {
+      const states = EXTRACTION_BAKEOFF_ARMS.map((arm) => {
+        const result = results[arm].find(
+          ({ documentId: id }) => id === documentId,
+        )
+        return result
+          ? `${result.status}\u0000${result.outputHash ?? 'none'}\u0000${result.byteStable}`
+          : 'missing'
+      })
+      return new Set(states).size > 1
+    })
+    return {
+      stratum,
+      layout,
+      scores,
+      winner: winner(scores),
+      disagreementDocumentIds,
+    }
+  })
+}
+
+/**
+ * Run all arms against one corpus.  The runner never passes case labels to an
+ * arm, scores held-out documents once per candidate identity, and rejects any
+ * unverified candidate instead of publishing a partial structure.
+ */
+export async function runExtractionBakeoff({
+  corpus,
+  arms,
+  includeDevelopment = false,
+}: {
+  corpus: ExtractionBakeoffCorpus
+  arms: readonly ExtractionBakeoffArm[]
+  includeDevelopment?: boolean
+}): Promise<ExtractionBakeoffReport> {
+  const corpusReceipt = validateExtractionBakeoffCorpus(corpus)
+  if (
+    arms.length !== EXTRACTION_BAKEOFF_ARMS.length ||
+    new Set(arms.map(({ id }) => id)).size !== arms.length
+  ) {
+    throw new Error('EXTRACTION_BAKEOFF_REQUIRES_BASELINE_AND_BOTH_ARMS')
+  }
+  for (const arm of arms)
+    if (!EXTRACTION_BAKEOFF_ARMS.includes(arm.id))
+      throw new Error(`UNKNOWN_EXTRACTION_BAKEOFF_ARM:${arm.id}`)
+
+  const candidateIdentities = Object.fromEntries(
+    arms.map(({ id, identity }) => [id, { ...identity }]),
+  ) as Record<ExtractionBakeoffArmId, ExtractionBakeoffModelIdentity>
+  const resultByArm = {
+    'geometric-baseline': [],
+    'llm-authored': [],
+    'llm-grounded': [],
+  } as Record<ExtractionBakeoffArmId, ExtractionBakeoffDocumentResult[]>
+  const identityRunKeys = new Set<string>()
+  const documents = includeDevelopment
+    ? [...corpus.development, ...corpus.heldOut]
+    : corpus.heldOut
+
+  for (const arm of arms) {
+    for (const document of documents) {
+      const runKey = `${structuredExtractionHash(arm.identity)}\u0000${document.id}`
+      if (document.split === 'held-out' && identityRunKeys.has(runKey))
+        throw new Error(
+          `HELD_OUT_SCORED_MORE_THAN_ONCE:${arm.id}:${document.id}`,
+        )
+      const inputArm =
+        arm.id === 'geometric-baseline' ? 'geometric-baseline' : arm.id
+      const firstInput = modelInputForStructuredExtraction(
+        document.context,
+        inputArm,
+      )
+      const first = await arm.run(firstInput)
+      if (!first || typeof first !== 'object')
+        throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
+      if (document.split === 'held-out')
+        assertNoHeldOutContamination(arm, first.proposal, document.split)
+      const firstVerification = verifyStructuredExtraction(
+        document.context,
+        first.proposal,
+      )
+      const secondInput = modelInputForStructuredExtraction(
+        document.context,
+        inputArm,
+      )
+      const second = await arm.run(secondInput)
+      if (!second || typeof second !== 'object')
+        throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
+      if (document.split === 'held-out')
+        assertNoHeldOutContamination(arm, second.proposal, document.split)
+      const secondVerification = verifyStructuredExtraction(
+        document.context,
+        second.proposal,
+      )
+      const byteStable =
+        firstVerification.status === 'passed' &&
+        secondVerification.status === 'passed' &&
+        structuredExtractionStableJson(firstVerification.output) ===
+          structuredExtractionStableJson(secondVerification.output)
+      const verification = verificationSummary(firstVerification)
+      const metrics = first.metrics
+      if (!metrics) throw new Error(`MISSING_EXTRACTION_RUN_METRICS:${arm.id}`)
+      if (
+        !finiteNonNegative(metrics.latencyMs) ||
+        !finiteNonNegative(metrics.costUsd) ||
+        (metrics.pageCount !== undefined &&
+          (!Number.isSafeInteger(metrics.pageCount) || metrics.pageCount < 1))
+      )
+        throw new Error(`INVALID_EXTRACTION_RUN_METRICS:${arm.id}`)
+      const pages = metrics.pageCount ?? pageCount(document.context)
+      const output =
+        firstVerification.status === 'passed' && byteStable
+          ? firstVerification.output
+          : null
+      const caseScores = document.cases.map((caseInput) =>
+        scoreCase(
+          caseInput,
+          output,
+          byteStable
+            ? verification
+            : {
+                status: 'failed',
+                issueCodes: [
+                  ...verification.issueCodes,
+                  ...(byteStable ? [] : ['byte-instability']),
+                ],
+                issueCount: verification.issueCount + (byteStable ? 0 : 1),
+              },
+        ),
+      )
+      const status: ExtractionBakeoffDocumentResult['status'] = !byteStable
+        ? 'disqualified'
+        : firstVerification.status === 'passed'
+          ? 'passed'
+          : 'failed'
+      resultByArm[arm.id].push({
+        documentId: document.id,
+        split: document.split,
+        layout: document.layout,
+        status,
+        verification: byteStable
+          ? verification
+          : {
+              status: 'failed',
+              issueCodes: [...verification.issueCodes, 'byte-instability'],
+              issueCount: verification.issueCount + 1,
+            },
+        outputHash: output ? structuredExtractionHash(output) : null,
+        byteStable,
+        latencyMsPerPage: metrics.latencyMs / pages,
+        costUsdPerPage: metrics.costUsd / pages,
+        caseScores,
+      })
+      if (document.split === 'held-out') identityRunKeys.add(runKey)
+    }
+  }
+
+  const comparison = comparisons(corpus, resultByArm)
+  const disagreements = comparison.flatMap((row) => {
+    const armResults = EXTRACTION_BAKEOFF_ARMS.map((arm) =>
+      resultByArm[arm].filter((result) =>
+        result.caseScores.some(
+          (score) =>
+            score.stratum === row.stratum && score.layout === row.layout,
+        ),
+      ),
+    )
+    const ids = [
+      ...new Set(
+        armResults.flatMap((items) =>
+          items.map(({ documentId }) => documentId),
+        ),
+      ),
+    ].sort()
+    return ids.flatMap((documentId) => {
+      const states = EXTRACTION_BAKEOFF_ARMS.map((arm) => {
+        const result = resultByArm[arm].find(
+          (item) => item.documentId === documentId,
+        )
+        return {
+          arm,
+          result,
+          state: result
+            ? `${result.status}\u0000${result.outputHash ?? 'none'}\u0000${result.byteStable}`
+            : 'missing',
+        }
+      })
+      if (new Set(states.map(({ state }) => state)).size === 1) return []
+      const matches = states
+        .filter(({ result }) =>
+          result?.caseScores.some(
+            (score) =>
+              score.stratum === row.stratum && score.layout === row.layout,
+          ),
+        )
+        .map(({ arm }) => arm)
+      return [
+        {
+          documentId,
+          stratum: row.stratum,
+          layout: row.layout,
+          arms: matches,
+          reason: states.some(({ result }) => result?.status !== 'passed')
+            ? ('verification' as const)
+            : ('structure' as const),
+        },
+      ]
+    })
+  })
+  const reportWithoutHash = {
+    schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
+    corpusId: corpus.id,
+    heldOutIdentitySha256: corpusReceipt.heldOutIdentitySha256,
+    candidateIdentities,
+    heldOutScoredOnce: true as const,
+    arms: Object.fromEntries(
+      EXTRACTION_BAKEOFF_ARMS.map((arm) => [
+        arm,
+        {
+          documents: resultByArm[arm],
+          byStratumAndLayout: scoreByStratumAndLayout(resultByArm[arm]),
+          disqualified: resultByArm[arm].some(
+            ({ status }) => status === 'disqualified',
+          ),
+        },
+      ]),
+    ) as ExtractionBakeoffReport['arms'],
+    comparison,
+    disagreements,
+  }
+  return {
+    ...reportWithoutHash,
+    reportSha256: structuredExtractionHash(reportWithoutHash),
+  }
+}
+
+export function createExtractionArchitectureDecision({
+  report,
+  decisionId = 'extraction-architecture-v1',
+}: {
+  report: ExtractionBakeoffReport
+  decisionId?: string
+}): ExtractionArchitectureDecision {
+  const perStratum: Record<string, ExtractionBakeoffArmId | 'tie' | 'pending'> =
+    {}
+  for (const row of report.comparison) {
+    const previous = perStratum[row.stratum]
+    if (previous === undefined)
+      perStratum[row.stratum] = row.winner ?? 'pending'
+    else if (previous !== row.winner && row.winner !== null)
+      perStratum[row.stratum] = 'tie'
+  }
+  const winners = Object.values(perStratum).filter(
+    (value): value is ExtractionBakeoffArmId =>
+      EXTRACTION_BAKEOFF_ARMS.includes(value as ExtractionBakeoffArmId),
+  )
+  const uniqueWinners = [...new Set(winners)]
+  const owner: ExtractionArchitectureDecision['owner'] =
+    uniqueWinners.length === 0
+      ? 'pending'
+      : uniqueWinners.length > 1
+        ? 'pending'
+        : uniqueWinners[0]!
+  return {
+    schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
+    decisionId,
+    owner,
+    humanDecisionRequired: uniqueWinners.length > 1,
+    perStratum,
+    geometricRole:
+      'Remain the source-run, asset-bound, and publication verifier in every arm; it may provide the fail-closed fallback.',
+    reversalCriteria: [
+      'Reverse only after a new hash-pinned held-out split is scored once per candidate version.',
+      'A proposed winner must improve the affected stratum and layout without lowering any other held-out stratum below the recorded baseline.',
+      'Any unverified span, model-authored alt text, or model-authored asset bounds disqualifies the candidate regardless of score.',
+    ],
+    heldOutIdentitySha256: report.heldOutIdentitySha256,
+    reportSha256: report.reportSha256,
+  }
+}
+
+export function serializeExtractionBakeoffReport(
+  report: ExtractionBakeoffReport,
+) {
+  return `${stableJson(report)}\n`
+}

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  modelInputForStructuredExtraction,
+  verifyStructuredExtraction,
+  type StructuredExtractionContext,
+  type StructuredExtractionProposal,
+} from './structured-extraction'
+
+const sourceSha256 = '1'.repeat(64)
+const assetSha256 = '2'.repeat(64)
+
+function context(): StructuredExtractionContext {
+  return {
+    documentId: 'fixture-paper',
+    sourceSha256,
+    split: 'held-out',
+    layout: 'two-column',
+    sourceRuns: [
+      { id: 'title-run', text: 'A source-backed title', page: 1, order: 1 },
+      { id: 'caption-run', text: 'Figure 1. A caption', page: 1, order: 2 },
+      { id: 'figure-run', text: 'Figure 1', page: 1, order: 3 },
+      { id: 'body-run', text: 'A continuous paragraph.', page: 1, order: 4 },
+      { id: 'table-head', text: 'Measure', page: 2, order: 5 },
+      { id: 'table-value', text: '42', page: 2, order: 6 },
+      { id: 'running-head', text: 'Journal title', page: 1, order: 7 },
+    ],
+    sourceAssets: [
+      {
+        id: 'figure-asset',
+        kind: 'figure',
+        page: 1,
+        bounds: { x: 0.1, y: 0.2, width: 0.3, height: 0.2 },
+        bytesSha256: assetSha256,
+        sourceObjectIds: ['native-figure'],
+        captionRunIds: ['caption-run'],
+      },
+    ],
+    provenArtifacts: [
+      { id: 'lane-1', kind: 'region-lane', sourceRunIds: ['body-run'] },
+    ],
+    boilerplateRunIds: ['running-head'],
+  }
+}
+
+function validProposal(): StructuredExtractionProposal {
+  return {
+    schemaVersion: '1.0.0',
+    nodes: [
+      {
+        id: 'title',
+        type: 'title',
+        sourceRunIds: ['title-run'],
+        text: 'A source-backed title',
+      },
+      {
+        id: 'caption',
+        type: 'paragraph',
+        sourceRunIds: ['caption-run'],
+        text: 'Figure 1. A caption',
+      },
+      {
+        id: 'figure',
+        type: 'figure',
+        sourceRunIds: ['figure-run'],
+        assetId: 'figure-asset',
+        captionNodeId: 'caption',
+        altText: 'Figure 1. A caption',
+        altTextSource: 'caption',
+      },
+      {
+        id: 'body',
+        type: 'paragraph',
+        sourceRunIds: ['body-run'],
+        text: 'A continuous paragraph.',
+      },
+    ],
+    assetIds: ['figure-asset'],
+    excludedBoilerplateRunIds: ['running-head'],
+  }
+}
+
+describe('source-backed structured extraction verifier', () => {
+  it('materializes text and alt text from source runs rather than proposal text', () => {
+    const proposal = validProposal()
+    proposal.nodes[0]!.text = 'A source-backed title'
+    const result = verifyStructuredExtraction(context(), proposal)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.nodes[0]!.text).toBe('A source-backed title')
+      expect(result.output.nodes[2]!.altText).toBe('Figure 1. A caption')
+      expect(result.output.nodes[2]!.altTextSource).toBe('caption')
+      expect(result.output.nodes[2]!).not.toHaveProperty('bytes')
+      expect(result.output.nodes[2]!).not.toHaveProperty('bounds')
+    }
+  })
+
+  it('fails closed for an unverified or model-authored span', () => {
+    const proposal = validProposal()
+    proposal.nodes[3]!.text = 'Invented paragraph.'
+    const result = verifyStructuredExtraction(context(), proposal)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'source-text-mismatch',
+      )
+      expect(result.output).toBeNull()
+    }
+  })
+
+  it('rejects model-authored alt text even when an asset is otherwise valid', () => {
+    const proposal = validProposal()
+    proposal.nodes[2]!.altText = 'A detailed description invented from pixels'
+    const result = verifyStructuredExtraction(context(), proposal)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'model-authored-alt-text',
+      )
+    }
+  })
+
+  it('requires boilerplate to be explicitly accounted for and excludes it from body flow', () => {
+    const proposal = validProposal()
+    proposal.excludedBoilerplateRunIds = []
+    const result = verifyStructuredExtraction(context(), proposal)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'boilerplate-not-accounted',
+      )
+    }
+  })
+
+  it('keeps table cell provenance source-backed', () => {
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'table',
+      type: 'table',
+      sourceRunIds: ['table-head', 'table-value'],
+      table: {
+        rows: [
+          { cells: [{ sourceRunIds: ['table-head'], headerScope: 'column' }] },
+          { cells: [{ sourceRunIds: ['table-value'], headerScope: 'none' }] },
+        ],
+      },
+    })
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(
+        result.output.nodes.at(-1)?.table?.rows[0]?.cells[0],
+      ).toMatchObject({
+        text: 'Measure',
+        sourceRunIds: ['table-head'],
+        headerScope: 'column',
+      })
+    }
+  })
+
+  it('only exposes proved artifacts to the grounded arm and stays byte-stable', () => {
+    const input = modelInputForStructuredExtraction(context(), 'llm-grounded')
+    expect(input.provenArtifacts).toHaveLength(1)
+    expect(input).not.toHaveProperty('groundTruth')
+    const first = verifyStructuredExtraction(context(), validProposal())
+    const second = verifyStructuredExtraction(
+      context(),
+      structuredClone(validProposal()),
+    )
+    expect(first).toEqual(second)
+  })
+})

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -109,6 +109,18 @@ describe('source-backed structured extraction verifier', () => {
     }
   })
 
+  it('rejects an empty candidate instead of treating it as a publishable output', () => {
+    const result = verifyStructuredExtraction(context(), {
+      schemaVersion: '1.0.0',
+      nodes: [],
+    })
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('invalid-output')
+    }
+  })
+
   it('rejects model-authored alt text even when an asset is otherwise valid', () => {
     const proposal = validProposal()
     proposal.nodes[2]!.altText = 'A detailed description invented from pixels'
@@ -159,6 +171,74 @@ describe('source-backed structured extraction verifier', () => {
         sourceRunIds: ['table-head'],
         headerScope: 'column',
       })
+    }
+  })
+
+  it('rejects table cells that reuse a source run from another table', () => {
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'table-one',
+        type: 'table',
+        sourceRunIds: ['table-head'],
+        table: {
+          rows: [{ cells: [{ sourceRunIds: ['table-head'] }] }],
+        },
+      },
+      {
+        id: 'table-two',
+        type: 'table',
+        sourceRunIds: ['table-head'],
+        table: {
+          rows: [{ cells: [{ sourceRunIds: ['table-head'] }] }],
+        },
+      },
+    )
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'duplicate-source-run',
+            sourceRunId: 'table-head',
+          }),
+        ]),
+      )
+    }
+  })
+
+  it('rejects boilerplate hidden inside table cells', () => {
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'table',
+      type: 'table',
+      sourceRunIds: ['table-head'],
+      table: {
+        rows: [{ cells: [{ sourceRunIds: ['running-head'] }] }],
+      },
+    })
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'boilerplate-in-body',
+      )
+    }
+  })
+
+  it('unions explicit and node-referenced deterministic assets', () => {
+    const candidate = validProposal()
+    candidate.assetIds = []
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.assetIds).toEqual(['figure-asset'])
     }
   })
 

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -283,7 +283,7 @@ const nodeSchema = z
 const proposalSchema = z
   .object({
     schemaVersion: z.literal(STRUCTURED_EXTRACTION_SCHEMA_VERSION).optional(),
-    nodes: z.array(nodeSchema),
+    nodes: z.array(nodeSchema).min(1),
     assetIds: z.array(idSchema).optional(),
     excludedBoilerplateRunIds: z.array(idSchema).optional(),
     diagnostics: z.array(z.string()).optional(),
@@ -494,6 +494,7 @@ function verifyNodeTable(
   runsById: ReadonlyMap<string, StructuredSourceRun>,
   claimed: Set<string>,
   issues: StructuredExtractionVerificationIssue[],
+  boilerplate: ReadonlySet<string>,
 ) {
   if (!node.table || node.type !== 'table') return undefined
   if (node.table.rows.length === 0) {
@@ -526,6 +527,15 @@ function verifyNodeTable(
         return undefined
       }
       for (const sourceRunId of cell.sourceRunIds) {
+        if (boilerplate.has(sourceRunId)) {
+          issues.push(
+            issue(
+              'boilerplate-in-body',
+              `Boilerplate run ${sourceRunId} cannot enter a table cell.`,
+              { nodeId: node.id, sourceRunId },
+            ),
+          )
+        }
         if (!runsById.has(sourceRunId)) {
           issues.push(
             issue('unknown-source-run', `Unknown source run ${sourceRunId}.`, {
@@ -795,7 +805,12 @@ export function verifyStructuredExtraction(
     new Set(context.sourceAssets.map(({ id }) => id)).size !==
     context.sourceAssets.length
   ) {
-    issues.push(issue('invalid-output', 'Deterministic asset identifiers must be unique.'))
+    issues.push(
+      issue(
+        'invalid-output',
+        'Deterministic asset identifiers must be unique.',
+      ),
+    )
   }
 
   if (nodesById.size !== proposal.nodes.length) {
@@ -814,6 +829,7 @@ export function verifyStructuredExtraction(
         ),
       )
     }
+    const claimedBeforeNode = new Set(claimed)
     const text = validateNodeText(node, runsById, claimed, issues)
     for (const sourceRunId of node.sourceRunIds) {
       if (boilerplate.has(sourceRunId)) {
@@ -829,12 +845,26 @@ export function verifyStructuredExtraction(
     // Table cells are the semantic spans. Their source runs may also be
     // listed on the table node so the node itself remains source anchored;
     // avoid treating that intentional containment as duplicate emission.
-    const tableClaimed = node.type === 'table' ? new Set<string>() : claimed
-    const table = verifyNodeTable(node, runsById, tableClaimed, issues)
+    const tableClaimed =
+      node.type === 'table' ? new Set(claimedBeforeNode) : claimed
+    const table = verifyNodeTable(
+      node,
+      runsById,
+      tableClaimed,
+      issues,
+      boilerplate,
+    )
     if (node.type === 'table') {
       for (const sourceRunId of tableClaimed) claimed.add(sourceRunId)
       // The node-level source references and cell-level references describe
       // the same source ownership, not two emitted text spans.
+      const nodeSourceCounts = new Map<string, number>()
+      for (const sourceRunId of node.sourceRunIds) {
+        nodeSourceCounts.set(
+          sourceRunId,
+          (nodeSourceCounts.get(sourceRunId) ?? 0) + 1,
+        )
+      }
       for (const sourceRunId of node.sourceRunIds) {
         const duplicate = issues.find(
           (entry) =>
@@ -842,7 +872,12 @@ export function verifyStructuredExtraction(
             entry.nodeId === node.id &&
             entry.sourceRunId === sourceRunId,
         )
-        if (duplicate) {
+        if (
+          duplicate &&
+          nodeSourceCounts.get(sourceRunId) === 1 &&
+          !claimedBeforeNode.has(sourceRunId) &&
+          tableClaimed.has(sourceRunId)
+        ) {
           const index = issues.indexOf(duplicate)
           issues.splice(index, 1)
         }
@@ -917,10 +952,10 @@ export function verifyStructuredExtraction(
   }
 
   const assetIds = [
-    ...new Set(
-      proposal.assetIds ??
-        proposal.nodes.flatMap((node) => (node.assetId ? [node.assetId] : [])),
-    ),
+    ...new Set([
+      ...(proposal.assetIds ?? []),
+      ...proposal.nodes.flatMap((node) => (node.assetId ? [node.assetId] : [])),
+    ]),
   ]
   for (const assetId of assetIds) {
     if (!assetsById.has(assetId))

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -1,0 +1,1010 @@
+import { z } from 'zod'
+import { sha256HexSync } from './sha256-sync.ts'
+import type { PdfReconstruction } from './import-types'
+
+/**
+ * The model-facing extraction contract is intentionally smaller than the
+ * publication graph.  Models may suggest references to source runs and
+ * deterministic assets; they never supply authoritative text or bytes.
+ */
+export const STRUCTURED_EXTRACTION_SCHEMA_VERSION = '1.0.0' as const
+
+export const STRUCTURED_EXTRACTION_NODE_TYPES = [
+  'title',
+  'author',
+  'affiliation',
+  'abstract',
+  'heading',
+  'paragraph',
+  'code',
+  'table',
+  'figure',
+  'equation',
+  'footnote',
+  'reference',
+] as const
+
+export type StructuredExtractionNodeType =
+  (typeof STRUCTURED_EXTRACTION_NODE_TYPES)[number]
+
+export const STRUCTURED_EXTRACTION_LAYOUTS = [
+  'one-column',
+  'two-column',
+] as const
+
+export type StructuredExtractionLayout =
+  (typeof STRUCTURED_EXTRACTION_LAYOUTS)[number]
+
+export const STRUCTURED_EXTRACTION_SPLITS = ['development', 'held-out'] as const
+
+export type StructuredExtractionSplit =
+  (typeof STRUCTURED_EXTRACTION_SPLITS)[number]
+
+export type StructuredSourceRun = {
+  id: string
+  text: string
+  page: number
+  order: number
+  /** A source run is already normalized by the deterministic extractor. */
+  layout?: StructuredExtractionLayout
+  stratum?: string
+}
+
+export type StructuredSourceAsset = {
+  id: string
+  kind: 'figure' | 'diagram' | 'table' | 'equation'
+  page: number
+  bounds: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+  bytesSha256: string
+  sourceObjectIds: string[]
+  captionRunIds?: string[]
+}
+
+export type StructuredProvenArtifact = {
+  id: string
+  kind:
+    | 'region-lane'
+    | 'table-scope'
+    | 'line-boundary'
+    | 'note-relationship'
+    | 'citation-relationship'
+    | 'source-run-provenance'
+  sourceRunIds: string[]
+}
+
+export type StructuredExtractionContext = {
+  documentId: string
+  sourceSha256: string
+  split: StructuredExtractionSplit
+  layout: StructuredExtractionLayout
+  sourceRuns: StructuredSourceRun[]
+  sourceAssets: StructuredSourceAsset[]
+  provenArtifacts?: StructuredProvenArtifact[]
+  /** These runs remain accounted for but may not enter body flow. */
+  boilerplateRunIds?: string[]
+  /** Ground truth is deliberately not part of this model input. */
+  readonly groundTruth?: never
+}
+
+export type StructuredExtractionTableCell = {
+  sourceRunIds: string[]
+  headerScope?: 'row' | 'column' | 'rowgroup' | 'colgroup' | 'none'
+}
+
+export type StructuredExtractionTable = {
+  rows: Array<{ cells: StructuredExtractionTableCell[] }>
+}
+
+export type StructuredExtractionNode = {
+  id: string
+  type: StructuredExtractionNodeType
+  sourceRunIds: string[]
+  /** Optional proposal text. The verifier replaces it with source text. */
+  text?: string
+  level?: number
+  assetId?: string
+  captionNodeId?: string
+  altText?: string
+  altTextSource?: 'caption' | 'model' | 'image'
+  table?: StructuredExtractionTable
+}
+
+export type StructuredExtractionProposal = {
+  schemaVersion?: typeof STRUCTURED_EXTRACTION_SCHEMA_VERSION
+  nodes: StructuredExtractionNode[]
+  /** All deterministic assets that the model associates with the flow. */
+  assetIds?: string[]
+  /** Explicit accounting for page furniture omitted from body flow. */
+  excludedBoilerplateRunIds?: string[]
+  /** Optional model diagnostics are never copied to the publication graph. */
+  diagnostics?: string[]
+}
+
+export type VerifiedStructuredExtractionNode = Omit<
+  StructuredExtractionNode,
+  'text' | 'altText' | 'altTextSource' | 'table'
+> & {
+  text: string
+  provenance: {
+    sourceRunIds: string[]
+  }
+  altText?: string
+  altTextSource?: 'caption'
+  table?: {
+    rows: Array<{
+      cells: Array<{
+        text: string
+        sourceRunIds: string[]
+        headerScope: NonNullable<StructuredExtractionTableCell['headerScope']>
+      }>
+    }>
+  }
+}
+
+export type VerifiedStructuredExtraction = {
+  schemaVersion: typeof STRUCTURED_EXTRACTION_SCHEMA_VERSION
+  documentId: string
+  sourceSha256: string
+  nodes: VerifiedStructuredExtractionNode[]
+  assetIds: string[]
+  excludedBoilerplateRunIds: string[]
+  accountedSourceRunIds: string[]
+}
+
+export type StructuredExtractionVerificationIssueCode =
+  | 'invalid-output'
+  | 'unknown-source-run'
+  | 'unverified-span'
+  | 'source-text-mismatch'
+  | 'duplicate-source-run'
+  | 'boilerplate-in-body'
+  | 'boilerplate-not-accounted'
+  | 'unknown-asset'
+  | 'asset-kind-mismatch'
+  | 'asset-identity-mismatch'
+  | 'asset-bytes-or-bounds-authored'
+  | 'missing-caption'
+  | 'model-authored-alt-text'
+  | 'invalid-heading-level'
+  | 'invalid-table'
+
+export type StructuredExtractionVerificationIssue = {
+  code: StructuredExtractionVerificationIssueCode
+  nodeId?: string
+  sourceRunId?: string
+  assetId?: string
+  message: string
+}
+
+export type StructuredExtractionVerificationResult =
+  | {
+      status: 'passed'
+      output: VerifiedStructuredExtraction
+      issues: []
+    }
+  | {
+      status: 'failed'
+      output: null
+      issues: StructuredExtractionVerificationIssue[]
+    }
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/u)
+const idSchema = z.string().min(1).max(256)
+const sourceRunSchema = z
+  .object({
+    id: idSchema,
+    text: z.string(),
+    page: z.number().int().positive(),
+    order: z.number().int().nonnegative(),
+    layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS).optional(),
+    stratum: z.string().min(1).optional(),
+  })
+  .strict()
+
+const sourceAssetSchema = z
+  .object({
+    id: idSchema,
+    kind: z.enum(['figure', 'diagram', 'table', 'equation']),
+    page: z.number().int().positive(),
+    bounds: z
+      .object({
+        x: z.number().finite(),
+        y: z.number().finite(),
+        width: z.number().positive(),
+        height: z.number().positive(),
+      })
+      .strict(),
+    bytesSha256: sha256Schema,
+    sourceObjectIds: z.array(idSchema),
+    captionRunIds: z.array(idSchema).optional(),
+  })
+  .strict()
+
+const sourceArtifactSchema = z
+  .object({
+    id: idSchema,
+    kind: z.enum([
+      'region-lane',
+      'table-scope',
+      'line-boundary',
+      'note-relationship',
+      'citation-relationship',
+      'source-run-provenance',
+    ]),
+    sourceRunIds: z.array(idSchema),
+  })
+  .strict()
+
+const contextSchema = z
+  .object({
+    documentId: idSchema,
+    sourceSha256: sha256Schema,
+    split: z.enum(STRUCTURED_EXTRACTION_SPLITS),
+    layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS),
+    sourceRuns: z.array(sourceRunSchema),
+    sourceAssets: z.array(sourceAssetSchema),
+    provenArtifacts: z.array(sourceArtifactSchema).optional(),
+    boilerplateRunIds: z.array(idSchema).optional(),
+  })
+  .strict()
+
+const tableCellSchema = z
+  .object({
+    sourceRunIds: z.array(idSchema).min(1),
+    headerScope: z
+      .enum(['row', 'column', 'rowgroup', 'colgroup', 'none'])
+      .optional(),
+  })
+  .strict()
+
+const nodeSchema = z
+  .object({
+    id: idSchema,
+    type: z.enum(STRUCTURED_EXTRACTION_NODE_TYPES),
+    sourceRunIds: z.array(idSchema).min(1),
+    text: z.string().optional(),
+    level: z.number().int().min(1).max(6).optional(),
+    assetId: idSchema.optional(),
+    captionNodeId: idSchema.optional(),
+    altText: z.string().optional(),
+    altTextSource: z.enum(['caption', 'model', 'image']).optional(),
+    table: z
+      .object({ rows: z.array(z.object({ cells: z.array(tableCellSchema) })) })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const proposalSchema = z
+  .object({
+    schemaVersion: z.literal(STRUCTURED_EXTRACTION_SCHEMA_VERSION).optional(),
+    nodes: z.array(nodeSchema),
+    assetIds: z.array(idSchema).optional(),
+    excludedBoilerplateRunIds: z.array(idSchema).optional(),
+    diagnostics: z.array(z.string()).optional(),
+  })
+  .strict()
+
+/**
+ * Adapt the deterministic PDF reconstruction into the arm-neutral context.
+ * IDs are derived from region/line/run positions and are therefore stable for
+ * a fixed reconstruction receipt; no source text is copied into a receipt.
+ */
+export function structuredExtractionContextFromReconstruction({
+  reconstruction,
+  documentId = reconstruction.source.fileName,
+  split,
+  layout,
+  stratum,
+}: {
+  reconstruction: PdfReconstruction
+  documentId?: string
+  split: StructuredExtractionSplit
+  layout: StructuredExtractionLayout
+  stratum?: string
+}): StructuredExtractionContext {
+  const sourceRuns: StructuredSourceRun[] = []
+  const runIdsByKey = new Map<string, string>()
+  let order = 0
+  for (const region of reconstruction.regions) {
+    for (const line of region.lines) {
+      for (const [runIndex, run] of line.runs.entries()) {
+        const id = `r-${region.id}-${line.id}-${runIndex}`
+        runIdsByKey.set(`${region.id}\u0000${line.id}\u0000${runIndex}`, id)
+        sourceRuns.push({
+          id,
+          text: run.text,
+          page: run.page,
+          order: order++,
+          layout,
+          ...(stratum ? { stratum } : {}),
+        })
+      }
+    }
+  }
+  const runIdsForRegion = (regionId: string) => {
+    const region = reconstruction.regions.find(({ id }) => id === regionId)
+    if (!region) return []
+    return region.lines.flatMap((line) =>
+      line.runs
+        .map((_, runIndex) =>
+          runIdsByKey.get(`${region.id}\u0000${line.id}\u0000${runIndex}`)!,
+        )
+        .filter(Boolean),
+    )
+  }
+  const sourceAssets: StructuredSourceAsset[] = reconstruction.assets.map(
+    (asset) => {
+      const relationship = reconstruction.visualRelationships.find(
+        ({ assetIds }) => assetIds.includes(asset.id),
+      )
+      const kind: StructuredSourceAsset['kind'] =
+        asset.kind === 'table'
+          ? 'table'
+          : asset.kind === 'equation'
+            ? 'equation'
+            : relationship?.kind === 'figure'
+              ? 'figure'
+              : 'diagram'
+      const box = asset.sourceCropBox ?? asset.sourceBoxes[0]
+      return {
+        id: asset.id,
+        kind,
+        page: box?.page ?? 1,
+        bounds: {
+          x: box?.x ?? 0,
+          y: box?.y ?? 0,
+          width: box?.width ?? 0.001,
+          height: box?.height ?? 0.001,
+        },
+        bytesSha256: asset.sha256,
+        sourceObjectIds: [...asset.sourceObjectIds],
+        ...(relationship
+          ? { captionRunIds: runIdsForRegion(relationship.captionRegionId) }
+          : {}),
+      }
+    },
+  )
+  const boilerplateRunIds = reconstruction.regions
+    .filter((region) =>
+      ['header', 'footer', 'page-number'].includes(region.kind),
+    )
+    .flatMap(({ id }) => runIdsForRegion(id))
+  const provenArtifacts: StructuredProvenArtifact[] = [
+    ...reconstruction.regions.map((region) => ({
+      id: region.id,
+      kind: 'region-lane' as const,
+      sourceRunIds: runIdsForRegion(region.id),
+    })),
+    ...reconstruction.visualRelationships
+      .filter(({ kind }) => kind === 'table')
+      .map((relationship) => ({
+        id: relationship.id,
+        kind: 'table-scope' as const,
+        sourceRunIds: relationship.sourceRegionIds.flatMap(runIdsForRegion),
+      })),
+    ...reconstruction.lineBoundaryDecisions.map((decision) => ({
+      id: decision.id,
+      kind: 'line-boundary' as const,
+      sourceRunIds: runIdsForRegion(decision.regionId),
+    })),
+    ...reconstruction.noteRelationships.map((relationship) => ({
+      id: relationship.id,
+      kind: 'note-relationship' as const,
+      sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
+    })),
+    ...reconstruction.citationRelationships.map((relationship) => ({
+      id: relationship.id,
+      kind: 'citation-relationship' as const,
+      sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
+    })),
+    {
+      id: 'source-run-provenance',
+      kind: 'source-run-provenance' as const,
+      sourceRunIds: sourceRuns.map(({ id }) => id),
+    },
+  ]
+  return {
+    documentId,
+    sourceSha256: reconstruction.source.sha256,
+    split,
+    layout,
+    sourceRuns,
+    sourceAssets,
+    provenArtifacts,
+    boilerplateRunIds,
+  }
+}
+
+function normalizedText(value: string) {
+  return value.normalize('NFKC').replace(/\s+/gu, ' ').trim()
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`,
+      )
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(child)
+    }
+    Object.freeze(value)
+  }
+  return value
+}
+
+export function structuredExtractionStableJson(value: unknown) {
+  return stableJson(value)
+}
+
+export function structuredExtractionHash(value: unknown) {
+  return sha256HexSync(stableJson(value))
+}
+
+export function parseStructuredExtractionContext(
+  value: unknown,
+): StructuredExtractionContext {
+  return contextSchema.parse(value)
+}
+
+export function parseStructuredExtractionProposal(
+  value: unknown,
+): StructuredExtractionProposal {
+  return proposalSchema.parse(value) as StructuredExtractionProposal
+}
+
+function sourceTextForRunIds(
+  sourceRunIds: readonly string[],
+  runsById: ReadonlyMap<string, StructuredSourceRun>,
+) {
+  return normalizedText(
+    sourceRunIds
+      .map((id) => runsById.get(id)?.text ?? '')
+      .filter((text) => text.length > 0)
+      .join(' '),
+  )
+}
+
+function issue(
+  code: StructuredExtractionVerificationIssueCode,
+  message: string,
+  fields: Partial<StructuredExtractionVerificationIssue> = {},
+): StructuredExtractionVerificationIssue {
+  return { code, message, ...fields }
+}
+
+function verifyNodeTable(
+  node: StructuredExtractionNode,
+  runsById: ReadonlyMap<string, StructuredSourceRun>,
+  claimed: Set<string>,
+  issues: StructuredExtractionVerificationIssue[],
+) {
+  if (!node.table || node.type !== 'table') return undefined
+  if (node.table.rows.length === 0) {
+    issues.push(
+      issue('invalid-table', 'A table must contain at least one row.', {
+        nodeId: node.id,
+      }),
+    )
+    return undefined
+  }
+  const rows: VerifiedStructuredExtractionNode['table'] = { rows: [] }
+  for (const row of node.table.rows) {
+    if (row.cells.length === 0) {
+      issues.push(
+        issue('invalid-table', 'A table row must contain cells.', {
+          nodeId: node.id,
+        }),
+      )
+      return undefined
+    }
+    const cells = []
+    for (const cell of row.cells) {
+      const cellText = sourceTextForRunIds(cell.sourceRunIds, runsById)
+      if (!cellText) {
+        issues.push(
+          issue('unverified-span', 'A table cell has no source text.', {
+            nodeId: node.id,
+          }),
+        )
+        return undefined
+      }
+      for (const sourceRunId of cell.sourceRunIds) {
+        if (!runsById.has(sourceRunId)) {
+          issues.push(
+            issue('unknown-source-run', `Unknown source run ${sourceRunId}.`, {
+              nodeId: node.id,
+              sourceRunId,
+            }),
+          )
+        } else if (claimed.has(sourceRunId)) {
+          issues.push(
+            issue(
+              'duplicate-source-run',
+              `Source run ${sourceRunId} is emitted more than once.`,
+              { nodeId: node.id, sourceRunId },
+            ),
+          )
+        }
+        claimed.add(sourceRunId)
+      }
+      cells.push({
+        text: cellText,
+        sourceRunIds: [...cell.sourceRunIds],
+        headerScope: cell.headerScope ?? 'none',
+      })
+    }
+    rows.rows.push({ cells })
+  }
+  return rows
+}
+
+function validateNodeText(
+  node: StructuredExtractionNode,
+  runsById: ReadonlyMap<string, StructuredSourceRun>,
+  claimed: Set<string>,
+  issues: StructuredExtractionVerificationIssue[],
+) {
+  if (!Array.isArray(node.sourceRunIds) || node.sourceRunIds.length === 0) {
+    issues.push(
+      issue(
+        'unverified-span',
+        'Every emitted node must reference source runs.',
+        { nodeId: node.id },
+      ),
+    )
+    return ''
+  }
+  const text = sourceTextForRunIds(node.sourceRunIds, runsById)
+  if (!text) {
+    issues.push(
+      issue('unverified-span', 'A node references no readable source text.', {
+        nodeId: node.id,
+      }),
+    )
+  }
+  if (node.text !== undefined && normalizedText(node.text) !== text) {
+    issues.push(
+      issue(
+        'source-text-mismatch',
+        'Model text does not exactly match the referenced source runs.',
+        { nodeId: node.id },
+      ),
+    )
+  }
+  const sourceOrders = node.sourceRunIds
+    .map((sourceRunId) => runsById.get(sourceRunId)?.order)
+    .filter((order): order is number => order !== undefined)
+  if (
+    sourceOrders.some(
+      (order, index) => index > 0 && order < sourceOrders[index - 1]!,
+    )
+  ) {
+    issues.push(
+      issue(
+        'unverified-span',
+        'Source runs must be emitted in deterministic source order.',
+        { nodeId: node.id },
+      ),
+    )
+  }
+  for (const sourceRunId of node.sourceRunIds) {
+    if (!runsById.has(sourceRunId)) {
+      issues.push(
+        issue('unknown-source-run', `Unknown source run ${sourceRunId}.`, {
+          nodeId: node.id,
+          sourceRunId,
+        }),
+      )
+    } else if (claimed.has(sourceRunId)) {
+      issues.push(
+        issue(
+          'duplicate-source-run',
+          `Source run ${sourceRunId} is emitted more than once.`,
+          { nodeId: node.id, sourceRunId },
+        ),
+      )
+    }
+    claimed.add(sourceRunId)
+  }
+  return text
+}
+
+function verifyAsset(
+  node: StructuredExtractionNode,
+  context: StructuredExtractionContext,
+  assetsById: ReadonlyMap<string, StructuredSourceAsset>,
+  nodesById: ReadonlyMap<string, StructuredExtractionNode>,
+  issues: StructuredExtractionVerificationIssue[],
+) {
+  if (!node.assetId) return
+  const asset = assetsById.get(node.assetId)
+  if (!asset) {
+    issues.push(
+      issue('unknown-asset', `Unknown deterministic asset ${node.assetId}.`, {
+        nodeId: node.id,
+        assetId: node.assetId,
+      }),
+    )
+    return
+  }
+  if (
+    (node.type === 'figure' && !['figure', 'diagram'].includes(asset.kind)) ||
+    (node.type === 'table' && asset.kind !== 'table') ||
+    (node.type === 'equation' && asset.kind !== 'equation')
+  ) {
+    issues.push(
+      issue(
+        'asset-kind-mismatch',
+        `Asset ${node.assetId} cannot back a ${node.type} node.`,
+        { nodeId: node.id, assetId: node.assetId },
+      ),
+    )
+  }
+  // The proposal type has no bytes/bounds fields. Reject them defensively if
+  // an untyped caller smuggles them in, rather than silently accepting model
+  // authored geometry.
+  const untyped = node as StructuredExtractionNode & Record<string, unknown>
+  if ('bytes' in untyped || 'bounds' in untyped || 'bytesSha256' in untyped) {
+    issues.push(
+      issue(
+        'asset-bytes-or-bounds-authored',
+        `Asset ${node.assetId} bytes and bounds belong to the deterministic layer.`,
+        { nodeId: node.id, assetId: node.assetId },
+      ),
+    )
+  }
+  if (node.type === 'figure') {
+    if (!node.captionNodeId || !nodesById.has(node.captionNodeId)) {
+      issues.push(
+        issue(
+          'missing-caption',
+          `Figure ${node.id} must reference a source-backed caption.`,
+          { nodeId: node.id, assetId: node.assetId },
+        ),
+      )
+    } else if (node.altTextSource !== 'caption') {
+      issues.push(
+        issue(
+          'model-authored-alt-text',
+          `Figure ${node.id} alt text must be caption-derived.`,
+          { nodeId: node.id, assetId: node.assetId },
+        ),
+      )
+    } else {
+      const caption = nodesById.get(node.captionNodeId)!
+      const captionText = sourceTextForRunIds(
+        caption.sourceRunIds,
+        new Map(context.sourceRuns.map((run) => [run.id, run])),
+      )
+      if (
+        asset.captionRunIds &&
+        (asset.captionRunIds.length !== caption.sourceRunIds.length ||
+          asset.captionRunIds.some(
+            (runId, index) => runId !== caption.sourceRunIds[index],
+          ))
+      ) {
+        issues.push(
+          issue(
+            'asset-identity-mismatch',
+            `Figure ${node.id} caption does not match the deterministic asset caption ownership.`,
+            { nodeId: node.id, assetId: node.assetId },
+          ),
+        )
+      }
+      if (
+        node.altText !== undefined &&
+        normalizedText(node.altText) !== captionText
+      ) {
+        issues.push(
+          issue(
+            'model-authored-alt-text',
+            `Figure ${node.id} alt text does not equal its caption.`,
+            { nodeId: node.id, assetId: node.assetId },
+          ),
+        )
+      }
+    }
+  }
+}
+
+function captionTextForNode(
+  node: StructuredExtractionNode,
+  nodesById: ReadonlyMap<string, StructuredExtractionNode>,
+  runsById: ReadonlyMap<string, StructuredSourceRun>,
+) {
+  if (!node.captionNodeId) return undefined
+  const caption = nodesById.get(node.captionNodeId)
+  return caption
+    ? sourceTextForRunIds(caption.sourceRunIds, runsById)
+    : undefined
+}
+
+/**
+ * Verify and materialize a model proposal.  On any violation this function
+ * returns no document; callers must use the deterministic fallback instead of
+ * partially publishing a candidate.
+ */
+export function verifyStructuredExtraction(
+  contextInput: StructuredExtractionContext,
+  proposalInput: unknown,
+): StructuredExtractionVerificationResult {
+  let context: StructuredExtractionContext
+  let proposal: StructuredExtractionProposal
+  try {
+    context = parseStructuredExtractionContext(contextInput)
+    proposal = parseStructuredExtractionProposal(proposalInput)
+  } catch (error) {
+    return {
+      status: 'failed',
+      output: null,
+      issues: [
+        issue(
+          'invalid-output',
+          error instanceof z.ZodError
+            ? error.issues
+                .map((entry) => `${entry.path.join('.')}: ${entry.message}`)
+                .join('; ')
+            : 'Structured extraction proposal is invalid.',
+        ),
+      ],
+    }
+  }
+
+  const issues: StructuredExtractionVerificationIssue[] = []
+  const runsById = new Map(context.sourceRuns.map((run) => [run.id, run]))
+  const assetsById = new Map(
+    context.sourceAssets.map((asset) => [asset.id, asset]),
+  )
+  const nodesById = new Map(proposal.nodes.map((node) => [node.id, node]))
+  const claimed = new Set<string>()
+  const boilerplate = new Set(context.boilerplateRunIds ?? [])
+  const excluded = new Set(proposal.excludedBoilerplateRunIds ?? [])
+  const nodes: VerifiedStructuredExtractionNode[] = []
+
+  if (
+    new Set(context.sourceRuns.map(({ id }) => id)).size !==
+      context.sourceRuns.length ||
+    new Set(context.sourceRuns.map(({ order }) => order)).size !==
+      context.sourceRuns.length
+  ) {
+    issues.push(
+      issue(
+        'invalid-output',
+        'Source run identifiers and source order positions must be unique.',
+      ),
+    )
+  }
+  if (
+    new Set(context.sourceAssets.map(({ id }) => id)).size !==
+    context.sourceAssets.length
+  ) {
+    issues.push(issue('invalid-output', 'Deterministic asset identifiers must be unique.'))
+  }
+
+  if (nodesById.size !== proposal.nodes.length) {
+    issues.push(issue('invalid-output', 'Node identifiers must be unique.'))
+  }
+  for (const node of proposal.nodes) {
+    if (
+      node.type === 'heading' &&
+      (node.level === undefined || node.level < 1 || node.level > 6)
+    ) {
+      issues.push(
+        issue(
+          'invalid-heading-level',
+          'Headings require a level from 1 through 6.',
+          { nodeId: node.id },
+        ),
+      )
+    }
+    const text = validateNodeText(node, runsById, claimed, issues)
+    for (const sourceRunId of node.sourceRunIds) {
+      if (boilerplate.has(sourceRunId)) {
+        issues.push(
+          issue(
+            'boilerplate-in-body',
+            `Boilerplate run ${sourceRunId} cannot enter body flow.`,
+            { nodeId: node.id, sourceRunId },
+          ),
+        )
+      }
+    }
+    // Table cells are the semantic spans. Their source runs may also be
+    // listed on the table node so the node itself remains source anchored;
+    // avoid treating that intentional containment as duplicate emission.
+    const tableClaimed = node.type === 'table' ? new Set<string>() : claimed
+    const table = verifyNodeTable(node, runsById, tableClaimed, issues)
+    if (node.type === 'table') {
+      for (const sourceRunId of tableClaimed) claimed.add(sourceRunId)
+      // The node-level source references and cell-level references describe
+      // the same source ownership, not two emitted text spans.
+      for (const sourceRunId of node.sourceRunIds) {
+        const duplicate = issues.find(
+          (entry) =>
+            entry.code === 'duplicate-source-run' &&
+            entry.nodeId === node.id &&
+            entry.sourceRunId === sourceRunId,
+        )
+        if (duplicate) {
+          const index = issues.indexOf(duplicate)
+          issues.splice(index, 1)
+        }
+      }
+    }
+    verifyAsset(node, context, assetsById, nodesById, issues)
+    const captionText =
+      node.type === 'figure'
+        ? captionTextForNode(node, nodesById, runsById)
+        : undefined
+    if (node.type === 'figure' && captionText !== undefined) {
+      // Never carry proposal text into the verified graph. Caption-derived alt
+      // text is rebuilt from the source run ledger even when the proposal did
+      // not include an altText field.
+      node.altText = captionText
+      node.altTextSource = 'caption'
+    }
+    nodes.push({
+      id: node.id,
+      type: node.type,
+      sourceRunIds: [...node.sourceRunIds],
+      text,
+      ...(node.level === undefined ? {} : { level: node.level }),
+      ...(node.assetId === undefined ? {} : { assetId: node.assetId }),
+      ...(node.captionNodeId === undefined
+        ? {}
+        : { captionNodeId: node.captionNodeId }),
+      ...(node.altText === undefined ? {} : { altText: node.altText }),
+      ...(node.altTextSource === 'caption'
+        ? { altTextSource: 'caption' as const }
+        : {}),
+      provenance: { sourceRunIds: [...node.sourceRunIds] },
+      ...(table ? { table } : {}),
+    })
+  }
+
+  for (const sourceRunId of excluded) {
+    if (!boilerplate.has(sourceRunId)) {
+      issues.push(
+        issue(
+          'boilerplate-not-accounted',
+          `Run ${sourceRunId} is not declared boilerplate.`,
+          { sourceRunId },
+        ),
+      )
+    }
+    if (!runsById.has(sourceRunId)) {
+      issues.push(
+        issue('unknown-source-run', `Unknown boilerplate run ${sourceRunId}.`, {
+          sourceRunId,
+        }),
+      )
+    }
+  }
+  for (const sourceRunId of boilerplate) {
+    if (!runsById.has(sourceRunId)) {
+      issues.push(
+        issue('unknown-source-run', `Unknown boilerplate run ${sourceRunId}.`, {
+          sourceRunId,
+        }),
+      )
+    }
+    if (!excluded.has(sourceRunId) && !claimed.has(sourceRunId)) {
+      issues.push(
+        issue(
+          'boilerplate-not-accounted',
+          `Boilerplate run ${sourceRunId} was neither excluded nor emitted.`,
+          { sourceRunId },
+        ),
+      )
+    }
+  }
+
+  const assetIds = [
+    ...new Set(
+      proposal.assetIds ??
+        proposal.nodes.flatMap((node) => (node.assetId ? [node.assetId] : [])),
+    ),
+  ]
+  for (const assetId of assetIds) {
+    if (!assetsById.has(assetId))
+      issues.push(
+        issue('unknown-asset', `Unknown deterministic asset ${assetId}.`, {
+          assetId,
+        }),
+      )
+  }
+  const accountedSourceRunIds = [...new Set([...claimed, ...excluded])].sort()
+  if (issues.length > 0) return { status: 'failed', output: null, issues }
+  return {
+    status: 'passed',
+    issues: [],
+    output: {
+      schemaVersion: STRUCTURED_EXTRACTION_SCHEMA_VERSION,
+      documentId: context.documentId,
+      sourceSha256: context.sourceSha256,
+      nodes,
+      assetIds: assetIds.sort(),
+      excludedBoilerplateRunIds: [...excluded].sort(),
+      accountedSourceRunIds,
+    },
+  }
+}
+
+export function verifyStructuredExtractionOrThrow(
+  context: StructuredExtractionContext,
+  proposal: unknown,
+) {
+  const result = verifyStructuredExtraction(context, proposal)
+  if (result.status === 'failed') {
+    throw new Error(
+      result.issues
+        .map(({ code, message }) => `${code}: ${message}`)
+        .join('\n'),
+    )
+  }
+  return result.output
+}
+
+// Public vocabulary aliases used by callers that refer to the shared
+// contract as "structured output" rather than "structured extraction".
+export const verifyStructuredOutput = verifyStructuredExtraction
+export const verifyStructuredOutputOrThrow = verifyStructuredExtractionOrThrow
+
+/** Build the source-only input each candidate is allowed to receive. */
+export function modelInputForStructuredExtraction(
+  context: StructuredExtractionContext,
+  arm: 'geometric-baseline' | 'llm-authored' | 'llm-grounded',
+): StructuredExtractionContext {
+  const base: StructuredExtractionContext = {
+    documentId: context.documentId,
+    sourceSha256: context.sourceSha256,
+    split: context.split,
+    layout: context.layout,
+    sourceRuns: context.sourceRuns.map((run) => ({ ...run })),
+    sourceAssets: context.sourceAssets.map((asset) => ({
+      ...asset,
+      bounds: { ...asset.bounds },
+      sourceObjectIds: [...asset.sourceObjectIds],
+      ...(asset.captionRunIds
+        ? { captionRunIds: [...asset.captionRunIds] }
+        : {}),
+    })),
+    ...(context.boilerplateRunIds
+      ? { boilerplateRunIds: [...context.boilerplateRunIds] }
+      : {}),
+  }
+  if (arm === 'geometric-baseline' || arm === 'llm-grounded') {
+    base.provenArtifacts = (context.provenArtifacts ?? []).map((artifact) => ({
+      ...artifact,
+      sourceRunIds: [...artifact.sourceRunIds],
+    }))
+  }
+  return deepFreeze(base)
+}
+
+export function isStructuredExtractionByteStable(
+  first: VerifiedStructuredExtraction,
+  second: VerifiedStructuredExtraction,
+) {
+  return (
+    structuredExtractionStableJson(first) ===
+    structuredExtractionStableJson(second)
+  )
+}

--- a/src/research/structured-output.ts
+++ b/src/research/structured-output.ts
@@ -1,0 +1,1 @@
+export * from './structured-extraction.ts'

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises'
+import {
+  createExtractionArchitectureDecision,
+  EXTRACTION_BAKEOFF_STRATA,
+  runExtractionBakeoff,
+} from '../src/research/extraction-bakeoff.ts'
+
+const SHA_A = 'a'.repeat(64)
+const SHA_B = 'b'.repeat(64)
+
+function context(id, split, layout) {
+  return {
+    documentId: id,
+    sourceSha256: id.startsWith('development') ? SHA_A : SHA_B,
+    split,
+    layout,
+    sourceRuns: [
+      { id: `${id}-title`, text: 'Synthetic title', page: 1, order: 1 },
+      {
+        id: `${id}-body`,
+        text: 'Synthetic source paragraph.',
+        page: 1,
+        order: 2,
+      },
+    ],
+    sourceAssets: [],
+  }
+}
+
+function proposal(input, quality = 'complete') {
+  const nodes = [
+    {
+      id: `${input.documentId}-title`,
+      type: 'title',
+      sourceRunIds: [`${input.documentId}-title`],
+    },
+    {
+      id: `${input.documentId}-body`,
+      type: 'paragraph',
+      sourceRunIds: [`${input.documentId}-body`],
+    },
+  ]
+  if (quality === 'baseline') nodes.pop()
+  if (quality === 'authored')
+    nodes[1].text = 'Model-authored text that cannot be verified.'
+  return {
+    schemaVersion: '1.0.0',
+    nodes,
+  }
+}
+
+function makeCorpus() {
+  const documents = [
+    ['development-one', 'development', 'one-column'],
+    ['heldout-one', 'held-out', 'one-column'],
+    ['heldout-two', 'held-out', 'two-column'],
+  ].map(([id, split, layout]) => {
+    const source = context(id, split, layout)
+    return {
+      id,
+      split,
+      layout,
+      context: source,
+      cases: EXTRACTION_BAKEOFF_STRATA.map((stratum) => ({
+        id: `${id}-${stratum}`,
+        documentId: id,
+        stratum,
+        layout,
+        expectedNodeTypes: ['title', 'paragraph'],
+        expectedSourceRunIds: [`${id}-title`, `${id}-body`],
+      })),
+    }
+  })
+  return {
+    id: 'synthetic-extraction-bakeoff-v1',
+    development: documents.filter(({ split }) => split === 'development'),
+    heldOut: documents.filter(({ split }) => split === 'held-out'),
+  }
+}
+
+function arm(id) {
+  return {
+    id,
+    identity: {
+      providerId: id,
+      modelId: `${id}-model`,
+      modelVersion: 'fixture-1.0.0',
+      modelDigest: SHA_A,
+      promptHash: SHA_B,
+    },
+    tunedOn: ['development'],
+    run: async (input) => ({
+      proposal: proposal(
+        input,
+        id === 'geometric-baseline'
+          ? 'baseline'
+          : id === 'llm-authored'
+            ? 'authored'
+            : 'complete',
+      ),
+      metrics: { latencyMs: 1, costUsd: 0 },
+    }),
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (!args.includes('--self-test')) {
+    process.stderr.write(
+      'Usage: node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test [--out <path>]\n',
+    )
+    process.exitCode = 2
+    return
+  }
+  const report = await runExtractionBakeoff({
+    corpus: makeCorpus(),
+    arms: [arm('geometric-baseline'), arm('llm-authored'), arm('llm-grounded')],
+  })
+  const decision = createExtractionArchitectureDecision({ report })
+  const payload = `${JSON.stringify({ report, decision }, null, 2)}\n`
+  const outIndex = args.indexOf('--out')
+  if (outIndex >= 0) {
+    const outputPath = args[outIndex + 1]
+    if (!outputPath) throw new Error('--out requires a path')
+    await writeFile(outputPath, payload, 'utf8')
+  } else {
+    process.stdout.write(payload)
+  }
+  const reportOutIndex = args.indexOf('--report-out')
+  if (reportOutIndex >= 0) {
+    const reportPath = args[reportOutIndex + 1]
+    if (!reportPath) throw new Error('--report-out requires a path')
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  }
+  const decisionOutIndex = args.indexOf('--decision-out')
+  if (decisionOutIndex >= 0) {
+    const decisionPath = args[decisionOutIndex + 1]
+    if (!decisionPath) throw new Error('--decision-out requires a path')
+    await writeFile(
+      decisionPath,
+      `${JSON.stringify(decision, null, 2)}\n`,
+      'utf8',
+    )
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : 'Extraction bake-off failed.'}\n`,
+  )
+  process.exitCode = 1
+})

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('extraction bake-off CLI', () => {
+  it('runs the privacy-safe synthetic held-out smoke benchmark', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--self-test',
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+    expect(result.status, result.stderr).toBe(0)
+    const payload = JSON.parse(result.stdout)
+    expect(payload.report.heldOutScoredOnce).toBe(true)
+    expect(payload.report.comparison).toHaveLength(16)
+    expect(
+      payload.report.candidateIdentities['llm-grounded'].promptHash,
+    ).toMatch(/^[a-f0-9]{64}$/u)
+    expect(payload.decision.owner).toBe('llm-grounded')
+    expect(payload.report).not.toHaveProperty('sourceText')
+  })
+})


### PR DESCRIPTION
Closes #95

## Summary
- bind held-out identity to complete source-plus-label cases
- disqualify contaminated arms without aborting the other candidates
- keep held-out-only comparisons and fail closed on unresolved strata
- harden source-backed table/asset/boilerplate verification

## Evidence
- focused Vitest: 18 passed
- credential-scrubbed Astro production build: 0 errors, 0 warnings
- report/decision hashes recomputed and match
- no private providers or owner-local documents used