### PR TITLE
chore: close out automerge authority fixes and dedupe head-branch globs

### DIFF
--- a/.agent/merge-policy.yaml
+++ b/.agent/merge-policy.yaml
@@ -11,8 +11,6 @@ eligible:
   head_branch_patterns:
     - "codex/*"
     - "claude/*"
-    - "codex/*"
-    - "claude/*"
     - "coordinator/*"
   automatic_path_patterns:
     - "docs/**"


### PR DESCRIPTION
Closes #150.

Both causes in #150 are now fixed and verified live; this PR lands the remaining policy cleanup and closes the issue.

## Cause 1 — app 403 reading branch protection: fixed via repository ruleset

Repository ruleset `main-required-checks` (id `20651369`, enforcement `active`, target `~DEFAULT_BRANCH`, `bypass_actors: []`) enforces the same required checks as the classic protection: `checks`, `evidence`, `secret-scan` with `strict_required_status_checks_policy: true`. The ruleset path is readable without the App `Administration: read` grant:

- `GET /repos/erniesg/erniesg/rules/branches/main` returns the `required_status_checks` rule (ruleset_id 20651369)
- `GET /repos/erniesg/erniesg/rulesets` returns the ruleset (no longer `[]`)

## Cause 2 — `-rucksack` head-branch suffix: fixed by #157/#152; this PR dedupes

#157 widened `head_branch_patterns` to `codex/*` / `claude/*` and #152 added `coordinator/*`, but the overlap left `codex/*` and `claude/*` listed twice. This PR removes the duplicate globs. Effective eligibility is unchanged: `codex/*`, `claude/*`, `coordinator/*`.

## End-to-end proof

PR #162 (docs-only, green, zero unresolved threads) merged through the guarded path with the exact refusal from #150 gone:

- `rucksack autopilot merge erniesg/erniesg --pr 162` → `decision: allowed` / `all merge policy gates passed`
- `--execute` squash-merged at exact head `96c3723` → merge commit `67eb5f60eb2a5c253b70f3be64bfa08a632bad2e`, verified ancestor of `origin/main`; linked issue #161 auto-closed.

`.agent/merge-policy.yaml` is a deploy path, so this PR itself takes the human-gated lane by design.
