### PR TITLE
fix: match automation head branches without the copied -rucksack suffix (#150)

### DIFF
--- a/.agent/merge-policy.yaml
+++ b/.agent/merge-policy.yaml
@@ -9,8 +9,8 @@ eligible:
     - main
     - staging
   head_branch_patterns:
-    - "codex/issue-*-rucksack"
-    - "claude/issue-*-rucksack"
+    - "codex/*"
+    - "claude/*"
     - "codex/*"
     - "claude/*"
     - "coordinator/*"


### PR DESCRIPTION
Fixes cause 2 of #150: `head_branch_patterns` in `.agent/merge-policy.yaml` were copied verbatim from `erniesg/rucksack`, `-rucksack` suffix included, so free-form automation branches (`claude/js-yaml-audit`, `coordinator/drain-unit-regen`) never matched and those PRs were ineligible for automated merge evaluation. This widens them to the same `codex/*` / `claude/*` globs rucksack itself uses. Eligibility only — required checks (`checks`, `evidence`, `secret-scan`), evidence gate, and linked-issue gate are unchanged.

Cause 1 (app 403 reading branch protection) is resolved separately: repository ruleset `main-required-checks` (id 20651369) now enforces the same required checks server-side, and the app can read rulesets, so `_required_status_checks_are_enforced` passes via its ruleset fallback without an App permission change.