### PR TITLE
fix: close extraction eval review gaps

### DIFF
--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -3,8 +3,8 @@
   "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
-    "fileSha256": "36aed098cd1a6e2a12dbb05737ae667f639ef06021415b5c8c2cb498c784f462",
-    "evalSetSha256": "5d6d6abd1258221e68a39b9bc81724867e69747522a7012443a3cfae1062f3d4"
+    "fileSha256": "bf826158cecefe3900079e8cec860966aea89d47a5db7b25ca484171ba067e24",
+    "evalSetSha256": "3972a0b379ecb7ede12ce36f5bb508ddb2f90da148d11bc1abda40e76cf3b90f"
   },
   "evaluationStatus": "reported-only",
   "providers": [

--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -3,8 +3,8 @@
   "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
-    "fileSha256": "4708145c2660fca302e3f1a9e6f4f126e9dac75c62143165b3f746b694b68d76",
-    "evalSetSha256": "4bdda41446d0e4b34ff69aa3daa5e9320752fdb11c13d4bfb5409b77fa95c34b"
+    "fileSha256": "bf826158cecefe3900079e8cec860966aea89d47a5db7b25ca484171ba067e24",
+    "evalSetSha256": "3972a0b379ecb7ede12ce36f5bb508ddb2f90da148d11bc1abda40e76cf3b90f"
   },
   "evaluationStatus": "reported-only",
   "providers": [

--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -3,8 +3,8 @@
   "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
-    "fileSha256": "bf826158cecefe3900079e8cec860966aea89d47a5db7b25ca484171ba067e24",
-    "evalSetSha256": "3972a0b379ecb7ede12ce36f5bb508ddb2f90da148d11bc1abda40e76cf3b90f"
+    "fileSha256": "fd1fcde6bd011c2c56f7a580c3cbdb9f18477b7f69eaa472ef91f3a0c230f1e6",
+    "evalSetSha256": "fb3385f20c6d53342a9857f4aa0719947f6ffce436f5097f236835e8032f5e5f"
   },
   "evaluationStatus": "reported-only",
   "providers": [

--- a/benchmarks/pdf/extraction-eval-providers-v1.json
+++ b/benchmarks/pdf/extraction-eval-providers-v1.json
@@ -3,8 +3,8 @@
   "id": "scholarly-pdf-extraction-provider-comparison-2026-08-v1",
   "evalSet": {
     "path": "benchmarks/pdf/extraction-eval-strata-v1.json",
-    "fileSha256": "bf826158cecefe3900079e8cec860966aea89d47a5db7b25ca484171ba067e24",
-    "evalSetSha256": "3972a0b379ecb7ede12ce36f5bb508ddb2f90da148d11bc1abda40e76cf3b90f"
+    "fileSha256": "4708145c2660fca302e3f1a9e6f4f126e9dac75c62143165b3f746b694b68d76",
+    "evalSetSha256": "4bdda41446d0e4b34ff69aa3daa5e9320752fdb11c13d4bfb5409b77fa95c34b"
   },
   "evaluationStatus": "reported-only",
   "providers": [

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -436,7 +436,7 @@
                   "text": "12"
                 }
               ],
-              "box": [0.117647, 0.555556, 0.359477, 0.611112],
+              "box": [0.117647, 0.555556, 0.24183, 0.055556],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-table-structure-table-1-region"
               ],
@@ -503,7 +503,7 @@
                   "text": "10"
                 }
               ],
-              "box": [0.117647, 0.689394, 0.281046, 0.727273],
+              "box": [0.117647, 0.689394, 0.163399, 0.037879],
               "sourceRegionIds": [
                 "structured-scientific-table-structure-table-1-region"
               ],
@@ -665,7 +665,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.359477, 0.719697, 0.669935, 0.780303],
+              "box": [0.359477, 0.719697, 0.310458, 0.060606],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-display-equation-equation-1-region"
               ],
@@ -701,7 +701,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.367647, 0.805556, 0.637255, 0.858586],
+              "box": [0.367647, 0.805556, 0.269608, 0.05303],
               "sourceRegionIds": [
                 "structured-scientific-display-equation-equation-1-region"
               ],
@@ -737,7 +737,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.294118, 0.166667, 0.702615, 0.356061],
+              "box": [0.294118, 0.166667, 0.408497, 0.189394],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-figure-diagram-figure-1-region"
               ],
@@ -773,7 +773,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.359477, 0.280303, 0.784314, 0.419192],
+              "box": [0.359477, 0.280303, 0.424837, 0.138889],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-1-region"
               ],
@@ -788,7 +788,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.392157, 0.494949, 0.637255, 0.583333],
+              "box": [0.392157, 0.494949, 0.245098, 0.088384],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-2-region"
               ],

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -297,7 +297,7 @@
           "excluding-most-body-lines",
           "running-head-or-page-number-left-in-body-flow"
         ],
-        "detection": "Missing identities, inconsistent counters, or over-exclusion score zero; valid partial identity matches receive F1 and an explicit abstention scores 0.25.",
+        "detection": "Missing identities, inconsistent counters, any reviewed furniture left in body flow, or over-exclusion score zero; complete furniture removal with extra exclusions receives identity F1 and an explicit abstention scores 0.25.",
         "score": 0,
         "abstentionScore": 0.25,
         "failClosed": true

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -279,9 +279,9 @@
       },
       "metric": {
         "id": "boilerplate-contamination-rate",
-        "name": "running-head and page-number contamination",
-        "unit": "zero-contamination-indicator",
-        "formula": "1 iff both contamination counters are zero and excludedCount is bounded; otherwise 0",
+        "name": "source-reviewed furniture exclusion",
+        "unit": "identity-f1",
+        "formula": "F1 over exact source-reviewed furniture identities; contamination counters must equal unmatched reviewed identities",
         "scoreRange": [0, 1],
         "abstentionScore": 0.25,
         "degenerateScore": 0,
@@ -292,10 +292,12 @@
         "id": "boilerplate-exclusion-degenerate-answer-guard",
         "rejects": [
           "missing-contamination-counters",
+          "missing-source-reviewed-furniture-identities",
+          "inconsistent-contamination-counters",
           "excluding-most-body-lines",
           "running-head-or-page-number-left-in-body-flow"
         ],
-        "detection": "Over-exclusion and contamination both score zero; an explicit abstention scores 0.25.",
+        "detection": "Missing identities, inconsistent counters, or over-exclusion score zero; valid partial identity matches receive F1 and an explicit abstention scores 0.25.",
         "score": 0,
         "abstentionScore": 0.25,
         "failClosed": true
@@ -434,12 +436,7 @@
                   "text": "12"
                 }
               ],
-              "box": [
-                0.117647,
-                0.555556,
-                0.24183,
-                0.055556
-              ],
+              "box": [0.117647, 0.555556, 0.24183, 0.055556],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-table-structure-table-1-region"
               ],
@@ -506,12 +503,7 @@
                   "text": "10"
                 }
               ],
-              "box": [
-                0.117647,
-                0.689394,
-                0.163399,
-                0.037879
-              ],
+              "box": [0.117647, 0.689394, 0.163399, 0.037879],
               "sourceRegionIds": [
                 "structured-scientific-table-structure-table-1-region"
               ],
@@ -673,12 +665,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [
-                0.359477,
-                0.719697,
-                0.310458,
-                0.060606
-              ],
+              "box": [0.359477, 0.719697, 0.310458, 0.060606],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-display-equation-equation-1-region"
               ],
@@ -714,12 +701,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [
-                0.367647,
-                0.805556,
-                0.269608,
-                0.05303
-              ],
+              "box": [0.367647, 0.805556, 0.269608, 0.05303],
               "sourceRegionIds": [
                 "structured-scientific-display-equation-equation-1-region"
               ],
@@ -755,12 +737,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [
-                0.294118,
-                0.166667,
-                0.408497,
-                0.189394
-              ],
+              "box": [0.294118, 0.166667, 0.408497, 0.189394],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-figure-diagram-figure-1-region"
               ],
@@ -796,12 +773,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [
-                0.359477,
-                0.280303,
-                0.424837,
-                0.138889
-              ],
+              "box": [0.359477, 0.280303, 0.424837, 0.138889],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-1-region"
               ],
@@ -816,12 +788,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [
-                0.392157,
-                0.494949,
-                0.245098,
-                0.088384
-              ],
+              "box": [0.392157, 0.494949, 0.245098, 0.088384],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-2-region"
               ],

--- a/benchmarks/pdf/extraction-eval-strata-v1.json
+++ b/benchmarks/pdf/extraction-eval-strata-v1.json
@@ -436,7 +436,7 @@
                   "text": "12"
                 }
               ],
-              "box": [0.117647, 0.555556, 0.24183, 0.055556],
+              "box": [0.117647, 0.555556, 0.359477, 0.611112],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-table-structure-table-1-region"
               ],
@@ -503,7 +503,7 @@
                   "text": "10"
                 }
               ],
-              "box": [0.117647, 0.689394, 0.163399, 0.037879],
+              "box": [0.117647, 0.689394, 0.281046, 0.727273],
               "sourceRegionIds": [
                 "structured-scientific-table-structure-table-1-region"
               ],
@@ -665,7 +665,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.359477, 0.719697, 0.310458, 0.060606],
+              "box": [0.359477, 0.719697, 0.669935, 0.780303],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-display-equation-equation-1-region"
               ],
@@ -701,7 +701,7 @@
               "kind": "display-equation",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.367647, 0.805556, 0.269608, 0.05303],
+              "box": [0.367647, 0.805556, 0.637255, 0.858586],
               "sourceRegionIds": [
                 "structured-scientific-display-equation-equation-1-region"
               ],
@@ -737,7 +737,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.294118, 0.166667, 0.408497, 0.189394],
+              "box": [0.294118, 0.166667, 0.702615, 0.356061],
               "sourceRegionIds": [
                 "pdf-to-epub-fidelity-figure-diagram-figure-1-region"
               ],
@@ -773,7 +773,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.359477, 0.280303, 0.424837, 0.138889],
+              "box": [0.359477, 0.280303, 0.784314, 0.419192],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-1-region"
               ],
@@ -788,7 +788,7 @@
               "kind": "figure-or-diagram",
               "bounded": true,
               "captionRelationship": "caption-of",
-              "box": [0.392157, 0.494949, 0.245098, 0.088384],
+              "box": [0.392157, 0.494949, 0.637255, 0.583333],
               "sourceRegionIds": [
                 "structured-scientific-figure-diagram-figure-2-region"
               ],

--- a/docs/schemas/pdf-extraction-eval-candidate.schema.json
+++ b/docs/schemas/pdf-extraction-eval-candidate.schema.json
@@ -43,6 +43,10 @@
       "type": "string",
       "pattern": "^[a-f0-9]{64}$"
     },
