### PR TITLE
fix(deps): bump js-yaml past GHSA-5p4m-2wfm-xmqj to unblock CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9861,9 +9861,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11314,9 +11314,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Problem

`npm audit --audit-level=high` in the `checks` workflow started failing on **every** erniesg PR today, including one-line docs changes. This is a repo-wide CI outage, not a defect in any PR.

Advisory [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870, quadratic CPU consumption in `!!omap` resolution) was published against js-yaml `3.0.0 - 3.15.0 || 4.0.0 - 4.3.0`. `npm audit` queries the live advisory database, so a lockfile that was green yesterday turns red today with no commit in between.

Evidence it is pre-existing and unrelated to any diff:

- Reproduced on a clean checkout of `origin/main` (`cf0911e`) with zero source changes: `npm audit --audit-level=high` exits 1.
- PR #147 passed `checks` on 2026-08-06 (run 31091383064).
- PR #148, a one-line `docs/issues/*.md` change, failed `checks` on 2026-08-07 (run 31152783529).

## Fix

`npm audit fix` is a no-op here — it reports a fix is available but changes nothing, because the advisory notes the patch was not backported into the ranges npm considers.

Both affected trees are nonetheless fixable **within their existing semver ranges**, so no dependency declaration changes:

| tree | before | after | satisfies |
|---|---|---|---|
| `node_modules/js-yaml` | 4.3.0 | 4.3.1 | `^4.1.x` (astro, @astrojs/internal-helpers, @vivliostyle/vfm) |
| `node_modules/gray-matter/node_modules/js-yaml` | 3.15.0 | 3.15.1 | `^3.13.1` (gray-matter) |

Both target versions are exactly one patch above the advisory's upper bounds (`3.15.0` and `4.3.0`).

**Lockfile only.** `package.json` is untouched and no range is widened. The diff is 6 lines: two `version`/`resolved`/`integrity` triples.

## Verification

- `npm audit --audit-level=high` → `found 0 vulnerabilities`, exit 0
- `npm ci` from the updated lockfile → exit 0
- gray-matter parses frontmatter correctly on 3.15.1 (smoke test)
- `vitest run src/lib/i18n.test.ts` → 8/8 passed
- `vitest run tools/translation/ src/publication/` → 169/169 passed across 19 files

gray-matter is used in production source (`src/publication/adapters/astro.ts`) as well as tooling, so it was exercised deliberately rather than assumed safe.

## Note on the Cloudflare Pages check

`Cloudflare Pages` is also failing, on #147 and #148 alike. That is a separate pre-existing failure and is **not** addressed here; this PR only clears the `checks` job.


Closes #151
