### PR TITLE
Fix cross-repository queue pulse serialization

### DIFF
--- a/tools/struct-queue-pulse.mjs
+++ b/tools/struct-queue-pulse.mjs
@@ -463,11 +463,6 @@ const writeAtomicCheckpoint = (path, value) => {
   renameSync(temporary, path)
 }
 
-const directCodexWorkerIsLive = (processArgs) =>
-  processArgs.some((command) =>
-    /(?:^|\s)(?:\S*\/)?codex\s+.*\bexec\b/u.test(command),
-  )
-
 const loadCleanupManifest = (path, stateRoot) => {
   if (!existsSync(path)) return []
   const manifest = readJson(path)
@@ -708,9 +703,11 @@ export const runQueuePulse = () => {
       })
     }
     if (
-      vmSessionState.live.length > 0 ||
-      directCodexWorkerIsLive(processArgs)
+      vmSessionState.live.length > 0
     ) {
+      // Process names alone do not establish an issue worker. The VM session
+      // ledger paired with exact tmux-process matching is authoritative;
+      // coordinators, reviewers, and other repo lanes also run Codex exec.
       return finish('worker-active', 0, {
         failure_class: null,
         live_sessions: vmSessionState.live.map((item) => ({

--- a/tools/struct-queue-pulse.test.mjs
+++ b/tools/struct-queue-pulse.test.mjs
@@ -452,7 +452,7 @@ describe('STRUCT queue pulse resumability', () => {
     expect(systemctlCalls.some((args) => args.includes('start'))).toBe(false)
   })
 
-  it('recognizes a normal codex exec process and never clears containment masks', () => {
+  it('does not serialize the repository behind an unrelated codex coordinator', () => {
     const { result, checkpoint, systemctlCalls } = runPulse({
       processArgs: [
         '/home/ubuntu/.local/bin/codex exec --model gpt-5.6-sol resume',
@@ -460,9 +460,13 @@ describe('STRUCT queue pulse resumability', () => {
     })
 
     expect(result.status).toBe(0)
-    expect(checkpoint.outcome).toBe('worker-active')
-    expect(systemctlCalls.some((args) => args.includes('start'))).toBe(false)
-    expect(systemctlCalls.some((args) => args.includes('unmask'))).toBe(false)
+    expect(checkpoint.outcome).toBe('dispatch-requested')
+    expect(systemctlCalls).toContainEqual([
+      '--user',
+      'start',
+      '--no-block',
+      'rucksack-autopilot-v1-ZXJuaWVzZy9lcm5pZXNn-drain.service',
+    ])
   })
 
   it('fails closed at high water and records the recovery action', () => {


### PR DESCRIPTION
Root cause: the STRUCT queue pulse treated any Codex exec process as an erniesg issue worker, so the unrelated Rucksack coordinator suppressed erniesg dispatch. The VM session ledger and exact issue tmux process are the authoritative worker signals; coordinators and reviewers must not serialize other repositories. This change removes the broad process-name guard and adds a regression test for independent dispatch. Validation: npx vitest run tools/struct-queue-pulse.test.mjs (18/18).