+    "diagnostic": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+    },
     "case": {
       "type": "object",
       "additionalProperties": false,
@@ -55,7 +59,7 @@
         },
         "diagnostics": {
           "type": "array",
-          "items": { "$ref": "#/$defs/id" }
+          "items": { "$ref": "#/$defs/diagnostic" }
         }
       },
       "allOf": [

--- a/docs/schemas/pdf-extraction-eval-review-1.0.0.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review-1.0.0.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.1.0.json",
-  "title": "Source-only extraction evaluation review evidence",
-  "description": "Roster and decision artifacts bind reviewer identities and labels without exposing private source content or consulting candidate output.",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.0.0.json",
+  "title": "Legacy v1 source-only extraction evaluation review evidence",
+  "description": "Published compatibility contract for schemaVersion 1.0.0 roster and decision artifacts. Runtime validation additionally requires unique reviewerId and identityEvidenceSha256 values across the legacy roster array.",
   "oneOf": [{ "$ref": "#/$defs/roster" }, { "$ref": "#/$defs/decisions" }],
   "$defs": {
     "id": {
@@ -13,26 +13,28 @@
       "type": "string",
       "pattern": "^[a-f0-9]{64}$"
     },
-    "alias": {
-      "allOf": [
-        { "$ref": "#/$defs/id" },
-        { "not": { "$ref": "#/$defs/sha256" } }
-      ]
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewerId", "identityEvidenceSha256"],
+      "properties": {
+        "reviewerId": { "$ref": "#/$defs/id" },
+        "identityEvidenceSha256": { "$ref": "#/$defs/sha256" }
+      }
     },
     "roster": {
       "type": "object",
       "additionalProperties": false,
       "required": ["schemaVersion", "kind", "evalSetId", "reviewers"],
       "properties": {
-        "schemaVersion": { "const": "1.1.0" },
+        "schemaVersion": { "const": "1.0.0" },
         "kind": { "const": "pdf-extraction-reviewer-roster" },
         "evalSetId": { "$ref": "#/$defs/id" },
         "reviewers": {
-          "description": "Map from authoritative reviewer identity-evidence hashes to non-authoritative reviewer aliases. Object keys make duplicate identity evidence structurally unrepresentable.",
-          "type": "object",
-          "minProperties": 2,
-          "propertyNames": { "$ref": "#/$defs/sha256" },
-          "additionalProperties": { "$ref": "#/$defs/alias" }
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/reviewer" }
         }
       }
     },
@@ -49,7 +51,7 @@
         "decisions"
       ],
       "properties": {
-        "schemaVersion": { "const": "1.1.0" },
+        "schemaVersion": { "const": "1.0.0" },
         "kind": { "const": "pdf-extraction-source-only-decisions" },
         "evalSetId": { "$ref": "#/$defs/id" },
         "evalSetSha256": { "$ref": "#/$defs/sha256" },

--- a/docs/schemas/pdf-extraction-eval-review-1.0.0.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review-1.0.0.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.0.0.json",
   "title": "Legacy v1 source-only extraction evaluation review evidence",
-  "description": "Published compatibility contract for schemaVersion 1.0.0 roster and decision artifacts. Runtime validation additionally requires unique reviewerId and identityEvidenceSha256 values across the legacy roster array.",
+  "description": "Published compatibility contract for schemaVersion 1.0.0 roster and decision artifacts. Runtime validation preserves legacy reviewerId references and requires those IDs to be unique; schema-valid duplicate identityEvidenceSha256 values remain accepted for frozen v1 compatibility.",
   "oneOf": [{ "$ref": "#/$defs/roster" }, { "$ref": "#/$defs/decisions" }],
   "$defs": {
     "id": {

--- a/docs/schemas/pdf-extraction-eval-review.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review.schema.json
@@ -3,10 +3,7 @@
   "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.1.0.json",
   "title": "Source-only extraction evaluation review evidence",
   "description": "Roster and decision artifacts bind reviewer identities and labels without exposing private source content or consulting candidate output.",
-  "oneOf": [
-    { "$ref": "#/$defs/roster" },
-    { "$ref": "#/$defs/decisions" }
-  ],
+  "oneOf": [{ "$ref": "#/$defs/roster" }, { "$ref": "#/$defs/decisions" }],
   "$defs": {
     "id": {
       "type": "string",
@@ -73,7 +70,7 @@
                 "type": "array",
                 "minItems": 2,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/sha256" }
+                "items": { "$ref": "#/$defs/id" }
               },
               "decision": { "const": "agreed" },
               "decisionSha256": { "$ref": "#/$defs/sha256" }

--- a/docs/schemas/pdf-extraction-eval-review.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review.schema.json
@@ -73,7 +73,7 @@
                 "type": "array",
                 "minItems": 2,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/id" }
+                "items": { "$ref": "#/$defs/sha256" }
               },
               "decision": { "const": "agreed" },
               "decisionSha256": { "$ref": "#/$defs/sha256" }

--- a/docs/schemas/pdf-extraction-eval-review.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.0.0.json",
+  "$id": "https://ernie.sg/schemas/pdf-extraction-eval-review-1.1.0.json",
   "title": "Source-only extraction evaluation review evidence",
   "description": "Roster and decision artifacts bind reviewer identities and labels without exposing private source content or consulting candidate output.",
   "oneOf": [
@@ -21,22 +21,15 @@
       "additionalProperties": false,
       "required": ["schemaVersion", "kind", "evalSetId", "reviewers"],
       "properties": {
-        "schemaVersion": { "const": "1.0.0" },
+        "schemaVersion": { "const": "1.1.0" },
         "kind": { "const": "pdf-extraction-reviewer-roster" },
         "evalSetId": { "$ref": "#/$defs/id" },
         "reviewers": {
-          "type": "array",
-          "minItems": 2,
-          "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["reviewerId", "identityEvidenceSha256"],
-            "properties": {
-              "reviewerId": { "$ref": "#/$defs/id" },
-              "identityEvidenceSha256": { "$ref": "#/$defs/sha256" }
-            }
-          }
+          "description": "Map from authoritative reviewer identity-evidence hashes to non-authoritative reviewer aliases. Object keys make duplicate identity evidence structurally unrepresentable.",
+          "type": "object",
+          "minProperties": 2,
+          "propertyNames": { "$ref": "#/$defs/sha256" },
+          "additionalProperties": { "$ref": "#/$defs/id" }
         }
       }
     },
@@ -53,7 +46,7 @@
         "decisions"
       ],
       "properties": {
-        "schemaVersion": { "const": "1.0.0" },
+        "schemaVersion": { "const": "1.1.0" },
         "kind": { "const": "pdf-extraction-source-only-decisions" },
         "evalSetId": { "$ref": "#/$defs/id" },
         "evalSetSha256": { "$ref": "#/$defs/sha256" },

--- a/docs/schemas/pdf-extraction-eval-review.schema.json
+++ b/docs/schemas/pdf-extraction-eval-review.schema.json
@@ -28,7 +28,7 @@
         "kind": { "const": "pdf-extraction-reviewer-roster" },
         "evalSetId": { "$ref": "#/$defs/id" },
         "reviewers": {
-          "description": "Map from authoritative reviewer identity-evidence hashes to non-authoritative reviewer aliases. Object keys make duplicate identity evidence structurally unrepresentable.",
+          "description": "Map from authoritative reviewer identity-evidence hashes to non-authoritative display aliases. Decisions and completed eval reviews reference only the hash keys, so aliases need not participate in identity resolution.",
           "type": "object",
           "minProperties": 2,
           "propertyNames": { "$ref": "#/$defs/sha256" },
@@ -76,7 +76,7 @@
                 "type": "array",
                 "minItems": 2,
                 "uniqueItems": true,
-                "items": { "$ref": "#/$defs/id" }
+                "items": { "$ref": "#/$defs/sha256" }
               },
               "decision": { "const": "agreed" },
               "decisionSha256": { "$ref": "#/$defs/sha256" }

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -82,7 +82,7 @@
         "reviewers": {
           "type": "array",
           "uniqueItems": true,
-          "items": { "$ref": "#/$defs/sha256" }
+          "items": { "$ref": "#/$defs/id" }
         },
         "parserOutputConsulted": { "const": false },
         "reviewEvidence": {

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -47,7 +47,7 @@
       "pattern": "^[a-f0-9]{64}$"
     },
     "box": {
-      "$comment": "The four entries are normalized left, top, right, and bottom page endpoints. Bounding every endpoint to [0, 1] makes page containment enforceable in standard JSON Schema; zero-area boxes cannot source-bind for scoring.",
+      "$comment": "The four entries are normalized left, top, right, and bottom page endpoints. Bounding every endpoint to [0, 1] makes page containment enforceable in standard JSON Schema; scoring additionally requires right > left and bottom > top, otherwise the source binding is degenerate.",
       "type": "array",
       "minItems": 4,
       "maxItems": 4,

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -47,15 +47,15 @@
       "pattern": "^[a-f0-9]{64}$"
     },
     "box": {
-      "$comment": "The four entries are normalized left, top, right, and bottom page endpoints. Bounding every endpoint to [0, 1] makes page containment enforceable in standard JSON Schema; scoring additionally requires right > left and bottom > top, otherwise the source binding is degenerate.",
+      "$comment": "The four entries retain the v1 contract: normalized left, top, width, and height. Width and height must be positive. Runtime validation additionally enforces left + width <= 1 and top + height <= 1 because standard JSON Schema cannot compare array entries.",
       "type": "array",
       "minItems": 4,
       "maxItems": 4,
       "prefixItems": [
-        { "type": "number", "minimum": 0, "maximum": 1 },
-        { "type": "number", "minimum": 0, "maximum": 1 },
-        { "type": "number", "minimum": 0, "maximum": 1 },
-        { "type": "number", "minimum": 0, "maximum": 1 }
+        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
+        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
+        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 }
       ],
       "items": false
     },

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -47,6 +47,7 @@
       "pattern": "^[a-f0-9]{64}$"
     },
     "box": {
+      "$comment": "The four entries are independently normalized x, y, width, and height components. Exact source-binding comparison prevents a non-matching candidate box from receiving a perfect score.",
       "type": "array",
       "minItems": 4,
       "maxItems": 4,
@@ -85,10 +86,7 @@
         },
         "parserOutputConsulted": { "const": false },
         "reviewEvidence": {
-          "oneOf": [
-            { "type": "null" },
-            { "$ref": "#/$defs/reviewEvidence" }
-          ]
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/reviewEvidence" }]
         }
       },
       "oneOf": [
@@ -111,7 +109,12 @@
     "reviewEvidence": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["rosterPath", "rosterSha256", "decisionPath", "decisionSha256"],
+      "required": [
+        "rosterPath",
+        "rosterSha256",
+        "decisionPath",
+        "decisionSha256"
+      ],
       "properties": {
         "rosterPath": { "type": "string", "pattern": "^[A-Za-z0-9._/-]+$" },
         "rosterSha256": { "$ref": "#/$defs/sha256" },

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -47,15 +47,15 @@
       "pattern": "^[a-f0-9]{64}$"
     },
     "box": {
-      "$comment": "The four entries are independently normalized x, y, width, and height components. Exact source-binding comparison prevents a non-matching candidate box from receiving a perfect score.",
+      "$comment": "The four entries are normalized left, top, right, and bottom page endpoints. Bounding every endpoint to [0, 1] makes page containment enforceable in standard JSON Schema; zero-area boxes cannot source-bind for scoring.",
       "type": "array",
       "minItems": 4,
       "maxItems": 4,
       "prefixItems": [
-        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
-        { "type": "number", "minimum": 0, "exclusiveMaximum": 1 },
-        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
-        { "type": "number", "exclusiveMinimum": 0, "maximum": 1 }
+        { "type": "number", "minimum": 0, "maximum": 1 },
+        { "type": "number", "minimum": 0, "maximum": 1 },
+        { "type": "number", "minimum": 0, "maximum": 1 },
+        { "type": "number", "minimum": 0, "maximum": 1 }
       ],
       "items": false
     },

--- a/docs/schemas/pdf-extraction-eval-strata.schema.json
+++ b/docs/schemas/pdf-extraction-eval-strata.schema.json
@@ -82,7 +82,7 @@
         "reviewers": {
           "type": "array",
           "uniqueItems": true,
-          "items": { "$ref": "#/$defs/id" }
+          "items": { "$ref": "#/$defs/sha256" }
         },
         "parserOutputConsulted": { "const": false },
         "reviewEvidence": {

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -52,7 +52,10 @@ const SAFE_DIAGNOSTIC = /^[A-Z][A-Z0-9_]{2,63}$/
 const MAX_JSON_BYTES = 32 * 1024 * 1024
 const ABSTENTION_SCORE = 0.25
 const DEGENERATE_SCORE = 0
-const REVIEW_STATUSES = Object.freeze(['review-required', 'two-reviewer-agreed'])
+const REVIEW_STATUSES = Object.freeze([
+  'review-required',
+  'two-reviewer-agreed',
+])
 const REVIEW_EVIDENCE_VALIDATED = Symbol('pdfExtractionReviewEvidenceValidated')
 
 function isRecord(value) {
@@ -195,9 +198,7 @@ function isNormalizedBox(value) {
     value[2] > 0 &&
     value[2] <= 1 &&
     value[3] > 0 &&
-    value[3] <= 1 &&
-    value[0] + value[2] <= 1 &&
-    value[1] + value[3] <= 1
+    value[3] <= 1
   )
 }
 
@@ -903,13 +904,16 @@ async function validateReviewEvidenceFiles(value, identity) {
     (review) => review.reviewStatus === 'two-reviewer-agreed',
   )
   if (agreed.length === 0) return
-  if (reviewValues.some((review) => review.reviewStatus === 'review-required')) {
+  if (
+    reviewValues.some((review) => review.reviewStatus === 'review-required')
+  ) {
     invalid('PDF_EXTRACTION_REVIEW_INCOMPLETE')
   }
   const evidence = agreed[0].reviewEvidence
   if (
     agreed.some(
-      (review) => canonicalJson(review.reviewEvidence) !== canonicalJson(evidence),
+      (review) =>
+        canonicalJson(review.reviewEvidence) !== canonicalJson(evidence),
     )
   ) {
     invalid('PDF_EXTRACTION_REVIEW_EVIDENCE_BINDING_MISMATCH')
@@ -944,6 +948,14 @@ async function validateReviewEvidenceFiles(value, identity) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
     }
   }
+  if (
+    !uniqueBy(
+      rosterArtifact.value.reviewers,
+      (reviewer) => reviewer.identityEvidenceSha256,
+    )
+  ) {
+    invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+  }
   const rosterIds = new Set(
     rosterArtifact.value.reviewers.map((reviewer) => reviewer.reviewerId),
   )
@@ -962,7 +974,8 @@ async function validateReviewEvidenceFiles(value, identity) {
       'candidateOutputConsultedForLabel',
       'decisions',
     ]) ||
-    decisionArtifact.value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    decisionArtifact.value.schemaVersion !==
+      PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
     decisionArtifact.value.kind !== 'pdf-extraction-source-only-decisions' ||
     decisionArtifact.value.evalSetId !== identity.id ||
     decisionArtifact.value.evalSetSha256 !== identity.evalSetSha256 ||
@@ -1390,6 +1403,7 @@ function proseScore(expected, prediction) {
 function boilerplateScore(expected, prediction) {
   if (!isRecord(prediction)) return degenerateResult()
   const counters = prediction.contamination
+  const excluded = predictionArray(prediction, 'excluded')
   if (
     !isRecord(counters) ||
     !exactKeys(counters, [
@@ -1402,22 +1416,59 @@ function boilerplateScore(expected, prediction) {
     return degenerateResult('MISSING_BOILERPLATE_COUNTERS')
   }
   if (
-    counters.excludedCount > expected.bodyLineCount ||
-    counters.excludedCount > expected.bodyLineCount * 0.75
+    !excluded ||
+    excluded.some(
+      (item) =>
+        !isRecord(item) ||
+        !exactKeys(item, ['id', 'sourcePage', 'kind']) ||
+        !SAFE_ID.test(item.id ?? '') ||
+        !Number.isSafeInteger(item.sourcePage) ||
+        item.sourcePage < 1 ||
+        !['running-head', 'page-number'].includes(item.kind),
+    ) ||
+    !uniqueBy(
+      excluded,
+      (item) => `${item.id}\0${item.sourcePage}\0${item.kind}`,
+    )
+  ) {
+    return degenerateResult('MISSING_BOILERPLATE_IDENTITIES')
+  }
+  if (
+    excluded.length > expected.bodyLineCount ||
+    excluded.length > expected.bodyLineCount * 0.75
   ) {
     return degenerateResult('DEGENERATE_EXCLUDING_EVERY_LINE')
   }
-  if (counters.excludedCount !== expected.excluded.length) {
-    return diagnosticResult(0, 'scored', ['INCOMPLETE_BOILERPLATE_EXCLUSION'], {
-      expectedExcluded: expected.excluded.length,
-      predictedExcluded: counters.excludedCount,
-    })
+  const identity = (item) => `${item.id}\0${item.sourcePage}\0${item.kind}`
+  const expectedKeys = new Set(expected.excluded.map(identity))
+  const predictedKeys = new Set(excluded.map(identity))
+  const missed = expected.excluded.filter(
+    (item) => !predictedKeys.has(identity(item)),
+  )
+  if (
+    counters.excludedCount !== excluded.length ||
+    counters.runningHeadContaminationCount !==
+      missed.filter((item) => item.kind === 'running-head').length ||
+    counters.pageNumberContaminationCount !==
+      missed.filter((item) => item.kind === 'page-number').length
+  ) {
+    return degenerateResult('INVALID_BOILERPLATE_COUNTERS')
   }
-  const contamination =
-    counters.runningHeadContaminationCount +
-    counters.pageNumberContaminationCount
-  const score = contamination === 0 ? 1 : 0
-  return diagnosticResult(score, 'scored', [], { contamination })
+  const matched = excluded.filter((item) =>
+    expectedKeys.has(identity(item)),
+  ).length
+  const score =
+    expected.excluded.length === 0 && excluded.length === 0
+      ? 1
+      : f1(matched, expected.excluded.length, excluded.length)
+  const diagnostics =
+    matched === expected.excluded.length && matched === excluded.length
+      ? []
+      : ['INCOMPLETE_BOILERPLATE_EXCLUSION']
+  return diagnosticResult(score, 'scored', diagnostics, {
+    expectedExcluded: expected.excluded.length,
+    predictedExcluded: excluded.length,
+  })
 }
 
 function relationshipScore(expected, prediction) {
@@ -1432,9 +1483,16 @@ function relationshipScore(expected, prediction) {
     return degenerateResult('DEGENERATE_DUPLICATE_FOOTNOTE_RELATIONSHIP')
   }
   if (
-    new Set(expected.references.map((reference) => reference.bodyId)).size > 1 &&
+    new Set(expected.references.map((reference) => reference.bodyId)).size >
+      1 &&
     relationships.length > 1 &&
-    new Set(relationships.map((item) => item?.bodyId)).size === 1
+    new Set(relationships.map((item) => item?.bodyId)).size === 1 &&
+    relationships.some((item) => {
+      const expectedReference = expected.references.find(
+        (reference) => reference.id === item?.referenceId,
+      )
+      return expectedReference && expectedReference.bodyId !== item?.bodyId
+    })
   ) {
     return degenerateResult('DEGENERATE_SINGLE_FOOTNOTE_OWNER')
   }
@@ -1580,8 +1638,9 @@ export function createAbstainingPdfExtractionCandidate(evalSet, provider) {
  */
 export function comparePdfExtractionProviders(evalSet, providers) {
   const identity = validatePdfExtractionEvalSet(evalSet)
+  const reviewValues = reviewValuesForEvalSet(evalSet)
   if (
-    reviewValuesForEvalSet(evalSet).some(
+    reviewValues.some(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
     ) &&
     evalSet[REVIEW_EVIDENCE_VALIDATED] !== true
@@ -1653,9 +1712,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
         providerRows.push(row)
       }
     }
-    const hasScoredOutput = providerRows.some(
-      (row) => row.scoredCaseCount > 0,
-    )
+    const hasScoredOutput = providerRows.some((row) => row.scoredCaseCount > 0)
     providerSummaries.push({
       providerId: candidate.provider.id,
       providerKind: candidate.provider.kind,
@@ -1672,11 +1729,23 @@ export function comparePdfExtractionProviders(evalSet, providers) {
   const hasScoredOutput = providerSummaries.some(
     (provider) => provider.score !== null,
   )
+  const reviewsComplete =
+    reviewValues.every(
+      (review) => review.reviewStatus === 'two-reviewer-agreed',
+    ) && evalSet[REVIEW_EVIDENCE_VALIDATED] === true
+  const reviewBlocksComparison = hasScoredOutput && !reviewsComplete
+  if (reviewBlocksComparison) {
+    for (const provider of providerSummaries) provider.score = null
+  }
   const reportWithoutHash = {
     schemaVersion: PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION,
     privacy: PDF_EXTRACTION_EVAL_REPORT_PRIVACY,
-    status: hasScoredOutput ? 'comparison' : 'reported-only',
-    diagnosticCodes: hasScoredOutput ? [] : ['NO_SCORED_PROVIDER_OUTPUT'],
+    status: hasScoredOutput && reviewsComplete ? 'comparison' : 'reported-only',
+    diagnosticCodes: reviewBlocksComparison
+      ? ['PDF_EXTRACTION_REVIEW_INCOMPLETE']
+      : hasScoredOutput
+        ? []
+        : ['NO_SCORED_PROVIDER_OUTPUT'],
     evalSet: {
       id: identity.id,
       schemaVersion: identity.schemaVersion,

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -998,9 +998,7 @@ async function validateReviewEvidenceFiles(value, identity) {
       const legacyHashes = identityHashesByAlias.get(reference)
       return legacyHashes?.length === 1 ? legacyHashes[0] : null
     }
-    if (rosterIdentities.has(reference)) return reference
-    const hashes = identityHashesByAlias.get(reference)
-    return hashes?.length === 1 ? hashes[0] : null
+    return rosterIdentities.has(reference) ? reference : null
   }
   const decisionArtifact = await readRepositoryJson(
     evidence.decisionPath,

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -257,7 +257,7 @@ function validateGroundTruthReview(value, code) {
     !REVIEW_STATUSES.includes(value.reviewStatus) ||
     !Array.isArray(value.reviewers) ||
     !uniqueBy(value.reviewers, (reviewer) => reviewer) ||
-    !value.reviewers.every((reviewer) => SAFE_ID.test(reviewer)) ||
+    !value.reviewers.every((reviewer) => SHA256.test(reviewer)) ||
     value.parserOutputConsulted !== false
   ) {
     invalid(code)

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -1089,7 +1089,10 @@ async function validateReviewEvidenceFiles(value, identity) {
     }
   }
   Object.defineProperty(value, REVIEW_EVIDENCE_VALIDATED, {
-    value: identity.evalSetSha256,
+    value: Object.freeze({
+      evalSetSha256: identity.evalSetSha256,
+      reviewValuesSha256: canonicalHash(reviewValuesForEvalSet(value)),
+    }),
     enumerable: false,
     configurable: true,
   })
@@ -1101,6 +1104,15 @@ function reviewValuesForEvalSet(value) {
     ...value.strata.map((item) => item.groundTruth),
     ...value.cases.map((item) => item.source.groundTruth.review),
   ]
+}
+
+function hasValidatedReviewEvidence(value, identity) {
+  const marker = value[REVIEW_EVIDENCE_VALIDATED]
+  return (
+    isRecord(marker) &&
+    marker.evalSetSha256 === identity.evalSetSha256 &&
+    marker.reviewValuesSha256 === canonicalHash(reviewValuesForEvalSet(value))
+  )
 }
 
 export async function validatePdfExtractionEvalSetFiles(value) {
@@ -1533,6 +1545,15 @@ function relationshipScore(expected, prediction) {
   if (!uniqueBy(relationshipKeys, (key) => key)) {
     return degenerateResult('DEGENERATE_DUPLICATE_FOOTNOTE_RELATIONSHIP')
   }
+  const expectedKeys = new Set(
+    expected.references.map(
+      (reference) =>
+        `${reference.id}\0${reference.bodyId}\0${reference.marker}`,
+    ),
+  )
+  if (relationshipKeys.some((key) => !expectedKeys.has(key))) {
+    return degenerateResult('DEGENERATE_DANGLING_FOOTNOTE_RELATIONSHIP')
+  }
   if (
     new Set(expected.references.map((reference) => reference.bodyId)).size >
       1 &&
@@ -1551,12 +1572,6 @@ function relationshipScore(expected, prediction) {
   ) {
     return degenerateResult('DEGENERATE_SINGLE_FOOTNOTE_OWNER')
   }
-  const expectedKeys = new Set(
-    expected.references.map(
-      (reference) =>
-        `${reference.id}\0${reference.bodyId}\0${reference.marker}`,
-    ),
-  )
   const matched = relationships.filter((relationship) =>
     expectedKeys.has(
       `${relationship?.referenceId}\0${relationship?.bodyId}\0${relationship?.marker}`,
@@ -1698,7 +1713,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
     reviewValues.some(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
     ) &&
-    evalSet[REVIEW_EVIDENCE_VALIDATED] !== identity.evalSetSha256
+    !hasValidatedReviewEvidence(evalSet, identity)
   ) {
     invalid('PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED')
   }
@@ -1791,7 +1806,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
   const reviewsComplete =
     reviewValues.every(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
-    ) && evalSet[REVIEW_EVIDENCE_VALIDATED] === identity.evalSetSha256
+    ) && hasValidatedReviewEvidence(evalSet, identity)
   const reviewBlocksComparison = comparisonAttempted && !reviewsComplete
   if (reviewBlocksComparison) {
     for (const provider of providerSummaries) {

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url'
 export const PDF_EXTRACTION_EVAL_SCHEMA_VERSION = '1.0.0'
 export const PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION = '1.1.0'
 export const PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION = '1.0.0'
+const PDF_EXTRACTION_EVAL_LEGACY_REVIEW_SCHEMA_VERSION = '1.0.0'
 export const PDF_EXTRACTION_EVAL_PRIVACY =
   'repository-fixture-identities-source-reviewed-no-private-inputs'
 export const PDF_EXTRACTION_EVAL_REPORT_PRIVACY =
@@ -934,7 +935,7 @@ async function validateReviewEvidenceFiles(value, identity) {
     sha256(rosterArtifact.bytes) !== evidence.rosterSha256 ||
     !exactKeys(roster, ['schemaVersion', 'kind', 'evalSetId', 'reviewers']) ||
     ![
-      PDF_EXTRACTION_EVAL_SCHEMA_VERSION,
+      PDF_EXTRACTION_EVAL_LEGACY_REVIEW_SCHEMA_VERSION,
       PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION,
     ].includes(roster.schemaVersion) ||
     roster.kind !== 'pdf-extraction-reviewer-roster' ||
@@ -943,7 +944,9 @@ async function validateReviewEvidenceFiles(value, identity) {
     invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
   }
   let reviewerEntries
-  if (roster.schemaVersion === PDF_EXTRACTION_EVAL_SCHEMA_VERSION) {
+  if (
+    roster.schemaVersion === PDF_EXTRACTION_EVAL_LEGACY_REVIEW_SCHEMA_VERSION
+  ) {
     if (
       !Array.isArray(roster.reviewers) ||
       roster.reviewers.length < 2 ||
@@ -989,6 +992,12 @@ async function validateReviewEvidenceFiles(value, identity) {
     identityHashesByAlias.set(alias, hashes)
   }
   const resolveReviewerReference = (reference) => {
+    if (
+      roster.schemaVersion === PDF_EXTRACTION_EVAL_LEGACY_REVIEW_SCHEMA_VERSION
+    ) {
+      const legacyHashes = identityHashesByAlias.get(reference)
+      return legacyHashes?.length === 1 ? legacyHashes[0] : null
+    }
     if (rosterIdentities.has(reference)) return reference
     const hashes = identityHashesByAlias.get(reference)
     return hashes?.length === 1 ? hashes[0] : null

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -951,10 +951,6 @@ async function validateReviewEvidenceFiles(value, identity) {
       !Array.isArray(roster.reviewers) ||
       roster.reviewers.length < 2 ||
       !uniqueBy(roster.reviewers, (reviewer) => reviewer.reviewerId) ||
-      !uniqueBy(
-        roster.reviewers,
-        (reviewer) => reviewer.identityEvidenceSha256,
-      ) ||
       roster.reviewers.some(
         (reviewer) =>
           !exactKeys(reviewer, ['reviewerId', 'identityEvidenceSha256']) ||
@@ -995,8 +991,7 @@ async function validateReviewEvidenceFiles(value, identity) {
     if (
       roster.schemaVersion === PDF_EXTRACTION_EVAL_LEGACY_REVIEW_SCHEMA_VERSION
     ) {
-      const legacyHashes = identityHashesByAlias.get(reference)
-      return legacyHashes?.length === 1 ? legacyHashes[0] : null
+      return identityHashesByAlias.has(reference) ? reference : null
     }
     return rosterIdentities.has(reference) ? reference : null
   }
@@ -1507,6 +1502,9 @@ function boilerplateScore(expected, prediction) {
   ) {
     return degenerateResult('INVALID_BOILERPLATE_COUNTERS')
   }
+  if (missed.length > 0) {
+    return degenerateResult('RUNNING_HEAD_OR_PAGE_NUMBER_LEFT_IN_BODY_FLOW')
+  }
   const matched = excluded.filter((item) =>
     expectedKeys.has(identity(item)),
   ).length
@@ -1714,11 +1712,15 @@ export function comparePdfExtractionProviders(evalSet, providers) {
   const strata = stratumById(evalSet)
   const rows = []
   const providerSummaries = []
+  let comparisonAttempted = false
   for (const candidate of providers) {
     validateCandidateProvider(
       candidate,
       identity,
       'INVALID_PDF_EXTRACTION_CANDIDATE',
+    )
+    comparisonAttempted ||= candidate.cases.some(
+      (item) => item.status === 'scored',
     )
     const outputMap = new Map(
       candidate.cases.map((item) => [item.caseId, item]),
@@ -1790,14 +1792,18 @@ export function comparePdfExtractionProviders(evalSet, providers) {
     reviewValues.every(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
     ) && evalSet[REVIEW_EVIDENCE_VALIDATED] === identity.evalSetSha256
-  const reviewBlocksComparison = hasScoredOutput && !reviewsComplete
+  const reviewBlocksComparison = comparisonAttempted && !reviewsComplete
   if (reviewBlocksComparison) {
-    for (const provider of providerSummaries) provider.score = null
+    for (const provider of providerSummaries) {
+      provider.score = null
+      provider.diagnosticCodes = []
+    }
     for (const row of rows) {
       row.scoredCaseCount = 0
       row.abstainedCaseCount = 0
       row.degenerateCaseCount = 0
       row.score = null
+      row.diagnostics = []
     }
   }
   const reportWithoutHash = {

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -196,8 +196,10 @@ function isNormalizedBox(value) {
 }
 
 function normalizedBoxArea(value) {
-  if (!isNormalizedBox(value)) return 0
-  return Math.abs(value[2] - value[0]) * Math.abs(value[3] - value[1])
+  if (!isNormalizedBox(value) || value[2] <= value[0] || value[3] <= value[1]) {
+    return 0
+  }
+  return (value[2] - value[0]) * (value[3] - value[1])
 }
 
 function validateSourceBinding(value, code) {
@@ -1189,6 +1191,7 @@ function hasValidSourceBinding(value) {
   return (
     isRecord(value) &&
     isNormalizedBox(value.box) &&
+    normalizedBoxArea(value.box) > 0 &&
     Array.isArray(value.sourceRegionIds) &&
     value.sourceRegionIds.length > 0 &&
     uniqueBy(value.sourceRegionIds, (id) => id) &&

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -15,6 +15,7 @@ import { resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 export const PDF_EXTRACTION_EVAL_SCHEMA_VERSION = '1.0.0'
+export const PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION = '1.1.0'
 export const PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION = '1.0.0'
 export const PDF_EXTRACTION_EVAL_PRIVACY =
   'repository-fixture-identities-source-reviewed-no-private-inputs'
@@ -930,35 +931,27 @@ async function validateReviewEvidenceFiles(value, identity) {
       'evalSetId',
       'reviewers',
     ]) ||
-    rosterArtifact.value.schemaVersion !== PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+    rosterArtifact.value.schemaVersion !==
+      PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION ||
     rosterArtifact.value.kind !== 'pdf-extraction-reviewer-roster' ||
     rosterArtifact.value.evalSetId !== identity.id ||
-    !Array.isArray(rosterArtifact.value.reviewers) ||
-    rosterArtifact.value.reviewers.length < 2 ||
-    !uniqueBy(rosterArtifact.value.reviewers, (reviewer) => reviewer.reviewerId)
+    !isRecord(rosterArtifact.value.reviewers) ||
+    Object.keys(rosterArtifact.value.reviewers).length < 2
   ) {
     invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
   }
-  for (const reviewer of rosterArtifact.value.reviewers) {
+  for (const [identityEvidenceSha256, reviewerId] of Object.entries(
+    rosterArtifact.value.reviewers,
+  )) {
     if (
-      !exactKeys(reviewer, ['reviewerId', 'identityEvidenceSha256']) ||
-      !SAFE_ID.test(reviewer.reviewerId ?? '') ||
-      !SHA256.test(reviewer.identityEvidenceSha256 ?? '')
+      !SHA256.test(identityEvidenceSha256) ||
+      typeof reviewerId !== 'string' ||
+      !SAFE_ID.test(reviewerId ?? '')
     ) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
     }
   }
-  if (
-    !uniqueBy(
-      rosterArtifact.value.reviewers,
-      (reviewer) => reviewer.identityEvidenceSha256,
-    )
-  ) {
-    invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
-  }
-  const rosterIds = new Set(
-    rosterArtifact.value.reviewers.map((reviewer) => reviewer.reviewerId),
-  )
+  const rosterIds = new Set(Object.keys(rosterArtifact.value.reviewers))
   const decisionArtifact = await readRepositoryJson(
     evidence.decisionPath,
     'PDF_EXTRACTION_REVIEW_DECISION_FILE',
@@ -975,7 +968,7 @@ async function validateReviewEvidenceFiles(value, identity) {
       'decisions',
     ]) ||
     decisionArtifact.value.schemaVersion !==
-      PDF_EXTRACTION_EVAL_SCHEMA_VERSION ||
+      PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION ||
     decisionArtifact.value.kind !== 'pdf-extraction-source-only-decisions' ||
     decisionArtifact.value.evalSetId !== identity.id ||
     decisionArtifact.value.evalSetSha256 !== identity.evalSetSha256 ||
@@ -1492,7 +1485,11 @@ function relationshipScore(expected, prediction) {
       const expectedReference = expected.references.find(
         (reference) => reference.id === item?.referenceId,
       )
-      return expectedReference && expectedReference.bodyId !== item?.bodyId
+      return (
+        !expectedReference ||
+        expectedReference.bodyId !== item?.bodyId ||
+        expectedReference.marker !== item?.marker
+      )
     })
   ) {
     return degenerateResult('DEGENERATE_SINGLE_FOOTNOTE_OWNER')
@@ -1737,6 +1734,12 @@ export function comparePdfExtractionProviders(evalSet, providers) {
   const reviewBlocksComparison = hasScoredOutput && !reviewsComplete
   if (reviewBlocksComparison) {
     for (const provider of providerSummaries) provider.score = null
+    for (const row of rows) {
+      row.scoredCaseCount = 0
+      row.abstainedCaseCount = 0
+      row.degenerateCaseCount = 0
+      row.score = null
+    }
   }
   const reportWithoutHash = {
     schemaVersion: PDF_EXTRACTION_EVAL_REPORT_SCHEMA_VERSION,

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -257,7 +257,7 @@ function validateGroundTruthReview(value, code) {
     !REVIEW_STATUSES.includes(value.reviewStatus) ||
     !Array.isArray(value.reviewers) ||
     !uniqueBy(value.reviewers, (reviewer) => reviewer) ||
-    !value.reviewers.every((reviewer) => SHA256.test(reviewer)) ||
+    !value.reviewers.every((reviewer) => SAFE_ID.test(reviewer)) ||
     value.parserOutputConsulted !== false
   ) {
     invalid(code)
@@ -923,35 +923,69 @@ async function validateReviewEvidenceFiles(value, identity) {
     evidence.rosterPath,
     'PDF_EXTRACTION_REVIEW_ROSTER_FILE',
   )
+  const roster = rosterArtifact.value
   if (
     sha256(rosterArtifact.bytes) !== evidence.rosterSha256 ||
-    !exactKeys(rosterArtifact.value, [
-      'schemaVersion',
-      'kind',
-      'evalSetId',
-      'reviewers',
-    ]) ||
-    rosterArtifact.value.schemaVersion !==
-      PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION ||
-    rosterArtifact.value.kind !== 'pdf-extraction-reviewer-roster' ||
-    rosterArtifact.value.evalSetId !== identity.id ||
-    !isRecord(rosterArtifact.value.reviewers) ||
-    Object.keys(rosterArtifact.value.reviewers).length < 2
+    !exactKeys(roster, ['schemaVersion', 'kind', 'evalSetId', 'reviewers']) ||
+    ![
+      PDF_EXTRACTION_EVAL_SCHEMA_VERSION,
+      PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION,
+    ].includes(roster.schemaVersion) ||
+    roster.kind !== 'pdf-extraction-reviewer-roster' ||
+    roster.evalSetId !== identity.id
   ) {
     invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
   }
-  for (const [identityEvidenceSha256, reviewerId] of Object.entries(
-    rosterArtifact.value.reviewers,
-  )) {
+  let reviewerEntries
+  if (roster.schemaVersion === PDF_EXTRACTION_EVAL_SCHEMA_VERSION) {
     if (
-      !SHA256.test(identityEvidenceSha256) ||
-      typeof reviewerId !== 'string' ||
-      !SAFE_ID.test(reviewerId ?? '')
+      !Array.isArray(roster.reviewers) ||
+      roster.reviewers.length < 2 ||
+      !uniqueBy(roster.reviewers, (reviewer) => reviewer.reviewerId) ||
+      !uniqueBy(
+        roster.reviewers,
+        (reviewer) => reviewer.identityEvidenceSha256,
+      ) ||
+      roster.reviewers.some(
+        (reviewer) =>
+          !exactKeys(reviewer, ['reviewerId', 'identityEvidenceSha256']) ||
+          !SAFE_ID.test(reviewer.reviewerId ?? '') ||
+          !SHA256.test(reviewer.identityEvidenceSha256 ?? ''),
+      )
     ) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
     }
+    reviewerEntries = roster.reviewers.map((reviewer) => [
+      reviewer.identityEvidenceSha256,
+      reviewer.reviewerId,
+    ])
+  } else {
+    if (
+      !isRecord(roster.reviewers) ||
+      Object.keys(roster.reviewers).length < 2 ||
+      Object.entries(roster.reviewers).some(
+        ([identityEvidenceSha256, reviewerId]) =>
+          !SHA256.test(identityEvidenceSha256) ||
+          typeof reviewerId !== 'string' ||
+          !SAFE_ID.test(reviewerId),
+      )
+    ) {
+      invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+    }
+    reviewerEntries = Object.entries(roster.reviewers)
   }
-  const rosterIds = new Set(Object.keys(rosterArtifact.value.reviewers))
+  const rosterIdentities = new Set(reviewerEntries.map(([hash]) => hash))
+  const identityHashesByAlias = new Map()
+  for (const [hash, alias] of reviewerEntries) {
+    const hashes = identityHashesByAlias.get(alias) ?? []
+    hashes.push(hash)
+    identityHashesByAlias.set(alias, hashes)
+  }
+  const resolveReviewerReference = (reference) => {
+    if (rosterIdentities.has(reference)) return reference
+    const hashes = identityHashesByAlias.get(reference)
+    return hashes?.length === 1 ? hashes[0] : null
+  }
   const decisionArtifact = await readRepositoryJson(
     evidence.decisionPath,
     'PDF_EXTRACTION_REVIEW_DECISION_FILE',
@@ -967,8 +1001,7 @@ async function validateReviewEvidenceFiles(value, identity) {
       'candidateOutputConsultedForLabel',
       'decisions',
     ]) ||
-    decisionArtifact.value.schemaVersion !==
-      PDF_EXTRACTION_EVAL_REVIEW_SCHEMA_VERSION ||
+    decisionArtifact.value.schemaVersion !== roster.schemaVersion ||
     decisionArtifact.value.kind !== 'pdf-extraction-source-only-decisions' ||
     decisionArtifact.value.evalSetId !== identity.id ||
     decisionArtifact.value.evalSetSha256 !== identity.evalSetSha256 ||
@@ -999,7 +1032,13 @@ async function validateReviewEvidenceFiles(value, identity) {
       !Array.isArray(decision.reviewers) ||
       decision.reviewers.length < 2 ||
       !uniqueBy(decision.reviewers, (reviewer) => reviewer) ||
-      !decision.reviewers.every((reviewer) => rosterIds.has(reviewer)) ||
+      decision.reviewers.some(
+        (reviewer) => resolveReviewerReference(reviewer) === null,
+      ) ||
+      !uniqueBy(
+        decision.reviewers.map(resolveReviewerReference),
+        (reviewer) => reviewer,
+      ) ||
       decision.decision !== 'agreed' ||
       !SHA256.test(decision.decisionSha256 ?? '')
     ) {
@@ -1019,7 +1058,11 @@ async function validateReviewEvidenceFiles(value, identity) {
     ]),
   )
   for (const review of agreed) {
-    if (review.reviewers.some((reviewer) => !rosterIds.has(reviewer))) {
+    const resolvedReviewers = review.reviewers.map(resolveReviewerReference)
+    if (
+      resolvedReviewers.some((reviewer) => reviewer === null) ||
+      !uniqueBy(resolvedReviewers, (reviewer) => reviewer)
+    ) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
     }
   }
@@ -1028,8 +1071,10 @@ async function validateReviewEvidenceFiles(value, identity) {
     const caseReview = item.source.groundTruth.review
     if (
       !decision ||
-      canonicalJson([...caseReview.reviewers].sort()) !==
-        canonicalJson([...decision.reviewers].sort())
+      canonicalJson(
+        caseReview.reviewers.map(resolveReviewerReference).sort(),
+      ) !==
+        canonicalJson(decision.reviewers.map(resolveReviewerReference).sort())
     ) {
       invalid('PDF_EXTRACTION_REVIEW_DECISION_MISMATCH')
     }

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -192,15 +192,21 @@ function isNormalizedBox(value) {
     Array.isArray(value) &&
     value.length === 4 &&
     value.every((item) => typeof item === 'number' && Number.isFinite(item)) &&
-    value.every((item) => item >= 0 && item <= 1)
+    value[0] >= 0 &&
+    value[0] < 1 &&
+    value[1] >= 0 &&
+    value[1] < 1 &&
+    value[2] > 0 &&
+    value[2] <= 1 &&
+    value[3] > 0 &&
+    value[3] <= 1 &&
+    value[0] + value[2] <= 1 &&
+    value[1] + value[3] <= 1
   )
 }
 
 function normalizedBoxArea(value) {
-  if (!isNormalizedBox(value) || value[2] <= value[0] || value[3] <= value[1]) {
-    return 0
-  }
-  return (value[2] - value[0]) * (value[3] - value[1])
+  return isNormalizedBox(value) ? value[2] * value[3] : 0
 }
 
 function validateSourceBinding(value, code) {
@@ -967,7 +973,8 @@ async function validateReviewEvidenceFiles(value, identity) {
         ([identityEvidenceSha256, reviewerId]) =>
           !SHA256.test(identityEvidenceSha256) ||
           typeof reviewerId !== 'string' ||
-          !SAFE_ID.test(reviewerId),
+          !SAFE_ID.test(reviewerId) ||
+          SHA256.test(reviewerId),
       )
     ) {
       invalid('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')

--- a/tools/pdf-extraction-eval.mjs
+++ b/tools/pdf-extraction-eval.mjs
@@ -191,15 +191,13 @@ function isNormalizedBox(value) {
     Array.isArray(value) &&
     value.length === 4 &&
     value.every((item) => typeof item === 'number' && Number.isFinite(item)) &&
-    value[0] >= 0 &&
-    value[0] < 1 &&
-    value[1] >= 0 &&
-    value[1] < 1 &&
-    value[2] > 0 &&
-    value[2] <= 1 &&
-    value[3] > 0 &&
-    value[3] <= 1
+    value.every((item) => item >= 0 && item <= 1)
   )
+}
+
+function normalizedBoxArea(value) {
+  if (!isNormalizedBox(value)) return 0
+  return Math.abs(value[2] - value[0]) * Math.abs(value[3] - value[1])
 }
 
 function validateSourceBinding(value, code) {
@@ -1042,7 +1040,7 @@ async function validateReviewEvidenceFiles(value, identity) {
     }
   }
   Object.defineProperty(value, REVIEW_EVIDENCE_VALIDATED, {
-    value: true,
+    value: identity.evalSetSha256,
     enumerable: false,
     configurable: true,
   })
@@ -1177,6 +1175,8 @@ function predictionArray(prediction, key) {
 function sourceBindingMatches(expected, candidate) {
   return (
     hasValidSourceBinding(candidate) &&
+    normalizedBoxArea(expected.box) > 0 &&
+    normalizedBoxArea(candidate.box) > 0 &&
     canonicalJson(candidate.box) === canonicalJson(expected.box) &&
     canonicalJson(candidate.sourceRegionIds) ===
       canonicalJson(expected.sourceRegionIds) &&
@@ -1246,8 +1246,7 @@ function tableScore(expected, prediction) {
   if (
     predictedTables.some(
       (table) =>
-        table?.pageWide === true ||
-        (Array.isArray(table?.box) && table.box[2] * table.box[3] > 0.8),
+        table?.pageWide === true || normalizedBoxArea(table?.box) > 0.8,
     )
   ) {
     return degenerateResult('DEGENERATE_PAGE_WIDE_GRID')
@@ -1331,8 +1330,7 @@ function objectScore(expected, prediction, key, degenerateCode) {
   if (
     objects.some(
       (object) =>
-        object?.pageWide === true ||
-        (Array.isArray(object?.box) && object.box[2] * object.box[3] > 0.9),
+        object?.pageWide === true || normalizedBoxArea(object?.box) > 0.9,
     )
   ) {
     return degenerateResult(degenerateCode)
@@ -1643,7 +1641,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
     reviewValues.some(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
     ) &&
-    evalSet[REVIEW_EVIDENCE_VALIDATED] !== true
+    evalSet[REVIEW_EVIDENCE_VALIDATED] !== identity.evalSetSha256
   ) {
     invalid('PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED')
   }
@@ -1732,7 +1730,7 @@ export function comparePdfExtractionProviders(evalSet, providers) {
   const reviewsComplete =
     reviewValues.every(
       (review) => review.reviewStatus === 'two-reviewer-agreed',
-    ) && evalSet[REVIEW_EVIDENCE_VALIDATED] === true
+    ) && evalSet[REVIEW_EVIDENCE_VALIDATED] === identity.evalSetSha256
   const reviewBlocksComparison = hasScoredOutput && !reviewsComplete
   if (reviewBlocksComparison) {
     for (const provider of providerSummaries) provider.score = null

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -348,8 +348,8 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     const evalSet = await readEvalSet()
     evalSet.documents[0].groundTruthReview.reviewStatus = 'two-reviewer-agreed'
     evalSet.documents[0].groundTruthReview.reviewers = [
-      'fixture-reviewer-a',
-      'fixture-reviewer-b',
+      'a'.repeat(64),
+      'b'.repeat(64),
     ]
     evalSet.documents[0].groundTruthReview.reviewEvidence = null
     expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
@@ -681,7 +681,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     ]
     for (const review of reviews) {
       review.reviewStatus = 'two-reviewer-agreed'
-      review.reviewers = ['fixture-reviewer-a', 'fixture-reviewer-b']
+      review.reviewers = ['a'.repeat(64), 'b'.repeat(64)]
       review.reviewEvidence = {
         rosterPath: 'docs/reviews/roster.json',
         rosterSha256: 'a'.repeat(64),
@@ -842,7 +842,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         ...evalSet.cases.map((item) => item.source.groundTruth.review),
       ]) {
         review.reviewStatus = 'two-reviewer-agreed'
-        review.reviewers = ['fixture-reviewer-a', 'fixture-reviewer-b']
+        review.reviewers = ['a'.repeat(64), 'b'.repeat(64)]
         review.reviewEvidence = {
           rosterPath: 'docs/reviews/roster.json',
           rosterSha256: 'a'.repeat(64),
@@ -951,6 +951,60 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validate(roster)).toBe(false)
     roster.reviewers['b'.repeat(64)] = 'reviewer-b'
     expect(validate(roster)).toBe(true)
+  })
+
+  it('publishes hash-based reviewer references in both review schemas', async () => {
+    const reviewSchema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-review.schema.json',
+        'utf8',
+      ),
+    )
+    const evalSchema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-strata.schema.json',
+        'utf8',
+      ),
+    )
+    const ajv = new Ajv2020({ strict: false })
+    const validateReview = ajv.compile(reviewSchema)
+    const validateEvalSet = ajv.compile(evalSchema)
+    const reviewerHashes = ['a'.repeat(64), 'b'.repeat(64)]
+    const aliases = ['reviewer-a', 'reviewer-b']
+    const decision = {
+      schemaVersion: '1.1.0',
+      kind: 'pdf-extraction-source-only-decisions',
+      evalSetId: 'fixture-eval',
+      evalSetSha256: 'c'.repeat(64),
+      sourceOnly: true,
+      candidateOutputConsultedForLabel: false,
+      decisions: [
+        {
+          caseId: 'fixture-case',
+          sourceSha256: 'd'.repeat(64),
+          reviewers: aliases,
+          decision: 'agreed',
+          decisionSha256: 'e'.repeat(64),
+        },
+      ],
+    }
+    expect(validateReview(decision)).toBe(false)
+    decision.decisions[0].reviewers = reviewerHashes
+    expect(validateReview(decision)).toBe(true)
+
+    const evalSet = await readEvalSet()
+    const review = evalSet.documents[0].groundTruthReview
+    review.reviewStatus = 'two-reviewer-agreed'
+    review.reviewers = aliases
+    review.reviewEvidence = {
+      rosterPath: 'docs/reviews/roster.json',
+      rosterSha256: 'f'.repeat(64),
+      decisionPath: 'docs/reviews/decisions.json',
+      decisionSha256: '0'.repeat(64),
+    }
+    expect(validateEvalSet(evalSet)).toBe(false)
+    review.reviewers = reviewerHashes
+    expect(validateEvalSet(evalSet)).toBe(true)
   })
 
   it('enforces page-contained endpoint boxes without perfect-scoring zero area', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -26,10 +26,10 @@ async function attachVerifiedReviews(
     legacy = false,
     reviewerA = 'fixture-reviewer-a',
     reviewerB = 'fixture-reviewer-b',
+    reviewerHashA = 'a'.repeat(64),
+    reviewerHashB = 'b'.repeat(64),
   } = {},
 ) {
-  const reviewerHashA = 'a'.repeat(64)
-  const reviewerHashB = 'b'.repeat(64)
   const reviewerReferences = legacy
     ? [reviewerA, reviewerB]
     : [reviewerHashA, reviewerHashB]
@@ -225,8 +225,45 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     ).toMatchObject({ score: null, scoredCaseCount: 0 })
   })
 
+  it('redacts degenerate scored attempts until every review is verified', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    tableCase.status = 'scored'
+    tableCase.prediction = { tables: [] }
+    tableCase.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    const row = report.rows.find(
+      (item) =>
+        item.stratum === 'table-structure' && item.layout === 'one-column',
+    )
+    expect(report).toMatchObject({
+      status: 'reported-only',
+      diagnosticCodes: ['PDF_EXTRACTION_REVIEW_INCOMPLETE'],
+    })
+    expect(report.providers[0]).toMatchObject({
+      score: null,
+      diagnosticCodes: [],
+    })
+    expect(row).toMatchObject({
+      score: null,
+      scoredCaseCount: 0,
+      abstainedCaseCount: 0,
+      degenerateCaseCount: 0,
+      diagnostics: [],
+    })
+  })
+
   it('scores abstention above guarded degenerate answers', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -255,6 +292,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('does not give metadata-only table or object predictions a perfect score', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -427,6 +465,36 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
           row.layout === furnitureCase.layout,
       ),
     ).toMatchObject({ degenerateCaseCount: 0, scoredCaseCount: 1 })
+
+    output.prediction.excluded = [
+      { ...furnitureCase.source.groundTruth.excluded[0] },
+    ]
+    const missed = furnitureCase.source.groundTruth.excluded.slice(1)
+    output.prediction.contamination = {
+      runningHeadContaminationCount: missed.filter(
+        (item) => item.kind === 'running-head',
+      ).length,
+      pageNumberContaminationCount: missed.filter(
+        (item) => item.kind === 'page-number',
+      ).length,
+      excludedCount: 1,
+    }
+    report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'boilerplate-exclusion' &&
+          row.layout === furnitureCase.layout,
+      ),
+    ).toMatchObject({
+      score: 0.125,
+      degenerateCaseCount: 1,
+      scoredCaseCount: 0,
+      diagnostics: [
+        'CANDIDATE_ABSTAINED',
+        'RUNNING_HEAD_OR_PAGE_NUMBER_LEFT_IN_BODY_FLOW',
+      ],
+    })
   })
 
   it('scores valid many-to-one footnote references instead of treating them as degenerate', async () => {
@@ -551,6 +619,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       marker: '2',
       bodyId: 'footnote-2',
     })
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -651,6 +720,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('fails closed on extra or invalid table cells', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -862,6 +932,21 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         attachVerifiedReviews(evalSet, directory, {
           legacy: true,
           reviewerA: 'b'.repeat(64),
+        }),
+      ).resolves.toBeUndefined()
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves schema-valid duplicate v1.0 identity evidence hashes', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-v1-duplicate-')
+    try {
+      await expect(
+        attachVerifiedReviews(evalSet, directory, {
+          legacy: true,
+          reviewerHashB: 'a'.repeat(64),
         }),
       ).resolves.toBeUndefined()
     } finally {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -22,10 +22,12 @@ async function readEvalSet() {
 async function attachVerifiedReviews(
   evalSet,
   directory,
-  { legacy = false } = {},
+  {
+    legacy = false,
+    reviewerA = 'fixture-reviewer-a',
+    reviewerB = 'fixture-reviewer-b',
+  } = {},
 ) {
-  const reviewerA = 'fixture-reviewer-a'
-  const reviewerB = 'fixture-reviewer-b'
   const reviewerHashA = 'a'.repeat(64)
   const reviewerHashB = 'b'.repeat(64)
   const rosterPath = join(directory, 'roster.json')
@@ -974,6 +976,86 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validate(roster)).toBe(true)
   })
 
+  it('publishes the accepted legacy v1.0 review contract', async () => {
+    const schema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-review-1.0.0.schema.json',
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const roster = {
+      schemaVersion: '1.0.0',
+      kind: 'pdf-extraction-reviewer-roster',
+      evalSetId: 'fixture-eval',
+      reviewers: [
+        {
+          reviewerId: 'reviewer-a',
+          identityEvidenceSha256: 'a'.repeat(64),
+        },
+        {
+          reviewerId: 'reviewer-b',
+          identityEvidenceSha256: 'b'.repeat(64),
+        },
+      ],
+    }
+    expect(validate(roster)).toBe(true)
+
+    expect(
+      validate({
+        schemaVersion: '1.0.0',
+        kind: 'pdf-extraction-source-only-decisions',
+        evalSetId: 'fixture-eval',
+        evalSetSha256: 'c'.repeat(64),
+        sourceOnly: true,
+        candidateOutputConsultedForLabel: false,
+        decisions: [
+          {
+            caseId: 'fixture-case',
+            sourceSha256: 'd'.repeat(64),
+            reviewers: ['reviewer-a', 'reviewer-b'],
+            decision: 'agreed',
+            decisionSha256: 'e'.repeat(64),
+          },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects v1.1 reviewer aliases that collide with identity hash keys', async () => {
+    const schema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-review.schema.json',
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const reviewerHashA = 'a'.repeat(64)
+    const reviewerHashB = 'b'.repeat(64)
+    const roster = {
+      schemaVersion: '1.1.0',
+      kind: 'pdf-extraction-reviewer-roster',
+      evalSetId: 'fixture-eval',
+      reviewers: {
+        [reviewerHashA]: reviewerHashB,
+        [reviewerHashB]: 'reviewer-b',
+      },
+    }
+    expect(validate(roster)).toBe(false)
+
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-hash-alias-')
+    try {
+      await expect(
+        attachVerifiedReviews(evalSet, directory, {
+          reviewerA: reviewerHashB,
+        }),
+      ).rejects.toThrow('PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('publishes resolvable reviewer aliases in both review schemas', async () => {
     const reviewSchema = JSON.parse(
       await readFile(
@@ -1028,7 +1110,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validateEvalSet(evalSet)).toBe(true)
   })
 
-  it('enforces page-contained endpoint boxes without perfect-scoring zero area', async () => {
+  it('preserves v1 left-top-width-height boxes and rejects invalid extents', async () => {
     const evalSet = await readEvalSet()
     const tableCase = evalSet.cases.find((item) =>
       item.id.endsWith('.table-structure'),
@@ -1041,46 +1123,50 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     )
     const validate = new Ajv2020({ strict: false }).compile(schema)
 
-    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 1.6, 0.5]
+    expect(schema.$id).toBe(
+      'https://ernie.sg/schemas/pdf-extraction-eval-strata-1.0.0.json',
+    )
+    expect(schema.$defs.box.$comment).toContain('left, top, width, and height')
+
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.3, 0.5]
+    expect(validate(evalSet)).toBe(true)
+    expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
+      'INVALID_PDF_EXTRACTION_EVAL_SET',
+    )
+
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0, 0.5]
     expect(validate(evalSet)).toBe(false)
     expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
       'INVALID_PDF_EXTRACTION_EVAL_SET',
     )
 
-    for (const box of [
-      [0.8, 0, 0.8, 0.5],
-      [0.8, 0.5, 0.2, 0.1],
-    ]) {
-      tableCase.source.groundTruth.tables[0].box = box
-      expect(validate(evalSet)).toBe(true)
-      expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
-      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
-        id: 'candidate-a',
-        kind: 'candidate',
-        version: 'candidate-a-v1',
-      })
-      const output = candidate.cases.find(
-        (item) => item.caseId === tableCase.id,
-      )
-      output.status = 'scored'
-      output.prediction = {
-        tables: [{ ...tableCase.source.groundTruth.tables[0] }],
-      }
-      output.diagnostics = []
-      const report = comparePdfExtractionProviders(evalSet, [candidate])
-      expect(
-        report.rows.find(
-          (row) =>
-            row.stratum === 'table-structure' &&
-            row.layout === tableCase.layout,
-        ),
-      ).toMatchObject({
-        score: 0,
-        scoredCaseCount: 0,
-        degenerateCaseCount: 1,
-        diagnostics: ['MISSING_TABLE_GEOMETRY_OR_LINEAGE'],
-      })
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.2, 0.5]
+    expect(validate(evalSet)).toBe(true)
+    expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
+    await verifyEvalSet(evalSet)
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find((item) => item.caseId === tableCase.id)
+    output.status = 'scored'
+    output.prediction = {
+      tables: [{ ...tableCase.source.groundTruth.tables[0] }],
     }
+    output.diagnostics = []
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === tableCase.layout,
+      ),
+    ).toMatchObject({
+      score: 1,
+      scoredCaseCount: 1,
+      degenerateCaseCount: 0,
+      diagnostics: [],
+    })
   })
 
   it('refuses regex-only prose continuity evidence', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -885,27 +885,40 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       'INVALID_PDF_EXTRACTION_EVAL_SET',
     )
 
-    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.8, 0.5]
-    expect(validate(evalSet)).toBe(true)
-    expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
-    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
-      id: 'candidate-a',
-      kind: 'candidate',
-      version: 'candidate-a-v1',
-    })
-    const output = candidate.cases.find((item) => item.caseId === tableCase.id)
-    output.status = 'scored'
-    output.prediction = {
-      tables: [{ ...tableCase.source.groundTruth.tables[0] }],
+    for (const box of [
+      [0.8, 0, 0.8, 0.5],
+      [0.8, 0.5, 0.2, 0.1],
+    ]) {
+      tableCase.source.groundTruth.tables[0].box = box
+      expect(validate(evalSet)).toBe(true)
+      expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
+      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-a',
+        kind: 'candidate',
+        version: 'candidate-a-v1',
+      })
+      const output = candidate.cases.find(
+        (item) => item.caseId === tableCase.id,
+      )
+      output.status = 'scored'
+      output.prediction = {
+        tables: [{ ...tableCase.source.groundTruth.tables[0] }],
+      }
+      output.diagnostics = []
+      const report = comparePdfExtractionProviders(evalSet, [candidate])
+      expect(
+        report.rows.find(
+          (row) =>
+            row.stratum === 'table-structure' &&
+            row.layout === tableCase.layout,
+        ),
+      ).toMatchObject({
+        score: 0,
+        scoredCaseCount: 0,
+        degenerateCaseCount: 1,
+        diagnostics: ['MISSING_TABLE_GEOMETRY_OR_LINEAGE'],
+      })
     }
-    output.diagnostics = []
-    const report = comparePdfExtractionProviders(evalSet, [candidate])
-    expect(
-      report.rows.find(
-        (row) =>
-          row.stratum === 'table-structure' && row.layout === tableCase.layout,
-      ).score,
-    ).toBe(0)
   })
 
   it('refuses regex-only prose continuity evidence', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -19,6 +19,67 @@ async function readEvalSet() {
   return JSON.parse(await readFile(evalPath, 'utf8'))
 }
 
+async function attachVerifiedReviews(evalSet, directory) {
+  const reviewerA = 'fixture-reviewer-a'
+  const reviewerB = 'fixture-reviewer-b'
+  const rosterPath = join(directory, 'roster.json')
+  const decisionPath = join(directory, 'decisions.json')
+  const reviews = [
+    ...evalSet.documents.map((item) => item.groundTruthReview),
+    ...evalSet.strata.map((item) => item.groundTruth),
+    ...evalSet.cases.map((item) => item.source.groundTruth.review),
+  ]
+  for (const review of reviews) {
+    review.reviewStatus = 'two-reviewer-agreed'
+    review.reviewers = [reviewerA, reviewerB]
+    review.reviewEvidence = {
+      rosterPath,
+      rosterSha256: '0'.repeat(64),
+      decisionPath,
+      decisionSha256: '0'.repeat(64),
+    }
+  }
+  const roster = {
+    schemaVersion: '1.0.0',
+    kind: 'pdf-extraction-reviewer-roster',
+    evalSetId: evalSet.id,
+    reviewers: [
+      { reviewerId: reviewerA, identityEvidenceSha256: 'a'.repeat(64) },
+      { reviewerId: reviewerB, identityEvidenceSha256: 'b'.repeat(64) },
+    ],
+  }
+  const identity = validatePdfExtractionEvalSet(evalSet)
+  const documentById = new Map(evalSet.documents.map((item) => [item.id, item]))
+  const decisionArtifact = {
+    schemaVersion: '1.0.0',
+    kind: 'pdf-extraction-source-only-decisions',
+    evalSetId: evalSet.id,
+    evalSetSha256: identity.evalSetSha256,
+    sourceOnly: true,
+    candidateOutputConsultedForLabel: false,
+    decisions: evalSet.cases.map((item) => ({
+      caseId: item.id,
+      sourceSha256: documentById.get(item.documentId).sha256,
+      reviewers: [reviewerA, reviewerB],
+      decision: 'agreed',
+      decisionSha256: 'd'.repeat(64),
+    })),
+  }
+  const rosterBytes = Buffer.from(`${JSON.stringify(roster)}\n`)
+  const decisionBytes = Buffer.from(`${JSON.stringify(decisionArtifact)}\n`)
+  await writeFile(rosterPath, rosterBytes)
+  await writeFile(decisionPath, decisionBytes)
+  for (const review of reviews) {
+    review.reviewEvidence = {
+      rosterPath,
+      rosterSha256: sha256(rosterBytes),
+      decisionPath,
+      decisionSha256: sha256(decisionBytes),
+    }
+  }
+  await validatePdfExtractionEvalSetFiles(evalSet)
+}
+
 describe('source-reviewed PDF extraction strata benchmark', () => {
   it('validates the reviewed table/structure slice and both layout lanes', async () => {
     const evalSet = await readEvalSet()
@@ -109,6 +170,33 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     )
   })
 
+  it('keeps directly scored output reported-only until every review is verified', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const tableCase = candidate.cases.find((item) =>
+      item.caseId.endsWith('.table-structure'),
+    )
+    const expectedTable = evalSet.cases.find((item) =>
+      item.id.endsWith('.table-structure'),
+    ).source.groundTruth.tables[0]
+    tableCase.status = 'scored'
+    tableCase.prediction = { tables: [{ ...expectedTable }] }
+    tableCase.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+
+    expect(report).toMatchObject({
+      status: 'reported-only',
+      diagnosticCodes: ['PDF_EXTRACTION_REVIEW_INCOMPLETE'],
+    })
+    expect(report.providers[0].score).toBeNull()
+    expect(report.summary.scoredProviderCount).toBe(0)
+  })
+
   it('scores abstention above guarded degenerate answers', async () => {
     const evalSet = await readEvalSet()
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
@@ -185,12 +273,14 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     const report = comparePdfExtractionProviders(evalSet, [candidate])
     expect(
       report.rows.find(
-        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === 'one-column',
       ),
     ).toMatchObject({ score: 0, degenerateCaseCount: 1 })
     expect(
       report.rows.find(
-        (row) => row.stratum === 'figure-diagram' && row.layout === 'one-column',
+        (row) =>
+          row.stratum === 'figure-diagram' && row.layout === 'one-column',
       ),
     ).toMatchObject({ score: 0, degenerateCaseCount: 1 })
   })
@@ -216,7 +306,8 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     const report = comparePdfExtractionProviders(evalSet, [candidate])
     expect(
       report.rows.find(
-        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === 'one-column',
       ),
     ).toMatchObject({ score: 1, scoredCaseCount: 1, degenerateCaseCount: 0 })
   })
@@ -232,9 +323,9 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(candidate.evalSetSha256).toBe(identity.evalSetSha256)
 
     delete candidate.evalSetSha256
-    expect(() =>
-      comparePdfExtractionProviders(evalSet, [candidate]),
-    ).toThrow('INVALID_PDF_EXTRACTION_CANDIDATE')
+    expect(() => comparePdfExtractionProviders(evalSet, [candidate])).toThrow(
+      'INVALID_PDF_EXTRACTION_CANDIDATE',
+    )
   })
 
   it('rejects two-reviewer labels without roster-bound source-only evidence', async () => {
@@ -261,6 +352,51 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         expect.objectContaining({ kind: 'page-number' }),
       ]),
     )
+  })
+
+  it('scores boilerplate exclusion against reviewed furniture identities', async () => {
+    const evalSet = await readEvalSet()
+    const furnitureCase = evalSet.cases.find(
+      (item) => item.id === 'diagnostic-overlays.boilerplate-exclusion',
+    )
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find(
+      (item) => item.caseId === furnitureCase.id,
+    )
+    output.status = 'scored'
+    output.prediction = {
+      contamination: {
+        runningHeadContaminationCount: 0,
+        pageNumberContaminationCount: 0,
+        excludedCount: furnitureCase.source.groundTruth.excluded.length,
+      },
+    }
+    output.diagnostics = []
+
+    let report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'boilerplate-exclusion' &&
+          row.layout === furnitureCase.layout,
+      ),
+    ).toMatchObject({ degenerateCaseCount: 1 })
+
+    output.prediction.excluded = furnitureCase.source.groundTruth.excluded.map(
+      (item) => ({ ...item }),
+    )
+    report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'boilerplate-exclusion' &&
+          row.layout === furnitureCase.layout,
+      ),
+    ).toMatchObject({ degenerateCaseCount: 0, scoredCaseCount: 1 })
   })
 
   it('scores valid many-to-one footnote references instead of treating them as degenerate', async () => {
@@ -302,39 +438,105 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(
       report.rows.find(
         (row) =>
-          row.stratum === 'footnote-resolution' && row.layout === footnoteCase.layout,
+          row.stratum === 'footnote-resolution' &&
+          row.layout === footnoteCase.layout,
       ),
     ).toMatchObject({ score: 1, degenerateCaseCount: 0, scoredCaseCount: 1 })
   })
 
-  it('includes abstained rows in sparse provider aggregates', async () => {
+  it('scores a correct partial many-to-one footnote result across multiple bodies', async () => {
     const evalSet = await readEvalSet()
+    const footnoteCase = evalSet.cases.find((item) =>
+      item.id.endsWith('.footnote-resolution'),
+    )
+    footnoteCase.source.groundTruth.references.push(
+      {
+        id: 'note-reference-2',
+        sourcePage: footnoteCase.source.sourcePage,
+        marker: '1',
+        bodyId: 'footnote-1',
+      },
+      {
+        id: 'note-reference-3',
+        sourcePage: footnoteCase.source.sourcePage,
+        marker: '2',
+        bodyId: 'footnote-2',
+      },
+    )
+    footnoteCase.source.groundTruth.bodies.push({
+      id: 'footnote-2',
+      sourcePage: footnoteCase.source.sourcePage,
+      marker: '2',
+    })
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
       version: 'candidate-a-v1',
     })
-    const tableCase = candidate.cases.find((item) =>
-      item.caseId.endsWith('.table-structure'),
+    const output = candidate.cases.find(
+      (item) => item.caseId === footnoteCase.id,
     )
-    const expectedTable = evalSet.cases.find((item) =>
-      item.id.endsWith('.table-structure'),
-    ).source.groundTruth.tables[0]
-    tableCase.status = 'scored'
-    tableCase.prediction = { tables: [{ ...expectedTable }] }
-    tableCase.diagnostics = []
+    output.status = 'scored'
+    output.prediction = {
+      relationships: [
+        {
+          referenceId: 'note-reference-1',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+        {
+          referenceId: 'note-reference-2',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+      ],
+    }
+    output.diagnostics = []
 
     const report = comparePdfExtractionProviders(evalSet, [candidate])
-    const provider = report.providers[0]
-    const expectedAggregate = Number(
-      (
-        report.rows.reduce((sum, row) => sum + row.score, 0) /
-        report.rows.length
-      ).toFixed(5),
-    )
-    expect(provider.score).toBe(expectedAggregate)
-    expect(provider.score).toBeLessThan(1)
-    expect(provider.score).toBeGreaterThan(0.25)
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'footnote-resolution' &&
+          row.layout === footnoteCase.layout,
+      ),
+    ).toMatchObject({ degenerateCaseCount: 0, scoredCaseCount: 1 })
+  })
+
+  it('includes abstained rows in sparse provider aggregates', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-aggregate-')
+    try {
+      await attachVerifiedReviews(evalSet, directory)
+      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-a',
+        kind: 'candidate',
+        version: 'candidate-a-v1',
+      })
+      const tableCase = candidate.cases.find((item) =>
+        item.caseId.endsWith('.table-structure'),
+      )
+      const expectedTable = evalSet.cases.find((item) =>
+        item.id.endsWith('.table-structure'),
+      ).source.groundTruth.tables[0]
+      tableCase.status = 'scored'
+      tableCase.prediction = { tables: [{ ...expectedTable }] }
+      tableCase.diagnostics = []
+
+      const report = comparePdfExtractionProviders(evalSet, [candidate])
+      const provider = report.providers[0]
+      const expectedAggregate = Number(
+        (
+          report.rows.reduce((sum, row) => sum + row.score, 0) /
+          report.rows.length
+        ).toFixed(5),
+      )
+      expect(provider.score).toBe(expectedAggregate)
+      expect(provider.score).toBeLessThan(1)
+      expect(provider.score).toBeGreaterThan(0.25)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 
   it('matches bounded objects by source binding rather than array order', async () => {
@@ -393,7 +595,8 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     const report = comparePdfExtractionProviders(evalSet, [candidate])
     expect(
       report.rows.find(
-        (row) => row.stratum === 'table-structure' && row.layout === 'one-column',
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === 'one-column',
       ),
     ).toMatchObject({ score: 0, scoredCaseCount: 0, degenerateCaseCount: 1 })
   })
@@ -500,9 +703,30 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       }
       for (const review of reviews) review.reviewEvidence = evidence
 
-      await expect(validatePdfExtractionEvalSetFiles(evalSet)).resolves.toMatchObject(
-        { evalSetSha256: identity.evalSetSha256 },
+      await expect(
+        validatePdfExtractionEvalSetFiles(evalSet),
+      ).resolves.toMatchObject({ evalSetSha256: identity.evalSetSha256 })
+
+      roster.reviewers[2].identityEvidenceSha256 =
+        roster.reviewers[0].identityEvidenceSha256
+      const duplicateIdentityRosterBytes = Buffer.from(
+        `${JSON.stringify(roster)}\n`,
       )
+      await writeFile(rosterPath, duplicateIdentityRosterBytes)
+      for (const review of reviews) {
+        review.reviewEvidence.rosterSha256 = sha256(
+          duplicateIdentityRosterBytes,
+        )
+      }
+      await expect(validatePdfExtractionEvalSetFiles(evalSet)).rejects.toThrow(
+        'PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH',
+      )
+
+      roster.reviewers[2].identityEvidenceSha256 = 'c'.repeat(64)
+      await writeFile(rosterPath, rosterBytes)
+      for (const review of reviews) {
+        review.reviewEvidence.rosterSha256 = sha256(rosterBytes)
+      }
 
       evalSet.cases[0].source.groundTruth.review.reviewers = [
         ...evalSet.cases[1].source.groundTruth.review.reviewers,
@@ -543,7 +767,10 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       const predictionBytes = Buffer.from(`${JSON.stringify(candidate)}\n`)
       await writeFile(predictionsPath, predictionBytes)
       const manifest = JSON.parse(
-        await readFile('benchmarks/pdf/extraction-eval-providers-v1.json', 'utf8'),
+        await readFile(
+          'benchmarks/pdf/extraction-eval-providers-v1.json',
+          'utf8',
+        ),
       )
       manifest.evalSet.evalSetSha256 = identity.evalSetSha256
       manifest.evaluationStatus = 'comparison-ready'
@@ -563,9 +790,9 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       ).resolves.toHaveLength(1)
 
       await writeFile(predictionsPath, `${predictionBytes} `)
-      await expect(loadProviderManifest(manifest, identity, evalSet)).rejects.toThrow(
-        'PDF_EXTRACTION_PROVIDER_PREDICTIONS_HASH_MISMATCH',
-      )
+      await expect(
+        loadProviderManifest(manifest, identity, evalSet),
+      ).rejects.toThrow('PDF_EXTRACTION_PROVIDER_PREDICTIONS_HASH_MISMATCH')
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
@@ -579,7 +806,10 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       version: 'candidate-a-v1',
     })
     const schema = JSON.parse(
-      await readFile('docs/schemas/pdf-extraction-eval-candidate.schema.json', 'utf8'),
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-candidate.schema.json',
+        'utf8',
+      ),
     )
     const validate = new Ajv2020({ strict: false }).compile(schema)
     expect(validate(candidate)).toBe(true)
@@ -590,6 +820,46 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     candidate.cases[0].status = 'scored'
     candidate.cases[0].prediction = null
     expect(validate(candidate)).toBe(true)
+  })
+
+  it('publishes the runtime diagnostic-code constraint in the candidate schema', async () => {
+    const evalSet = await readEvalSet()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const schema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-candidate.schema.json',
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    expect(validate(candidate)).toBe(true)
+
+    candidate.cases[0].diagnostics = ['warning']
+    expect(validate(candidate)).toBe(false)
+    candidate.cases[0].diagnostics = ['UPPERCASE_DIAGNOSTIC_1']
+    expect(validate(candidate)).toBe(true)
+  })
+
+  it('aligns runtime box validation with the published normalized-component schema', async () => {
+    const evalSet = await readEvalSet()
+    const tableCase = evalSet.cases.find((item) =>
+      item.id.endsWith('.table-structure'),
+    )
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.8, 0.5]
+    const schema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-strata.schema.json',
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+
+    expect(validate(evalSet)).toBe(true)
+    expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
   })
 
   it('refuses regex-only prose continuity evidence', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -851,6 +851,21 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     }
   })
 
+  it('keeps hash-shaped v1.0 reviewer IDs alias-bound', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-v1-alias-')
+    try {
+      await expect(
+        attachVerifiedReviews(evalSet, directory, {
+          legacy: true,
+          reviewerA: 'b'.repeat(64),
+        }),
+      ).resolves.toBeUndefined()
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('requires the manifest hash to match exact file-mode prediction bytes', async () => {
     const evalSet = await readEvalSet()
     const directory = await mkdtemp('.tmp-pdf-extraction-provider-')

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -30,6 +30,9 @@ async function attachVerifiedReviews(
 ) {
   const reviewerHashA = 'a'.repeat(64)
   const reviewerHashB = 'b'.repeat(64)
+  const reviewerReferences = legacy
+    ? [reviewerA, reviewerB]
+    : [reviewerHashA, reviewerHashB]
   const rosterPath = join(directory, 'roster.json')
   const decisionPath = join(directory, 'decisions.json')
   const reviews = [
@@ -39,7 +42,7 @@ async function attachVerifiedReviews(
   ]
   for (const review of reviews) {
     review.reviewStatus = 'two-reviewer-agreed'
-    review.reviewers = [reviewerA, reviewerB]
+    review.reviewers = reviewerReferences
     review.reviewEvidence = {
       rosterPath,
       rosterSha256: '0'.repeat(64),
@@ -70,7 +73,7 @@ async function attachVerifiedReviews(
     decisions: evalSet.cases.map((item) => ({
       caseId: item.id,
       sourceSha256: documentById.get(item.documentId).sha256,
-      reviewers: [reviewerA, reviewerB],
+      reviewers: reviewerReferences,
       decision: 'agreed',
       decisionSha256: 'd'.repeat(64),
     })),
@@ -1071,7 +1074,37 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     }
   })
 
-  it('publishes resolvable reviewer aliases in both review schemas', async () => {
+  it('publishes authoritative hash-only v1.1 decision references', async () => {
+    const schema = JSON.parse(
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-review.schema.json',
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const decision = {
+      schemaVersion: '1.1.0',
+      kind: 'pdf-extraction-source-only-decisions',
+      evalSetId: 'fixture-eval',
+      evalSetSha256: 'c'.repeat(64),
+      sourceOnly: true,
+      candidateOutputConsultedForLabel: false,
+      decisions: [
+        {
+          caseId: 'fixture-case',
+          sourceSha256: 'd'.repeat(64),
+          reviewers: ['shared-alias', 'reviewer-b'],
+          decision: 'agreed',
+          decisionSha256: 'e'.repeat(64),
+        },
+      ],
+    }
+    expect(validate(decision)).toBe(false)
+    decision.decisions[0].reviewers = ['a'.repeat(64), 'b'.repeat(64)]
+    expect(validate(decision)).toBe(true)
+  })
+
+  it('publishes authoritative v1.1 and legacy-compatible eval references', async () => {
     const reviewSchema = JSON.parse(
       await readFile(
         'docs/schemas/pdf-extraction-eval-review.schema.json',
@@ -1106,7 +1139,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         },
       ],
     }
-    expect(validateReview(decision)).toBe(true)
+    expect(validateReview(decision)).toBe(false)
     decision.decisions[0].reviewers = reviewerHashes
     expect(validateReview(decision)).toBe(true)
 

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -19,9 +19,15 @@ async function readEvalSet() {
   return JSON.parse(await readFile(evalPath, 'utf8'))
 }
 
-async function attachVerifiedReviews(evalSet, directory) {
-  const reviewerA = 'a'.repeat(64)
-  const reviewerB = 'b'.repeat(64)
+async function attachVerifiedReviews(
+  evalSet,
+  directory,
+  { legacy = false } = {},
+) {
+  const reviewerA = 'fixture-reviewer-a'
+  const reviewerB = 'fixture-reviewer-b'
+  const reviewerHashA = 'a'.repeat(64)
+  const reviewerHashB = 'b'.repeat(64)
   const rosterPath = join(directory, 'roster.json')
   const decisionPath = join(directory, 'decisions.json')
   const reviews = [
@@ -40,18 +46,20 @@ async function attachVerifiedReviews(evalSet, directory) {
     }
   }
   const roster = {
-    schemaVersion: '1.1.0',
+    schemaVersion: legacy ? '1.0.0' : '1.1.0',
     kind: 'pdf-extraction-reviewer-roster',
     evalSetId: evalSet.id,
-    reviewers: {
-      [reviewerA]: 'fixture-reviewer-a',
-      [reviewerB]: 'fixture-reviewer-b',
-    },
+    reviewers: legacy
+      ? [
+          { reviewerId: reviewerA, identityEvidenceSha256: reviewerHashA },
+          { reviewerId: reviewerB, identityEvidenceSha256: reviewerHashB },
+        ]
+      : { [reviewerHashA]: reviewerA, [reviewerHashB]: reviewerB },
   }
   const identity = validatePdfExtractionEvalSet(evalSet)
   const documentById = new Map(evalSet.documents.map((item) => [item.id, item]))
   const decisionArtifact = {
-    schemaVersion: '1.1.0',
+    schemaVersion: legacy ? '1.0.0' : '1.1.0',
     kind: 'pdf-extraction-source-only-decisions',
     evalSetId: evalSet.id,
     evalSetSha256: identity.evalSetSha256,
@@ -806,9 +814,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       )
       await writeFile(rosterPath, missingIdentityRosterBytes)
       for (const review of reviews) {
-        review.reviewEvidence.rosterSha256 = sha256(
-          missingIdentityRosterBytes,
-        )
+        review.reviewEvidence.rosterSha256 = sha256(missingIdentityRosterBytes)
       }
       await expect(validatePdfExtractionEvalSetFiles(evalSet)).rejects.toThrow(
         'PDF_EXTRACTION_REVIEW_DECISION_MISMATCH',
@@ -826,6 +832,18 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       await expect(validatePdfExtractionEvalSetFiles(evalSet)).rejects.toThrow(
         'PDF_EXTRACTION_REVIEW_DECISION_MISMATCH',
       )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('continues to validate completed v1.0 review evidence', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-v1-')
+    try {
+      await expect(
+        attachVerifiedReviews(evalSet, directory, { legacy: true }),
+      ).resolves.toBeUndefined()
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
@@ -938,7 +956,10 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('publishes distinct reviewer identity evidence in the review schema', async () => {
     const schema = JSON.parse(
-      await readFile('docs/schemas/pdf-extraction-eval-review.schema.json', 'utf8'),
+      await readFile(
+        'docs/schemas/pdf-extraction-eval-review.schema.json',
+        'utf8',
+      ),
     )
     const validate = new Ajv2020({ strict: false }).compile(schema)
     const roster = {
@@ -953,7 +974,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validate(roster)).toBe(true)
   })
 
-  it('publishes hash-based reviewer references in both review schemas', async () => {
+  it('publishes resolvable reviewer aliases in both review schemas', async () => {
     const reviewSchema = JSON.parse(
       await readFile(
         'docs/schemas/pdf-extraction-eval-review.schema.json',
@@ -988,7 +1009,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         },
       ],
     }
-    expect(validateReview(decision)).toBe(false)
+    expect(validateReview(decision)).toBe(true)
     decision.decisions[0].reviewers = reviewerHashes
     expect(validateReview(decision)).toBe(true)
 
@@ -1002,7 +1023,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       decisionPath: 'docs/reviews/decisions.json',
       decisionSha256: '0'.repeat(64),
     }
-    expect(validateEvalSet(evalSet)).toBe(false)
+    expect(validateEvalSet(evalSet)).toBe(true)
     review.reviewers = reviewerHashes
     expect(validateEvalSet(evalSet)).toBe(true)
   })

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -632,6 +632,28 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     )
   })
 
+  it('binds verified review evidence to the exact evaluated identity', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-identity-')
+    try {
+      await attachVerifiedReviews(evalSet, directory)
+      evalSet.cases.find((item) =>
+        item.id.endsWith('.table-structure'),
+      ).source.groundTruth.tables[0].cells[0].text = 'mutated-after-review'
+      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-a',
+        kind: 'candidate',
+        version: 'candidate-a-v1',
+      })
+
+      expect(() => comparePdfExtractionProviders(evalSet, [candidate])).toThrow(
+        'PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED',
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('binds each case reviewer list to its corresponding decision', async () => {
     const evalSet = await readEvalSet()
     const directory = await mkdtemp('.tmp-pdf-extraction-review-')
@@ -844,12 +866,11 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validate(candidate)).toBe(true)
   })
 
-  it('aligns runtime box validation with the published normalized-component schema', async () => {
+  it('enforces page-contained endpoint boxes without perfect-scoring zero area', async () => {
     const evalSet = await readEvalSet()
     const tableCase = evalSet.cases.find((item) =>
       item.id.endsWith('.table-structure'),
     )
-    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.8, 0.5]
     const schema = JSON.parse(
       await readFile(
         'docs/schemas/pdf-extraction-eval-strata.schema.json',
@@ -858,8 +879,33 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     )
     const validate = new Ajv2020({ strict: false }).compile(schema)
 
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 1.6, 0.5]
+    expect(validate(evalSet)).toBe(false)
+    expect(() => validatePdfExtractionEvalSet(evalSet)).toThrow(
+      'INVALID_PDF_EXTRACTION_EVAL_SET',
+    )
+
+    tableCase.source.groundTruth.tables[0].box = [0.8, 0, 0.8, 0.5]
     expect(validate(evalSet)).toBe(true)
     expect(() => validatePdfExtractionEvalSet(evalSet)).not.toThrow()
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find((item) => item.caseId === tableCase.id)
+    output.status = 'scored'
+    output.prediction = {
+      tables: [{ ...tableCase.source.groundTruth.tables[0] }],
+    }
+    output.diagnostics = []
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === tableCase.layout,
+      ).score,
+    ).toBe(0)
   })
 
   it('refuses regex-only prose continuity evidence', async () => {

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -655,6 +655,54 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     ).toMatchObject({ degenerateCaseCount: 1, scoredCaseCount: 0 })
   })
 
+  it('keeps a mixed correct and dangling footnote result degenerate', async () => {
+    const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
+    const footnoteCase = evalSet.cases.find((item) =>
+      item.id.endsWith('.footnote-resolution'),
+    )
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find(
+      (item) => item.caseId === footnoteCase.id,
+    )
+    const expected = footnoteCase.source.groundTruth.references[0]
+    output.status = 'scored'
+    output.prediction = {
+      relationships: [
+        {
+          referenceId: expected.id,
+          bodyId: expected.bodyId,
+          marker: expected.marker,
+        },
+        {
+          referenceId: 'unknown-reference',
+          bodyId: 'unknown-body',
+          marker: 'x',
+        },
+      ],
+    }
+    output.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'footnote-resolution' &&
+          row.layout === footnoteCase.layout,
+      ),
+    ).toMatchObject({
+      degenerateCaseCount: 1,
+      scoredCaseCount: 0,
+      diagnostics: expect.arrayContaining([
+        'DEGENERATE_DANGLING_FOOTNOTE_RELATIONSHIP',
+      ]),
+    })
+  })
+
   it('includes abstained rows in sparse provider aggregates', async () => {
     const evalSet = await readEvalSet()
     const directory = await mkdtemp('.tmp-pdf-extraction-aggregate-')
@@ -799,6 +847,41 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         kind: 'candidate',
         version: 'candidate-a-v1',
       })
+
+      expect(() => comparePdfExtractionProviders(evalSet, [candidate])).toThrow(
+        'PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED',
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('invalidates verified review evidence when its hashes change', async () => {
+    const evalSet = await readEvalSet()
+    const directory = await mkdtemp('.tmp-pdf-extraction-review-snapshot-')
+    try {
+      await attachVerifiedReviews(evalSet, directory)
+      for (const review of [
+        ...evalSet.documents.map((item) => item.groundTruthReview),
+        ...evalSet.strata.map((item) => item.groundTruth),
+        ...evalSet.cases.map((item) => item.source.groundTruth.review),
+      ]) {
+        review.reviewEvidence.decisionSha256 = 'e'.repeat(64)
+      }
+      const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+        id: 'candidate-a',
+        kind: 'candidate',
+        version: 'candidate-a-v1',
+      })
+      const tableCase = candidate.cases.find((item) =>
+        item.caseId.endsWith('.table-structure'),
+      )
+      const expectedTable = evalSet.cases.find((item) =>
+        item.id.endsWith('.table-structure'),
+      ).source.groundTruth.tables[0]
+      tableCase.status = 'scored'
+      tableCase.prediction = { tables: [{ ...expectedTable }] }
+      tableCase.diagnostics = []
 
       expect(() => comparePdfExtractionProviders(evalSet, [candidate])).toThrow(
         'PDF_EXTRACTION_REVIEW_EVIDENCE_NOT_VERIFIED',

--- a/tools/pdf-extraction-eval.test.mjs
+++ b/tools/pdf-extraction-eval.test.mjs
@@ -20,8 +20,8 @@ async function readEvalSet() {
 }
 
 async function attachVerifiedReviews(evalSet, directory) {
-  const reviewerA = 'fixture-reviewer-a'
-  const reviewerB = 'fixture-reviewer-b'
+  const reviewerA = 'a'.repeat(64)
+  const reviewerB = 'b'.repeat(64)
   const rosterPath = join(directory, 'roster.json')
   const decisionPath = join(directory, 'decisions.json')
   const reviews = [
@@ -40,18 +40,18 @@ async function attachVerifiedReviews(evalSet, directory) {
     }
   }
   const roster = {
-    schemaVersion: '1.0.0',
+    schemaVersion: '1.1.0',
     kind: 'pdf-extraction-reviewer-roster',
     evalSetId: evalSet.id,
-    reviewers: [
-      { reviewerId: reviewerA, identityEvidenceSha256: 'a'.repeat(64) },
-      { reviewerId: reviewerB, identityEvidenceSha256: 'b'.repeat(64) },
-    ],
+    reviewers: {
+      [reviewerA]: 'fixture-reviewer-a',
+      [reviewerB]: 'fixture-reviewer-b',
+    },
   }
   const identity = validatePdfExtractionEvalSet(evalSet)
   const documentById = new Map(evalSet.documents.map((item) => [item.id, item]))
   const decisionArtifact = {
-    schemaVersion: '1.0.0',
+    schemaVersion: '1.1.0',
     kind: 'pdf-extraction-source-only-decisions',
     evalSetId: evalSet.id,
     evalSetSha256: identity.evalSetSha256,
@@ -78,6 +78,15 @@ async function attachVerifiedReviews(evalSet, directory) {
     }
   }
   await validatePdfExtractionEvalSetFiles(evalSet)
+}
+
+async function verifyEvalSet(evalSet) {
+  const directory = await mkdtemp('.tmp-pdf-extraction-verified-')
+  try {
+    await attachVerifiedReviews(evalSet, directory)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 }
 
 describe('source-reviewed PDF extraction strata benchmark', () => {
@@ -195,6 +204,12 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     })
     expect(report.providers[0].score).toBeNull()
     expect(report.summary.scoredProviderCount).toBe(0)
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'table-structure' && row.layout === 'one-column',
+      ),
+    ).toMatchObject({ score: null, scoredCaseCount: 0 })
   })
 
   it('scores abstention above guarded degenerate answers', async () => {
@@ -287,6 +302,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('accepts a prediction only when its source geometry and lineage match', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -356,6 +372,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('scores boilerplate exclusion against reviewed furniture identities', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const furnitureCase = evalSet.cases.find(
       (item) => item.id === 'diagnostic-overlays.boilerplate-exclusion',
     )
@@ -410,6 +427,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       marker: '1',
       bodyId: 'footnote-1',
     })
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -468,6 +486,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       sourcePage: footnoteCase.source.sourcePage,
       marker: '2',
     })
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -501,6 +520,57 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
           row.layout === footnoteCase.layout,
       ),
     ).toMatchObject({ degenerateCaseCount: 0, scoredCaseCount: 1 })
+  })
+
+  it('keeps unknown collapsed footnote relationships degenerate', async () => {
+    const evalSet = await readEvalSet()
+    const footnoteCase = evalSet.cases.find((item) =>
+      item.id.endsWith('.footnote-resolution'),
+    )
+    footnoteCase.source.groundTruth.bodies.push({
+      id: 'footnote-2',
+      sourcePage: footnoteCase.source.sourcePage,
+      marker: '2',
+    })
+    footnoteCase.source.groundTruth.references.push({
+      id: 'note-reference-2',
+      sourcePage: footnoteCase.source.sourcePage,
+      marker: '2',
+      bodyId: 'footnote-2',
+    })
+    const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
+      id: 'candidate-a',
+      kind: 'candidate',
+      version: 'candidate-a-v1',
+    })
+    const output = candidate.cases.find(
+      (item) => item.caseId === footnoteCase.id,
+    )
+    output.status = 'scored'
+    output.prediction = {
+      relationships: [
+        {
+          referenceId: 'unknown-reference-1',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+        {
+          referenceId: 'unknown-reference-2',
+          bodyId: 'footnote-1',
+          marker: '1',
+        },
+      ],
+    }
+    output.diagnostics = []
+
+    const report = comparePdfExtractionProviders(evalSet, [candidate])
+    expect(
+      report.rows.find(
+        (row) =>
+          row.stratum === 'footnote-resolution' &&
+          row.layout === footnoteCase.layout,
+      ),
+    ).toMatchObject({ degenerateCaseCount: 1, scoredCaseCount: 0 })
   })
 
   it('includes abstained rows in sparse provider aggregates', async () => {
@@ -541,6 +611,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
 
   it('matches bounded objects by source binding rather than array order', async () => {
     const evalSet = await readEvalSet()
+    await verifyEvalSet(evalSet)
     const candidate = createAbstainingPdfExtractionCandidate(evalSet, {
       id: 'candidate-a',
       kind: 'candidate',
@@ -659,9 +730,9 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     const directory = await mkdtemp('.tmp-pdf-extraction-review-')
     const rosterPath = join(directory, 'roster.json')
     const decisionPath = join(directory, 'decisions.json')
-    const reviewerA = 'fixture-reviewer-a'
-    const reviewerB = 'fixture-reviewer-b'
-    const reviewerC = 'fixture-reviewer-c'
+    const reviewerA = 'a'.repeat(64)
+    const reviewerB = 'b'.repeat(64)
+    const reviewerC = 'c'.repeat(64)
     try {
       const reviews = [
         ...evalSet.documents.map((item) => item.groundTruthReview),
@@ -684,14 +755,14 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
       })
 
       const roster = {
-        schemaVersion: '1.0.0',
+        schemaVersion: '1.1.0',
         kind: 'pdf-extraction-reviewer-roster',
         evalSetId: evalSet.id,
-        reviewers: [
-          { reviewerId: reviewerA, identityEvidenceSha256: 'a'.repeat(64) },
-          { reviewerId: reviewerB, identityEvidenceSha256: 'b'.repeat(64) },
-          { reviewerId: reviewerC, identityEvidenceSha256: 'c'.repeat(64) },
-        ],
+        reviewers: {
+          [reviewerA]: 'fixture-reviewer-a',
+          [reviewerB]: 'fixture-reviewer-b',
+          [reviewerC]: 'fixture-reviewer-c',
+        },
       }
       const identity = validatePdfExtractionEvalSet(evalSet)
       const documentById = new Map(
@@ -705,7 +776,7 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         decisionSha256: 'd'.repeat(64),
       }))
       const decisionArtifact = {
-        schemaVersion: '1.0.0',
+        schemaVersion: '1.1.0',
         kind: 'pdf-extraction-source-only-decisions',
         evalSetId: evalSet.id,
         evalSetSha256: identity.evalSetSha256,
@@ -729,22 +800,21 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
         validatePdfExtractionEvalSetFiles(evalSet),
       ).resolves.toMatchObject({ evalSetSha256: identity.evalSetSha256 })
 
-      roster.reviewers[2].identityEvidenceSha256 =
-        roster.reviewers[0].identityEvidenceSha256
-      const duplicateIdentityRosterBytes = Buffer.from(
+      delete roster.reviewers[reviewerC]
+      const missingIdentityRosterBytes = Buffer.from(
         `${JSON.stringify(roster)}\n`,
       )
-      await writeFile(rosterPath, duplicateIdentityRosterBytes)
+      await writeFile(rosterPath, missingIdentityRosterBytes)
       for (const review of reviews) {
         review.reviewEvidence.rosterSha256 = sha256(
-          duplicateIdentityRosterBytes,
+          missingIdentityRosterBytes,
         )
       }
       await expect(validatePdfExtractionEvalSetFiles(evalSet)).rejects.toThrow(
-        'PDF_EXTRACTION_REVIEW_ROSTER_MISMATCH',
+        'PDF_EXTRACTION_REVIEW_DECISION_MISMATCH',
       )
 
-      roster.reviewers[2].identityEvidenceSha256 = 'c'.repeat(64)
+      roster.reviewers[reviewerC] = 'fixture-reviewer-c'
       await writeFile(rosterPath, rosterBytes)
       for (const review of reviews) {
         review.reviewEvidence.rosterSha256 = sha256(rosterBytes)
@@ -864,6 +934,23 @@ describe('source-reviewed PDF extraction strata benchmark', () => {
     expect(validate(candidate)).toBe(false)
     candidate.cases[0].diagnostics = ['UPPERCASE_DIAGNOSTIC_1']
     expect(validate(candidate)).toBe(true)
+  })
+
+  it('publishes distinct reviewer identity evidence in the review schema', async () => {
+    const schema = JSON.parse(
+      await readFile('docs/schemas/pdf-extraction-eval-review.schema.json', 'utf8'),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const roster = {
+      schemaVersion: '1.1.0',
+      kind: 'pdf-extraction-reviewer-roster',
+      evalSetId: 'fixture-eval',
+      reviewers: { ['a'.repeat(64)]: 'reviewer-a' },
+    }
+
+    expect(validate(roster)).toBe(false)
+    roster.reviewers['b'.repeat(64)] = 'reviewer-b'
+    expect(validate(roster)).toBe(true)
   })
 
   it('enforces page-contained endpoint boxes without perfect-scoring zero area', async () => {


### PR DESCRIPTION
Closes #89.

Addresses the six post-merge review findings preserved on the issue:

- keeps scored output reported-only until every review artifact is verified
- scores boilerplate exclusion against exact source-reviewed furniture identities
- aligns published diagnostic and normalized-box contracts with runtime validation
- scores valid partial many-to-one footnote relationships
- requires distinct reviewer identity evidence
- updates the checked-in metric contract and eval-set identity

Validation:
- `npx vitest run tools/pdf-corpus-audit.test.mjs tools/pdf-benchmark-compare.test.mjs tools/pdf-fidelity-eval.test.mjs tools/pdf-extraction-eval.test.mjs` — 148 passed
- `npm run pdf:benchmark:extraction` — passed, reported-only as expected
- full local `npm test`: 2813 passed, 1 skipped, with 2 unrelated workstation failures (pinned Chrome patch-version mismatch and global Git hook cleanliness fixture)
- local build reached a clean Astro build (0 errors) and then stopped on the same pinned Chrome patch-version mismatch
- staged secret scan passed

No secrets or private source content are included.