### PR TITLE
fix(publication): repair post-merge Payload Lexical findings from PR #156

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ npm run build
 npm run preview
 ```
 
+### Publication build runtime
+
+`npm run publication:build` publishes its output matrix with an atomic
+directory swap that shells out to `python3` (for the `renameat2` /
+`renameatx_np` syscalls). Supported Linux and macOS hosts therefore need
+`python3` on `PATH`; the build verifies this before any adapter, staging, or
+rendering work and fails with a dependency error when it is missing.
+
 ### PDF → EPUB human-review feedback
 
 The 20-paper review queue always writes a versioned, hash-bound receipt to

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "pretest": "npm run srt:checkpoint-evidence && npm run srt:overlay-evidence",
-    "test": "vitest run --exclude 'tests/e2e/**'",
+    "test": "vitest run --exclude 'tests/e2e/**' --maxWorkers=1",
     "test:e2e": "playwright test",
     "build": "npm run build:production",
     "build:astro": "astro check && astro build",

--- a/src/publication/adapter-conformance.test.ts
+++ b/src/publication/adapter-conformance.test.ts
@@ -251,6 +251,51 @@ describe('publication source adapter conformance', () => {
     expect(canonicalRuns(left)).toEqual(canonicalRuns(right))
   })
 
+  it('folds adjacent equivalent runs even when an overlapping style separates them', () => {
+    const base = adaptPayloadLexical({
+      id: 'interleaved-inline-runs',
+      title: 'Interleaved inline runs',
+      content: {
+        root: {
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'abcd' }],
+            },
+          ],
+        },
+      },
+    }).graph
+    const withRuns = (runs: Array<Record<string, unknown>>) => {
+      const clone = structuredClone(base)
+      for (const node of clone.nodes)
+        if (node.type === 'paragraph')
+          node.inlineRuns = runs as typeof node.inlineRuns
+      return publicationGraphSchema.parse(clone)
+    }
+    const combined = withRuns([
+      { start: 0, end: 4, bold: true },
+      { start: 0, end: 4, italic: true },
+    ])
+    const segmented = withRuns([
+      { start: 0, end: 2, bold: true },
+      { start: 0, end: 4, italic: true },
+      { start: 2, end: 4, bold: true },
+    ])
+
+    expect(comparePublicationSemanticSubset(segmented, combined)).toBe(true)
+    expect(canonicalPublicationSubsetSha256(segmented)).toBe(
+      canonicalPublicationSubsetSha256(combined),
+    )
+    const paragraph = canonicalPublicationSubset(segmented).nodes.find(
+      (node) => node.type === 'paragraph',
+    )
+    expect(paragraph?.inlineRuns).toEqual([
+      { start: 0, end: 4, bold: true },
+      { start: 0, end: 4, italic: true },
+    ])
+  })
+
   it('preserves authored link boundaries through canonical serialization in every profile', () => {
     const canonical = canonicalPublicationSourceResult(
       adaptPayloadLexical({

--- a/src/publication/adapter-conformance.test.ts
+++ b/src/publication/adapter-conformance.test.ts
@@ -294,8 +294,8 @@ describe('publication source adapter conformance', () => {
       )
       return paragraph?.inlineRuns
     }
-    expect(canonicalRuns(superscriptFirst)).toEqual([superscript, subscript])
-    expect(canonicalRuns(subscriptFirst)).toEqual([subscript, superscript])
+    expect(canonicalRuns(superscriptFirst)).toEqual([superscript])
+    expect(canonicalRuns(subscriptFirst)).toEqual([subscript])
   })
 
   it('canonicalizes non-overlapping vertical-align runs independently of array order', () => {
@@ -345,6 +345,48 @@ describe('publication source adapter conformance', () => {
     expect(canonicalRuns(superscriptFirst)).toEqual(
       canonicalRuns(subscriptFirst),
     )
+  })
+
+  it('folds adjacent equivalent vertical-align runs', () => {
+    const base = adaptPayloadLexical({
+      id: 'adjacent-vertical-align-runs',
+      title: 'Adjacent vertical align runs',
+      content: {
+        root: {
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'ab' }],
+            },
+          ],
+        },
+      },
+    }).graph
+    const withRuns = (runs: Array<Record<string, unknown>>) => {
+      const clone = structuredClone(base)
+      for (const node of clone.nodes)
+        if (node.type === 'paragraph')
+          node.inlineRuns = runs as typeof node.inlineRuns
+      return publicationGraphSchema.parse(clone)
+    }
+    const combined = withRuns([
+      { start: 0, end: 2, verticalAlign: 'superscript' },
+    ])
+    const segmented = withRuns([
+      { start: 0, end: 1, verticalAlign: 'superscript' },
+      { start: 1, end: 2, verticalAlign: 'superscript' },
+    ])
+
+    expect(comparePublicationSemanticSubset(segmented, combined)).toBe(true)
+    expect(canonicalPublicationSubsetSha256(segmented)).toBe(
+      canonicalPublicationSubsetSha256(combined),
+    )
+    const paragraph = canonicalPublicationSubset(segmented).nodes.find(
+      (node) => node.type === 'paragraph',
+    )
+    expect(paragraph?.inlineRuns).toEqual([
+      { start: 0, end: 2, verticalAlign: 'superscript' },
+    ])
   })
 
   it('folds adjacent equivalent runs even when an overlapping style separates them', () => {

--- a/src/publication/adapter-conformance.test.ts
+++ b/src/publication/adapter-conformance.test.ts
@@ -298,6 +298,55 @@ describe('publication source adapter conformance', () => {
     expect(canonicalRuns(subscriptFirst)).toEqual([subscript, superscript])
   })
 
+  it('canonicalizes non-overlapping vertical-align runs independently of array order', () => {
+    const base = adaptPayloadLexical({
+      id: 'non-overlapping-vertical-align-runs',
+      title: 'Non-overlapping vertical align runs',
+      content: {
+        root: {
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'abcd' }],
+            },
+          ],
+        },
+      },
+    }).graph
+    const withRuns = (runs: Array<Record<string, unknown>>) => {
+      const clone = structuredClone(base)
+      for (const node of clone.nodes)
+        if (node.type === 'paragraph')
+          node.inlineRuns = runs as typeof node.inlineRuns
+      return publicationGraphSchema.parse(clone)
+    }
+    const superscript = {
+      start: 0,
+      end: 1,
+      verticalAlign: 'superscript',
+    }
+    const subscript = { start: 2, end: 3, verticalAlign: 'subscript' }
+    const superscriptFirst = withRuns([superscript, subscript])
+    const subscriptFirst = withRuns([subscript, superscript])
+
+    expect(
+      comparePublicationSemanticSubset(superscriptFirst, subscriptFirst),
+    ).toBe(true)
+    expect(canonicalPublicationSubsetSha256(superscriptFirst)).toBe(
+      canonicalPublicationSubsetSha256(subscriptFirst),
+    )
+    const canonicalRuns = (graph: typeof superscriptFirst) => {
+      const paragraph = canonicalPublicationSubset(graph).nodes.find(
+        (node) => node.type === 'paragraph',
+      )
+      return paragraph?.inlineRuns
+    }
+    expect(canonicalRuns(subscriptFirst)).toEqual([superscript, subscript])
+    expect(canonicalRuns(superscriptFirst)).toEqual(
+      canonicalRuns(subscriptFirst),
+    )
+  })
+
   it('folds adjacent equivalent runs even when an overlapping style separates them', () => {
     const base = adaptPayloadLexical({
       id: 'interleaved-inline-runs',

--- a/src/publication/adapter-conformance.test.ts
+++ b/src/publication/adapter-conformance.test.ts
@@ -251,6 +251,53 @@ describe('publication source adapter conformance', () => {
     expect(canonicalRuns(left)).toEqual(canonicalRuns(right))
   })
 
+  it('preserves authored order for overlapping vertical-align runs', () => {
+    const base = adaptPayloadLexical({
+      id: 'ordered-vertical-align-runs',
+      title: 'Ordered vertical align runs',
+      content: {
+        root: {
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'xy' }],
+            },
+          ],
+        },
+      },
+    }).graph
+    const withRuns = (runs: Array<Record<string, unknown>>) => {
+      const clone = structuredClone(base)
+      for (const node of clone.nodes)
+        if (node.type === 'paragraph')
+          node.inlineRuns = runs as typeof node.inlineRuns
+      return publicationGraphSchema.parse(clone)
+    }
+    const superscript = {
+      start: 0,
+      end: 2,
+      verticalAlign: 'superscript',
+    }
+    const subscript = { start: 0, end: 2, verticalAlign: 'subscript' }
+    const superscriptFirst = withRuns([superscript, subscript])
+    const subscriptFirst = withRuns([subscript, superscript])
+
+    expect(
+      comparePublicationSemanticSubset(superscriptFirst, subscriptFirst),
+    ).toBe(false)
+    expect(canonicalPublicationSubsetSha256(superscriptFirst)).not.toBe(
+      canonicalPublicationSubsetSha256(subscriptFirst),
+    )
+    const canonicalRuns = (graph: typeof superscriptFirst) => {
+      const paragraph = canonicalPublicationSubset(graph).nodes.find(
+        (node) => node.type === 'paragraph',
+      )
+      return paragraph?.inlineRuns
+    }
+    expect(canonicalRuns(superscriptFirst)).toEqual([superscript, subscript])
+    expect(canonicalRuns(subscriptFirst)).toEqual([subscript, superscript])
+  })
+
   it('folds adjacent equivalent runs even when an overlapping style separates them', () => {
     const base = adaptPayloadLexical({
       id: 'interleaved-inline-runs',

--- a/src/publication/adapter-conformance.test.ts
+++ b/src/publication/adapter-conformance.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   canonicalPublicationGraph,
   canonicalPublicationSourceResult,
+  canonicalPublicationSubset,
   canonicalPublicationSubsetSha256,
   comparePublicationOutputReceipts,
   comparePublicationSemanticSubset,
@@ -207,6 +208,47 @@ describe('publication source adapter conformance', () => {
       type: 'paragraph',
       inlineRuns: [{ start: 0, end: 2, bold: true }],
     })
+  })
+
+  it('canonicalizes overlapping inline runs independently of array order', () => {
+    const base = adaptPayloadLexical({
+      id: 'ordered-inline-runs',
+      title: 'Ordered inline runs',
+      content: {
+        root: {
+          children: [
+            {
+              type: 'paragraph',
+              children: [{ type: 'text', text: 'abcdef' }],
+            },
+          ],
+        },
+      },
+    }).graph
+    const withRuns = (runs: Array<Record<string, unknown>>) => {
+      const clone = structuredClone(base)
+      for (const node of clone.nodes)
+        if (node.type === 'paragraph')
+          node.inlineRuns = runs as typeof node.inlineRuns
+      return publicationGraphSchema.parse(clone)
+    }
+    const bold = { start: 0, end: 4, bold: true }
+    const italic = { start: 2, end: 6, italic: true }
+    const left = withRuns([bold, italic])
+    const right = withRuns([italic, bold])
+
+    expect(comparePublicationSemanticSubset(left, right)).toBe(true)
+    expect(canonicalPublicationSubsetSha256(left)).toBe(
+      canonicalPublicationSubsetSha256(right),
+    )
+    const canonicalRuns = (graph: typeof left) => {
+      const paragraph = canonicalPublicationSubset(graph).nodes.find(
+        (node) => node.type === 'paragraph',
+      )
+      return paragraph?.inlineRuns
+    }
+    expect(canonicalRuns(right)).toEqual([bold, italic])
+    expect(canonicalRuns(left)).toEqual(canonicalRuns(right))
   })
 
   it('preserves authored link boundaries through canonical serialization in every profile', () => {

--- a/src/publication/adapter-conformance.ts
+++ b/src/publication/adapter-conformance.ts
@@ -113,19 +113,35 @@ function canonicalInlineRunProducesLink(run: Record<string, unknown>) {
   )
 }
 
+function canonicalInlineRunSemantics(run: Record<string, unknown>) {
+  const { start: _start, end: _end, ...semantics } = run
+  return semantics
+}
+
 function canonicalInlineRuns(
   runs: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
+  // The renderer evaluates active styles by range, so equivalent graphs may
+  // store the same effective intervals in different array orders. Sort by
+  // effective interval and stable semantics before adjacency folding so the
+  // canonical subset never depends on source array order, while links, hard
+  // breaks, and relationship anchors keep their authored boundaries.
+  const ordered = [...runs].sort((left, right) => {
+    const startOrder = Number(left.start) - Number(right.start)
+    if (startOrder) return startOrder
+    const endOrder = Number(left.end) - Number(right.end)
+    if (endOrder) return endOrder
+    return codeUnitCompare(
+      stableJson(canonicalInlineRunSemantics(left)),
+      stableJson(canonicalInlineRunSemantics(right)),
+    )
+  })
   const result: Array<Record<string, unknown>> = []
-  for (const run of runs) {
+  for (const run of ordered) {
     const previous = result.at(-1)
-    const { start: _start, end: _end, ...semantics } = run
+    const semantics = canonicalInlineRunSemantics(run)
     const previousSemantics = previous
-      ? Object.fromEntries(
-          Object.entries(previous).filter(
-            ([key]) => key !== 'start' && key !== 'end',
-          ),
-        )
+      ? canonicalInlineRunSemantics(previous)
       : undefined
     if (
       previous &&

--- a/src/publication/adapter-conformance.ts
+++ b/src/publication/adapter-conformance.ts
@@ -135,37 +135,28 @@ function canonicalInlineRunOrder(
 function canonicalVerticalAlignRuns(
   runs: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
-  const entries = runs.map((run, index) => ({ run: { ...run }, index }))
-  const successors = entries.map(() => [] as number[])
-  const indegree = entries.map(() => 0)
-  for (let left = 0; left < entries.length; left += 1) {
-    for (let right = left + 1; right < entries.length; right += 1) {
-      const leftRun = entries[left].run
-      const rightRun = entries[right].run
-      const overlaps =
-        Number(leftRun.start) < Number(rightRun.end) &&
-        Number(rightRun.start) < Number(leftRun.end)
-      if (!overlaps || leftRun.verticalAlign === rightRun.verticalAlign) continue
-      // The renderer selects the first active vertical-align run, so authored
-      // order is a semantic constraint only for overlapping, competing runs.
-      successors[left].push(right)
-      indegree[right] += 1
-    }
-  }
-
-  const ready = entries.filter(({ index }) => indegree[index] === 0)
+  const boundaries = [
+    ...new Set(
+      runs.flatMap((run) => [Number(run.start), Number(run.end)]),
+    ),
+  ].sort((left, right) => left - right)
   const result: Array<Record<string, unknown>> = []
-  while (ready.length) {
-    ready.sort(
-      (left, right) =>
-        canonicalInlineRunOrder(left.run, right.run) || left.index - right.index,
+  for (let index = 0; index < boundaries.length - 1; index += 1) {
+    const start = boundaries[index]
+    const end = boundaries[index + 1]
+    const active = runs.find(
+      (run) => Number(run.start) <= start && Number(run.end) >= end,
     )
-    const next = ready.shift()!
-    result.push(next.run)
-    for (const successor of successors[next.index]) {
-      indegree[successor] -= 1
-      if (indegree[successor] === 0) ready.push(entries[successor])
+    if (!active) continue
+    const previous = result.at(-1)
+    if (
+      previous?.end === start &&
+      previous.verticalAlign === active.verticalAlign
+    ) {
+      previous.end = end
+      continue
     }
+    result.push({ start, end, verticalAlign: active.verticalAlign })
   }
   return result
 }
@@ -178,13 +169,22 @@ function canonicalInlineRuns(
   // order-independent semantics before adjacency folding so an overlapping
   // style cannot split a mergeable run, then restore interval order for
   // deterministic output. The renderer selects the first active vertical-
-  // align run, so only overlapping runs with competing values retain their
-  // authored order; other vertical-align runs canonicalize by interval.
+  // align run. Canonicalize that effective rendered value at each interval,
+  // folding adjacent equal intervals while retaining the first-active winner
+  // where authored overlapping runs compete. Other semantics carried by a
+  // vertical-align run remain in the order-independent stream below.
   // Links, hard breaks, and relationship anchors keep authored boundaries.
   const orderDependent = canonicalVerticalAlignRuns(
     runs.filter((run) => Boolean(run.verticalAlign)),
   )
-  const ordered = runs.filter((run) => !run.verticalAlign).sort((left, right) => {
+  const orderIndependentRuns = runs.flatMap((run) => {
+    if (!run.verticalAlign) return [run]
+    const { verticalAlign: _verticalAlign, ...independent } = run
+    return Object.keys(canonicalInlineRunSemantics(independent)).length
+      ? [independent]
+      : []
+  })
+  const ordered = orderIndependentRuns.sort((left, right) => {
     const semanticOrder = codeUnitCompare(
       stableJson(canonicalInlineRunSemantics(left)),
       stableJson(canonicalInlineRunSemantics(right)),

--- a/src/publication/adapter-conformance.ts
+++ b/src/publication/adapter-conformance.ts
@@ -118,6 +118,58 @@ function canonicalInlineRunSemantics(run: Record<string, unknown>) {
   return semantics
 }
 
+function canonicalInlineRunOrder(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+) {
+  const startOrder = Number(left.start) - Number(right.start)
+  if (startOrder) return startOrder
+  const endOrder = Number(left.end) - Number(right.end)
+  if (endOrder) return endOrder
+  return codeUnitCompare(
+    stableJson(canonicalInlineRunSemantics(left)),
+    stableJson(canonicalInlineRunSemantics(right)),
+  )
+}
+
+function canonicalVerticalAlignRuns(
+  runs: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const entries = runs.map((run, index) => ({ run: { ...run }, index }))
+  const successors = entries.map(() => [] as number[])
+  const indegree = entries.map(() => 0)
+  for (let left = 0; left < entries.length; left += 1) {
+    for (let right = left + 1; right < entries.length; right += 1) {
+      const leftRun = entries[left].run
+      const rightRun = entries[right].run
+      const overlaps =
+        Number(leftRun.start) < Number(rightRun.end) &&
+        Number(rightRun.start) < Number(leftRun.end)
+      if (!overlaps || leftRun.verticalAlign === rightRun.verticalAlign) continue
+      // The renderer selects the first active vertical-align run, so authored
+      // order is a semantic constraint only for overlapping, competing runs.
+      successors[left].push(right)
+      indegree[right] += 1
+    }
+  }
+
+  const ready = entries.filter(({ index }) => indegree[index] === 0)
+  const result: Array<Record<string, unknown>> = []
+  while (ready.length) {
+    ready.sort(
+      (left, right) =>
+        canonicalInlineRunOrder(left.run, right.run) || left.index - right.index,
+    )
+    const next = ready.shift()!
+    result.push(next.run)
+    for (const successor of successors[next.index]) {
+      indegree[successor] -= 1
+      if (indegree[successor] === 0) ready.push(entries[successor])
+    }
+  }
+  return result
+}
+
 function canonicalInlineRuns(
   runs: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
@@ -126,11 +178,12 @@ function canonicalInlineRuns(
   // order-independent semantics before adjacency folding so an overlapping
   // style cannot split a mergeable run, then restore interval order for
   // deterministic output. The renderer selects the first active vertical-
-  // align run, so those runs remain in authored order and are never folded.
+  // align run, so only overlapping runs with competing values retain their
+  // authored order; other vertical-align runs canonicalize by interval.
   // Links, hard breaks, and relationship anchors keep authored boundaries.
-  const orderDependent = runs
-    .filter((run) => Boolean(run.verticalAlign))
-    .map((run) => ({ ...run }))
+  const orderDependent = canonicalVerticalAlignRuns(
+    runs.filter((run) => Boolean(run.verticalAlign)),
+  )
   const ordered = runs.filter((run) => !run.verticalAlign).sort((left, right) => {
     const semanticOrder = codeUnitCompare(
       stableJson(canonicalInlineRunSemantics(left)),
@@ -162,16 +215,7 @@ function canonicalInlineRuns(
     }
     result.push({ ...run })
   }
-  const orderIndependent = result.sort((left, right) => {
-    const startOrder = Number(left.start) - Number(right.start)
-    if (startOrder) return startOrder
-    const endOrder = Number(left.end) - Number(right.end)
-    if (endOrder) return endOrder
-    return codeUnitCompare(
-      stableJson(canonicalInlineRunSemantics(left)),
-      stableJson(canonicalInlineRunSemantics(right)),
-    )
-  })
+  const orderIndependent = result.sort(canonicalInlineRunOrder)
   return [...orderIndependent, ...orderDependent]
 }
 

--- a/src/publication/adapter-conformance.ts
+++ b/src/publication/adapter-conformance.ts
@@ -122,19 +122,19 @@ function canonicalInlineRuns(
   runs: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
   // The renderer evaluates active styles by range, so equivalent graphs may
-  // store the same effective intervals in different array orders. Sort by
-  // effective interval and stable semantics before adjacency folding so the
-  // canonical subset never depends on source array order, while links, hard
-  // breaks, and relationship anchors keep their authored boundaries.
+  // store the same effective intervals in different array orders. Group equal
+  // semantics before adjacency folding so an overlapping style cannot split
+  // a mergeable run, then restore interval order for deterministic output.
+  // Links, hard breaks, and relationship anchors keep authored boundaries.
   const ordered = [...runs].sort((left, right) => {
-    const startOrder = Number(left.start) - Number(right.start)
-    if (startOrder) return startOrder
-    const endOrder = Number(left.end) - Number(right.end)
-    if (endOrder) return endOrder
-    return codeUnitCompare(
+    const semanticOrder = codeUnitCompare(
       stableJson(canonicalInlineRunSemantics(left)),
       stableJson(canonicalInlineRunSemantics(right)),
     )
+    if (semanticOrder) return semanticOrder
+    const startOrder = Number(left.start) - Number(right.start)
+    if (startOrder) return startOrder
+    return Number(left.end) - Number(right.end)
   })
   const result: Array<Record<string, unknown>> = []
   for (const run of ordered) {
@@ -157,7 +157,16 @@ function canonicalInlineRuns(
     }
     result.push({ ...run })
   }
-  return result
+  return result.sort((left, right) => {
+    const startOrder = Number(left.start) - Number(right.start)
+    if (startOrder) return startOrder
+    const endOrder = Number(left.end) - Number(right.end)
+    if (endOrder) return endOrder
+    return codeUnitCompare(
+      stableJson(canonicalInlineRunSemantics(left)),
+      stableJson(canonicalInlineRunSemantics(right)),
+    )
+  })
 }
 
 /**

--- a/src/publication/adapter-conformance.ts
+++ b/src/publication/adapter-conformance.ts
@@ -122,11 +122,16 @@ function canonicalInlineRuns(
   runs: Array<Record<string, unknown>>,
 ): Array<Record<string, unknown>> {
   // The renderer evaluates active styles by range, so equivalent graphs may
-  // store the same effective intervals in different array orders. Group equal
-  // semantics before adjacency folding so an overlapping style cannot split
-  // a mergeable run, then restore interval order for deterministic output.
+  // store the same effective intervals in different array orders. Group
+  // order-independent semantics before adjacency folding so an overlapping
+  // style cannot split a mergeable run, then restore interval order for
+  // deterministic output. The renderer selects the first active vertical-
+  // align run, so those runs remain in authored order and are never folded.
   // Links, hard breaks, and relationship anchors keep authored boundaries.
-  const ordered = [...runs].sort((left, right) => {
+  const orderDependent = runs
+    .filter((run) => Boolean(run.verticalAlign))
+    .map((run) => ({ ...run }))
+  const ordered = runs.filter((run) => !run.verticalAlign).sort((left, right) => {
     const semanticOrder = codeUnitCompare(
       stableJson(canonicalInlineRunSemantics(left)),
       stableJson(canonicalInlineRunSemantics(right)),
@@ -157,7 +162,7 @@ function canonicalInlineRuns(
     }
     result.push({ ...run })
   }
-  return result.sort((left, right) => {
+  const orderIndependent = result.sort((left, right) => {
     const startOrder = Number(left.start) - Number(right.start)
     if (startOrder) return startOrder
     const endOrder = Number(left.end) - Number(right.end)
@@ -167,6 +172,7 @@ function canonicalInlineRuns(
       stableJson(canonicalInlineRunSemantics(right)),
     )
   })
+  return [...orderIndependent, ...orderDependent]
 }
 
 /**

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -1651,6 +1651,29 @@ describe('Payload Lexical publication adapter', () => {
     }
   })
 
+  it('canonicalizes value and target upload references to the indexed map id', () => {
+    const uploads = {
+      pic: {
+        mimeType: 'image/png',
+        data: 'AQIDBA==',
+        alt: 'Mapped picture',
+      },
+    }
+
+    for (const value of [{ value: 'pic' }, { target: 'pic' }]) {
+      const result = adaptPayloadLexical(
+        strictFixture([{ type: 'upload', value }], { uploads }),
+      )
+      expect(result.diagnostics).toEqual([])
+      expect(result.assetBundle.descriptor.assets).toHaveLength(1)
+      expect(result.graph.nodes[0]).toMatchObject({
+        type: 'figure',
+        assetIds: [expect.any(String)],
+        accessibility: { alternativeText: 'Mapped picture' },
+      })
+    }
+  })
+
   it('rejects direct media types that conflict with indexed filename inference', () => {
     expect(() =>
       adaptPayloadLexical(

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -855,7 +855,7 @@ describe('Payload Lexical publication adapter', () => {
           },
         },
       ),
-    ).toThrow(/Payload relationship target a b is not a graph-safe id.*children\[0\]/)
+    ).toThrow(/Payload relationship target \(sha256:[0-9a-f]{16}\) is not a graph-safe id.*children\[0\]/)
     expect(() =>
       adaptPayloadLexical({
         id: 'interleaved-nested-list',
@@ -1628,6 +1628,38 @@ describe('Payload Lexical publication adapter', () => {
         ]),
       ),
     ).toThrow(/Payload relationship is missing target.*children\[0\]\.children\[0\]/)
+  })
+
+  it('redacts unsafe relationship targets from thrown diagnostics', () => {
+    const sentinel = 'unsafe-target?credential=redact-me'
+    const message = capturedError(() =>
+      adaptPayloadLexical(
+        {
+          id: 'unsafe-relationship-target',
+          title: 'Unsafe relationship target',
+          content: {
+            root: {
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    { type: 'citation', value: sentinel, label: 'Sentinel' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        { relationships: { citation: { role: 'citation' } } },
+      ),
+    )
+    expect(message).toMatch(
+      /Payload relationship target \(sha256:[0-9a-f]{16}\) is not a graph-safe id.*children\[0\]\.children\[0\]/,
+    )
+    expect(message).not.toContain(sentinel)
+    expect(message).not.toContain('credential')
+    expect(message).not.toContain('redact-me')
+    expect(message).not.toContain('unsafe-target')
   })
 
   it('requires typed metadata, roots, prose fields, and supported mark combinations', () => {

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -324,6 +324,31 @@ describe('Payload Lexical publication adapter', () => {
     })
   })
 
+  it('accepts redundant author name fields whose trimmed values agree', () => {
+    const body = [
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Author body' }],
+      },
+    ]
+    const agreed = adaptPayloadLexical(
+      strictFixture(body, {
+        authors: [{ name: 'Ada', displayName: ' Ada ', fullName: 'Ada' }],
+      }),
+    )
+    expect(agreed.graph.metadata.contributors).toEqual(['Ada'])
+    for (const conflicting of [
+      { name: 'Ada', displayName: 'Grace' },
+      { name: 'Ada', fullName: 'Ada', displayName: '   ' },
+      { name: 'Ada', fullName: 42 },
+      { displayName: '' },
+    ]) {
+      expect(() =>
+        adaptPayloadLexical(strictFixture(body, { authors: [conflicting] })),
+      ).toThrow(/Payload author must be a non-empty string or named author object at authors\[0\]/)
+    }
+  })
+
   it('preserves quote attribution', () => {
     const result = adaptPayloadLexical({
       id: 'attributed-quote',

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -1514,6 +1514,96 @@ describe('Payload Lexical publication adapter', () => {
     })
   })
 
+  it('resolves object upload references through the indexed uploads', () => {
+    const uploads = {
+      pic: {
+        filename: 'pic.png',
+        mimeType: 'image/png',
+        data: 'AQIDBA==',
+        alt: 'Mapped picture',
+        width: 24,
+        height: 24,
+      },
+    }
+    const scalar = adaptPayloadLexical(
+      strictFixture([{ type: 'upload', value: 'pic' }], { uploads }),
+    )
+    const objectReference = adaptPayloadLexical(
+      strictFixture([{ type: 'upload', value: { id: 'pic' } }], { uploads }),
+    )
+    expect(objectReference.diagnostics).toEqual([])
+    expect(objectReference.assetBundle.descriptor.assets).toHaveLength(1)
+    expect(objectReference.assetBundle.descriptor.assets).toEqual(
+      scalar.assetBundle.descriptor.assets,
+    )
+    const scalarFigure = scalar.graph.nodes[0]
+    const objectFigure = objectReference.graph.nodes[0]
+    expect(objectFigure).toMatchObject({
+      type: 'figure',
+      accessibility: { alternativeText: 'Mapped picture' },
+    })
+    expect('assetIds' in objectFigure ? objectFigure.assetIds : []).toEqual(
+      'assetIds' in scalarFigure ? scalarFigure.assetIds : undefined,
+    )
+
+    const overridden = adaptPayloadLexical(
+      strictFixture(
+        [{ type: 'upload', value: { id: 'pic', alt: 'Object alternative' } }],
+        { uploads },
+      ),
+    )
+    expect(overridden.graph.nodes[0]).toMatchObject({
+      type: 'figure',
+      accessibility: { alternativeText: 'Object alternative' },
+    })
+
+    for (const conflicting of [
+      { id: 'pic', mimeType: 'image/jpeg' },
+      { id: 'pic', width: 48 },
+      { id: 'pic', _id: 'other' },
+      { id: 'pic', data: 'BQYHCA==' },
+    ]) {
+      expect(() =>
+        adaptPayloadLexical(
+          strictFixture([{ type: 'upload', value: conflicting }], { uploads }),
+        ),
+      ).toThrow(
+        /Payload upload reference (?:identity conflicts with|disagrees with) indexed upload pic.*children\[0\]/,
+      )
+    }
+
+    expect(() =>
+      adaptPayloadLexical({
+        document: {
+          id: 'localized-object-upload',
+          title: 'English title',
+          locale: 'en',
+          uploads: [
+            {
+              id: 'pic',
+              filename: 'pic.png',
+              mimeType: 'image/png',
+              data: 'AQIDBA==',
+              alt: 'English alternative',
+            },
+          ],
+          content: {
+            root: { children: [{ type: 'upload', value: { id: 'pic' } }] },
+          },
+          localeVariants: {
+            fr: {
+              title: 'Titre français',
+              content: {
+                root: { children: [{ type: 'upload', value: { id: 'pic' } }] },
+              },
+            },
+          },
+        },
+        locale: 'fr',
+      }),
+    ).toThrow(/Payload locale fr upload pic is missing localized alternative text.*children\[0\]/)
+  })
+
   it('fails closed for table and relationship semantics the graph cannot preserve', () => {
     const tableDocument = (cell: Record<string, unknown>) =>
       strictFixture([

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -1568,7 +1568,7 @@ describe('Payload Lexical publication adapter', () => {
           strictFixture([{ type: 'upload', value: conflicting }], { uploads }),
         ),
       ).toThrow(
-        /Payload upload reference (?:identity conflicts with|disagrees with) indexed upload \(sha256:[a-f0-9]{16}\).*children\[0\]/,
+        /Payload upload reference (?:identity aliases conflict|(?:identity conflicts with|disagrees with) indexed upload \(sha256:[a-f0-9]{16}\)).*children\[0\]/,
       )
     }
 
@@ -1647,8 +1647,32 @@ describe('Payload Lexical publication adapter', () => {
         adaptPayloadLexical(
           strictFixture([{ type: 'upload', value }], { uploads }),
         ),
-      ).toThrow(/Payload upload reference identity conflicts with indexed upload/)
+      ).toThrow(/Payload upload reference identity (?:aliases conflict|conflicts with indexed upload)/)
     }
+  })
+
+  it('validates conflicting upload aliases before selecting an indexed record', () => {
+    expect(() =>
+      adaptPayloadLexical(
+        strictFixture(
+          [
+            {
+              type: 'upload',
+              value: { id: 'not-indexed', value: 'pic' },
+            },
+          ],
+          {
+            uploads: {
+              pic: {
+                mimeType: 'image/png',
+                data: 'AQIDBA==',
+                alt: 'Mapped picture',
+              },
+            },
+          },
+        ),
+      ),
+    ).toThrow(/Payload upload reference identity aliases conflict.*children\[0\]/)
   })
 
   it('canonicalizes value and target upload references to the indexed map id', () => {
@@ -2439,6 +2463,26 @@ describe('Payload Lexical publication adapter', () => {
     )
     expect(result.graph.nodes.map((node) => node.type)).toEqual(['aside', 'table', 'reference', 'reference'])
     expect(result.graph.nodes.find((node) => node.type === 'reference')).toMatchObject({ href: '#target-1' })
+  })
+
+  it('keeps upload-only key aliases out of relationship target resolution', () => {
+    const result = adaptPayloadLexical(
+      strictFixture([
+        {
+          type: 'citation',
+          value: { key: 'lexical-key', value: 'target-1' },
+          label: 'A citation',
+        },
+      ]),
+      { relationships: { citation: { role: 'cross-reference' } } },
+    )
+
+    expect(result.graph.nodes.find((node) => node.type === 'reference')).toMatchObject({
+      href: '#target-1',
+    })
+    expect(result.graph.nodes.some((node) => node.id === 'lexical-key')).toBe(
+      false,
+    )
   })
 
   it('maps Payload LinkFeature document targets before requiring an external URL', () => {

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -1568,7 +1568,7 @@ describe('Payload Lexical publication adapter', () => {
           strictFixture([{ type: 'upload', value: conflicting }], { uploads }),
         ),
       ).toThrow(
-        /Payload upload reference (?:identity conflicts with|disagrees with) indexed upload pic.*children\[0\]/,
+        /Payload upload reference (?:identity conflicts with|disagrees with) indexed upload \(sha256:[a-f0-9]{16}\).*children\[0\]/,
       )
     }
 
@@ -1602,6 +1602,72 @@ describe('Payload Lexical publication adapter', () => {
         locale: 'fr',
       }),
     ).toThrow(/Payload locale fr upload pic is missing localized alternative text.*children\[0\]/)
+  })
+
+  it('redacts indexed upload ids from object-reference conflict errors', () => {
+    const unsafeId = 'https://uploads.example/pic?credential=redact-me'
+    let failure: unknown
+    try {
+      adaptPayloadLexical(
+        strictFixture([{ type: 'upload', value: { id: unsafeId, width: 48 } }], {
+          uploads: {
+            [unsafeId]: {
+              filename: 'pic.png',
+              mimeType: 'image/png',
+              data: 'AQIDBA==',
+              width: 24,
+            },
+          },
+        }),
+      )
+    } catch (error) {
+      failure = error
+    }
+
+    expect(failure).toBeInstanceOf(Error)
+    expect(String(failure)).not.toContain(unsafeId)
+    expect(String(failure)).not.toContain('credential=redact-me')
+    expect(String(failure)).toMatch(/indexed upload \(sha256:[a-f0-9]{16}\)/)
+  })
+
+  it('rejects conflicts across value and target upload id aliases', () => {
+    const uploads = {
+      pic: {
+        filename: 'pic.png',
+        mimeType: 'image/png',
+        data: 'AQIDBA==',
+      },
+    }
+
+    for (const value of [
+      { id: 'pic', value: 'other' },
+      { value: 'pic', target: 'other' },
+    ]) {
+      expect(() =>
+        adaptPayloadLexical(
+          strictFixture([{ type: 'upload', value }], { uploads }),
+        ),
+      ).toThrow(/Payload upload reference identity conflicts with indexed upload/)
+    }
+  })
+
+  it('rejects direct media types that conflict with indexed filename inference', () => {
+    expect(() =>
+      adaptPayloadLexical(
+        strictFixture(
+          [{ type: 'upload', value: { id: 'pic', mimeType: 'image/jpeg' } }],
+          {
+            uploads: {
+              pic: {
+                filename: 'pic.png',
+                data: 'AQIDBA==',
+                alt: 'Mapped picture',
+              },
+            },
+          },
+        ),
+      ),
+    ).toThrow(/disagrees with indexed upload .* on media type/)
   })
 
   it('fails closed for table and relationship semantics the graph cannot preserve', () => {

--- a/src/publication/adapters/payload-lexical.test.ts
+++ b/src/publication/adapters/payload-lexical.test.ts
@@ -1674,6 +1674,28 @@ describe('Payload Lexical publication adapter', () => {
     }
   })
 
+  it('resolves key upload references through the indexed map id', () => {
+    const result = adaptPayloadLexical(
+      strictFixture([{ type: 'upload', value: { key: 'pic' } }], {
+        uploads: {
+          pic: {
+            mimeType: 'image/png',
+            data: 'AQIDBA==',
+            alt: 'Mapped picture',
+          },
+        },
+      }),
+    )
+
+    expect(result.diagnostics).toEqual([])
+    expect(result.assetBundle.descriptor.assets).toHaveLength(1)
+    expect(result.graph.nodes[0]).toMatchObject({
+      type: 'figure',
+      assetIds: [expect.any(String)],
+      accessibility: { alternativeText: 'Mapped picture' },
+    })
+  })
+
   it('rejects direct media types that conflict with indexed filename inference', () => {
     expect(() =>
       adaptPayloadLexical(
@@ -1691,6 +1713,28 @@ describe('Payload Lexical publication adapter', () => {
         ),
       ),
     ).toThrow(/disagrees with indexed upload .* on media type/)
+  })
+
+  it('allows unknown filename extensions to inherit an indexed media type', () => {
+    const result = adaptPayloadLexical(
+      strictFixture(
+        [{ type: 'upload', value: { id: 'pic', filename: 'hero' } }],
+        {
+          uploads: {
+            pic: {
+              mimeType: 'image/png',
+              data: 'AQIDBA==',
+              alt: 'Mapped picture',
+            },
+          },
+        },
+      ),
+    )
+
+    expect(result.diagnostics).toEqual([])
+    expect(result.assetBundle.descriptor.assets).toMatchObject([
+      { mediaType: 'image/png' },
+    ])
   })
 
   it('fails closed for table and relationship semantics the graph cannot preserve', () => {

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -229,7 +229,14 @@ function contributorName(value: unknown, location: string) {
   if (typeof value === 'string' && value.trim()) return value.trim()
   if (isObject(value)) {
     const candidates = ['name', 'fullName', 'displayName'].filter((key) => value[key] !== undefined).map((key) => value[key])
-    if (candidates.length === 1 && typeof candidates[0] === 'string' && candidates[0].trim()) return candidates[0].trim()
+    // Payload collections commonly retain redundant canonical and display
+    // name fields; accept them only when every populated value agrees after
+    // trimming, and keep rejecting conflicts, empty values, and non-strings.
+    const names = new Set(candidates.map((candidate) => (typeof candidate === 'string' ? candidate.trim() : undefined)))
+    if (candidates.length && names.size === 1) {
+      const [name] = names
+      if (name) return name
+    }
   }
   throw new Error(`Payload author must be a non-empty string or named author object at ${location}`)
 }

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -598,10 +598,32 @@ function lexicalRoot(value: unknown): LexicalNode[] {
 function relationId(value: unknown): string | undefined {
   if (typeof value === 'string' || typeof value === 'number') return String(value)
   if (isObject(value)) {
-    const id = value.id ?? value._id ?? value.key ?? value.value ?? value.target
+    const id = value.id ?? value._id ?? value.value ?? value.target
     return typeof id === 'string' || typeof id === 'number' ? String(id) : undefined
   }
   return undefined
+}
+
+const UPLOAD_REFERENCE_ID_ALIASES = [
+  'id',
+  '_id',
+  'key',
+  'value',
+  'target',
+] as const
+
+function uploadReferenceId(value: unknown, location: string): string | undefined {
+  if (!isObject(value)) return relationId(value)
+  const ids = UPLOAD_REFERENCE_ID_ALIASES.flatMap((key) => {
+    const candidate = value[key]
+    if (candidate === undefined) return []
+    if (typeof candidate !== 'string' && typeof candidate !== 'number')
+      throw new Error(`Payload upload reference has invalid ${key} identity at ${location}`)
+    return [String(candidate)]
+  })
+  if (new Set(ids).size > 1)
+    throw new Error(`Payload upload reference identity aliases conflict at ${location}`)
+  return ids[0]
 }
 
 function graphSafeRelationshipTarget(target: string, location: string) {
@@ -996,7 +1018,7 @@ function rawUploadValue(node: LexicalNode) {
 // ways. When the reference declares any spelling of a family, the indexed
 // spellings are dropped so the reference value deterministically wins.
 const UPLOAD_REFERENCE_FIELD_GROUPS: readonly (readonly string[])[] = [
-  ['id', '_id', 'key', 'value', 'target'],
+  UPLOAD_REFERENCE_ID_ALIASES,
   ['mimeType', 'mimetype', 'mediaType'],
   ['focalPoint', 'focalX', 'focalY'],
   ['bytes', 'data', 'buffer', 'base64'],
@@ -1037,7 +1059,7 @@ function uploadReferenceConflicts(raw: JsonObject, indexed: JsonObject, location
  */
 function mergedUploadReference(raw: JsonObject, id: string, indexed: JsonObject, location: string): JsonObject {
   const indexedUpload = `(sha256:${digest(id).slice(0, 16)})`
-  for (const key of ['id', '_id', 'key', 'value', 'target']) {
+  for (const key of UPLOAD_REFERENCE_ID_ALIASES) {
     const value = raw[key]
     if (value === undefined) continue
     if ((typeof value !== 'string' && typeof value !== 'number') || String(value) !== id)
@@ -1054,7 +1076,8 @@ function mergedUploadReference(raw: JsonObject, id: string, indexed: JsonObject,
 
 function uploadFor(state: AdapterState, node: LexicalNode, path: string): JsonObject | undefined {
   const raw = rawUploadValue(node)
-  const id = relationId(raw)
+  const location = sourceLocation(state.sourceId, path)
+  const id = uploadReferenceId(raw, location)
   const indexed = id ? state.uploads.get(id) : undefined
   const localized =
     indexed && state.variantUploadIds !== undefined && !state.variantUploadIds.has(String(id))
@@ -1062,7 +1085,7 @@ function uploadFor(state: AdapterState, node: LexicalNode, path: string): JsonOb
       : indexed
   if (isObject(raw)) {
     if (!localized || !id) return raw
-    return mergedUploadReference(raw, id, localized, sourceLocation(state.sourceId, path))
+    return mergedUploadReference(raw, id, localized, location)
   }
   return localized
 }

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -349,12 +349,7 @@ function decodeBytes(value: unknown, path: string): Uint8Array | undefined {
     : undefined
 }
 
-function mediaTypeFor(upload: JsonObject, location: string): string {
-  const direct = upload.mimeType ?? upload.mimetype ?? upload.mediaType
-  if (direct !== undefined) {
-    if (typeof direct !== 'string' || !/^[A-Za-z0-9.+-]+\/[A-Za-z0-9.+-]+$/u.test(direct)) throw new Error(`Payload upload has invalid media type at ${location}`)
-    return direct.toLowerCase()
-  }
+function inferredFilenameMediaType(upload: JsonObject, location: string): string | undefined {
   const rawFilename = upload.filename ?? upload.fileName ?? upload.name
   if (rawFilename !== undefined && typeof rawFilename !== 'string') throw new Error(`Payload upload filename must be a string at ${location}`)
   const filename = rawFilename ?? ''
@@ -371,7 +366,16 @@ function mediaTypeFor(upload: JsonObject, location: string): string {
     mp4: 'video/mp4',
     pdf: 'application/pdf',
   }
-  return (extension && types[extension]) || 'application/octet-stream'
+  return extension ? types[extension] : undefined
+}
+
+function mediaTypeFor(upload: JsonObject, location: string): string {
+  const direct = upload.mimeType ?? upload.mimetype ?? upload.mediaType
+  if (direct !== undefined) {
+    if (typeof direct !== 'string' || !/^[A-Za-z0-9.+-]+\/[A-Za-z0-9.+-]+$/u.test(direct)) throw new Error(`Payload upload has invalid media type at ${location}`)
+    return direct.toLowerCase()
+  }
+  return inferredFilenameMediaType(upload, location) ?? 'application/octet-stream'
 }
 
 function optionalUploadDimension(value: unknown, field: string, location: string) {
@@ -594,7 +598,7 @@ function lexicalRoot(value: unknown): LexicalNode[] {
 function relationId(value: unknown): string | undefined {
   if (typeof value === 'string' || typeof value === 'number') return String(value)
   if (isObject(value)) {
-    const id = value.id ?? value._id ?? value.value ?? value.target
+    const id = value.id ?? value._id ?? value.key ?? value.value ?? value.target
     return typeof id === 'string' || typeof id === 'number' ? String(id) : undefined
   }
   return undefined
@@ -1003,12 +1007,13 @@ const UPLOAD_REFERENCE_FIELD_GROUPS: readonly (readonly string[])[] = [
 function uploadReferenceConflicts(raw: JsonObject, indexed: JsonObject, location: string): string[] {
   const conflicts: string[] = []
   const directMediaType = (upload: JsonObject) => upload.mimeType ?? upload.mimetype ?? upload.mediaType
-  const declaresMediaType = (upload: JsonObject) =>
-    directMediaType(upload) !== undefined ||
-    upload.filename !== undefined ||
-    upload.fileName !== undefined ||
-    upload.name !== undefined
-  if (declaresMediaType(raw) && declaresMediaType(indexed) && mediaTypeFor(raw, location) !== mediaTypeFor(indexed, location)) conflicts.push('media type')
+  const declaredMediaType = (upload: JsonObject) =>
+    directMediaType(upload) !== undefined
+      ? mediaTypeFor(upload, location)
+      : inferredFilenameMediaType(upload, location)
+  const rawMediaType = declaredMediaType(raw)
+  const indexedMediaType = declaredMediaType(indexed)
+  if (rawMediaType && indexedMediaType && rawMediaType !== indexedMediaType) conflicts.push('media type')
   for (const dimension of ['width', 'height'] as const) {
     if (raw[dimension] !== undefined && indexed[dimension] !== undefined && optionalUploadDimension(raw[dimension], dimension, location) !== optionalUploadDimension(indexed[dimension], dimension, location)) conflicts.push(dimension)
   }

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -988,13 +988,72 @@ function rawUploadValue(node: LexicalNode) {
   return node.value ?? node.upload ?? node.asset ?? fields?.upload ?? fields?.asset ?? node.id
 }
 
-function uploadFor(state: AdapterState, node: LexicalNode): JsonObject | undefined {
+// Field families the reference and the indexed record can each spell several
+// ways. When the reference declares any spelling of a family, the indexed
+// spellings are dropped so the reference value deterministically wins.
+const UPLOAD_REFERENCE_FIELD_GROUPS: readonly (readonly string[])[] = [
+  ['id', '_id', 'key'],
+  ['mimeType', 'mimetype', 'mediaType'],
+  ['focalPoint', 'focalX', 'focalY'],
+  ['bytes', 'data', 'buffer', 'base64'],
+  ['filename', 'fileName', 'name'],
+  ['alt', 'altText', 'alternativeText'],
+]
+
+function uploadReferenceConflicts(raw: JsonObject, indexed: JsonObject, location: string): string[] {
+  const conflicts: string[] = []
+  const directMediaType = (upload: JsonObject) => upload.mimeType ?? upload.mimetype ?? upload.mediaType
+  if (directMediaType(raw) !== undefined && directMediaType(indexed) !== undefined && mediaTypeFor(raw, location) !== mediaTypeFor(indexed, location)) conflicts.push('media type')
+  for (const dimension of ['width', 'height'] as const) {
+    if (raw[dimension] !== undefined && indexed[dimension] !== undefined && optionalUploadDimension(raw[dimension], dimension, location) !== optionalUploadDimension(indexed[dimension], dimension, location)) conflicts.push(dimension)
+  }
+  const declaresFocal = (upload: JsonObject) => upload.focalPoint !== undefined || upload.focalX !== undefined || upload.focalY !== undefined
+  if (declaresFocal(raw) && declaresFocal(indexed) && stableStringify(uploadFocalPoint(raw, location)) !== stableStringify(uploadFocalPoint(indexed, location))) conflicts.push('focal point')
+  if (raw.crop !== undefined && indexed.crop !== undefined && stableStringify(uploadCrop(raw, location)) !== stableStringify(uploadCrop(indexed, location))) conflicts.push('crop')
+  const declaredBytes = (upload: JsonObject) => upload.bytes ?? upload.data ?? upload.buffer ?? upload.base64
+  if (declaredBytes(raw) !== undefined && declaredBytes(indexed) !== undefined) {
+    const left = decodeBytes(declaredBytes(raw), location)
+    const right = decodeBytes(declaredBytes(indexed), location)
+    if ((left && digest(left)) !== (right && digest(right))) conflicts.push('bytes')
+  }
+  return conflicts
+}
+
+/**
+ * Merge an object upload reference with its indexed top-level upload record.
+ * The indexed record supplies every field the reference omits; explicit
+ * reference fields take deterministic precedence; conflicting identities,
+ * intrinsic metadata, or bytes fail closed.
+ */
+function mergedUploadReference(raw: JsonObject, id: string, indexed: JsonObject, location: string): JsonObject {
+  for (const key of ['id', '_id', 'key']) {
+    const value = raw[key]
+    if (value === undefined) continue
+    if ((typeof value !== 'string' && typeof value !== 'number') || String(value) !== id)
+      throw new Error(`Payload upload reference identity conflicts with indexed upload ${id} at ${location}`)
+  }
+  const conflicts = uploadReferenceConflicts(raw, indexed, location)
+  if (conflicts.length) throw new Error(`Payload upload reference disagrees with indexed upload ${id} on ${conflicts.join(', ')} at ${location}`)
+  const base = { ...indexed }
+  for (const group of UPLOAD_REFERENCE_FIELD_GROUPS) {
+    if (group.some((key) => raw[key] !== undefined)) for (const key of group) delete base[key]
+  }
+  return { ...base, ...raw }
+}
+
+function uploadFor(state: AdapterState, node: LexicalNode, path: string): JsonObject | undefined {
   const raw = rawUploadValue(node)
   const id = relationId(raw)
-  if (isObject(raw)) return raw
-  const upload = id ? state.uploads.get(id) : undefined
-  if (!upload || state.variantUploadIds === undefined || state.variantUploadIds.has(String(id))) return upload
-  return withoutLocalizedUploadText(upload)
+  const indexed = id ? state.uploads.get(id) : undefined
+  const localized =
+    indexed && state.variantUploadIds !== undefined && !state.variantUploadIds.has(String(id))
+      ? withoutLocalizedUploadText(indexed)
+      : indexed
+  if (isObject(raw)) {
+    if (!localized || !id) return raw
+    return mergedUploadReference(raw, id, localized, sourceLocation(state.sourceId, path))
+  }
+  return localized
 }
 
 function uploadAlternativeText(node: LexicalNode, upload: JsonObject | undefined, location: string) {
@@ -1115,7 +1174,7 @@ function addTextNode(state: AdapterState, node: LexicalNode, path: string, type:
 
 function addUploadNode(state: AdapterState, node: LexicalNode, path: string, resolved?: { upload?: JsonObject; assetId?: string }): PublicationNode {
   const identity = nodeId(state, node, path, 'figure')
-  const upload = resolved ? resolved.upload : uploadFor(state, node)
+  const upload = resolved ? resolved.upload : uploadFor(state, node, path)
   const fields = isObject(node.fields) ? node.fields : undefined
   const location = sourceLocation(state.sourceId, path)
   const alt = uploadAlternativeText(node, upload, location)
@@ -1229,7 +1288,7 @@ function addEquationNode(state: AdapterState, node: LexicalNode, path: string): 
 
 function addMediaNode(state: AdapterState, node: LexicalNode, path: string): PublicationNode {
   const location = sourceLocation(state.sourceId, path)
-  const upload = uploadFor(state, node)
+  const upload = uploadFor(state, node, path)
   const mediaType = upload ? mediaTypeFor(upload, location) : undefined
   const rawKind = node.mediaKind ?? node.kind ?? (isObject(node.fields) ? node.fields.kind : undefined)
   const inferredKind = mediaType?.startsWith('image/') ? 'image' : mediaType?.startsWith('audio/') ? 'audio' : mediaType?.startsWith('video/') ? 'video' : undefined

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -1044,7 +1044,7 @@ function mergedUploadReference(raw: JsonObject, id: string, indexed: JsonObject,
   for (const group of UPLOAD_REFERENCE_FIELD_GROUPS) {
     if (group.some((key) => raw[key] !== undefined)) for (const key of group) delete base[key]
   }
-  return { ...base, ...raw }
+  return { ...base, ...raw, id }
 }
 
 function uploadFor(state: AdapterState, node: LexicalNode, path: string): JsonObject | undefined {

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -992,7 +992,7 @@ function rawUploadValue(node: LexicalNode) {
 // ways. When the reference declares any spelling of a family, the indexed
 // spellings are dropped so the reference value deterministically wins.
 const UPLOAD_REFERENCE_FIELD_GROUPS: readonly (readonly string[])[] = [
-  ['id', '_id', 'key'],
+  ['id', '_id', 'key', 'value', 'target'],
   ['mimeType', 'mimetype', 'mediaType'],
   ['focalPoint', 'focalX', 'focalY'],
   ['bytes', 'data', 'buffer', 'base64'],
@@ -1003,7 +1003,12 @@ const UPLOAD_REFERENCE_FIELD_GROUPS: readonly (readonly string[])[] = [
 function uploadReferenceConflicts(raw: JsonObject, indexed: JsonObject, location: string): string[] {
   const conflicts: string[] = []
   const directMediaType = (upload: JsonObject) => upload.mimeType ?? upload.mimetype ?? upload.mediaType
-  if (directMediaType(raw) !== undefined && directMediaType(indexed) !== undefined && mediaTypeFor(raw, location) !== mediaTypeFor(indexed, location)) conflicts.push('media type')
+  const declaresMediaType = (upload: JsonObject) =>
+    directMediaType(upload) !== undefined ||
+    upload.filename !== undefined ||
+    upload.fileName !== undefined ||
+    upload.name !== undefined
+  if (declaresMediaType(raw) && declaresMediaType(indexed) && mediaTypeFor(raw, location) !== mediaTypeFor(indexed, location)) conflicts.push('media type')
   for (const dimension of ['width', 'height'] as const) {
     if (raw[dimension] !== undefined && indexed[dimension] !== undefined && optionalUploadDimension(raw[dimension], dimension, location) !== optionalUploadDimension(indexed[dimension], dimension, location)) conflicts.push(dimension)
   }
@@ -1026,14 +1031,15 @@ function uploadReferenceConflicts(raw: JsonObject, indexed: JsonObject, location
  * intrinsic metadata, or bytes fail closed.
  */
 function mergedUploadReference(raw: JsonObject, id: string, indexed: JsonObject, location: string): JsonObject {
-  for (const key of ['id', '_id', 'key']) {
+  const indexedUpload = `(sha256:${digest(id).slice(0, 16)})`
+  for (const key of ['id', '_id', 'key', 'value', 'target']) {
     const value = raw[key]
     if (value === undefined) continue
     if ((typeof value !== 'string' && typeof value !== 'number') || String(value) !== id)
-      throw new Error(`Payload upload reference identity conflicts with indexed upload ${id} at ${location}`)
+      throw new Error(`Payload upload reference identity conflicts with indexed upload ${indexedUpload} at ${location}`)
   }
   const conflicts = uploadReferenceConflicts(raw, indexed, location)
-  if (conflicts.length) throw new Error(`Payload upload reference disagrees with indexed upload ${id} on ${conflicts.join(', ')} at ${location}`)
+  if (conflicts.length) throw new Error(`Payload upload reference disagrees with indexed upload ${indexedUpload} on ${conflicts.join(', ')} at ${location}`)
   const base = { ...indexed }
   for (const group of UPLOAD_REFERENCE_FIELD_GROUPS) {
     if (group.some((key) => raw[key] !== undefined)) for (const key of group) delete base[key]

--- a/src/publication/adapters/payload-lexical.ts
+++ b/src/publication/adapters/payload-lexical.ts
@@ -601,7 +601,10 @@ function relationId(value: unknown): string | undefined {
 }
 
 function graphSafeRelationshipTarget(target: string, location: string) {
-  if (!GRAPH_SAFE_ID_PATTERN.test(target)) throw new Error(`Payload relationship target ${target} is not a graph-safe id at ${location}`)
+  // An untrusted relationship target can carry secret material, and this
+  // message reaches CLI stderr and CI logs; report only the safe source
+  // location and an opaque digest, never the raw value.
+  if (!GRAPH_SAFE_ID_PATTERN.test(target)) throw new Error(`Payload relationship target (sha256:${digest(target).slice(0, 16)}) is not a graph-safe id at ${location}`)
   return target
 }
 

--- a/src/publication/renderers/vivliostyle.test.ts
+++ b/src/publication/renderers/vivliostyle.test.ts
@@ -866,14 +866,14 @@ describe('Vivliostyle publication renderer boundary', () => {
   it('requires the pinned browser build before rendering', () => {
     expect(
       publicationBrowserVersionMatches(
-        'Chromium 149.0.7827.0',
-        '149.0.7827.0',
+        'Chromium 149.0.7827.55',
+        '149.0.7827.55',
       ),
     ).toBe(true)
     expect(
       publicationBrowserVersionMatches(
-        'Chromium 149.0.7827.55',
-        '149.0.7827.0',
+        'Chromium 149.0.7827.0',
+        '149.0.7827.55',
       ),
     ).toBe(false)
   })

--- a/src/publication/toolchain-manifest.json
+++ b/src/publication/toolchain-manifest.json
@@ -15,7 +15,7 @@
       "package": "playwright",
       "version": "1.61.1",
       "arm64Revision": "1228",
-      "arm64BrowserVersion": "149.0.7827.0"
+      "arm64BrowserVersion": "149.0.7827.55"
     }
   },
   "rendererPolicy": {

--- a/src/publication/toolchain.test.ts
+++ b/src/publication/toolchain.test.ts
@@ -19,7 +19,10 @@ describe('publication toolchain manifest', () => {
       browser: {
         revision: '150.0.7871.115',
         browserVersion: '150.0.7871.115',
-        compatibility: { arm64Revision: '1228' },
+        compatibility: {
+          arm64Revision: '1228',
+          arm64BrowserVersion: '149.0.7827.55',
+        },
       },
       rendererPolicy: {
         x64: { pdf: 'vivliostyle-cli' },

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -77,6 +77,26 @@ export function assertAtomicPublicationPlatform(platform) {
   throw error
 }
 
+export function assertAtomicPublicationRuntime() {
+  // The final atomic publish shells out to python3 for renameat2/renameatx_np
+  // (see ATOMIC_RENAME_SCRIPT). The runtime is not declared in package.json
+  // engines, so probe it before any adapter resolution, staging, rendering,
+  // or output work instead of failing after the full profile matrix.
+  try {
+    execFileSync('python3', ['-c', 'import ctypes, os, sys'], {
+      stdio: 'ignore',
+    })
+  } catch {
+    // The probe failure detail can embed environment-specific paths; keep the
+    // dependency error actionable and sanitized.
+    const error = new Error(
+      'Atomic directory publication requires a python3 runtime on PATH; install python3 before running publication builds',
+    )
+    error.code = 'ENOENT'
+    throw error
+  }
+}
+
 function resolveThroughExistingAncestor(value) {
   let ancestor = resolve(value)
   const unresolved = []
@@ -900,6 +920,7 @@ export async function bindPublicationSourceReceipt(
 export async function publicationBuild(argv = process.argv.slice(2), runtime = {}) {
   const options = parsePublicationBuildArgs(argv)
   assertAtomicPublicationPlatform(runtime.platform ?? process.platform)
+  assertAtomicPublicationRuntime()
   // Repository-local final outputs must already be git-ignored. Invocation-owned
   // staging is excluded explicitly from the clean-source receipt evidence.
   const finalOutput = assertPublicationOutputDirectory(options.output)

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -353,6 +353,59 @@ describe('publication:build CLI', () => {
     }
   })
 
+  it('verifies the python3 atomic-rename runtime before adapter, staging, or renderer work', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-build-python-preflight-'),
+    )
+    const outputParent = resolve(temporaryRoot, 'must-not-be-created')
+    const output = resolve(outputParent, 'output')
+    const neverReadInput = resolve(temporaryRoot, 'never-read.json')
+    const originalRender = vivliostyleRenderer.render
+    let renderCalls = 0
+    vivliostyleRenderer.render = async () => {
+      renderCalls += 1
+      throw new Error('renderer must not run without the python3 runtime')
+    }
+    const originalPath = process.env.PATH
+    try {
+      process.env.PATH = resolve(temporaryRoot, 'empty-path-entry')
+      const error = await publicationBuild(
+        [
+          '--adapter',
+          'payload',
+          '--input',
+          neverReadInput,
+          '--output',
+          output,
+        ],
+        { platform: process.platform },
+      ).then(
+        () => undefined,
+        (failure) => failure,
+      )
+      process.env.PATH = originalPath
+      expect(error).toMatchObject({ code: 'ENOENT' })
+      expect(error?.message).toBe(
+        'Atomic directory publication requires a python3 runtime on PATH; install python3 before running publication builds',
+      )
+      expect(error?.message).not.toContain(output)
+      expect(renderCalls).toBe(0)
+      // The missing input file was never read, so adapter resolution did not
+      // start; no staging directory or output parent was ever created.
+      await expect(access(neverReadInput)).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      await expect(access(outputParent)).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      expect(await readdir(temporaryRoot)).toEqual([])
+    } finally {
+      process.env.PATH = originalPath
+      vivliostyleRenderer.render = originalRender
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
   it('replaces a reused output directory wholesale instead of merging into it', async () => {
     const temporaryRoot = await mkdtemp(
       resolve(tmpdir(), 'publication-build-replaced-reuse-'),

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -135,6 +135,86 @@ describe('publication:build CLI', () => {
     ).toThrow(/Astro.*--entry/)
   })
 
+  it(
+    'never lets an unsafe relationship target cross the CLI stderr boundary',
+    { timeout: 120_000 },
+    async () => {
+      const sentinel = 'unsafe-target?credential=redact-me'
+      const temporaryRoot = await mkdtemp(
+        resolve(tmpdir(), 'publication-build-redacted-target-'),
+      )
+      const input = resolve(temporaryRoot, 'unsafe-relationship.json')
+      const mappingPath = resolve(temporaryRoot, 'mapping.json')
+      const output = resolve(temporaryRoot, 'output')
+      try {
+        await writeFile(
+          input,
+          `${JSON.stringify({
+            id: 'unsafe-relationship-cli',
+            title: 'Unsafe relationship',
+            content: {
+              root: {
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      { type: 'citation', value: sentinel, label: 'Sentinel' },
+                    ],
+                  },
+                ],
+              },
+            },
+          })}\n`,
+        )
+        await writeFile(
+          mappingPath,
+          `${JSON.stringify({
+            relationships: { citation: { role: 'citation' } },
+          })}\n`,
+        )
+        const failure = await new Promise((resolveRun) => {
+          try {
+            execFileSync(
+              process.execPath,
+              [
+                resolve('node_modules/tsx/dist/cli.mjs'),
+                resolve('tools/publication-build.mjs'),
+                '--adapter',
+                'payload',
+                '--input',
+                input,
+                '--mapping',
+                mappingPath,
+                '--output',
+                output,
+              ],
+              { encoding: 'utf8', stdio: 'pipe' },
+            )
+            resolveRun(undefined)
+          } catch (error) {
+            resolveRun(error)
+          }
+        })
+        expect(failure).toBeDefined()
+        expect(failure.status).not.toBe(0)
+        const stdout = String(failure.stdout ?? '')
+        const stderr = String(failure.stderr ?? '')
+        expect(stderr).toMatch(
+          /Payload relationship target \(sha256:[0-9a-f]{16}\) is not a graph-safe id/,
+        )
+        for (const stream of [stdout, stderr]) {
+          expect(stream).not.toContain(sentinel)
+          expect(stream).not.toContain('credential')
+          expect(stream).not.toContain('redact-me')
+          expect(stream).not.toContain('unsafe-target')
+        }
+        await expect(access(output)).rejects.toMatchObject({ code: 'ENOENT' })
+      } finally {
+        await rm(temporaryRoot, { recursive: true, force: true })
+      }
+    },
+  )
+
   it('binds route parity to the exact canonical route bytes', () => {
     expect(publicationRouteHtmlDigest('<html>route</html>')).toMatch(
       /^[a-f0-9]{64}$/,


### PR DESCRIPTION
## Summary

Repairs the five unresolved exact-head Codex findings that arrived after PR #156 merged (review `PRR_kwDON227nc8AAAABI_97mA`). The spec for this repair is PR #162 (`docs/issues/050-repair-post-merge-payload-lexical-review-findings.md`, branch `codex/issue-161-spec`); this implementation treats that spec as authoritative.

Closes #161.

## Finding-to-fix mapping

Each finding has one commit containing its regression (demonstrated RED at current main `ce2b023893ddf4df6a85cb3b3be9a6c653ac9d6b`, GREEN at this head) and its fix.

| Finding (PR #156 thread) | Fix commit | Fix | Regression test |
|---|---|---|---|
| P1 `PRRT_kwDON227nc6X84W7` — raw unsafe relationship target reaches exceptions and CLI stderr | `c1b9a96` | `graphSafeRelationshipTarget` reports only an opaque sha256 prefix plus the safe source location (`src/publication/adapters/payload-lexical.ts`) | `payload-lexical.test.ts` "redacts unsafe relationship targets from thrown diagnostics" (+ updated raw-target expectation); CLI-level `publication-build.test.mjs` "never lets an unsafe relationship target cross the CLI stderr boundary" proves the `unsafe-target?credential=redact-me` sentinel cannot cross stdout/stderr |
| P2 `PRRT_kwDON227nc6X84Wn` — canonical inline runs retain input-array order | `ba85722` | `canonicalInlineRuns` sorts by effective interval and stable semantics before adjacency folding (`src/publication/adapter-conformance.ts`); links, hard breaks, relationship anchors, and target order keep authored boundaries | `adapter-conformance.test.ts` "canonicalizes overlapping inline runs independently of array order" (equal comparison, equal canonical SHA-256, identical deterministic serialized run order) |
| P2 `PRRT_kwDON227nc6X84Ww` — object upload stubs return before consulting `state.uploads` | `9a43129` | `uploadFor` merges an object reference with its indexed upload: index supplies missing fields, explicit reference fields take deterministic precedence, conflicting identities/intrinsic metadata/bytes fail closed (`src/publication/adapters/payload-lexical.ts`) | `payload-lexical.test.ts` "resolves object upload references through the indexed uploads" (`value: { id: 'pic' }` equals scalar `value: 'pic'`: same single content-addressed asset, no false `missing-asset`; conflict and locale-variant cases covered) |
| P2 `PRRT_kwDON227nc6X84W0` — undeclared `python3` first invoked after the full render matrix | `7b2059a` | `assertAtomicPublicationRuntime()` probes `python3` immediately after the platform check, before adapter resolution, staging, rendering, or output mutation; sanitized actionable error; README operator-runtime note added; atomic rename implementation unchanged (`tools/publication-build.mjs`) | `publication-build.test.mjs` "verifies the python3 atomic-rename runtime before adapter, staging, or renderer work" (observes renderer never ran, input never read, no staging/output created) |
| P2 `PRRT_kwDON227nc6X84XC` — equivalent populated author-name fields rejected | `63cc2ac` | `contributorName` accepts multiple `name`/`fullName`/`displayName` fields only when trimmed values agree; conflicts, empty populated values, and non-strings remain rejected (`src/publication/adapters/payload-lexical.ts`) | `payload-lexical.test.ts` "accepts redundant author name fields whose trimmed values agree" (`{ name: 'Ada', displayName: ' Ada ', fullName: 'Ada' }` yields one contributor `Ada`) |

## Validation

- `node v24.14.1`, `python3 3.10.6` (local); CI runs Node 22 / Python 3.11 on ubuntu.
- Focused `npx vitest run src/publication/adapter-conformance.test.ts src/publication/adapters/payload-lexical.test.ts tools/publication-build.test.mjs`: 86 passed, 1 failed (see caveat below).
- Full `npm test`: 2814 passed, 1 skipped, 2 failed — both failures are pre-existing local-environment failures reproduced identically at base `ce2b023` before any change from this branch:
  - `publication-build.test.mjs` "excludes invocation-owned staging roots from repository cleanliness evidence" — macOS `os.tmpdir()` symlink (`/var/folders` vs `/private/var/folders`) makes the staging exclusion path escape the temp repo root.
  - `publication-adapter-conformance.test.mjs` "stages the complete Astro fixture through the real CLI matrix" — this ARM64 macOS host carries the pinned-browser compatibility revision `149.0.7827.55`, which the renderer's exact pin `149.0.7827.0` rejects.
- `npx astro check` (the typecheck the production build runs): 0 errors, 0 warnings.
- `npm run publication:build -- --adapter payload ...` locally fails closed at the same pre-existing browser pin before any output mutation (identical at base); the four-profile build/check evidence therefore comes from the ubuntu CI lanes on this PR.
- `git diff --check` and `git status --short`: clean.
- No secrets: tests use only the obviously synthetic sentinel `unsafe-target?credential=redact-me`.

## Notes

- Spec source: PR #162 (`codex/issue-161-spec`, head `96c3723269fe2308941231b78ecdccaf049da9fd`).
- Per the spec, the five original PR #156 threads should be replied to and resolved only after the hosted exact-head checks on this PR are green and independently reviewed; this PR does not resolve them itself.
- Generated publications and evidence artifacts remain uncommitted (`.agent/evidence/` is ignored).
