### PR TITLE
Reconstruct continuous prose across columns and pages

### DIFF
--- a/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
+++ b/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
@@ -37,7 +37,11 @@ cannot prove them:
 
 `prose-continuity` covers both the column break on page one and the page break
 between pages one and two of the checked-in fixture; a sentence left split
-across two paragraph elements fails it.
+across two paragraph elements fails it. Each prose-continuity checkpoint must
+also name its expected semantic-flow topology, source page, and spacing
+outcome. The pair fails unless the reconstruction reports a valid boundary
+ledger containing that exact decision; final paragraph HTML alone is not
+proof of a safe join.
 
 For an owner-local paper, provide a caller-owned output directory outside the
 repository. Local output is never written to Git or the PR evidence directory:

--- a/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
+++ b/docs/research/semantic-responsive-typesetting/source-output-checkpoints.md
@@ -24,6 +24,21 @@ pair fails when the source page is missing readable/visual evidence, the
 profile is wrong, the rendition is empty, or the named structure is absent. An
 image file by itself never passes a checkpoint.
 
+Two properties additionally carry a negative claim, because presence alone
+cannot prove them:
+
+- `hyphen-resolution` fails when the printed line-end fragment named by
+  `source.text` still appears anywhere in the rendition. A resolved
+  discretionary hyphen means the reader never receives the split form.
+- `markup-non-promotion` fails when the prose named by `output.text` also
+  appears inside a heading, an emphasis run, or a list item. Source text that
+  merely looks like Markdown must reach the reader as characters, not as
+  structure the source never carried.
+
+`prose-continuity` covers both the column break on page one and the page break
+between pages one and two of the checked-in fixture; a sentence left split
+across two paragraph elements fails it.
+
 For an owner-local paper, provide a caller-owned output directory outside the
 repository. Local output is never written to Git or the PR evidence directory:
 

--- a/docs/schemas/source-output-checkpoints.schema.json
+++ b/docs/schemas/source-output-checkpoints.schema.json
@@ -75,7 +75,20 @@
           "enum": ["figure", "caption", "prose", "heading", "table", "code"]
         },
         "text": { "type": "string", "minLength": 1 },
-        "level": { "type": "integer", "minimum": 1, "maximum": 6 }
+        "level": { "type": "integer", "minimum": 1, "maximum": 6 },
+        "semanticFlow": { "$ref": "#/$defs/semanticFlowExpectation" }
+      }
+    },
+    "semanticFlowExpectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topology", "fromPage", "outcome"],
+      "properties": {
+        "topology": {
+          "enum": ["same-page-column", "cross-page-column"]
+        },
+        "fromPage": { "type": "integer", "minimum": 1 },
+        "outcome": { "enum": ["space", "no-space"] }
       }
     }
   }

--- a/docs/schemas/source-output-checkpoints.schema.json
+++ b/docs/schemas/source-output-checkpoints.schema.json
@@ -40,6 +40,8 @@
             "figure-present",
             "caption-boundary",
             "prose-continuity",
+            "hyphen-resolution",
+            "markup-non-promotion",
             "heading-level",
             "table-structure",
             "code-block-structure",

--- a/src/research/epub.ts
+++ b/src/research/epub.ts
@@ -3725,9 +3725,12 @@ function isSourceSemanticFlowBoundaryManifestRecord(value: unknown) {
     typeof value.rotation === 'number' &&
     Number.isFinite(value.rotation) &&
     ['pdf-text', 'ocr'].includes(value.method as string) &&
-    ['inline-stacked-fragment', 'lexical-hyphen', 'same-page-column'].includes(
-      value.topology as string,
-    ) &&
+    [
+      'inline-stacked-fragment',
+      'lexical-hyphen',
+      'same-page-column',
+      'cross-page-column',
+    ].includes(value.topology as string) &&
     [
       'no-space',
       'space',

--- a/src/research/import-types.ts
+++ b/src/research/import-types.ts
@@ -105,7 +105,11 @@ export type PdfSourceSemanticFlowBoundaryDecision = {
   page: number
   rotation: number
   method: 'pdf-text' | 'ocr'
-  topology: 'inline-stacked-fragment' | 'lexical-hyphen' | 'same-page-column'
+  topology:
+    | 'inline-stacked-fragment'
+    | 'lexical-hyphen'
+    | 'same-page-column'
+    | 'cross-page-column'
   outcome:
     'no-space' | 'space' | 'discretionary-hyphen-delete' | 'hard-hyphen-retain'
   from: PdfSourceSemanticFlowBoundaryEndpoint

--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -1,5 +1,6 @@
 import { strFromU8 } from 'fflate'
-import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { beforeAll, describe, expect, it } from 'vitest'
 import {
   buildEpub,
   buildReadableEpub,
@@ -34,6 +35,8 @@ import {
   synthesizeRecoveredBibliographyClassifications,
 } from './pdf-layout'
 import { PDF_HYPHEN_LEXICAL_MODEL } from './pdf-hyphenation'
+import { reconstructPdf } from './pdf'
+import { pdfBodySourceOrderExtremaByPage } from './pdf-regions'
 import { assessPdfCompleteness } from './pdf-quality'
 import {
   canonicalTextIntegrityIssues,
@@ -45,6 +48,128 @@ import {
   createSourcePageCropAsset,
 } from './visual-assets'
 import type { ResearchNode } from './schema'
+
+describe('generated continuous-prose PDF fixture', () => {
+  let result: Awaited<ReturnType<typeof reconstructPdf>>
+
+  beforeAll(async () => {
+    const bytes = await readFile(
+      new URL(
+        '../../tests/fixtures/pdf/source-output-checkpoints.pdf',
+        import.meta.url,
+      ),
+    )
+    result = await reconstructPdf(
+      new File([bytes], 'source-output-checkpoints.pdf', {
+        type: 'application/pdf',
+      }),
+      undefined,
+      { language: 'en-US' },
+    )
+  }, 30_000)
+
+  const paragraphTexts = () =>
+    result.paper.nodes.flatMap((node) =>
+      node.type === 'paragraph' ? [node.text] : [],
+    )
+  const hasParagraphText = (expected: string) =>
+    paragraphTexts().some((text) => text.includes(expected))
+
+  it('proves the physical column and page joins in the semantic-flow ledger', () => {
+    expect(
+      hasParagraphText(
+        'The result continues toward the right column with source proof.',
+      ),
+    ).toBe(true)
+    expect(
+      hasParagraphText(
+        'A second result sentence runs off the bottom of this page and continues at the top of the next one without losing its clause.',
+      ),
+    ).toBe(true)
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ topology: 'same-page-column' }),
+        expect.objectContaining({ topology: 'cross-page-column' }),
+      ]),
+    )
+    expect(paragraphTexts().join(' ')).not.toContain(
+      'page and Source/output checkpoint fixture continues',
+    )
+  })
+
+  it('resolves only the source-attested discretionary hyphen', () => {
+    expect(
+      hasParagraphText('The high-resolution source photograph remains clear.'),
+    ).toBe(true)
+    expect(
+      hasParagraphText('The source preserves the rare-fragment compound.'),
+    ).toBe(true)
+    expect(result.lineBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          outcome: 'removed-discretionary-hyphen',
+          evidence: expect.arrayContaining([
+            'same-document-unhyphenated-word',
+          ]),
+        }),
+        expect.objectContaining({
+          outcome: 'preserved-lexical-hyphen',
+          evidence: expect.arrayContaining([
+            'hard-hyphen-form-valid:same-document',
+          ]),
+        }),
+      ]),
+    )
+  })
+
+  it('keeps literal Markdown, placeholders, and ordered markers as prose', () => {
+    const literal =
+      '## Not a heading and **not bold** and {placeholder} stay literal.'
+    const ordered = '1. Literal numbered syntax stays prose.'
+    expect(hasParagraphText(literal)).toBe(true)
+    expect(hasParagraphText(ordered)).toBe(true)
+    expect(
+      result.paper.nodes.filter(
+        (node) =>
+          'text' in node &&
+          (node.text === literal || node.text === ordered) &&
+          (node.type === 'heading' ||
+            (node.type === 'paragraph' && node.list !== undefined)),
+      ),
+    ).toEqual([])
+  })
+
+  it('honors indentation and source continuity rather than raw gap size', () => {
+    expect(
+      hasParagraphText(
+        'First indented paragraph begins and continues on its next line.',
+      ),
+    ).toBe(true)
+    expect(
+      hasParagraphText(
+        'Second indented paragraph begins and continues independently.',
+      ),
+    ).toBe(true)
+    expect(
+      hasParagraphText(
+        'A widely spaced source line begins and remains source-contiguous despite its spacing.',
+      ),
+    ).toBe(true)
+  })
+
+  it('keeps adjacent equation ownership out of canonical prose', () => {
+    expect(result.visualRelationships).toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: 'equation' })]),
+    )
+    expect(paragraphTexts()).toEqual(
+      expect.arrayContaining([
+        'Prose before the owned equation remains clean.',
+        'Prose after the owned equation remains clean.',
+      ]),
+    )
+    expect(paragraphTexts().join(' ')).not.toContain('E = m c 2 (1)')
+  })
+})
 
 function visualOrderHeading(
   id: string,
@@ -835,6 +960,168 @@ describe('PDF semantic reconstruction', () => {
         'exact-source-sequence-adjacency',
         'same-page-column-flow',
       ]),
+    })
+  })
+
+  describe('cross-page prose continuity', () => {
+    const onPage = (region: PdfPageRegion, page: number): PdfPageRegion => ({
+      ...region,
+      page,
+      box: { ...region.box, page },
+      lines: region.lines.map((line) => ({
+        ...line,
+        box: { ...line.box, page },
+        runs: line.runs.map((sourceRun) => ({ ...sourceRun, page })),
+      })),
+    })
+    const pageBreakPair = (label: string, tailSequence = 40) => ({
+      target: onPage(
+        sourceFlowRegion({
+          id: `${label}-target`,
+          column: 'right',
+          text: 'The measured drift therefore continues toward the',
+          x: 0.515,
+          y: 0.82,
+          sourceSequenceIndex: tailSequence,
+        }),
+        1,
+      ),
+      continuation: onPage(
+        sourceFlowRegion({
+          id: `${label}-continuation`,
+          column: 'left',
+          text: 'stationary regime described in the next section.',
+          x: 0.09,
+          y: 0.1,
+          sourceSequenceIndex: 1,
+        }),
+        2,
+      ),
+    })
+    const runningHead = (label: string) =>
+      onPage(
+        sourceFlowRegion({
+          id: `${label}-running-head`,
+          column: 'left',
+          text: 'Continuous prose reconstruction',
+          x: 0.09,
+          y: 0.03,
+          sourceSequenceIndex: 0,
+        }),
+        2,
+      )
+    const asFurniture = (region: PdfPageRegion): PdfPageRegion => ({
+      ...region,
+      column: 'span',
+      furniture: {
+        classification: 'repeated-text',
+        band: 'top',
+        pages: [1, 2],
+        boxes: [{ ...region.box }],
+        evidence: ['repeated-normalized-text'],
+      },
+    })
+    const joinAcrossPageBreak = async (
+      target: PdfPageRegion,
+      continuation: PdfPageRegion,
+      sourceRegions: PdfPageRegion[],
+    ) => {
+      const blocks = [target, continuation].map((region) => ({
+        type: 'paragraph' as const,
+        region,
+        text: region.text,
+        confidence: 1,
+      }))
+      const sourceSemanticFlowBoundaryDecisions: PdfSourceSemanticFlowBoundaryDecision[] =
+        []
+      await mergeProseContinuations(blocks, {
+        sourceSemanticFlowBoundaryDecisions,
+        bodySourceOrderExtremaByPage:
+          pdfBodySourceOrderExtremaByPage(sourceRegions),
+      })
+      return { blocks, sourceSemanticFlowBoundaryDecisions }
+    }
+
+    it('records a proven page-break join in the semantic-flow ledger', async () => {
+      const { target, continuation } = pageBreakPair('proven-page-break')
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(target, continuation, [target, continuation])
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].text).toBe(
+        'The measured drift therefore continues toward the stationary regime described in the next section.',
+      )
+      expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(1)
+      expect(sourceSemanticFlowBoundaryDecisions[0]).toMatchObject({
+        page: 1,
+        topology: 'cross-page-column',
+        outcome: 'space',
+        evidence: [
+          'cross-page-column-geometry',
+          'explicit-fragment-lineage',
+          'furniture-excluded-page-boundary',
+          'page-head-source-order-extremum',
+          'page-tail-source-order-extremum',
+        ],
+      })
+    })
+
+    it('keeps an intervening running head out of the joined paragraph', async () => {
+      // Issue 042 classifies the running head as furniture, so it is not body
+      // source order. The sentence therefore stays adjacent across the page
+      // break and the head never enters the paragraph.
+      const { target, continuation } = pageBreakPair('furniture-page-break')
+      const head = runningHead('furniture-page-break')
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(target, continuation, [
+          target,
+          asFurniture(head),
+          continuation,
+        ])
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].text).not.toContain('Continuous prose reconstruction')
+      expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(1)
+      expect(sourceSemanticFlowBoundaryDecisions[0].topology).toBe(
+        'cross-page-column',
+      )
+    })
+
+    it('refuses to prove a page-break join across unaccounted source text', async () => {
+      // The same page-two text, this time with no furniture evidence, is body
+      // source order the sentence would have to jump over. The prose may still
+      // be joined by the weaker unmarked-continuation heuristic, but nothing is
+      // written to the ledger, so the join is never claimed as proven.
+      const { target, continuation } = pageBreakPair('unaccounted-page-break')
+      const head = runningHead('unaccounted-page-break')
+      const { sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(target, continuation, [
+          target,
+          head,
+          continuation,
+        ])
+
+      expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(0)
+    })
+
+    it('refuses to prove a page-break join from a mid-page tail', async () => {
+      const { target, continuation } = pageBreakPair('mid-page-tail')
+      const midPageTail: PdfPageRegion = {
+        ...target,
+        box: { ...target.box, y: 0.2 },
+        lines: target.lines.map((line) => ({
+          ...line,
+          box: { ...line.box, y: 0.2 },
+          runs: line.runs.map((sourceRun) => ({ ...sourceRun, y: 0.2 })),
+        })),
+      }
+      const { sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(midPageTail, continuation, [
+          midPageTail,
+          continuation,
+        ])
+
+      expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(0)
     })
   })
 
@@ -5367,6 +5654,83 @@ describe('PDF semantic reconstruction', () => {
     expect(
       result.paper.nodes.filter((node) => node.type === 'heading'),
     ).toEqual([])
+  })
+
+  it('keeps markup-shaped body prose as literal text without independent evidence', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(
+            1,
+            'Ordinary body prose establishes the source typography.',
+            0.1,
+            0.1,
+            0.72,
+          ),
+          run(1, '# Literal heading syntax stays prose.', 0.1, 0.2, 0.72),
+          run(1, '** Literal emphasis syntax stays prose. **', 0.1, 0.3, 0.72),
+          run(1, '{placeholder}', 0.1, 0.4, 0.24),
+          run(1, '1. Literal numbered syntax stays prose.', 0.1, 0.5, 0.72),
+        ]),
+      ],
+      sourceHash: 'm'.repeat(64),
+      fileName: 'literal-markup-prose.pdf',
+      byteLength: 4096,
+    })
+
+    const prose = result.paper.nodes.filter(
+      (node): node is Extract<ResearchNode, { type: 'paragraph' }> =>
+        node.type === 'paragraph',
+    )
+    expect(result.paper.nodes.some((node) => node.type === 'heading')).toBe(
+      false,
+    )
+    expect(prose.map((node) => node.text)).toEqual([
+      'Ordinary body prose establishes the source typography.',
+      '# Literal heading syntax stays prose.',
+      '** Literal emphasis syntax stays prose. **',
+      '{placeholder}',
+      '1. Literal numbered syntax stays prose.',
+    ])
+    expect(prose.every((node) => node.list === undefined)).toBe(true)
+  })
+
+  it('does not promote a markup-shaped section phrase without source styling', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(
+            1,
+            'Ordinary body prose establishes the source typography.',
+            0.1,
+            0.1,
+            0.72,
+          ),
+          run(
+            1,
+            '1. Introduction',
+            0.1,
+            0.2,
+            0.72,
+          ),
+        ]),
+      ],
+      sourceHash: 'n'.repeat(64),
+      fileName: 'literal-markup-section-prose.pdf',
+      byteLength: 4096,
+    })
+
+    expect(result.paper.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'paragraph',
+          text: '1. Introduction',
+        }),
+      ]),
+    )
+    expect(result.paper.nodes.some((node) => node.type === 'heading')).toBe(
+      false,
+    )
   })
 
   it('keeps a flowing parenthesized enumeration as prose when only a wrapped middle marker starts a region', async () => {

--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -468,6 +468,21 @@ function page(
   }
 }
 
+function sourceOrderedPage(
+  number: number,
+  runs: PdfSourceRun[],
+  kind: PdfPageAnalysis['kind'] = 'born-digital',
+) {
+  return page(
+    number,
+    runs.map((sourceRun, sourceSequenceIndex) => ({
+      ...sourceRun,
+      sourceSequenceIndex,
+    })),
+    kind,
+  )
+}
+
 function withExplicitEnglishLanguage(page: PdfPageAnalysis): PdfPageAnalysis {
   return {
     ...page,
@@ -1025,6 +1040,10 @@ describe('PDF semantic reconstruction', () => {
       target: PdfPageRegion,
       continuation: PdfPageRegion,
       sourceRegions: PdfPageRegion[],
+      options: {
+        hardHyphenLexicon?: ReadonlySet<string>
+        unhyphenatedLexicon?: ReadonlySet<string>
+      } = {},
     ) => {
       const blocks = [target, continuation].map((region) => ({
         type: 'paragraph' as const,
@@ -1035,6 +1054,7 @@ describe('PDF semantic reconstruction', () => {
       const sourceSemanticFlowBoundaryDecisions: PdfSourceSemanticFlowBoundaryDecision[] =
         []
       await mergeProseContinuations(blocks, {
+        ...options,
         sourceSemanticFlowBoundaryDecisions,
         bodySourceOrderExtremaByPage:
           pdfBodySourceOrderExtremaByPage(sourceRegions),
@@ -1059,7 +1079,7 @@ describe('PDF semantic reconstruction', () => {
         evidence: [
           'cross-page-column-geometry',
           'explicit-fragment-lineage',
-          'furniture-excluded-page-boundary',
+          'non-prose-excluded-page-boundary',
           'page-head-source-order-extremum',
           'page-tail-source-order-extremum',
         ],
@@ -1108,6 +1128,147 @@ describe('PDF semantic reconstruction', () => {
       ])
       expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(0)
     })
+
+    it('records a source-proven citation-year page break in the semantic-flow ledger', async () => {
+      const target = onPage(
+        sourceFlowRegion({
+          id: 'citation-page-break-target',
+          column: 'right',
+          text: 'Prior evidence from Okafor et al.,',
+          x: 0.515,
+          y: 0.82,
+          sourceSequenceIndex: 40,
+        }),
+        1,
+      )
+      const continuation = onPage(
+        sourceFlowRegion({
+          id: 'citation-page-break-continuation',
+          column: 'left',
+          text: '2022) supports the source-backed result.',
+          x: 0.09,
+          y: 0.1,
+          sourceSequenceIndex: 0,
+        }),
+        2,
+      )
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(target, continuation, [target, continuation])
+
+      expect(blocks).toHaveLength(1)
+      expect(sourceSemanticFlowBoundaryDecisions).toEqual([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'space',
+          from: expect.objectContaining({ regionId: target.id }),
+          to: expect.objectContaining({ regionId: continuation.id }),
+        }),
+      ])
+    })
+
+    it('records a source-proven hard hyphen page break in the semantic-flow ledger', async () => {
+      const target = onPage(
+        sourceFlowRegion({
+          id: 'hard-hyphen-page-break-target',
+          column: 'right',
+          text: 'The source uses long-',
+          x: 0.515,
+          y: 0.82,
+          sourceSequenceIndex: 40,
+        }),
+        1,
+      )
+      const continuation = onPage(
+        sourceFlowRegion({
+          id: 'hard-hyphen-page-break-continuation',
+          column: 'left',
+          text: 'form examples throughout the evaluation.',
+          x: 0.09,
+          y: 0.1,
+          sourceSequenceIndex: 0,
+        }),
+        2,
+      )
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
+        await joinAcrossPageBreak(target, continuation, [target, continuation], {
+          hardHyphenLexicon: new Set(['long-form']),
+        })
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0].text).toBe(
+        'The source uses long-form examples throughout the evaluation.',
+      )
+      expect(sourceSemanticFlowBoundaryDecisions).toEqual([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'hard-hyphen-retain',
+          from: expect.objectContaining({ regionId: target.id }),
+          to: expect.objectContaining({ regionId: continuation.id }),
+        }),
+      ])
+    })
+
+    it.each([
+      {
+        name: 'citation year',
+        targetText: 'Prior evidence from Okafor et al.,',
+        continuationText: '2022) supports the source-backed result.',
+        options: {},
+      },
+      {
+        name: 'hard hyphen',
+        targetText: 'The source uses long-',
+        continuationText: 'form examples throughout the evaluation.',
+        options: { hardHyphenLexicon: new Set(['long-form']) },
+      },
+    ])(
+      'refuses a $name page break across unaccounted body source',
+      async ({ targetText, continuationText, options }) => {
+        const target = onPage(
+          sourceFlowRegion({
+            id: 'specialized-unaccounted-target',
+            column: 'right',
+            text: targetText,
+            x: 0.515,
+            y: 0.82,
+            sourceSequenceIndex: 40,
+          }),
+          1,
+        )
+        const unaccounted = onPage(
+          sourceFlowRegion({
+            id: 'specialized-unaccounted-source',
+            column: 'left',
+            text: 'Separate body source appears first on this page.',
+            x: 0.09,
+            y: 0.04,
+            sourceSequenceIndex: 0,
+          }),
+          2,
+        )
+        const continuation = onPage(
+          sourceFlowRegion({
+            id: 'specialized-unaccounted-continuation',
+            column: 'left',
+            text: continuationText,
+            x: 0.09,
+            y: 0.1,
+            sourceSequenceIndex: 1,
+          }),
+          2,
+        )
+        const { blocks, sourceSemanticFlowBoundaryDecisions } =
+          await joinAcrossPageBreak(
+            target,
+            continuation,
+            [target, unaccounted, continuation],
+            options,
+          )
+
+        expect(blocks).toHaveLength(2)
+        expect(sourceSemanticFlowBoundaryDecisions).toEqual([])
+      },
+    )
 
     it('refuses to prove a page-break join from a mid-page tail', async () => {
       const { target, continuation } = pageBreakPair('mid-page-tail')
@@ -17096,7 +17257,7 @@ describe('PDF semantic reconstruction', () => {
   )
 
   it('joins an uppercase scholarly-label continuation only across an owned cross-page float', async () => {
-    const secondPage = page(2, [
+    const secondPage = sourceOrderedPage(2, [
       run(2, 'Method', 0.12, 0.08, 0.12, 8),
       run(2, 'Score', 0.45, 0.08, 0.1, 8),
       run(2, 'DRAFT', 0.12, 0.105, 0.12, 8),
@@ -17129,7 +17290,7 @@ describe('PDF semantic reconstruction', () => {
     ])
     const result = await reconstructPageAnalyses({
       pages: [
-        page(1, [
+        sourceOrderedPage(1, [
           run(1, 'Float-interrupted prose', 0.12, 0.06, 0.68, 18),
           run(1, '1 Introduction', 0.12, 0.18, 0.3, 14),
           run(
@@ -17181,6 +17342,14 @@ describe('PDF semantic reconstruction', () => {
         expect.stringContaining('page-002-region-'),
       ]),
     })
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'space',
+        }),
+      ]),
+    )
     expect(
       result.paper.nodes.findIndex((node) => node.id === joined?.id),
     ).toBeLessThan(
@@ -17194,7 +17363,7 @@ describe('PDF semantic reconstruction', () => {
     const result = await reconstructPageAnalyses({
       pages: [
         withExplicitEnglishLanguage(
-          page(1, [
+          sourceOrderedPage(1, [
             run(1, 'Float-interrupted lexical prose', 0.12, 0.06, 0.68, 18),
             run(1, '1 Introduction', 0.12, 0.18, 0.3, 14),
             run(
@@ -17215,7 +17384,7 @@ describe('PDF semantic reconstruction', () => {
             },
           ]),
         ),
-        page(2, [
+        sourceOrderedPage(2, [
           run(2, 'Method', 0.12, 0.08, 0.12, 8),
           run(2, 'Score', 0.45, 0.08, 0.1, 8),
           run(2, 'DRAFT', 0.12, 0.105, 0.12, 8),
@@ -17268,6 +17437,14 @@ describe('PDF semantic reconstruction', () => {
       expectedInlineSpanCount: 1,
       mappedInlineSpanCount: 1,
     })
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'discretionary-hyphen-delete',
+        }),
+      ]),
+    )
     expect(
       result.diagnostics.some(
         (diagnostic) => diagnostic.code === 'CANONICAL_FLOW_ORDER_VIOLATION',
@@ -17479,7 +17656,7 @@ describe('PDF semantic reconstruction', () => {
   it('preserves a source-proven hard hyphen without inventing cross-page whitespace', async () => {
     const result = await reconstructPageAnalyses({
       pages: [
-        page(1, [
+        sourceOrderedPage(1, [
           run(1, 'Hard-hyphen continuity', 0.12, 0.06, 0.68, 18),
           run(
             1,
@@ -17490,7 +17667,7 @@ describe('PDF semantic reconstruction', () => {
           ),
           run(1, 'The source uses long-', 0.12, 0.82, 0.68),
         ]),
-        page(2, [
+        sourceOrderedPage(2, [
           run(2, 'form examples throughout the evaluation.', 0.12, 0.08, 0.68),
         ]),
       ],
@@ -17512,6 +17689,14 @@ describe('PDF semantic reconstruction', () => {
       pages: [1, 2],
     })
     expect(result.canonicalHyphenBoundaryDecisions).toEqual([])
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'hard-hyphen-retain',
+        }),
+      ]),
+    )
     expect(
       result.diagnostics.some(
         (diagnostic) => diagnostic.code === 'CANONICAL_FLOW_ORDER_VIOLATION',
@@ -18085,7 +18270,7 @@ describe('PDF semantic reconstruction', () => {
   })
 
   it('joins one paragraph across an owned page-tail table before the next page', async () => {
-    const firstPage = page(1, [
+    const firstPage = sourceOrderedPage(1, [
       run(1, 'Page-tail table continuity', 0.1, 0.035, 0.8, 18),
       run(1, '1 Evaluation', 0.09, 0.12, 0.3, 14),
       run(
@@ -18149,7 +18334,7 @@ describe('PDF semantic reconstruction', () => {
     const result = await reconstructPageAnalyses({
       pages: [
         firstPage,
-        page(2, [
+        sourceOrderedPage(2, [
           run(
             2,
             'to the standard metric used for classification.',
@@ -18196,6 +18381,14 @@ describe('PDF semantic reconstruction', () => {
           node.type === 'paragraph' && node.text.startsWith('to the standard'),
       ),
     ).toEqual([])
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'space',
+        }),
+      ]),
+    )
     expect(
       result.paper.nodes.findIndex((node) => node.id === joined?.id),
     ).toBeLessThan(
@@ -18302,7 +18495,7 @@ describe('PDF semantic reconstruction', () => {
   it('joins a citation year split across adjacent pages', async () => {
     const result = await reconstructPageAnalyses({
       pages: [
-        page(1, [
+        sourceOrderedPage(1, [
           run(1, 'Cross-page citation continuity', 0.1, 0.035, 0.8, 18),
           run(1, '1 Related Work', 0.09, 0.12, 0.3, 14),
           run(
@@ -18314,7 +18507,7 @@ describe('PDF semantic reconstruction', () => {
           ),
           run(1, 'Prior evidence from Okafor et al.,', 0.09, 0.84, 0.72),
         ]),
-        page(2, [
+        sourceOrderedPage(2, [
           run(2, '2022) supports the source-backed result.', 0.09, 0.08, 0.72),
         ]),
       ],
@@ -18333,6 +18526,14 @@ describe('PDF semantic reconstruction', () => {
       text: 'Prior evidence from Okafor et al., 2022) supports the source-backed result.',
     })
     expect(result.provenance[joined!.id]).toMatchObject({ pages: [1, 2] })
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          topology: 'cross-page-column',
+          outcome: 'space',
+        }),
+      ]),
+    )
   })
 
   it('joins a citation year split between adjacent same-column source regions', async () => {

--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -5705,6 +5705,61 @@ describe('PDF semantic reconstruction', () => {
     expect(prose.every((node) => node.list === undefined)).toBe(true)
   })
 
+  it('preserves a singleton numbered item from its source hanging indent', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [
+        page(1, [
+          run(
+            1,
+            'Ordinary body prose establishes the source typography.',
+            0.1,
+            0.1,
+            0.72,
+          ),
+          run(
+            1,
+            '1. Calibrate the source-backed threshold before export,',
+            0.1,
+            0.2,
+            0.5,
+          ),
+          run(
+            1,
+            'then verify the rendered checkpoint.',
+            0.128,
+            0.222,
+            0.44,
+          ),
+          run(
+            1,
+            'An independent paragraph follows the completed instruction.',
+            0.1,
+            0.31,
+            0.72,
+          ),
+        ]),
+      ],
+      sourceHash: 'h'.repeat(64),
+      fileName: 'singleton-hanging-indent-item.pdf',
+      byteLength: 4096,
+    })
+
+    const item = result.paper.nodes.find(
+      (node) =>
+        node.type === 'paragraph' &&
+        node.text.startsWith('Calibrate the source-backed threshold'),
+    )
+    expect(item).toMatchObject({
+      text: 'Calibrate the source-backed threshold before export, then verify the rendered checkpoint.',
+      list: {
+        ordered: true,
+        markerStyle: 'decimal',
+        markerText: '1.',
+        ordinal: 1,
+      },
+    })
+  })
+
   it('does not promote a markup-shaped section phrase without source styling', async () => {
     const result = await reconstructPageAnalyses({
       pages: [

--- a/src/research/pdf-layout.test.ts
+++ b/src/research/pdf-layout.test.ts
@@ -1089,18 +1089,23 @@ describe('PDF semantic reconstruction', () => {
 
     it('refuses to prove a page-break join across unaccounted source text', async () => {
       // The same page-two text, this time with no furniture evidence, is body
-      // source order the sentence would have to jump over. The prose may still
-      // be joined by the weaker unmarked-continuation heuristic, but nothing is
-      // written to the ledger, so the join is never claimed as proven.
+      // source order the sentence would have to jump over. With no validated
+      // boundary record, the weaker unmarked-continuation heuristic must not
+      // mutate the paragraph topology.
       const { target, continuation } = pageBreakPair('unaccounted-page-break')
       const head = runningHead('unaccounted-page-break')
-      const { sourceSemanticFlowBoundaryDecisions } =
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
         await joinAcrossPageBreak(target, continuation, [
           target,
           head,
           continuation,
         ])
 
+      expect(blocks).toHaveLength(2)
+      expect(blocks.map((block) => block.text)).toEqual([
+        target.text,
+        continuation.text,
+      ])
       expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(0)
     })
 
@@ -1115,12 +1120,17 @@ describe('PDF semantic reconstruction', () => {
           runs: line.runs.map((sourceRun) => ({ ...sourceRun, y: 0.2 })),
         })),
       }
-      const { sourceSemanticFlowBoundaryDecisions } =
+      const { blocks, sourceSemanticFlowBoundaryDecisions } =
         await joinAcrossPageBreak(midPageTail, continuation, [
           midPageTail,
           continuation,
         ])
 
+      expect(blocks).toHaveLength(2)
+      expect(blocks.map((block) => block.text)).toEqual([
+        midPageTail.text,
+        continuation.text,
+      ])
       expect(sourceSemanticFlowBoundaryDecisions).toHaveLength(0)
     })
   })
@@ -5737,33 +5747,60 @@ describe('PDF semantic reconstruction', () => {
     const result = await reconstructPageAnalyses({
       pages: [
         page(1, [
-          run(1, 'A Scholarly Paper', 0.1, 0.06, 0.72, 18),
-          run(1, '1 INTRODUCTION', 0.1, 0.12, 0.3, 14),
-          run(
-            1,
-            'We point out the following benefits: (1) exact scoring is available,',
-            0.1,
-            0.2,
-            0.72,
-          ),
-          run(
-            1,
-            'the first claim is exact, while (2) diverse inputs are available,',
-            0.1,
-            0.22,
-            0.72,
-          ),
-          run(1, '(3) contamination is unlikely,', 0.1, 0.24, 0.72),
-          run(1, 'and (4) the sequence length can increase', 0.1, 0.26, 0.72),
+          {
+            ...run(1, 'A Scholarly Paper', 0.1, 0.06, 0.72, 18),
+            sourceSequenceIndex: 0,
+          },
+          {
+            ...run(1, '1 INTRODUCTION', 0.1, 0.12, 0.3, 14),
+            sourceSequenceIndex: 1,
+          },
+          {
+            ...run(
+              1,
+              'We point out the following benefits: (1) exact scoring is available,',
+              0.1,
+              0.74,
+              0.72,
+            ),
+            sourceSequenceIndex: 2,
+          },
+          {
+            ...run(
+              1,
+              'the first claim is exact, while (2) diverse inputs are available,',
+              0.1,
+              0.76,
+              0.72,
+            ),
+            sourceSequenceIndex: 3,
+          },
+          {
+            ...run(1, '(3) contamination is unlikely,', 0.1, 0.78, 0.72),
+            sourceSequenceIndex: 4,
+          },
+          {
+            ...run(
+              1,
+              'and (4) the sequence length can increase',
+              0.1,
+              0.82,
+              0.72,
+            ),
+            sourceSequenceIndex: 5,
+          },
         ]),
         page(2, [
-          run(
-            2,
-            'without changing the task, and (5) strong baselines exist.',
-            0.1,
-            0.12,
-            0.72,
-          ),
+          {
+            ...run(
+              2,
+              'without changing the task, and (5) strong baselines exist.',
+              0.1,
+              0.12,
+              0.72,
+            ),
+            sourceSequenceIndex: 0,
+          },
         ]),
       ],
       sourceHash: 'a'.repeat(64),
@@ -5785,6 +5822,11 @@ describe('PDF semantic reconstruction', () => {
     expect(
       paragraphs.some((node) => node.list?.numberingId.startsWith('pdf-list-')),
     ).toBe(false)
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ topology: 'cross-page-column' }),
+      ]),
+    )
   })
 
   it('keeps a source-flowing suffixed enumeration in prose when its second hypothesis starts a region', async () => {
@@ -6002,23 +6044,32 @@ describe('PDF semantic reconstruction', () => {
     const result = await reconstructPageAnalyses({
       pages: [
         page(1, [
-          run(1, 'A Scholarly Paper', 0.1, 0.08, 0.72, 18),
-          run(
-            1,
-            'Nothing about the relationship felt real, not even the way he looked at her',
-            0.1,
-            0.82,
-            0.72,
-          ),
+          {
+            ...run(1, 'A Scholarly Paper', 0.1, 0.08, 0.72, 18),
+            sourceSequenceIndex: 0,
+          },
+          {
+            ...run(
+              1,
+              'Nothing about the relationship felt real, not even the way he looked at her',
+              0.1,
+              0.82,
+              0.72,
+            ),
+            sourceSequenceIndex: 1,
+          },
         ]),
         page(2, [
-          run(
-            2,
-            '– nothing was real except the fact that he had left.',
-            0.1,
-            0.1,
-            0.72,
-          ),
+          {
+            ...run(
+              2,
+              '– nothing was real except the fact that he had left.',
+              0.1,
+              0.1,
+              0.72,
+            ),
+            sourceSequenceIndex: 0,
+          },
         ]),
       ],
       sourceHash: 'a'.repeat(64),
@@ -6035,6 +6086,9 @@ describe('PDF semantic reconstruction', () => {
       }),
     ])
     expect(paragraphs[0]).not.toHaveProperty('list')
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual([
+      expect.objectContaining({ topology: 'cross-page-column' }),
+    ])
   })
 
   it('preserves an isolated dash-delimited scene divider instead of inventing a list', async () => {
@@ -16145,26 +16199,39 @@ describe('PDF semantic reconstruction', () => {
     const citationText =
       'Source-backed systems combine distinct inputs [37, 222] before producing a result.'
     const citationRun = run(1, citationText, 0.1, 0.78, 0.78)
+    citationRun.sourceSequenceIndex = 4
     const labels = ['37', '222']
     const linked = page(1, [
-      run(1, 'Cross-page Citation Link Study', 0.1, 0.04, 0.72, 22),
-      run(1, '1 Introduction', 0.1, 0.14, 0.3, 16),
-      run(
-        1,
-        'The opening sentence establishes ordinary body typography.',
-        0.1,
-        0.72,
-        0.78,
-      ),
-      run(
-        1,
-        'The next sentence provides enough adjacent source flow.',
-        0.1,
-        0.75,
-        0.78,
-      ),
+      {
+        ...run(1, 'Cross-page Citation Link Study', 0.1, 0.04, 0.72, 22),
+        sourceSequenceIndex: 0,
+      },
+      {
+        ...run(1, '1 Introduction', 0.1, 0.14, 0.3, 16),
+        sourceSequenceIndex: 1,
+      },
+      {
+        ...run(
+          1,
+          'The opening sentence establishes ordinary body typography.',
+          0.1,
+          0.72,
+          0.78,
+        ),
+        sourceSequenceIndex: 2,
+      },
+      {
+        ...run(
+          1,
+          'The next sentence provides enough adjacent source flow.',
+          0.1,
+          0.75,
+          0.78,
+        ),
+        sourceSequenceIndex: 3,
+      },
       citationRun,
-      run(1, 'This', 0.1, 0.81, 0.78),
+      { ...run(1, 'This', 0.1, 0.81, 0.78), sourceSequenceIndex: 5 },
     ])
     linked.links = labels.map((label, index) => {
       const start = citationText.indexOf(label)
@@ -16180,13 +16247,16 @@ describe('PDF semantic reconstruction', () => {
       pages: [
         linked,
         page(2, [
-          run(
-            2,
-            'continuation completes the paragraph with source-proven geometry.',
-            0.1,
-            0.08,
-            0.78,
-          ),
+          {
+            ...run(
+              2,
+              'continuation completes the paragraph with source-proven geometry.',
+              0.1,
+              0.08,
+              0.78,
+            ),
+            sourceSequenceIndex: 0,
+          },
         ]),
         page(3, [
           run(3, 'References', 0.1, 0.1, 0.3, 16),
@@ -16224,6 +16294,11 @@ describe('PDF semantic reconstruction', () => {
       ),
     ).toBe(true)
     expect(new Set(linkedRuns.map(({ href }) => href)).size).toBe(2)
+    expect(result.sourceSemanticFlowBoundaryDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ topology: 'cross-page-column' }),
+      ]),
+    )
     expect(result.completeness).toMatchObject({
       expectedHyperlinkCount: 2,
       mappedHyperlinkCount: 2,

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -2972,7 +2972,7 @@ function appendBlockContinuation(
     number,
     PdfBodySourceOrderExtremum
   > = new Map(),
-  requireSemanticFlowDecision = false,
+  requiredSemanticFlowDecision: PdfSourceSemanticFlowBoundaryDecision | null = null,
 ) {
   const targetTailLine = blockSourceSegments(target).at(-1)?.region.lines.at(-1)
   const continuationHeadLine =
@@ -3095,7 +3095,7 @@ function appendBlockContinuation(
     inferredTopology === 'cross-page-column'
       ? inferredTopology
       : null
-  const semanticFlowDecision =
+  const derivedSemanticFlowDecision =
     semanticDeletionDecision ??
     (recordableTopology &&
     semanticFlowOutcome !== 'unresolved' &&
@@ -3116,9 +3116,24 @@ function appendBlockContinuation(
           bodySourceOrderExtremaByPage,
         )
       : null)
-  if (requireSemanticFlowDecision && semanticFlowDecision === null) {
+  const requiredBoundaryAlreadyExists =
+    requiredSemanticFlowDecision !== null &&
+    sourceSemanticFlowBoundaryDecisions.some(
+      (decision) =>
+        decision.from.regionId === requiredSemanticFlowDecision.from.regionId &&
+        decision.from.lineId === requiredSemanticFlowDecision.from.lineId &&
+        decision.to.regionId === requiredSemanticFlowDecision.to.regionId &&
+        decision.to.lineId === requiredSemanticFlowDecision.to.lineId,
+    )
+  if (
+    requiredSemanticFlowDecision !== null &&
+    (derivedSemanticFlowDecision?.id !== requiredSemanticFlowDecision.id ||
+      requiredBoundaryAlreadyExists)
+  ) {
     return false
   }
+  const semanticFlowDecision =
+    requiredSemanticFlowDecision ?? derivedSemanticFlowDecision
   if (deletionApplied && deletionDecision) {
     hyphenDeletion!.decisions.push(deletionDecision)
   }
@@ -4922,16 +4937,18 @@ export async function mergeProseContinuations(
           blockSourceSegments(continuation)[0]?.region.page
       const crossPageContinuation =
         continuation?.type === 'paragraph' && !samePageContinuation
+      const crossPageHyphenVerdict =
+        crossPageContinuation &&
+        lowercaseHyphenContinuation &&
+        hyphenJoin.hyphenBoundary
+          ? sourceSemanticFlowHyphenVerdict(hyphenJoin.hyphenBoundary.proof)
+          : 'unresolved'
       const crossPageSemanticFlowOutcome =
         crossPageContinuation && continuation?.type === 'paragraph'
           ? lowercaseHyphenContinuation && hyphenJoin.hyphenBoundary
-            ? sourceSemanticFlowHyphenVerdict(
-                hyphenJoin.hyphenBoundary.proof,
-              ) === 'remove'
+            ? crossPageHyphenVerdict === 'remove'
               ? 'discretionary-hyphen-delete'
-              : sourceSemanticFlowHyphenVerdict(
-                    hyphenJoin.hyphenBoundary.proof,
-                  ) === 'preserve'
+              : crossPageHyphenVerdict === 'preserve'
                 ? 'hard-hyphen-retain'
                 : null
             : (sourceColumnFlowJoin(continuation, language)?.outcome ??
@@ -5034,7 +5051,7 @@ export async function mergeProseContinuations(
               ? 'same-page-column'
               : null,
         bodySourceOrderExtremaByPage,
-        crossPageContinuation,
+        crossPageSemanticFlowDecision,
       )
       if (!appended) break
       blocks.splice(continuationIndex, 1)

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -2099,6 +2099,60 @@ function sourceMarkupShape(value: string): SourceMarkupShape {
   }
 }
 
+function orderedMarkerHasWithinBlockHangingIndent(
+  block: RegionBlock,
+  marker: NonNullable<ReturnType<typeof parsedOrderedListMarker>>,
+) {
+  const visibleLines = block.region.lines.filter((line) => line.text.trim())
+  if (visibleLines.length < 2) return false
+  const firstLine = visibleLines[0]
+  const continuationLine = visibleLines[1]
+  const firstLineRuns = firstLine.runs.filter((run) => run.text.trim())
+  const continuationRuns = continuationLine.runs.filter((run) =>
+    run.text.trim(),
+  )
+  if (firstLineRuns.length === 0 || continuationRuns.length === 0) {
+    return false
+  }
+
+  const firstLineMarker = parsedOrderedListMarker(firstLine.text)
+  if (
+    !firstLineMarker ||
+    firstLineMarker.markerText !== marker.markerText ||
+    firstLineMarker.itemText.length === 0
+  ) {
+    return false
+  }
+  const markerRun = firstLineRuns[0]
+  const markerRunText = markerRun.text.trimStart()
+  if (!markerRunText.startsWith(marker.markerText)) return false
+  const markerStartX = markerRun.x
+  const contentStartX =
+    markerRunText === marker.markerText && firstLineRuns.length > 1
+      ? firstLineRuns[1].x
+      : markerRun.x +
+        markerRun.width *
+          (firstLineMarker.contentStart /
+            Math.max(Array.from(markerRun.text).length, 1))
+  const continuationStartX = Math.min(...continuationRuns.map((run) => run.x))
+  const verticalGap =
+    continuationLine.box.y - (firstLine.box.y + firstLine.box.height)
+  const fontRatio =
+    Math.max(firstLine.fontSize, continuationLine.fontSize) /
+    Math.max(1, Math.min(firstLine.fontSize, continuationLine.fontSize))
+  return (
+    contentStartX - markerStartX >= 0.012 &&
+    Math.abs(continuationStartX - contentStartX) <= 0.012 &&
+    verticalGap >= -0.004 &&
+    verticalGap <=
+      Math.max(
+        0.03,
+        Math.max(firstLine.box.height, continuationLine.box.height) * 2,
+      ) &&
+    fontRatio <= 1.12
+  )
+}
+
 function orderedMarkerHasIndependentEvidence(
   blockIndex: number,
   blocks: readonly RegionBlock[],
@@ -2116,6 +2170,8 @@ function orderedMarkerHasIndependentEvidence(
     firstLineRuns.length > 1 &&
     firstLineRuns[0].text.trim() === marker.markerText,
   )
+  const withinBlockHangingIndent =
+    orderedMarkerHasWithinBlockHangingIndent(block, marker)
   const largestFont = Math.max(
     ...block.region.lines.map((line) => line.fontSize),
     bodySize,
@@ -2135,6 +2191,7 @@ function orderedMarkerHasIndependentEvidence(
     )
   if (
     markerRunSeparated ||
+    withinBlockHangingIndent ||
     largestFont >= bodySize * 1.12 ||
     emphasizedShare >= 0.6
   ) {

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -4827,10 +4827,20 @@ export async function mergeProseContinuations(
         continuation?.type === 'paragraph' &&
         blockSourceSegments(target).at(-1)?.region.page ===
           blockSourceSegments(continuation)[0]?.region.page
+      const crossPageContinuation =
+        continuation?.type === 'paragraph' && !samePageContinuation
+      const sourceProvenCrossPageJoin =
+        sourceProvenCrossPageColumnFlow ||
+        sourceProvenFloatBoundary ||
+        sourceProvenCitationBoundary ||
+        (lowercaseHyphenContinuation &&
+          sourceProvenHyphenDecision &&
+          hyphenJoin.hyphenBoundary !== null)
       if (
         continuation?.type !== 'paragraph' ||
         continuation.list ||
         (samePageContinuation && !sourceBoundaryProven) ||
+        (crossPageContinuation && !sourceProvenCrossPageJoin) ||
         (crossesOwnedFloat && !sourceProvenFloatBoundary) ||
         (citationYearContinuation && !sourceProvenCitationBoundary) ||
         !sourceProvenHyphenDecision ||

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -2972,6 +2972,7 @@ function appendBlockContinuation(
     number,
     PdfBodySourceOrderExtremum
   > = new Map(),
+  requireSemanticFlowDecision = false,
 ) {
   const targetTailLine = blockSourceSegments(target).at(-1)?.region.lines.at(-1)
   const continuationHeadLine =
@@ -3027,6 +3028,7 @@ function appendBlockContinuation(
     : 'unresolved'
   const semanticDeletionDecision =
     deletionDecision === null &&
+    requestedTopology !== 'cross-page-column' &&
     hyphenDeletion?.proof.sourceBoundaryProven === true &&
     semanticHyphenVerdict === 'remove'
       ? sourceSemanticFlowBoundaryDecision(
@@ -3055,9 +3057,6 @@ function appendBlockContinuation(
     targetText = targetText.slice(0, -1)
     const tail = targetSegments.at(-1)!
     tail.text = tail.text.slice(0, -1)
-    if (deletionDecision) {
-      hyphenDeletion!.decisions.push(deletionDecision)
-    }
   }
   const semanticFlowOutcome: SourceSemanticFlowBoundaryCandidate['outcome'] =
     deletionApplied
@@ -3073,10 +3072,12 @@ function appendBlockContinuation(
   const continuationLineage = continuationHeadLine?.sourceFragmentLineage
   const inferredTopology:
     SourceSemanticFlowBoundaryCandidate['topology'] | null =
-    semanticFlowOutcome === 'discretionary-hyphen-delete' ||
-    semanticFlowOutcome === 'hard-hyphen-retain'
-      ? 'lexical-hyphen'
-      : targetLineage &&
+    requestedTopology === 'cross-page-column'
+      ? 'cross-page-column'
+      : semanticFlowOutcome === 'discretionary-hyphen-delete' ||
+          semanticFlowOutcome === 'hard-hyphen-retain'
+        ? 'lexical-hyphen'
+        : targetLineage &&
           continuationLineage &&
           targetLineage.sourceLineId === continuationLineage.sourceLineId &&
           (targetLineage.fragment.startsWith('inline-stacked-') ||
@@ -3100,7 +3101,9 @@ function appendBlockContinuation(
     semanticFlowOutcome !== 'unresolved' &&
     (recordableTopology === 'same-page-column' ||
     recordableTopology === 'cross-page-column'
-      ? semanticFlowOutcome === 'space' || semanticFlowOutcome === 'no-space'
+      ? recordableTopology === 'cross-page-column' ||
+        semanticFlowOutcome === 'space' ||
+        semanticFlowOutcome === 'no-space'
       : semanticFlowOutcome !== 'space'
         ? recordableTopology === 'inline-stacked-fragment' ||
           recordableTopology === 'lexical-hyphen'
@@ -3113,6 +3116,12 @@ function appendBlockContinuation(
           bodySourceOrderExtremaByPage,
         )
       : null)
+  if (requireSemanticFlowDecision && semanticFlowDecision === null) {
+    return false
+  }
+  if (deletionApplied && deletionDecision) {
+    hyphenDeletion!.decisions.push(deletionDecision)
+  }
   if (
     semanticFlowDecision &&
     !sourceSemanticFlowBoundaryDecisions.some(
@@ -3142,6 +3151,7 @@ function appendBlockContinuation(
   if (target.list && continuation.region.page > previousMaximumPage) {
     target.list.continuedFromPreviousPage = true
   }
+  return true
 }
 
 type InlineStackedParagraphFragment = {
@@ -4366,6 +4376,38 @@ function sourceProvenCrossPageColumnFlowBoundary(
     PdfBodySourceOrderExtremum
   >,
 ) {
+  if (
+    !sourceProvenCrossPageColumnGeometryBoundary(
+      target,
+      continuation,
+      language,
+      baseDirection,
+    ) ||
+    /[\p{L}\p{N}][-‐‑]$/u.test(target.text.trimEnd()) ||
+    detachedCitationYearContinuation(target.text, continuation.text) ||
+    !likelyUnmarkedCrossPageContinuation(target, continuation, {
+      admitUncasedScripts: true,
+    })
+  ) {
+    return false
+  }
+  return (
+    sourceSemanticFlowBoundaryCandidate(
+      target,
+      continuation,
+      sourceColumnFlowJoin(continuation, language)?.outcome ?? 'space',
+      'cross-page-column',
+      bodySourceOrderExtremaByPage,
+    ) !== null
+  )
+}
+
+function sourceProvenCrossPageColumnGeometryBoundary(
+  target: RegionBlock,
+  continuation: RegionBlock,
+  language: string | null,
+  baseDirection: ResearchPaper['baseDirection'] | null,
+) {
   const targetTailSegment = blockSourceSegments(target).at(-1)
   const continuationHeadSegment = blockSourceSegments(continuation)[0]
   const targetTailLine = targetTailSegment?.region.lines
@@ -4398,12 +4440,7 @@ function sourceProvenCrossPageColumnFlowBoundary(
     !tailColumns.has(targetTailSegment.region.column) ||
     !headColumns.has(continuationHeadSegment.region.column) ||
     targetTailLine.box.y + targetTailLine.box.height < 0.65 ||
-    continuationHeadLine.box.y > 0.35 ||
-    /[\p{L}\p{N}][-‐‑]$/u.test(target.text.trimEnd()) ||
-    detachedCitationYearContinuation(target.text, continuation.text) ||
-    !likelyUnmarkedCrossPageContinuation(target, continuation, {
-      admitUncasedScripts: true,
-    })
+    continuationHeadLine.box.y > 0.35
   ) {
     return false
   }
@@ -4413,16 +4450,7 @@ function sourceProvenCrossPageColumnFlowBoundary(
       1,
       Math.min(targetTailLine.fontSize, continuationHeadLine.fontSize),
     )
-  if (fontRatio > 1.12) return false
-  return (
-    sourceSemanticFlowBoundaryCandidate(
-      target,
-      continuation,
-      sourceColumnFlowJoin(continuation, language)?.outcome ?? 'space',
-      'cross-page-column',
-      bodySourceOrderExtremaByPage,
-    ) !== null
-  )
+  return fontRatio <= 1.12
 }
 
 function sourceProvenSamePageParagraphBoundary(
@@ -4806,6 +4834,14 @@ export async function mergeProseContinuations(
           baseDirection,
           bodySourceOrderExtremaByPage,
         )
+      const sourceProvenCrossPageColumnGeometry =
+        continuation?.type === 'paragraph' &&
+        sourceProvenCrossPageColumnGeometryBoundary(
+          target,
+          continuation,
+          language,
+          baseDirection,
+        )
       const samePageColumnFlowJoin =
         (sourceProvenSamePageColumnFlow || sourceProvenCrossPageColumnFlow) &&
         continuation?.type === 'paragraph'
@@ -4886,13 +4922,40 @@ export async function mergeProseContinuations(
           blockSourceSegments(continuation)[0]?.region.page
       const crossPageContinuation =
         continuation?.type === 'paragraph' && !samePageContinuation
+      const crossPageSemanticFlowOutcome =
+        crossPageContinuation && continuation?.type === 'paragraph'
+          ? lowercaseHyphenContinuation && hyphenJoin.hyphenBoundary
+            ? sourceSemanticFlowHyphenVerdict(
+                hyphenJoin.hyphenBoundary.proof,
+              ) === 'remove'
+              ? 'discretionary-hyphen-delete'
+              : sourceSemanticFlowHyphenVerdict(
+                    hyphenJoin.hyphenBoundary.proof,
+                  ) === 'preserve'
+                ? 'hard-hyphen-retain'
+                : null
+            : (sourceColumnFlowJoin(continuation, language)?.outcome ??
+              'space')
+          : null
+      const crossPageSemanticFlowDecision =
+        crossPageContinuation &&
+        continuation?.type === 'paragraph' &&
+        sourceProvenCrossPageColumnGeometry &&
+        crossPageSemanticFlowOutcome !== null &&
+        (sourceProvenCrossPageColumnFlow ||
+          sourceProvenFloatBoundary ||
+          sourceProvenCitationBoundary ||
+          (lowercaseHyphenContinuation && sourceProvenHyphenDecision))
+          ? sourceSemanticFlowBoundaryDecision(
+              target,
+              continuation,
+              crossPageSemanticFlowOutcome,
+              'cross-page-column',
+              bodySourceOrderExtremaByPage,
+            )
+          : null
       const sourceProvenCrossPageJoin =
-        sourceProvenCrossPageColumnFlow ||
-        sourceProvenFloatBoundary ||
-        sourceProvenCitationBoundary ||
-        (lowercaseHyphenContinuation &&
-          sourceProvenHyphenDecision &&
-          hyphenJoin.hyphenBoundary !== null)
+        crossPageSemanticFlowDecision !== null
       if (
         continuation?.type !== 'paragraph' ||
         continuation.list ||
@@ -4947,7 +5010,7 @@ export async function mergeProseContinuations(
           })
         }
       }
-      appendBlockContinuation(
+      const appended = appendBlockContinuation(
         target,
         continuation,
         samePageColumnFlowJoin?.separator ?? hyphenJoin.separator,
@@ -4961,17 +5024,19 @@ export async function mergeProseContinuations(
               }
             : null,
         sourceSemanticFlowBoundaryDecisions,
-        citationYearContinuation
-          ? target.region.column === continuation.region.column
-            ? 'same-column-citation-year'
-            : 'cross-column-citation-year'
-          : sourceProvenSamePageColumnFlow
-            ? 'same-page-column'
-            : sourceProvenCrossPageColumnFlow
-              ? 'cross-page-column'
+        crossPageContinuation
+          ? 'cross-page-column'
+          : citationYearContinuation
+            ? target.region.column === continuation.region.column
+              ? 'same-column-citation-year'
+              : 'cross-column-citation-year'
+            : sourceProvenSamePageColumnFlow
+              ? 'same-page-column'
               : null,
         bodySourceOrderExtremaByPage,
+        crossPageContinuation,
       )
+      if (!appended) break
       blocks.splice(continuationIndex, 1)
     }
   }
@@ -11617,6 +11682,13 @@ export async function reconstructPageAnalyses({
     sourceSemanticFlowBoundaryDecisions,
     bodySourceOrderExtremaByPage: pdfBodySourceOrderExtremaByPage(
       regionResult.regions,
+      new Set(
+        visualResult.relationships.flatMap((relationship) =>
+          relationship.status === 'matched' && relationship.kind !== 'equation'
+            ? [relationship.captionRegionId, ...relationship.sourceRegionIds]
+            : [],
+        ),
+      ),
     ),
   })
   await yieldPdfReconstructionTask(signal)

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -81,8 +81,11 @@ import {
   canonicalPdfSourceSemanticFlowEvidence,
   PDF_SOURCE_SEMANTIC_FLOW_BASE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE,
+  PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_NO_SPACE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_SPACE_WHITESPACE_EVIDENCE,
+  pdfBodySourceOrderExtremaByPage,
+  type PdfBodySourceOrderExtremum,
   pdfSourceColumnFlowJoinOutcome,
   pdfSourceColumnFlowStartsWithCjkNumericContinuation,
   pdfSourceFragmentId,
@@ -2074,6 +2077,131 @@ function parsedOrderedListMarker(value: string) {
   }
 }
 
+type SourceMarkupShape = {
+  heading: boolean
+  emphasis: boolean
+  template: boolean
+  orderedList: boolean
+}
+
+function sourceMarkupShape(value: string): SourceMarkupShape {
+  const trimmed = value.trim()
+  return {
+    heading: /^#{1,6}\s+/u.test(trimmed),
+    emphasis: /^(?:\*\*(?=\S)[\s\S]*\*\*|__(?=\S)[\s\S]*__)$/u.test(
+      trimmed,
+    ),
+    template: /^\{[A-Za-z_][A-Za-z0-9_.-]*\}$/u.test(trimmed),
+    orderedList:
+      /^(?:(?:\d+(?:\.\d+){0,3})[.)]|\(\s*\d{1,3}\s*\)|\[\s*\d{1,4}\s*\])\s+\S/u.test(
+        trimmed,
+      ),
+  }
+}
+
+function orderedMarkerHasIndependentEvidence(
+  blockIndex: number,
+  blocks: readonly RegionBlock[],
+  marker: NonNullable<ReturnType<typeof parsedOrderedListMarker>>,
+  bodySize: number,
+) {
+  const block = blocks[blockIndex]
+  if (!block) return false
+  const visibleRuns = block.region.lines.flatMap((line) =>
+    line.runs.filter((run) => run.text.trim()),
+  )
+  const firstLine = block.region.lines.find((line) => line.text.trim())
+  const firstLineRuns = firstLine?.runs.filter((run) => run.text.trim()) ?? []
+  const markerRunSeparated = Boolean(
+    firstLineRuns.length > 1 &&
+    firstLineRuns[0].text.trim() === marker.markerText,
+  )
+  const largestFont = Math.max(
+    ...block.region.lines.map((line) => line.fontSize),
+    bodySize,
+  )
+  const emphasizedShare =
+    visibleRuns.reduce(
+      (total, run) =>
+        total +
+        (run.bold || fontNameIndicatesEmphasizedFace(run.fontName)
+          ? run.text.trim().length
+          : 0),
+      0,
+    ) /
+    Math.max(
+      1,
+      visibleRuns.reduce((total, run) => total + run.text.trim().length, 0),
+    )
+  if (
+    markerRunSeparated ||
+    largestFont >= bodySize * 1.12 ||
+    emphasizedShare >= 0.6
+  ) {
+    return true
+  }
+
+  const preceding = blocks[blockIndex - 1]
+  if (preceding?.type === 'paragraph' && preceding.list?.ordered) {
+    return true
+  }
+  if (
+    preceding?.type === 'paragraph' &&
+    /:\s*$/u.test(preceding.text.trimEnd()) &&
+    block.region.box.x > preceding.region.box.x + 0.012
+  ) {
+    return true
+  }
+  if (
+    preceding?.type === 'paragraph' &&
+    block.region.page >= preceding.region.page &&
+    block.region.box.x >= preceding.region.box.x + 0.05
+  ) {
+    return true
+  }
+
+  return blocks.some((candidate, candidateIndex) => {
+    if (candidateIndex === blockIndex || candidate.type !== 'paragraph') {
+      return false
+    }
+    const parsedPeer = parsedOrderedListMarker(candidate.text)
+    const peer =
+      parsedPeer ??
+      (candidate.list?.ordered &&
+      candidate.list.markerText &&
+      candidate.list.ordinal !== undefined
+        ? {
+            markerText: candidate.list.markerText,
+            markerStyle: candidate.list.markerStyle,
+            ordinal: candidate.list.ordinal,
+          }
+        : null)
+    if (!peer) return false
+    const samePage = candidate.region.page === block.region.page
+    const adjacentPage =
+      candidate.region.page + 1 === block.region.page &&
+      candidate.region.column === block.region.column &&
+      Math.abs(candidate.region.box.x - block.region.box.x) <= 0.05
+    if (!samePage && !adjacentPage) return false
+    const sameStyle = peer.markerStyle === marker.markerStyle
+    const ordinalSequence =
+      sameStyle &&
+      Math.abs(peer.ordinal - marker.ordinal) === 1 &&
+      (adjacentPage ||
+        (candidate.region.column === block.region.column &&
+          Math.abs(candidate.region.box.x - block.region.box.x) <= 0.05 &&
+          Math.abs(candidate.region.box.y - block.region.box.y) <= 0.2))
+    const oppositeColumnRow =
+      candidate.region.column !== block.region.column &&
+      Math.abs(candidate.region.box.y - block.region.box.y) <= 0.035
+    const nestedGeometry =
+      candidate.region.column === block.region.column &&
+      candidate.region.box.x > block.region.box.x + 0.012 &&
+      Math.abs(candidate.region.box.y - block.region.box.y) <= 0.12
+    return ordinalSequence || oppositeColumnRow || nestedGeometry
+  })
+}
+
 function ambiguousParenthesizedRomanListMarker(
   marker: ReturnType<typeof parsedOrderedListMarker>,
 ) {
@@ -2550,7 +2678,12 @@ function sourceSemanticFlowBoundaryCandidate(
   continuation: RegionBlock,
   outcome: SourceSemanticFlowBoundaryCandidate['outcome'],
   topology: SourceSemanticFlowBoundaryCandidate['topology'],
+  bodySourceOrderExtremaByPage: ReadonlyMap<
+    number,
+    PdfBodySourceOrderExtremum
+  > = new Map(),
 ): SourceSemanticFlowBoundaryCandidate | null {
+  const crossPage = topology === 'cross-page-column'
   const targetTailSegment = blockSourceSegments(target).at(-1)
   const continuationHeadSegment = blockSourceSegments(continuation)[0]
   const targetEvidenceRegion =
@@ -2635,10 +2768,21 @@ function sourceSemanticFlowBoundaryCandidate(
   }
   const from = fromCandidates[0]
   const to = toCandidates[0]
-  const exactSourceAdjacency =
-    minimumToSequence === maximumFromSequence + 1 ||
-    (to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
-      to.run.sourceWhitespacePredecessorIndex === maximumFromSequence)
+  // Across a page break the two indexes belong to different per-page sequences,
+  // so adjacency is proved by extremity instead: the tail is the last body item
+  // its page paints and the head is the first body item the next page paints.
+  const crossPageSourceAdjacency = Boolean(
+    crossPage &&
+    to.run.page === from.run.page + 1 &&
+    bodySourceOrderExtremaByPage.get(from.run.page)?.last ===
+      maximumFromSequence &&
+    bodySourceOrderExtremaByPage.get(to.run.page)?.first === minimumToSequence,
+  )
+  const exactSourceAdjacency = crossPage
+    ? crossPageSourceAdjacency
+    : minimumToSequence === maximumFromSequence + 1 ||
+      (to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
+        to.run.sourceWhitespacePredecessorIndex === maximumFromSequence)
   const fromFragmentId = pdfSourceFragmentId(fromLine)
   const toFragmentId = pdfSourceFragmentId(toLine)
   const fromMetrics = dominantSemanticFlowLineMetrics(fromLine)
@@ -2649,7 +2793,9 @@ function sourceSemanticFlowBoundaryCandidate(
     !toFragmentId ||
     !fromMetrics ||
     !toMetrics ||
-    from.run.page !== to.run.page ||
+    (crossPage
+      ? to.run.page !== from.run.page + 1
+      : from.run.page !== to.run.page) ||
     from.run.rotation !== to.run.rotation ||
     from.run.method !== to.run.method ||
     (from.run.method !== 'pdf-text' && from.run.method !== 'ocr')
@@ -2663,6 +2809,7 @@ function sourceSemanticFlowBoundaryCandidate(
   if (
     fontRatio > 1.5 ||
     (topology !== 'same-page-column' &&
+      !crossPage &&
       baselineGap >
         Math.max(0.06, Math.max(fromMetrics.height, toMetrics.height) * 4))
   ) {
@@ -2675,28 +2822,30 @@ function sourceSemanticFlowBoundaryCandidate(
       toLine.sourceFragmentLineage.sourceLineId &&
     /^[,.;:!?%)}\]]/u.test(continuation.text.trimStart()),
   )
-  const noSpaceSamePageColumnTransition =
-    topology === 'same-page-column' &&
+  const noSpaceColumnFlowTransition =
+    (topology === 'same-page-column' || crossPage) &&
     outcome === 'no-space' &&
     to.run.sourceWhitespaceBefore !== 'pdf-text-item'
   if (
     (outcome === 'no-space' &&
       !exactStackedPunctuationTransition &&
-      !noSpaceSamePageColumnTransition) ||
+      !noSpaceColumnFlowTransition) ||
     (outcome === 'space' && exactStackedPunctuationTransition)
   ) {
     return null
   }
   const evidence = canonicalPdfSourceSemanticFlowEvidence(
-    topology === 'same-page-column'
-      ? PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE
-      : exactStackedPunctuationTransition
-        ? PDF_SOURCE_SEMANTIC_FLOW_NO_SPACE_EVIDENCE
-        : outcome === 'space' &&
-            to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
-            to.run.sourceWhitespacePredecessorIndex === maximumFromSequence
-          ? PDF_SOURCE_SEMANTIC_FLOW_SPACE_WHITESPACE_EVIDENCE
-          : PDF_SOURCE_SEMANTIC_FLOW_BASE_EVIDENCE,
+    crossPage
+      ? PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE
+      : topology === 'same-page-column'
+        ? PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE
+        : exactStackedPunctuationTransition
+          ? PDF_SOURCE_SEMANTIC_FLOW_NO_SPACE_EVIDENCE
+          : outcome === 'space' &&
+              to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
+              to.run.sourceWhitespacePredecessorIndex === maximumFromSequence
+            ? PDF_SOURCE_SEMANTIC_FLOW_SPACE_WHITESPACE_EVIDENCE
+            : PDF_SOURCE_SEMANTIC_FLOW_BASE_EVIDENCE,
   )
   const decision: SourceSemanticFlowBoundaryCandidate = {
     page: from.run.page,
@@ -2730,12 +2879,17 @@ function sourceSemanticFlowBoundaryDecision(
   continuation: RegionBlock,
   outcome: PdfSourceSemanticFlowBoundaryDecision['outcome'],
   topology: PdfSourceSemanticFlowBoundaryDecision['topology'],
+  bodySourceOrderExtremaByPage: ReadonlyMap<
+    number,
+    PdfBodySourceOrderExtremum
+  > = new Map(),
 ): PdfSourceSemanticFlowBoundaryDecision | null {
   const decision = sourceSemanticFlowBoundaryCandidate(
     target,
     continuation,
     outcome,
     topology,
+    bodySourceOrderExtremaByPage,
   )
   if (!decision) return null
   const canonicalDecision: Omit<PdfSourceSemanticFlowBoundaryDecision, 'id'> = {
@@ -2757,6 +2911,10 @@ function appendBlockContinuation(
   sourceSemanticFlowBoundaryDecisions: PdfSourceSemanticFlowBoundaryDecision[] = [],
   requestedTopology:
     SourceSemanticFlowBoundaryCandidate['topology'] | null = null,
+  bodySourceOrderExtremaByPage: ReadonlyMap<
+    number,
+    PdfBodySourceOrderExtremum
+  > = new Map(),
 ) {
   const targetTailLine = blockSourceSegments(target).at(-1)?.region.lines.at(-1)
   const continuationHeadLine =
@@ -2875,14 +3033,16 @@ function appendBlockContinuation(
   const recordableTopology =
     inferredTopology === 'inline-stacked-fragment' ||
     inferredTopology === 'lexical-hyphen' ||
-    inferredTopology === 'same-page-column'
+    inferredTopology === 'same-page-column' ||
+    inferredTopology === 'cross-page-column'
       ? inferredTopology
       : null
   const semanticFlowDecision =
     semanticDeletionDecision ??
     (recordableTopology &&
     semanticFlowOutcome !== 'unresolved' &&
-    (recordableTopology === 'same-page-column'
+    (recordableTopology === 'same-page-column' ||
+    recordableTopology === 'cross-page-column'
       ? semanticFlowOutcome === 'space' || semanticFlowOutcome === 'no-space'
       : semanticFlowOutcome !== 'space'
         ? recordableTopology === 'inline-stacked-fragment' ||
@@ -2893,6 +3053,7 @@ function appendBlockContinuation(
           continuation,
           semanticFlowOutcome,
           recordableTopology,
+          bodySourceOrderExtremaByPage,
         )
       : null)
   if (
@@ -4125,6 +4286,88 @@ function sourceProvenSamePageColumnFlowBoundary(
   return candidate !== null
 }
 
+const PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR = new Set(['right', 'single', 'span'])
+const PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR = new Set(['left', 'single', 'span'])
+
+/**
+ * A sentence that runs off the bottom of one page and resumes at the top of the
+ * next.  Everything asserted here is readable from the source: the two blocks
+ * are consecutive pages, the tail sits in the bottom band of the last column
+ * and the head in the top band of the first, typography matches, and the
+ * continuation carries language-agnostic unfinished-sentence evidence.  The
+ * remaining proof — that only page furniture was painted between them — lives
+ * in `sourceSemanticFlowBoundaryCandidate`, which needs the per-page body
+ * source-order extrema to establish it.
+ */
+function sourceProvenCrossPageColumnFlowBoundary(
+  target: RegionBlock,
+  continuation: RegionBlock,
+  language: string | null,
+  baseDirection: ResearchPaper['baseDirection'] | null,
+  bodySourceOrderExtremaByPage: ReadonlyMap<
+    number,
+    PdfBodySourceOrderExtremum
+  >,
+) {
+  const targetTailSegment = blockSourceSegments(target).at(-1)
+  const continuationHeadSegment = blockSourceSegments(continuation)[0]
+  const targetTailLine = targetTailSegment?.region.lines
+    .filter((line) => line.text.trim())
+    .at(-1)
+  const continuationHeadLine = continuationHeadSegment?.region.lines.find(
+    (line) => line.text.trim(),
+  )
+  if (
+    !targetTailSegment ||
+    !continuationHeadSegment ||
+    !targetTailLine ||
+    !continuationHeadLine ||
+    continuationHeadSegment.region.page !== targetTailSegment.region.page + 1
+  ) {
+    return false
+  }
+  const rtl =
+    baseDirection === 'rtl' ||
+    (baseDirection !== 'ltr' &&
+      baseDirection !== 'unknown' &&
+      (language ? rtlLanguage(language) : false))
+  const tailColumns = rtl
+    ? PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR
+    : PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR
+  const headColumns = rtl
+    ? PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR
+    : PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR
+  if (
+    !tailColumns.has(targetTailSegment.region.column) ||
+    !headColumns.has(continuationHeadSegment.region.column) ||
+    targetTailLine.box.y + targetTailLine.box.height < 0.65 ||
+    continuationHeadLine.box.y > 0.35 ||
+    /[\p{L}\p{N}][-‐‑]$/u.test(target.text.trimEnd()) ||
+    detachedCitationYearContinuation(target.text, continuation.text) ||
+    !likelyUnmarkedCrossPageContinuation(target, continuation, {
+      admitUncasedScripts: true,
+    })
+  ) {
+    return false
+  }
+  const fontRatio =
+    Math.max(targetTailLine.fontSize, continuationHeadLine.fontSize) /
+    Math.max(
+      1,
+      Math.min(targetTailLine.fontSize, continuationHeadLine.fontSize),
+    )
+  if (fontRatio > 1.12) return false
+  return (
+    sourceSemanticFlowBoundaryCandidate(
+      target,
+      continuation,
+      sourceColumnFlowJoin(continuation, language)?.outcome ?? 'space',
+      'cross-page-column',
+      bodySourceOrderExtremaByPage,
+    ) !== null
+  )
+}
+
 function sourceProvenSamePageParagraphBoundary(
   target: RegionBlock,
   continuation: RegionBlock,
@@ -4375,6 +4618,7 @@ export async function mergeProseContinuations(
     canonicalFloatScopes = [],
     canonicalHyphenBoundaryDecisions = [],
     sourceSemanticFlowBoundaryDecisions = [],
+    bodySourceOrderExtremaByPage = new Map(),
   }: {
     ownedFloatCaptionRegionIds?: ReadonlySet<string>
     hardHyphenLexicon?: ReadonlySet<string>
@@ -4385,6 +4629,10 @@ export async function mergeProseContinuations(
     canonicalFloatScopes?: CanonicalFloatScopeEvidence[]
     canonicalHyphenBoundaryDecisions?: PdfCanonicalHyphenBoundaryDecision[]
     sourceSemanticFlowBoundaryDecisions?: PdfSourceSemanticFlowBoundaryDecision[]
+    bodySourceOrderExtremaByPage?: ReadonlyMap<
+      number,
+      PdfBodySourceOrderExtremum
+    >
   } = {},
 ) {
   for (let index = 0; index < blocks.length; index += 1) {
@@ -4491,8 +4739,19 @@ export async function mergeProseContinuations(
           language,
           baseDirection,
         )
+      const sourceProvenCrossPageColumnFlow =
+        continuation?.type === 'paragraph' &&
+        interveningOwnedCaptions.length === 0 &&
+        sourceProvenCrossPageColumnFlowBoundary(
+          target,
+          continuation,
+          language,
+          baseDirection,
+          bodySourceOrderExtremaByPage,
+        )
       const samePageColumnFlowJoin =
-        sourceProvenSamePageColumnFlow && continuation?.type === 'paragraph'
+        (sourceProvenSamePageColumnFlow || sourceProvenCrossPageColumnFlow) &&
+        continuation?.type === 'paragraph'
           ? sourceColumnFlowJoin(continuation, language)
           : null
       const sourceProvenFloatBoundary =
@@ -4641,7 +4900,10 @@ export async function mergeProseContinuations(
             : 'cross-column-citation-year'
           : sourceProvenSamePageColumnFlow
             ? 'same-page-column'
-            : null,
+            : sourceProvenCrossPageColumnFlow
+              ? 'cross-page-column'
+              : null,
+        bodySourceOrderExtremaByPage,
       )
       blocks.splice(continuationIndex, 1)
     }
@@ -6027,10 +6289,20 @@ async function blocksFromRegions(
           /^[A-Z](?:\.\d+)+\.?\s+\p{Lu}/u.test(region.text.trim()) ||
           sequencedLetteredHeadingRegions.has(region) ||
           namedSectionPrefix)
+      const markup = sourceMarkupShape(region.text)
+      const sourceMarkupHasIndependentEvidence =
+        !Object.values(markup).some(Boolean) ||
+        representativeFontSize >= bodySize * 1.12 ||
+        emphasizedCharacters >= Math.max(1, visibleCharacters * 0.6) ||
+        sourceStyledLetteredHeading ||
+        sourceStyledNamedBoundaryHeading ||
+        sequencedNumberedHeadingRegions.has(region) ||
+        sequencedLetteredHeadingRegions.has(region)
       const heading =
         !probableFirstPageAuthorLine &&
         !appendixContentsEntry &&
         !probableTabularColumnHeader &&
+        sourceMarkupHasIndependentEvidence &&
         headingBoundaryEvidence &&
         (namedSectionHeading ||
           numberedSectionHeading ||
@@ -6276,6 +6548,17 @@ async function blocksFromRegions(
       activeList = undefined
       lastListBlock = undefined
       continue
+    }
+    if (
+      ordered &&
+      !orderedMarkerHasIndependentEvidence(
+        blockIndex,
+        blocks,
+        ordered,
+        bodySize,
+      )
+    ) {
+      ordered = null
     }
     if (!activeList && ambiguousParenthesizedRomanListMarker(ordered)) {
       const nextBlock = blocks[blockIndex + 1]
@@ -11265,6 +11548,9 @@ export async function reconstructPageAnalyses({
     canonicalFloatScopes,
     canonicalHyphenBoundaryDecisions,
     sourceSemanticFlowBoundaryDecisions,
+    bodySourceOrderExtremaByPage: pdfBodySourceOrderExtremaByPage(
+      regionResult.regions,
+    ),
   })
   await yieldPdfReconstructionTask(signal)
   noteNodeIds(blocks)

--- a/src/research/pdf-quality.test.ts
+++ b/src/research/pdf-quality.test.ts
@@ -2458,6 +2458,44 @@ describe('PDF semantic signal detection', () => {
       expect(result.semanticFlowBoundaryLedgerValid).toBe(false)
     })
 
+    it('does not let an unvalidated matched visual hide intervening body source', () => {
+      const { decision, paper, provenance, orderedRegions, head } =
+        crossPageFixture({ runningHeadIsFurniture: false })
+      const forgedRelationship: PdfVisualRelationship = {
+        id: 'forged-cross-page-table',
+        kind: 'table',
+        label: 'Table 99',
+        captionRegionId: head.id,
+        sourceRegionIds: [head.id],
+        sourceLineIds: [head.lines[0].id],
+        sourceObjectIds: [],
+        assetIds: [],
+        status: 'matched',
+        confidence: 1,
+        evidence: ['forged-test-relationship'],
+        candidates: [],
+        sourceBoxes: [{ ...head.box }],
+        sourceText: head.text,
+        altText: 'Forged table',
+        altTextSource: 'caption',
+        canonicalNodeId: null,
+        captionNodeId: null,
+      }
+
+      const result = provenanceTextConservation({
+        allRegions: [orderedRegions[0], head, orderedRegions[1]],
+        orderedRegions,
+        paper,
+        provenance,
+        visualRelationships: [forgedRelationship],
+        validatedVisualRelationships: [],
+        lineBoundaryDecisions: [],
+        sourceSemanticFlowBoundaryDecisions: [decision],
+      })
+
+      expect(result.semanticFlowBoundaryLedgerValid).toBe(false)
+    })
+
     it('rejects a canonical cross-page paragraph with no boundary decision', () => {
       const { paper, provenance, orderedRegions } = crossPageFixture({
         runningHeadIsFurniture: true,

--- a/src/research/pdf-quality.test.ts
+++ b/src/research/pdf-quality.test.ts
@@ -38,6 +38,7 @@ import {
 import {
   PDF_SOURCE_SEMANTIC_FLOW_BASE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE,
+  PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_NO_SPACE_EVIDENCE,
   pdfSourceSemanticFlowBoundaryDecisionId,
   pdfSourceSemanticFlowRunSha256,
@@ -2280,6 +2281,182 @@ describe('PDF semantic signal detection', () => {
     })
 
     expect(result.semanticTextViolationNodeIds).toEqual([])
+  })
+
+  describe('cross-page-column ledger verification', () => {
+    const crossPageFixture = ({
+      runningHeadIsFurniture,
+    }: {
+      runningHeadIsFurniture: boolean
+    }) => {
+      const tailRun = {
+        ...run(
+          'The measured drift therefore continues toward the',
+          0.515,
+          0.82,
+          10,
+          0.385,
+        ),
+        sourceSequenceIndex: 40,
+      }
+      const headRun = {
+        ...run('Continuous prose reconstruction', 0.09, 0.03, 10, 0.385),
+        page: 2,
+        sourceSequenceIndex: 0,
+      }
+      const continuationRun = {
+        ...run(
+          'stationary regime described in the next section.',
+          0.09,
+          0.1,
+          10,
+          0.385,
+        ),
+        page: 2,
+        sourceSequenceIndex: 1,
+      }
+      const region = (
+        id: string,
+        sourceRun: PdfSourceRun,
+        column: PdfPageRegion['column'],
+        furniture = false,
+      ): PdfPageRegion => ({
+        id,
+        page: sourceRun.page,
+        kind: 'body',
+        column,
+        text: sourceRun.text,
+        confidence: 1,
+        box: { ...sourceRun },
+        lines: [
+          {
+            id: `${id}-line`,
+            text: sourceRun.text,
+            fontSize: sourceRun.fontSize,
+            box: { ...sourceRun },
+            runs: [sourceRun],
+            sourceFragmentLineage: {
+              algorithm: 'source-run-fragment-v1',
+              sourceLineId: `${id}-source-line`,
+              fragment: 'whole',
+              sourceSequenceIndexes: [sourceRun.sourceSequenceIndex!],
+            },
+          },
+        ],
+        nativeObjectIds: [],
+        includedInReadingOrder: !furniture,
+        ...(furniture
+          ? {
+              furniture: {
+                classification: 'repeated-text' as const,
+                band: 'top' as const,
+                pages: [1, 2],
+                boxes: [{ ...sourceRun }],
+                evidence: ['repeated-normalized-text'],
+              },
+            }
+          : {}),
+      })
+      const tail = region('cross-page-tail', tailRun, 'right')
+      const head = region(
+        'cross-page-running-head',
+        headRun,
+        runningHeadIsFurniture ? 'span' : 'left',
+        runningHeadIsFurniture,
+      )
+      const continuation = region(
+        'cross-page-continuation',
+        continuationRun,
+        'left',
+      )
+      const endpoint = (
+        target: PdfPageRegion,
+        sourceRun: PdfSourceRun,
+      ) => ({
+        regionId: target.id,
+        lineId: target.lines[0].id,
+        runIndex: 0,
+        sourceSequenceIndex: sourceRun.sourceSequenceIndex!,
+        sourceRunSha256: pdfSourceSemanticFlowRunSha256(sourceRun),
+        sourceFragmentId: `${target.id}-source-line:whole`,
+      })
+      const decision = sourceSemanticFlowDecision({
+        page: 1,
+        rotation: 0,
+        method: 'pdf-text',
+        topology: 'cross-page-column',
+        outcome: 'space',
+        from: endpoint(tail, tailRun),
+        to: endpoint(continuation, continuationRun),
+        evidence: [...PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE],
+      })
+      const canonicalText = `${tailRun.text} ${continuationRun.text}`
+      const paper: ResearchPaper = {
+        id: 'cross-page-paper',
+        version: '1.0.0',
+        status: 'working',
+        title: '',
+        subtitle: 'Test',
+        authors: [],
+        updated: '2026-07-30',
+        abstract: 'Test',
+        nodes: [
+          {
+            id: 'cross-page-node',
+            type: 'paragraph',
+            text: canonicalText,
+            source: 'test',
+          },
+        ],
+      }
+      const orderedRegions = [tail, continuation]
+      const provenance: Record<string, NodeSourceEvidence> = {
+        'cross-page-node': {
+          confidence: 1,
+          pages: [1, 2],
+          regionIds: orderedRegions.map((target) => target.id),
+          boxes: orderedRegions.map((target) => ({ ...target.box })),
+          links: [],
+        },
+      }
+      return { decision, paper, provenance, orderedRegions, head }
+    }
+
+    it('accepts a page-break join whose only intervening source is furniture', () => {
+      const { decision, paper, provenance, orderedRegions, head } =
+        crossPageFixture({ runningHeadIsFurniture: true })
+
+      const result = provenanceTextConservation({
+        allRegions: [orderedRegions[0], head, orderedRegions[1]],
+        orderedRegions,
+        paper,
+        provenance,
+        lineBoundaryDecisions: [],
+        sourceSemanticFlowBoundaryDecisions: [decision],
+      })
+
+      expect(result.semanticFlowBoundaryLedgerValid).toBe(true)
+      expect(result.semanticTextViolationNodeIds).toEqual([])
+    })
+
+    it('rejects a page-break join that skips unaccounted body source', () => {
+      // Identical ledger entry, but the intervening page-two text carries no
+      // furniture evidence. The audit re-derives the page extrema itself, so a
+      // forged cross-page proof cannot survive without issue 042's evidence.
+      const { decision, paper, provenance, orderedRegions, head } =
+        crossPageFixture({ runningHeadIsFurniture: false })
+
+      const result = provenanceTextConservation({
+        allRegions: [orderedRegions[0], head, orderedRegions[1]],
+        orderedRegions,
+        paper,
+        provenance,
+        lineBoundaryDecisions: [],
+        sourceSemanticFlowBoundaryDecisions: [decision],
+      })
+
+      expect(result.semanticFlowBoundaryLedgerValid).toBe(false)
+    })
   })
 
   it('validates uncased-script same-page-column decisions from layout', () => {

--- a/src/research/pdf-quality.test.ts
+++ b/src/research/pdf-quality.test.ts
@@ -2457,6 +2457,24 @@ describe('PDF semantic signal detection', () => {
 
       expect(result.semanticFlowBoundaryLedgerValid).toBe(false)
     })
+
+    it('rejects a canonical cross-page paragraph with no boundary decision', () => {
+      const { paper, provenance, orderedRegions } = crossPageFixture({
+        runningHeadIsFurniture: true,
+      })
+
+      const result = provenanceTextConservation({
+        allRegions: orderedRegions,
+        orderedRegions,
+        paper,
+        provenance,
+        lineBoundaryDecisions: [],
+        sourceSemanticFlowBoundaryDecisions: [],
+      })
+
+      expect(result.semanticFlowBoundaryLedgerValid).toBe(false)
+      expect(result.semanticTextViolationNodeIds).toContain('cross-page-node')
+    })
   })
 
   it('validates uncased-script same-page-column decisions from layout', () => {

--- a/src/research/pdf-quality.ts
+++ b/src/research/pdf-quality.ts
@@ -41,10 +41,12 @@ import { unprovedInlineMathAtomNodeIds } from './pdf-inline-script-integrity'
 import { classifyPdfNoteMarkers } from './pdf-note-classifier'
 import {
   canonicalPdfSourceSemanticFlowEvidence,
+  pdfBodySourceOrderExtremaByPage,
   pdfSourceColumnFlowJoinOutcome,
   pdfSourceColumnFlowStartsWithCjkNumericContinuation,
   PDF_SOURCE_SEMANTIC_FLOW_BASE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE,
+  PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE,
   PDF_SOURCE_SEMANTIC_FLOW_NO_SPACE_EVIDENCE,
   pdfSourceFragmentId,
   pdfSourceSemanticFlowBoundaryDecisionId,
@@ -216,9 +218,12 @@ function isPdfSourceSemanticFlowBoundaryDecision(
     typeof value.rotation === 'number' &&
     Number.isFinite(value.rotation) &&
     ['pdf-text', 'ocr'].includes(value.method as string) &&
-    ['inline-stacked-fragment', 'lexical-hyphen', 'same-page-column'].includes(
-      value.topology as string,
-    ) &&
+    [
+      'inline-stacked-fragment',
+      'lexical-hyphen',
+      'same-page-column',
+      'cross-page-column',
+    ].includes(value.topology as string) &&
     [
       'no-space',
       'space',
@@ -1024,18 +1029,38 @@ function validatedSourceSemanticFlowBoundaryDecision(
   const toMinimumSequence = Math.min(
     ...toVisibleRuns.map((run) => run.sourceSequenceIndex!),
   )
-  const exactSourceAdjacency =
-    decision.to.sourceSequenceIndex === decision.from.sourceSequenceIndex + 1 ||
-    (to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
-      to.run.sourceWhitespacePredecessorIndex ===
-        decision.from.sourceSequenceIndex)
+  const crossPage = decision.topology === 'cross-page-column'
+  // Independent re-derivation of the page-break adjacency proof: the tail must
+  // be the last body text item its page paints and the head the first the next
+  // page paints, so only accounted page furniture can sit between them. The
+  // extrema sweep every region, so only a cross-page decision pays for it.
+  const crossPageSourceAdjacency =
+    crossPage &&
+    to.run.page === from.run.page + 1 &&
+    (() => {
+      const extrema = pdfBodySourceOrderExtremaByPage(allRegions)
+      return (
+        extrema.get(from.run.page)?.last ===
+          decision.from.sourceSequenceIndex &&
+        extrema.get(to.run.page)?.first === decision.to.sourceSequenceIndex
+      )
+    })()
+  const exactSourceAdjacency = crossPage
+    ? crossPageSourceAdjacency
+    : decision.to.sourceSequenceIndex ===
+        decision.from.sourceSequenceIndex + 1 ||
+      (to.run.sourceWhitespaceBefore === 'pdf-text-item' &&
+        to.run.sourceWhitespacePredecessorIndex ===
+          decision.from.sourceSequenceIndex)
   const fromMetrics = dominantSemanticFlowLineMetrics(from.line)
   const toMetrics = dominantSemanticFlowLineMetrics(to.line)
   if (
     from.region !== leftRegion ||
     to.region !== rightRegion ||
     decision.page !== from.run.page ||
-    decision.page !== to.run.page ||
+    (crossPage
+      ? decision.page + 1 !== to.run.page
+      : decision.page !== to.run.page) ||
     decision.rotation !== from.run.rotation ||
     decision.rotation !== to.run.rotation ||
     decision.method !== from.run.method ||
@@ -1055,6 +1080,7 @@ function validatedSourceSemanticFlowBoundaryDecision(
   if (
     fontRatio > 1.5 ||
     (decision.topology !== 'same-page-column' &&
+      !crossPage &&
       baselineGap >
         Math.max(0.06, Math.max(fromMetrics.height, toMetrics.height) * 4))
   ) {
@@ -1074,7 +1100,26 @@ function validatedSourceSemanticFlowBoundaryDecision(
     .match(/^([\p{L}\p{N}]+)/u)?.[1]
   let expectedOutcome: PdfSourceSemanticFlowBoundaryDecision['outcome']
   let expectedEvidence: readonly string[]
-  if (leftHyphenToken && rightHyphenToken) {
+  if (crossPage) {
+    if (
+      !sourceProvenCrossPageColumnFlowBoundary(
+        leftRegion,
+        rightRegion,
+        from.line,
+        to.line,
+        language,
+        baseDirection,
+      )
+    ) {
+      return null
+    }
+    expectedOutcome = pdfSourceColumnFlowJoinOutcome(
+      language,
+      rightRegion.text.trimStart(),
+      to.run,
+    ).outcome
+    expectedEvidence = PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE
+  } else if (leftHyphenToken && rightHyphenToken) {
     const proof = resolvePdfHyphenBoundary({
       left: leftHyphenToken,
       right: rightHyphenToken,
@@ -1160,16 +1205,16 @@ function sourceSemanticFlowBoundaryKey(
   return `${fromRegionId}\0${toRegionId}`
 }
 
-function sourceProvenSamePageColumnFlowBoundary(
-  leftRegion: PdfPageRegion,
-  rightRegion: PdfPageRegion,
-  fromLine: PdfPageRegion['lines'][number],
-  toLine: PdfPageRegion['lines'][number],
-  language: string | null,
-  baseDirection: ResearchPaper['baseDirection'] | null,
+// Language-agnostic evidence that a block leaves a sentence unfinished and the
+// next block resumes it. Mirrors `likelyUnmarkedCrossPageContinuation` in the
+// extractor; both the same-page column boundary and the cross-page boundary are
+// re-derived from it here, independently of how extraction reached them.
+function sourceProvenUnmarkedProseContinuation(
+  leftText: string,
+  rightText: string,
 ) {
-  const previousText = leftRegion.text.trimEnd()
-  const continuationText = rightRegion.text.trimStart()
+  const previousText = leftText.trimEnd()
+  const continuationText = rightText.trimStart()
   const detachedNumericContinuation =
     (/\b(?:a|an|the|of|for|from|with|without|among|between|over|under|by|than|approximately|about|around|nearly|roughly|exactly|includes?|including|contains?|containing|comprises?|comprising)\s*$/iu.test(
       previousText,
@@ -1186,7 +1231,7 @@ function sourceProvenSamePageColumnFlowBoundary(
     !/[.!?:;\u061F\u0964\u0965\u1362\u1803\u3002\uFF01\uFF0E\uFF1F](?:["'’”\])}]*)$/u.test(
       previousText,
     ) && /^[–—-]\s+\p{Ll}/u.test(continuationText)
-  const unmarkedContinuation = Boolean(
+  return Boolean(
     previousText &&
     continuationText &&
     !PDF_SENTENCE_END_WITH_CLOSING.test(previousText) &&
@@ -1194,6 +1239,20 @@ function sourceProvenSamePageColumnFlowBoundary(
       detachedNumericContinuation ||
       detachedScholarlyContinuation ||
       detachedDashContinuation),
+  )
+}
+
+function sourceProvenSamePageColumnFlowBoundary(
+  leftRegion: PdfPageRegion,
+  rightRegion: PdfPageRegion,
+  fromLine: PdfPageRegion['lines'][number],
+  toLine: PdfPageRegion['lines'][number],
+  language: string | null,
+  baseDirection: ResearchPaper['baseDirection'] | null,
+) {
+  const unmarkedContinuation = sourceProvenUnmarkedProseContinuation(
+    leftRegion.text,
+    rightRegion.text,
   )
   const rtl = rtlBaseDirection(language, baseDirection)
   const columnsMatch = rtl
@@ -1219,6 +1278,49 @@ function sourceProvenSamePageColumnFlowBoundary(
     Math.max(fromLine.fontSize, toLine.fontSize) /
     Math.max(1, Math.min(fromLine.fontSize, toLine.fontSize))
   return fontRatio <= 1.12
+}
+
+const PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR = new Set(['right', 'single', 'span'])
+const PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR = new Set(['left', 'single', 'span'])
+
+function sourceProvenCrossPageColumnFlowBoundary(
+  leftRegion: PdfPageRegion,
+  rightRegion: PdfPageRegion,
+  fromLine: PdfPageRegion['lines'][number],
+  toLine: PdfPageRegion['lines'][number],
+  language: string | null,
+  baseDirection: ResearchPaper['baseDirection'] | null,
+) {
+  const rtl = rtlBaseDirection(language, baseDirection)
+  const tailColumns = rtl
+    ? PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR
+    : PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR
+  const headColumns = rtl
+    ? PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR
+    : PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR
+  return (
+    rightRegion.page === leftRegion.page + 1 &&
+    tailColumns.has(leftRegion.column) &&
+    headColumns.has(rightRegion.column) &&
+    fromLine.id ===
+      leftRegion.lines.filter((line) => line.text.trim()).at(-1)?.id &&
+    toLine.id === rightRegion.lines.find((line) => line.text.trim())?.id &&
+    fromLine.box.y + fromLine.box.height >= 0.65 &&
+    toLine.box.y <= 0.35 &&
+    !/[\p{L}\p{N}][-‐‑]$/u.test(leftRegion.text.trimEnd()) &&
+    // A detached citation year has its own boundary topology; a page break must
+    // not be able to claim it as ordinary prose flow.
+    !(
+      /\b\p{Lu}[\p{L}'’.-]*(?:\s+et\s+al\.)?,\s*$/u.test(
+        leftRegion.text.trimEnd(),
+      ) &&
+      /^(?:18|19|20)\d{2}[a-z]?(?=[,;:)])/u.test(rightRegion.text.trimStart())
+    ) &&
+    sourceProvenUnmarkedProseContinuation(leftRegion.text, rightRegion.text) &&
+    Math.max(fromLine.fontSize, toLine.fontSize) /
+      Math.max(1, Math.min(fromLine.fontSize, toLine.fontSize)) <=
+      1.12
+  )
 }
 
 type SourceSemanticFlowBoundaryLedgerAudit = {

--- a/src/research/pdf-quality.ts
+++ b/src/research/pdf-quality.ts
@@ -942,6 +942,7 @@ function validatedSourceSemanticFlowBoundaryDecision(
   rightRegion: PdfPageRegion,
   allRegions: readonly PdfPageRegion[],
   visualRelationships: readonly PdfVisualRelationship[],
+  validatedNonProseRelationships: readonly PdfVisualRelationship[],
   lineBoundaryDecisions: readonly PdfLineBoundaryDecision[],
   decisions: readonly PdfSourceSemanticFlowBoundaryDecision[],
   hardHyphenLexicon: ReadonlySet<string>,
@@ -1031,7 +1032,7 @@ function validatedSourceSemanticFlowBoundaryDecision(
   )
   const crossPage = decision.topology === 'cross-page-column'
   const accountedNonProseRegionIds = new Set(
-    visualRelationships.flatMap((relationship) =>
+    validatedNonProseRelationships.flatMap((relationship) =>
       relationship.status === 'matched' && relationship.kind !== 'equation'
         ? [relationship.captionRegionId, ...relationship.sourceRegionIds]
         : [],
@@ -1408,6 +1409,7 @@ type SourceSemanticFlowBoundaryLedgerAudit = {
 function auditSourceSemanticFlowBoundaryLedger({
   allRegions,
   visualRelationships,
+  validatedNonProseRelationships,
   lineBoundaryDecisions,
   decisions,
   hardHyphenLexicon,
@@ -1417,6 +1419,7 @@ function auditSourceSemanticFlowBoundaryLedger({
 }: {
   allRegions: readonly PdfPageRegion[]
   visualRelationships: readonly PdfVisualRelationship[]
+  validatedNonProseRelationships: readonly PdfVisualRelationship[]
   lineBoundaryDecisions: readonly PdfLineBoundaryDecision[]
   decisions: readonly PdfSourceSemanticFlowBoundaryDecision[]
   hardHyphenLexicon: ReadonlySet<string>
@@ -1462,6 +1465,7 @@ function auditSourceSemanticFlowBoundaryLedger({
       toOwners[0],
       allRegions,
       visualRelationships,
+      validatedNonProseRelationships,
       lineBoundaryDecisions,
       [decision],
       hardHyphenLexicon,
@@ -2090,6 +2094,7 @@ export function provenanceTextConservation({
   paper,
   provenance,
   visualRelationships,
+  validatedVisualRelationships,
   assets,
   pages,
   lineBoundaryDecisions,
@@ -2100,6 +2105,7 @@ export function provenanceTextConservation({
   paper: ResearchPaper
   provenance: Record<string, NodeSourceEvidence>
   visualRelationships?: PdfVisualRelationship[]
+  validatedVisualRelationships?: PdfVisualRelationship[]
   assets?: PdfVisualAsset[]
   pages?: readonly PdfPageAnalysis[]
   lineBoundaryDecisions: readonly PdfLineBoundaryDecision[]
@@ -2112,6 +2118,7 @@ export function provenanceTextConservation({
   const semanticFlowBoundaryLedger = auditSourceSemanticFlowBoundaryLedger({
     allRegions,
     visualRelationships: visualRelationships ?? [],
+    validatedNonProseRelationships: validatedVisualRelationships ?? [],
     lineBoundaryDecisions,
     decisions: sourceSemanticFlowBoundaryDecisions,
     hardHyphenLexicon,
@@ -3758,6 +3765,7 @@ export function assessPdfCompleteness({
         paper,
         provenance,
         visualRelationships,
+        validatedVisualRelationships,
         assets,
         pages,
         lineBoundaryDecisions: lineBoundaryDecisions ?? [],

--- a/src/research/pdf-quality.ts
+++ b/src/research/pdf-quality.ts
@@ -1030,6 +1030,27 @@ function validatedSourceSemanticFlowBoundaryDecision(
     ...toVisibleRuns.map((run) => run.sourceSequenceIndex!),
   )
   const crossPage = decision.topology === 'cross-page-column'
+  const accountedNonProseRegionIds = new Set(
+    visualRelationships.flatMap((relationship) =>
+      relationship.status === 'matched' && relationship.kind !== 'equation'
+        ? [relationship.captionRegionId, ...relationship.sourceRegionIds]
+        : [],
+    ),
+  )
+  const accountedNonProseBetweenBoundary = [...accountedNonProseRegionIds]
+    .flatMap((regionId) => allRegions.filter((region) => region.id === regionId))
+    .some((region) =>
+      region.lines.some((line) =>
+        line.runs.some(
+          (run) =>
+            run.sourceSequenceIndex !== undefined &&
+            ((run.page === from.run.page &&
+              run.sourceSequenceIndex > decision.from.sourceSequenceIndex) ||
+              (run.page === to.run.page &&
+                run.sourceSequenceIndex < decision.to.sourceSequenceIndex)),
+        ),
+      ),
+    )
   // Independent re-derivation of the page-break adjacency proof: the tail must
   // be the last body text item its page paints and the head the first the next
   // page paints, so only accounted page furniture can sit between them. The
@@ -1038,7 +1059,10 @@ function validatedSourceSemanticFlowBoundaryDecision(
     crossPage &&
     to.run.page === from.run.page + 1 &&
     (() => {
-      const extrema = pdfBodySourceOrderExtremaByPage(allRegions)
+      const extrema = pdfBodySourceOrderExtremaByPage(
+        allRegions,
+        accountedNonProseRegionIds,
+      )
       return (
         extrema.get(from.run.page)?.last ===
           decision.from.sourceSequenceIndex &&
@@ -1102,7 +1126,7 @@ function validatedSourceSemanticFlowBoundaryDecision(
   let expectedEvidence: readonly string[]
   if (crossPage) {
     if (
-      !sourceProvenCrossPageColumnFlowBoundary(
+      !sourceProvenCrossPageColumnGeometryBoundary(
         leftRegion,
         rightRegion,
         from.line,
@@ -1113,11 +1137,47 @@ function validatedSourceSemanticFlowBoundaryDecision(
     ) {
       return null
     }
-    expectedOutcome = pdfSourceColumnFlowJoinOutcome(
-      language,
-      rightRegion.text.trimStart(),
-      to.run,
-    ).outcome
+    const detachedCitationYear = sourceProvenDetachedCitationYearContinuation(
+      leftRegion.text,
+      rightRegion.text,
+    )
+    const scholarlyLabelFloat = sourceProvenScholarlyLabelFloatContinuation(
+      leftRegion.text,
+      rightRegion.text,
+    )
+    if (leftHyphenToken && rightHyphenToken) {
+      const proof = resolvePdfHyphenBoundary({
+        left: leftHyphenToken,
+        right: rightHyphenToken,
+        language,
+        sourceProven: true,
+        hardHyphenLexicon,
+        unhyphenatedLexicon,
+      })
+      const semanticVerdict = sourceSemanticFlowHyphenVerdict(proof)
+      if (semanticVerdict === 'remove') {
+        expectedOutcome = 'discretionary-hyphen-delete'
+      } else if (semanticVerdict === 'preserve') {
+        expectedOutcome = 'hard-hyphen-retain'
+      } else {
+        return null
+      }
+    } else if (
+      detachedCitationYear ||
+      sourceProvenUnmarkedProseContinuation(
+        leftRegion.text,
+        rightRegion.text,
+      ) ||
+      (scholarlyLabelFloat && accountedNonProseBetweenBoundary)
+    ) {
+      expectedOutcome = pdfSourceColumnFlowJoinOutcome(
+        language,
+        rightRegion.text.trimStart(),
+        to.run,
+      ).outcome
+    } else {
+      return null
+    }
     expectedEvidence = PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE
   } else if (leftHyphenToken && rightHyphenToken) {
     const proof = resolvePdfHyphenBoundary({
@@ -1283,7 +1343,33 @@ function sourceProvenSamePageColumnFlowBoundary(
 const PDF_CROSS_PAGE_FLOW_TAIL_COLUMNS_LTR = new Set(['right', 'single', 'span'])
 const PDF_CROSS_PAGE_FLOW_HEAD_COLUMNS_LTR = new Set(['left', 'single', 'span'])
 
-function sourceProvenCrossPageColumnFlowBoundary(
+function sourceProvenDetachedCitationYearContinuation(
+  leftText: string,
+  rightText: string,
+) {
+  return (
+    /\b\p{Lu}[\p{L}'’.-]*(?:\s+et\s+al\.)?,\s*$/u.test(
+      leftText.trimEnd(),
+    ) &&
+    /^(?:18|19|20)\d{2}[a-z]?(?=[,;:)])/u.test(rightText.trimStart())
+  )
+}
+
+function sourceProvenScholarlyLabelFloatContinuation(
+  leftText: string,
+  rightText: string,
+) {
+  return (
+    /\b(?:in|of|to|from|with|by|at|on|as|than|between|for|following)\s*$/iu.test(
+      leftText.trimEnd(),
+    ) &&
+    /^(?:Table|Figure|Equation|Eq\.|Section|Appendix)\s+(?:\d+(?:\.\d+)*|[A-Z](?:\.\d+)*)\b/u.test(
+      rightText.trimStart(),
+    )
+  )
+}
+
+function sourceProvenCrossPageColumnGeometryBoundary(
   leftRegion: PdfPageRegion,
   rightRegion: PdfPageRegion,
   fromLine: PdfPageRegion['lines'][number],
@@ -1307,16 +1393,6 @@ function sourceProvenCrossPageColumnFlowBoundary(
     toLine.id === rightRegion.lines.find((line) => line.text.trim())?.id &&
     fromLine.box.y + fromLine.box.height >= 0.65 &&
     toLine.box.y <= 0.35 &&
-    !/[\p{L}\p{N}][-‐‑]$/u.test(leftRegion.text.trimEnd()) &&
-    // A detached citation year has its own boundary topology; a page break must
-    // not be able to claim it as ordinary prose flow.
-    !(
-      /\b\p{Lu}[\p{L}'’.-]*(?:\s+et\s+al\.)?,\s*$/u.test(
-        leftRegion.text.trimEnd(),
-      ) &&
-      /^(?:18|19|20)\d{2}[a-z]?(?=[,;:)])/u.test(rightRegion.text.trimStart())
-    ) &&
-    sourceProvenUnmarkedProseContinuation(leftRegion.text, rightRegion.text) &&
     Math.max(fromLine.fontSize, toLine.fontSize) /
       Math.max(1, Math.min(fromLine.fontSize, toLine.fontSize)) <=
       1.12
@@ -1410,6 +1486,7 @@ function sourceProvenBoundaryTokenText(
   language: string | null,
   regions: readonly PdfPageRegion[] = [],
   sourceSemanticFlowBoundaryLedger?: SourceSemanticFlowBoundaryLedgerAudit,
+  requireCrossPageDecision = false,
 ) {
   let combined = values[0] ?? ''
   for (const [offset, value] of values.slice(1).entries()) {
@@ -1423,6 +1500,14 @@ function sourceProvenBoundaryTokenText(
             ),
           )
         : null
+    if (
+      sourceSemanticFlowBoundaryLedger &&
+      requireCrossPageDecision &&
+      regions[boundaryIndex - 1]?.page !== regions[boundaryIndex]?.page &&
+      !semanticFlowDecision
+    ) {
+      sourceSemanticFlowBoundaryLedger.valid = false
+    }
     if (semanticFlowDecision && sourceSemanticFlowBoundaryLedger) {
       const consumed =
         (sourceSemanticFlowBoundaryLedger.consumptionById.get(
@@ -2429,6 +2514,10 @@ export function provenanceTextConservation({
               paper.language ?? null,
               sourceComponentRegions,
               semanticFlowBoundaryLedger,
+              semanticOutputNodes.length > 0 &&
+                semanticOutputNodes.every(
+                  (node) => node.type === 'paragraph' && !node.list,
+                ),
             )
           : comparableSourceText,
       ) !== meaningPreservingText(comparableOutputText)

--- a/src/research/pdf-regions.test.ts
+++ b/src/research/pdf-regions.test.ts
@@ -4723,15 +4723,21 @@ describe('deterministic scholarly page regions', () => {
           8,
           0.011,
         ),
-      ]),
+      ].map((sourceRun, sourceSequenceIndex) => ({
+        ...sourceRun,
+        sourceSequenceIndex,
+      }))),
       page(2, [
-        run(
-          2,
-          'vibrant research continues without intervening page furniture.',
-          0.094,
-          0.14,
-          0.72,
-        ),
+        {
+          ...run(
+            2,
+            'vibrant research continues without intervening page furniture.',
+            0.094,
+            0.14,
+            0.72,
+          ),
+          sourceSequenceIndex: 0,
+        },
       ]),
     ])
 

--- a/src/research/pdf-regions.ts
+++ b/src/research/pdf-regions.ts
@@ -124,6 +124,60 @@ export const PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE = Object.freeze(
   ].sort(),
 )
 
+// A page break is not a source-order adjacency: `sourceSequenceIndex` is the
+// per-page text-item index, so the tail of page N and the head of page N+1 are
+// never numerically adjacent. What the source can prove instead is that the
+// tail is the last body text item its page paints and the continuation is the
+// first body text item the next page paints, with only page furniture between
+// them. Issue 042 already classifies that furniture, so excluding it here is
+// what lets a running head sit between two halves of one sentence without
+// entering the paragraph.
+export const PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE = Object.freeze(
+  [
+    'cross-page-column-geometry',
+    'explicit-fragment-lineage',
+    'furniture-excluded-page-boundary',
+    'page-head-source-order-extremum',
+    'page-tail-source-order-extremum',
+  ].sort(),
+)
+
+export type PdfBodySourceOrderExtremum = { first: number; last: number }
+
+/**
+ * Per-page first and last source text-item index over everything that is not
+ * accounted page furniture.  Extraction and the independent quality audit both
+ * derive the cross-page prose boundary from this map, so they cannot disagree
+ * about which runs a page break is allowed to skip.
+ */
+export function pdfBodySourceOrderExtremaByPage(
+  regions: readonly Pick<
+    PdfPageRegion,
+    'page' | 'lines' | 'furniture'
+  >[],
+) {
+  const extrema = new Map<number, PdfBodySourceOrderExtremum>()
+  for (const region of regions) {
+    if (region.furniture) continue
+    for (const line of region.lines) {
+      for (const run of line.runs) {
+        if (!run.text.trim() || run.sourceSequenceIndex === undefined) continue
+        const current = extrema.get(run.page)
+        if (!current) {
+          extrema.set(run.page, {
+            first: run.sourceSequenceIndex,
+            last: run.sourceSequenceIndex,
+          })
+          continue
+        }
+        current.first = Math.min(current.first, run.sourceSequenceIndex)
+        current.last = Math.max(current.last, run.sourceSequenceIndex)
+      }
+    }
+  }
+  return extrema
+}
+
 export function pdfSourceColumnFlowStartsWithCjkNumericContinuation(
   continuationText: string,
 ) {

--- a/src/research/pdf-regions.ts
+++ b/src/research/pdf-regions.ts
@@ -127,16 +127,15 @@ export const PDF_SOURCE_SEMANTIC_FLOW_COLUMN_EVIDENCE = Object.freeze(
 // A page break is not a source-order adjacency: `sourceSequenceIndex` is the
 // per-page text-item index, so the tail of page N and the head of page N+1 are
 // never numerically adjacent. What the source can prove instead is that the
-// tail is the last body text item its page paints and the continuation is the
-// first body text item the next page paints, with only page furniture between
-// them. Issue 042 already classifies that furniture, so excluding it here is
-// what lets a running head sit between two halves of one sentence without
-// entering the paragraph.
+// tail is the last prose text item its page paints and the continuation is the
+// first prose text item the next page paints, with only independently accounted
+// non-prose between them. That includes issue 042 page furniture and validated
+// visual/table ownership, neither of which may enter the paragraph.
 export const PDF_SOURCE_SEMANTIC_FLOW_CROSS_PAGE_EVIDENCE = Object.freeze(
   [
     'cross-page-column-geometry',
     'explicit-fragment-lineage',
-    'furniture-excluded-page-boundary',
+    'non-prose-excluded-page-boundary',
     'page-head-source-order-extremum',
     'page-tail-source-order-extremum',
   ].sort(),
@@ -146,19 +145,20 @@ export type PdfBodySourceOrderExtremum = { first: number; last: number }
 
 /**
  * Per-page first and last source text-item index over everything that is not
- * accounted page furniture.  Extraction and the independent quality audit both
- * derive the cross-page prose boundary from this map, so they cannot disagree
- * about which runs a page break is allowed to skip.
+ * accounted page furniture or validated non-prose visual content. Extraction
+ * and the independent quality audit both derive the cross-page prose boundary
+ * from this map, so they cannot disagree about which runs a page break may skip.
  */
 export function pdfBodySourceOrderExtremaByPage(
   regions: readonly Pick<
     PdfPageRegion,
-    'page' | 'lines' | 'furniture'
+    'id' | 'page' | 'lines' | 'furniture'
   >[],
+  accountedNonProseRegionIds: ReadonlySet<string> = new Set(),
 ) {
   const extrema = new Map<number, PdfBodySourceOrderExtremum>()
   for (const region of regions) {
-    if (region.furniture) continue
+    if (region.furniture || accountedNonProseRegionIds.has(region.id)) continue
     for (const line of region.lines) {
       for (const run of line.runs) {
         if (!run.text.trim() || run.sourceSequenceIndex === undefined) continue

--- a/src/research/source-output-checkpoints.test.ts
+++ b/src/research/source-output-checkpoints.test.ts
@@ -232,6 +232,141 @@ describe('source/output checkpoints', () => {
     })
   })
 
+  it('rejects a page-break sentence left split across two paragraphs', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'page-break-continuity',
+          property: 'prose-continuity',
+          source: { feature: 'text', text: 'continues at the top' },
+          output: {
+            feature: 'prose',
+            text: 'runs off the bottom of this page and continues at the top of the next one',
+          },
+        },
+      ],
+    }).checkpoints[0]
+    const source = {
+      page: 2,
+      text: 'continues at the top of the next one',
+      hasVisual: false,
+    }
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>runs off the bottom of this page and</p><p>continues at the top of the next one</p>',
+        },
+      }),
+    ).toMatchObject({ checkpointId: 'page-break-continuity', status: 'failed' })
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>runs off the bottom of this page and continues at the top of the next one without losing its clause.</p>',
+        },
+      }),
+    ).toMatchObject({ checkpointId: 'page-break-continuity', status: 'passed' })
+  })
+
+  it('rejects a rendition that still carries the printed line-end hyphen', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'hyphen-resolution',
+          property: 'hyphen-resolution',
+          source: { feature: 'text', text: 'photo-' },
+          output: {
+            feature: 'prose',
+            text: 'photograph is attested elsewhere as photograph.',
+          },
+        },
+      ],
+    }).checkpoints[0]
+    const source = {
+      page: 2,
+      text: 'The high-resolution photo- graph is attested elsewhere as photograph.',
+      hasVisual: false,
+    }
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>photo- graph is attested elsewhere as photograph. photograph is attested elsewhere as photograph.</p>',
+        },
+      }),
+    ).toMatchObject({
+      status: 'failed',
+      reason: expect.stringContaining('hyphen fragment'),
+    })
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>The high-resolution photograph is attested elsewhere as photograph.</p>',
+        },
+      }),
+    ).toMatchObject({ checkpointId: 'hyphen-resolution', status: 'passed' })
+  })
+
+  it('rejects markup-shaped source text promoted to structure', () => {
+    const checkpoint = parseSourceOutputCheckpointSet({
+      schemaVersion: '1.0.0',
+      checkpoints: [
+        {
+          ...base,
+          id: 'markup-non-promotion',
+          property: 'markup-non-promotion',
+          source: { feature: 'text', text: '## Not a heading' },
+          output: {
+            feature: 'prose',
+            text: '## Not a heading and **not bold** and {placeholder} stay literal.',
+          },
+        },
+      ],
+    }).checkpoints[0]
+    const source = {
+      page: 2,
+      text: '## Not a heading and **not bold** and {placeholder} stay literal.',
+      hasVisual: false,
+    }
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>## Not a heading and **not bold** and {placeholder} stay literal.</p><h2>## Not a heading and **not bold** and {placeholder} stay literal.</h2>',
+        },
+      }),
+    ).toMatchObject({
+      status: 'failed',
+      reason: expect.stringContaining('<h2>'),
+    })
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>## Not a heading and **not bold** and {placeholder} stay literal.</p>',
+        },
+      }),
+    ).toMatchObject({ checkpointId: 'markup-non-promotion', status: 'passed' })
+  })
+
   it('rejects pseudocode flattened into running prose', () => {
     const checkpoint = parseSourceOutputCheckpointSet({
       schemaVersion: '1.0.0',

--- a/src/research/source-output-checkpoints.test.ts
+++ b/src/research/source-output-checkpoints.test.ts
@@ -208,6 +208,11 @@ describe('source/output checkpoints', () => {
           output: {
             feature: 'prose',
             text: 'The result sentence continues across a column break.',
+            semanticFlow: {
+              topology: 'same-page-column',
+              fromPage: 2,
+              outcome: 'space',
+            },
           },
         },
       ],
@@ -244,6 +249,11 @@ describe('source/output checkpoints', () => {
           output: {
             feature: 'prose',
             text: 'runs off the bottom of this page and continues at the top of the next one',
+            semanticFlow: {
+              topology: 'cross-page-column',
+              fromPage: 1,
+              outcome: 'space',
+            },
           },
         },
       ],
@@ -270,6 +280,28 @@ describe('source/output checkpoints', () => {
           profile: 'paperPro',
           width: 540,
           html: '<p>runs off the bottom of this page and continues at the top of the next one without losing its clause.</p>',
+        },
+      }),
+    ).toMatchObject({
+      checkpointId: 'page-break-continuity',
+      status: 'failed',
+      reason: expect.stringContaining('semantic-flow boundary ledger'),
+    })
+    expect(
+      evaluateSourceOutputCheckpoint(checkpoint, {
+        source,
+        rendition: {
+          profile: 'paperPro',
+          width: 540,
+          html: '<p>runs off the bottom of this page and continues at the top of the next one without losing its clause.</p>',
+          semanticFlowBoundaryLedgerValid: true,
+          semanticFlowBoundaryDecisions: [
+            {
+              page: 1,
+              topology: 'cross-page-column',
+              outcome: 'space',
+            },
+          ],
         },
       }),
     ).toMatchObject({ checkpointId: 'page-break-continuity', status: 'passed' })

--- a/src/research/source-output-checkpoints.ts
+++ b/src/research/source-output-checkpoints.ts
@@ -16,6 +16,8 @@ export const SOURCE_OUTPUT_CHECKPOINT_PROPERTIES = [
   'figure-present',
   'caption-boundary',
   'prose-continuity',
+  'hyphen-resolution',
+  'markup-non-promotion',
   'heading-level',
   'table-structure',
   'code-block-structure',
@@ -111,6 +113,8 @@ function expectedRenditionFeature(
     case 'caption-boundary':
       return 'caption'
     case 'prose-continuity':
+    case 'hyphen-resolution':
+    case 'markup-non-promotion':
       return 'prose'
     case 'heading-level':
       return 'heading'
@@ -131,6 +135,8 @@ function expectedSourceFeature(
     case 'caption-boundary':
       return 'visual'
     case 'prose-continuity':
+    case 'hyphen-resolution':
+    case 'markup-non-promotion':
       return 'text'
     case 'heading-level':
     case 'table-structure':
@@ -375,6 +381,54 @@ function hasProse(checkpoint: SourceOutputCheckpoint, html: string) {
   )
 }
 
+const MARKUP_PROMOTION_TAGS = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'li',
+] as const
+
+/**
+ * Text that merely looks like markup must reach the reader as the characters
+ * the source printed. Finding the named text inside a heading, an emphasis run,
+ * or a list item proves the opposite: the rendition promoted it to structure
+ * the source never carried.
+ */
+function promotedMarkupStructure(
+  checkpoint: SourceOutputCheckpoint,
+  html: string,
+) {
+  const expected = normalizedText(checkpoint.output.text ?? '')
+  if (!expected) return null
+  return (
+    MARKUP_PROMOTION_TAGS.find((tag) =>
+      tagContents(html, tag).some((content) =>
+        normalizedText(content).includes(expected),
+      ),
+    ) ?? null
+  )
+}
+
+/**
+ * A discretionary line-end hyphen is resolved only when the split form no
+ * longer reaches the reader. The printed fragment is the source expectation, so
+ * its survival anywhere in the rendition is the failure the checkpoint names.
+ */
+function unresolvedHyphenFragment(
+  checkpoint: SourceOutputCheckpoint,
+  html: string,
+) {
+  const fragment = normalizedText(checkpoint.source.text ?? '')
+  return Boolean(fragment && normalizedText(html).includes(fragment))
+}
+
 function outputFeaturePresent(
   checkpoint: SourceOutputCheckpoint,
   html: string,
@@ -477,6 +531,30 @@ export function evaluateSourceOutputCheckpoint(
       checkpointId: checkpoint.id,
       status: 'failed',
       reason: 'The source page does not contain the named source text.',
+    }
+  }
+  if (checkpoint.property === 'markup-non-promotion') {
+    const promoted = promotedMarkupStructure(
+      checkpoint,
+      observation.rendition.html,
+    )
+    if (promoted) {
+      return {
+        checkpointId: checkpoint.id,
+        status: 'failed',
+        reason: `Markup-shaped source text was promoted to <${promoted}> without source evidence.`,
+      }
+    }
+  }
+  if (
+    checkpoint.property === 'hyphen-resolution' &&
+    unresolvedHyphenFragment(checkpoint, observation.rendition.html)
+  ) {
+    return {
+      checkpointId: checkpoint.id,
+      status: 'failed',
+      reason:
+        'The rendition still carries the printed line-end hyphen fragment.',
     }
   }
   return { checkpointId: checkpoint.id, status: 'passed' }

--- a/src/research/source-output-checkpoints.ts
+++ b/src/research/source-output-checkpoints.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { PdfSourceSemanticFlowBoundaryDecision } from './import-types'
 import {
   getTargetProfile,
   TARGET_PROFILE_IDS,
@@ -51,11 +52,20 @@ const sourceExpectationSchema = z
   })
   .strict()
 
+const semanticFlowExpectationSchema = z
+  .object({
+    topology: z.enum(['same-page-column', 'cross-page-column']),
+    fromPage: z.number().int().positive(),
+    outcome: z.enum(['space', 'no-space']),
+  })
+  .strict()
+
 const renditionExpectationSchema = z
   .object({
     feature: z.enum(SOURCE_OUTPUT_RENDITION_FEATURES),
     text: z.string().min(1).optional(),
     level: z.number().int().min(1).max(6).optional(),
+    semanticFlow: semanticFlowExpectationSchema.optional(),
   })
   .strict()
 
@@ -94,6 +104,7 @@ export type CheckpointValidationIssue = {
     | 'duplicate-id'
     | 'property-feature-mismatch'
     | 'property-source-feature-mismatch'
+    | 'missing-semantic-flow-expectation'
   message: string
 }
 
@@ -204,6 +215,18 @@ export function validateSourceOutputCheckpointSet(
         message: `${checkpoint.property} must inspect source feature ${expectedSource}.`,
       })
     }
+
+    if (
+      checkpoint.property === 'prose-continuity' &&
+      checkpoint.output.semanticFlow === undefined
+    ) {
+      issues.push({
+        checkpointId: checkpoint.id,
+        code: 'missing-semantic-flow-expectation',
+        message:
+          'prose-continuity must name the source-proven semantic-flow boundary it expects.',
+      })
+    }
   }
   return issues
 }
@@ -251,6 +274,11 @@ export type RenditionCheckpointObservation = {
   profile: TargetProfileId
   width: number
   html: string
+  semanticFlowBoundaryLedgerValid?: boolean
+  semanticFlowBoundaryDecisions?: readonly Pick<
+    PdfSourceSemanticFlowBoundaryDecision,
+    'page' | 'topology' | 'outcome'
+  >[]
 }
 
 export type SourceOutputCheckpointObservation = {
@@ -531,6 +559,31 @@ export function evaluateSourceOutputCheckpoint(
       checkpointId: checkpoint.id,
       status: 'failed',
       reason: 'The source page does not contain the named source text.',
+    }
+  }
+  if (checkpoint.output.semanticFlow) {
+    if (observation.rendition.semanticFlowBoundaryLedgerValid !== true) {
+      return {
+        checkpointId: checkpoint.id,
+        status: 'failed',
+        reason:
+          'The reconstruction did not provide a valid semantic-flow boundary ledger.',
+      }
+    }
+    const expected = checkpoint.output.semanticFlow
+    const matchingDecision =
+      observation.rendition.semanticFlowBoundaryDecisions?.some(
+        (decision) =>
+          decision.page === expected.fromPage &&
+          decision.topology === expected.topology &&
+          decision.outcome === expected.outcome,
+      ) ?? false
+    if (!matchingDecision) {
+      return {
+        checkpointId: checkpoint.id,
+        status: 'failed',
+        reason: `The semantic-flow boundary ledger does not contain ${expected.topology} ${expected.outcome} proof from page ${expected.fromPage}.`,
+      }
     }
   }
   if (checkpoint.property === 'markup-non-promotion') {

--- a/tests/fixtures/pdf/README.md
+++ b/tests/fixtures/pdf/README.md
@@ -33,11 +33,18 @@ source-glyph equation raster, and bibliography entries. Its
 text and visual content were written for this repository and do not reduce or
 copy any external paper.
 
-`source-output-checkpoints.pdf` is the small source/output review fixture. It
-contains a source flowchart, a caption, a sentence explicitly labelled as
-continuing across a column break, and a pseudocode listing. The paired evidence
-command uses this page only; it never renders owner-local papers into the
-repository. Its named furniture-exclusion checkpoint also requires the
+`source-output-checkpoints.pdf` is the small source/output review fixture. Page
+one contains a source flowchart, a caption, a pseudocode listing, and the
+opening half of a sentence that runs off the bottom of the page. Page two
+repeats page one's running head and then carries that sentence's
+continuation, attested removable and hard-preserved line-end hyphens, literal
+Markdown, template-placeholder and numbered-list-shaped prose, two indented
+paragraphs, a widely spaced continuation, and prose adjacent to an equation.
+Page three is a dedicated two-column body with a sentence physically split
+from the bottom of its left column to the top of its right column.
+The paired
+evidence command uses these pages only; it never renders owner-local papers into
+the repository. Its named furniture-exclusion checkpoint also requires the
 reconstruction's per-document contamination counter.
 
 `sparse-embedded-text.pdf` is a title/divider page with no image content. It

--- a/tests/fixtures/pdf/generate-source-output-checkpoints.mjs
+++ b/tests/fixtures/pdf/generate-source-output-checkpoints.mjs
@@ -21,24 +21,73 @@ function imageObject() {
 }
 
 const content = [
-  textLine('Source/output checkpoint fixture', 72, 730, 20, 'F2'),
+  textLine('Source/output checkpoint fixture', 72, 760, 9),
+  textLine('Continuous prose checkpoint paper', 72, 720, 20, 'F2'),
   textLine('Figure 1. Source flowchart', 72, 680),
-  textLine('The result sentence continues across a column break.', 72, 640),
   textLine('Pseudocode', 72, 580, 14, 'F2'),
   textLine('for each source line:', 90, 550),
   textLine('compare source and rendition', 108, 528),
   textLine('keep the named property visible', 108, 506),
   'q\n360 0 0 160 126 300 cm\n/Im1 Do\nQ',
   textLine('Figure 1 caption stays below the source flowchart.', 72, 250, 10),
+  textLine('A second result sentence runs off the bottom of', 72, 104),
+  textLine('this page and', 72, 82),
+].join('\n')
+
+// Page two carries the halves of the sentence, the word, and the literal text
+// that issue 043's page-join, hyphen-resolution, and markup non-promotion
+// checkpoints name. The running head repeats page one's title so that furniture
+// exclusion has something to exclude between the two halves.
+const secondPageContent = [
+  textLine('Source/output checkpoint fixture', 72, 760, 9),
+  textLine('continues at the top of the next one without losing', 72, 700),
+  textLine('its clause.', 72, 680),
+  textLine('The high-resolution source photo-', 72, 620),
+  textLine('graph remains clear.', 72, 600),
+  textLine('A photograph attests the joined form.', 72, 575),
+  textLine('The source preserves the rare-', 72, 540),
+  textLine('fragment compound.', 72, 520),
+  textLine('The rare-fragment spelling is attested.', 72, 495),
+  textLine('## Not a heading and **not bold** and {placeholder}', 72, 470),
+  textLine('stay literal.', 72, 450),
+  textLine('1. Literal numbered syntax stays prose.', 72, 420),
+  textLine('First indented paragraph begins', 90, 370),
+  textLine('and continues on its next line.', 72, 350),
+  textLine('Second indented paragraph begins', 90, 336),
+  textLine('and continues independently.', 72, 316),
+  textLine('A widely spaced source line begins', 72, 270),
+  textLine('and remains source-contiguous despite its spacing.', 72, 244),
+  textLine('Prose before the owned equation remains clean.', 72, 180),
+  textLine('E = m c 2 (1)', 240, 150, 14, 'F2'),
+  textLine('Prose after the owned equation remains clean.', 72, 118),
+].join('\n')
+
+// Page three is deliberately only a two-column body. Keeping its source
+// geometry independent of the spanning visual fixture makes the column-flow
+// proof observable rather than relying on a sentence that merely says it
+// crossed a column.
+const thirdPageContent = [
+  textLine('Source/output checkpoint fixture', 72, 760, 9),
+  textLine('Left context establishes a column.', 72, 680),
+  textLine('Left evidence preserves source order.', 72, 640),
+  textLine('Left geometry reaches the final line.', 72, 600),
+  textLine('The result continues toward the', 72, 120),
+  textLine('right column with source proof.', 350, 680),
+  textLine('Right evidence preserves source order.', 350, 640),
+  textLine('Right context completes the gutter.', 350, 600),
 ].join('\n')
 
 const objects = [
   '<< /Type /Catalog /Pages 2 0 R >>',
-  '<< /Type /Pages /Kids [5 0 R] /Count 1 >>',
+  '<< /Type /Pages /Kids [5 0 R 7 0 R 9 0 R] /Count 3 >>',
   '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
   imageObject(),
   '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> /XObject << /Im1 4 0 R >> >> /Contents 6 0 R >>',
   `<< /Length ${Buffer.byteLength(content)} >>\nstream\n${content}\nendstream`,
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> >> /Contents 8 0 R >>',
+  `<< /Length ${Buffer.byteLength(secondPageContent)} >>\nstream\n${secondPageContent}\nendstream`,
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> >> /Contents 10 0 R >>',
+  `<< /Length ${Buffer.byteLength(thirdPageContent)} >>\nstream\n${thirdPageContent}\nendstream`,
 ]
 
 let pdf = '%PDF-1.4\n% synthetic fixture owned by erniesg\n'

--- a/tests/fixtures/pdf/manifest.json
+++ b/tests/fixtures/pdf/manifest.json
@@ -81,12 +81,21 @@
     },
     {
       "file": "source-output-checkpoints.pdf",
-      "sha256": "2265f0d49304011feb8c972bf24bf5b93db099180d4fa270826e19df23c2de30",
+      "sha256": "f31fdc50a8216f80599644b51ff619a778d8e97268edadd457c3f556d1df03e9",
       "features": [
         "source-output-checkpoints",
         "source-flowchart",
         "caption-boundary",
         "prose-continuity",
+        "cross-column-prose-continuity",
+        "cross-page-prose-continuity",
+        "hyphen-resolution",
+        "unattested-hyphen-preservation",
+        "markup-non-promotion",
+        "numbered-markup-non-promotion",
+        "paragraph-indentation",
+        "paragraph-spacing",
+        "adjacent-owned-equation",
         "pseudocode-block",
         "furniture-exclusion"
       ]

--- a/tests/fixtures/pdf/source-output-checkpoints.json
+++ b/tests/fixtures/pdf/source-output-checkpoints.json
@@ -31,7 +31,12 @@
       "source": { "feature": "text" },
       "output": {
         "feature": "prose",
-        "text": "The result continues toward the right column with source proof."
+        "text": "The result continues toward the right column with source proof.",
+        "semanticFlow": {
+          "topology": "same-page-column",
+          "fromPage": 3,
+          "outcome": "space"
+        }
       }
     },
     {
@@ -47,7 +52,12 @@
       },
       "output": {
         "feature": "prose",
-        "text": "A second result sentence runs off the bottom of this page and continues at the top of the next one without losing its clause."
+        "text": "A second result sentence runs off the bottom of this page and continues at the top of the next one without losing its clause.",
+        "semanticFlow": {
+          "topology": "cross-page-column",
+          "fromPage": 1,
+          "outcome": "space"
+        }
       }
     },
     {

--- a/tests/fixtures/pdf/source-output-checkpoints.json
+++ b/tests/fixtures/pdf/source-output-checkpoints.json
@@ -22,16 +22,71 @@
       "output": { "feature": "caption", "text": "Figure 1. Source flowchart" }
     },
     {
-      "id": "fidelity-page-1-prose-continuity",
+      "id": "fidelity-page-3-prose-continuity",
       "document": "source-output-checkpoints.pdf",
-      "page": 1,
+      "page": 3,
       "profile": "paperPro",
       "property": "prose-continuity",
       "criterion": "The result sentence remains one continuous prose block in the rendition.",
       "source": { "feature": "text" },
       "output": {
         "feature": "prose",
-        "text": "The result sentence continues across a column break."
+        "text": "The result continues toward the right column with source proof."
+      }
+    },
+    {
+      "id": "fidelity-page-2-prose-continuity",
+      "document": "source-output-checkpoints.pdf",
+      "page": 2,
+      "profile": "paperPro",
+      "property": "prose-continuity",
+      "criterion": "The sentence split by the page break is one continuous prose block in the rendition.",
+      "source": {
+        "feature": "text",
+        "text": "continues at the top of the next one"
+      },
+      "output": {
+        "feature": "prose",
+        "text": "A second result sentence runs off the bottom of this page and continues at the top of the next one without losing its clause."
+      }
+    },
+    {
+      "id": "fidelity-page-2-hyphen-resolution",
+      "document": "source-output-checkpoints.pdf",
+      "page": 2,
+      "profile": "paperPro",
+      "property": "hyphen-resolution",
+      "criterion": "The discretionary line-end hyphen resolves to the attested joined word and the printed fragment never reaches the reader.",
+      "source": { "feature": "text", "text": "photo-" },
+      "output": {
+        "feature": "prose",
+        "text": "The high-resolution source photograph remains clear."
+      }
+    },
+    {
+      "id": "fidelity-page-2-markup-non-promotion",
+      "document": "source-output-checkpoints.pdf",
+      "page": 2,
+      "profile": "paperPro",
+      "property": "markup-non-promotion",
+      "criterion": "Source text that merely looks like Markdown stays prose characters and is never promoted to heading, emphasis, or list structure.",
+      "source": { "feature": "text", "text": "## Not a heading" },
+      "output": {
+        "feature": "prose",
+        "text": "## Not a heading and **not bold** and {placeholder} stay literal."
+      }
+    },
+    {
+      "id": "fidelity-page-2-numbered-markup-non-promotion",
+      "document": "source-output-checkpoints.pdf",
+      "page": 2,
+      "profile": "paperPro",
+      "property": "markup-non-promotion",
+      "criterion": "Numbered-list-shaped source text stays prose when no independent source styling proves a list or heading.",
+      "source": { "feature": "text", "text": "1. Literal numbered syntax stays prose." },
+      "output": {
+        "feature": "prose",
+        "text": "1. Literal numbered syntax stays prose."
       }
     },
     {
@@ -45,9 +100,9 @@
       "output": { "feature": "code" }
     },
     {
-      "id": "fidelity-page-1-furniture-exclusion",
+      "id": "fidelity-page-3-furniture-exclusion",
       "document": "source-output-checkpoints.pdf",
-      "page": 1,
+      "page": 3,
       "profile": "paperPro",
       "property": "furniture-exclusion",
       "criterion": "The source/output pair records zero furniture contamination in canonical prose.",
@@ -57,7 +112,7 @@
       },
       "output": {
         "feature": "prose",
-        "text": "The result sentence continues across a column break."
+        "text": "The result continues toward the right column with source proof."
       }
     }
   ]

--- a/tests/fixtures/pdf/source-output-checkpoints.pdf
+++ b/tests/fixtures/pdf/source-output-checkpoints.pdf
@@ -4,7 +4,7 @@
 << /Type /Catalog /Pages 2 0 R >>
 endobj
 2 0 obj
-<< /Type /Pages /Kids [5 0 R] /Count 1 >>
+<< /Type /Pages /Kids [5 0 R 7 0 R 9 0 R] /Count 3 >>
 endobj
 3 0 obj
 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
@@ -19,22 +19,22 @@ endobj
 << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> /XObject << /Im1 4 0 R >> >> /Contents 6 0 R >>
 endobj
 6 0 obj
-<< /Length 542 >>
+<< /Length 645 >>
 stream
 BT
-/F2 20 Tf
-72 730 Td
+/F1 9 Tf
+72 760 Td
 (Source/output checkpoint fixture) Tj
+ET
+BT
+/F2 20 Tf
+72 720 Td
+(Continuous prose checkpoint paper) Tj
 ET
 BT
 /F1 12 Tf
 72 680 Td
 (Figure 1. Source flowchart) Tj
-ET
-BT
-/F1 12 Tf
-72 640 Td
-(The result sentence continues across a column break.) Tj
 ET
 BT
 /F2 14 Tf
@@ -65,19 +65,194 @@ BT
 72 250 Td
 (Figure 1 caption stays below the source flowchart.) Tj
 ET
+BT
+/F1 12 Tf
+72 104 Td
+(A second result sentence runs off the bottom of) Tj
+ET
+BT
+/F1 12 Tf
+72 82 Td
+(this page and) Tj
+ET
+endstream
+endobj
+7 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> >> /Contents 8 0 R >>
+endobj
+8 0 obj
+<< /Length 1357 >>
+stream
+BT
+/F1 9 Tf
+72 760 Td
+(Source/output checkpoint fixture) Tj
+ET
+BT
+/F1 12 Tf
+72 700 Td
+(continues at the top of the next one without losing) Tj
+ET
+BT
+/F1 12 Tf
+72 680 Td
+(its clause.) Tj
+ET
+BT
+/F1 12 Tf
+72 620 Td
+(The high-resolution source photo-) Tj
+ET
+BT
+/F1 12 Tf
+72 600 Td
+(graph remains clear.) Tj
+ET
+BT
+/F1 12 Tf
+72 575 Td
+(A photograph attests the joined form.) Tj
+ET
+BT
+/F1 12 Tf
+72 540 Td
+(The source preserves the rare-) Tj
+ET
+BT
+/F1 12 Tf
+72 520 Td
+(fragment compound.) Tj
+ET
+BT
+/F1 12 Tf
+72 495 Td
+(The rare-fragment spelling is attested.) Tj
+ET
+BT
+/F1 12 Tf
+72 470 Td
+(## Not a heading and **not bold** and {placeholder}) Tj
+ET
+BT
+/F1 12 Tf
+72 450 Td
+(stay literal.) Tj
+ET
+BT
+/F1 12 Tf
+72 420 Td
+(1. Literal numbered syntax stays prose.) Tj
+ET
+BT
+/F1 12 Tf
+90 370 Td
+(First indented paragraph begins) Tj
+ET
+BT
+/F1 12 Tf
+72 350 Td
+(and continues on its next line.) Tj
+ET
+BT
+/F1 12 Tf
+90 336 Td
+(Second indented paragraph begins) Tj
+ET
+BT
+/F1 12 Tf
+72 316 Td
+(and continues independently.) Tj
+ET
+BT
+/F1 12 Tf
+72 270 Td
+(A widely spaced source line begins) Tj
+ET
+BT
+/F1 12 Tf
+72 244 Td
+(and remains source-contiguous despite its spacing.) Tj
+ET
+BT
+/F1 12 Tf
+72 180 Td
+(Prose before the owned equation remains clean.) Tj
+ET
+BT
+/F2 14 Tf
+240 150 Td
+(E = m c 2 \(1\)) Tj
+ET
+BT
+/F1 12 Tf
+72 118 Td
+(Prose after the owned equation remains clean.) Tj
+ET
+endstream
+endobj
+9 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R /F2 3 0 R >> >> /Contents 10 0 R >>
+endobj
+10 0 obj
+<< /Length 532 >>
+stream
+BT
+/F1 9 Tf
+72 760 Td
+(Source/output checkpoint fixture) Tj
+ET
+BT
+/F1 12 Tf
+72 680 Td
+(Left context establishes a column.) Tj
+ET
+BT
+/F1 12 Tf
+72 640 Td
+(Left evidence preserves source order.) Tj
+ET
+BT
+/F1 12 Tf
+72 600 Td
+(Left geometry reaches the final line.) Tj
+ET
+BT
+/F1 12 Tf
+72 120 Td
+(The result continues toward the) Tj
+ET
+BT
+/F1 12 Tf
+350 680 Td
+(right column with source proof.) Tj
+ET
+BT
+/F1 12 Tf
+350 640 Td
+(Right evidence preserves source order.) Tj
+ET
+BT
+/F1 12 Tf
+350 600 Td
+(Right context completes the gutter.) Tj
+ET
 endstream
 endobj
 xref
-0 7
+0 11
 0000000000 65535 f 
 0000000046 00000 n 
 0000000095 00000 n 
-0000000152 00000 n 
-0000000222 00000 n 
-0000000446 00000 n 
-0000000608 00000 n 
+0000000164 00000 n 
+0000000234 00000 n 
+0000000458 00000 n 
+0000000620 00000 n 
+0000001316 00000 n 
+0000001452 00000 n 
+0000002861 00000 n 
+0000002998 00000 n 
 trailer
-<< /Size 7 /Root 1 0 R >>
+<< /Size 11 /Root 1 0 R >>
 startxref
-1201
+3582
 %%EOF

--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -388,12 +388,24 @@ async function createFixtureStructDocument({
       evidence: blockEvidence,
     },
   ]
+  // Issue 043 prose claims: a sentence the source split across a page break, a
+  // discretionary hyphen resolved to its attested joined form, and source text
+  // that merely looks like markup and must stay literal.
+  const pageJoinProse =
+    'A second result sentence runs off the bottom of this page and continues at the top of the next one without losing its clause.'
+  const hyphenResolutionProse =
+    'The high-resolution photograph is attested elsewhere as photograph.'
+  const literalMarkupProse =
+    '## Not a heading and **not bold** and {placeholder} stay literal.'
   const textCharacterCount = [
     'Checkpoint paper',
     'The result sentence continues across a column break.',
     'Figure 1. Source flowchart',
     'Table 1. Validated checkpoint values remain structured.',
     'for each source line:\n  compare source and rendition\n  keep the named property visible',
+    pageJoinProse,
+    hyphenResolutionProse,
+    literalMarkupProse,
     ...cells.map(({ text }) => text),
   ].reduce((total, value) => total + value.length, 0)
   const figureEvidence = {
@@ -485,6 +497,36 @@ async function createFixtureStructDocument({
         inline: [],
         evidence: blockEvidence,
       },
+      {
+        id: 'checkpoint-page-join-prose',
+        kind: 'paragraph',
+        text: pageJoinProse,
+        page,
+        order: 5,
+        column: 'single',
+        inline: [],
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-hyphen-prose',
+        kind: 'paragraph',
+        text: hyphenResolutionProse,
+        page,
+        order: 6,
+        column: 'single',
+        inline: [],
+        evidence: blockEvidence,
+      },
+      {
+        id: 'checkpoint-markup-prose',
+        kind: 'paragraph',
+        text: literalMarkupProse,
+        page,
+        order: 7,
+        column: 'single',
+        inline: [],
+        evidence: blockEvidence,
+      },
     ],
     assets: [
       {
@@ -514,6 +556,9 @@ async function createFixtureStructDocument({
           'checkpoint-figure',
           'checkpoint-table',
           'checkpoint-code',
+          'checkpoint-page-join-prose',
+          'checkpoint-hyphen-prose',
+          'checkpoint-markup-prose',
         ],
         columns: [
           {
@@ -525,6 +570,9 @@ async function createFixtureStructDocument({
               'checkpoint-figure',
               'checkpoint-table',
               'checkpoint-code',
+              'checkpoint-page-join-prose',
+              'checkpoint-hyphen-prose',
+              'checkpoint-markup-prose',
             ],
           },
         ],
@@ -540,14 +588,14 @@ async function createFixtureStructDocument({
     receipt: {
       schemaVersion: '0.1.0',
       sourceSha256: sourceHash,
-      blockCount: 5,
+      blockCount: 8,
       assetCount: 1,
       relationshipCount: 0,
       diagnosticCount: 0,
       textCharacterCount,
       conservation: {
-        sourceNodeCount: 5,
-        accountedSourceNodeCount: 5,
+        sourceNodeCount: 8,
+        accountedSourceNodeCount: 8,
         sourceRegionCount: 1,
         accountedSourceRegionCount: 1,
         sourceAnnotationCount: 0,
@@ -559,7 +607,7 @@ async function createFixtureStructDocument({
         sourceDiagnosticCount: 0,
         accountedSourceDiagnosticCount: 0,
         sourceTextCharacterCount: textCharacterCount,
-        structBlockCount: 5,
+        structBlockCount: 8,
         structAssetCount: 1,
         structRelationshipCount: 0,
         structDiagnosticCount: 0,

--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -40,6 +40,12 @@ const DEFAULT_OUTPUT = resolve(
   '.agent/evidence/srt-checkpoints',
 )
 const TOOL_VERSION = '1.0.0'
+const PDF_RECONSTRUCTION_PROPERTIES = new Set([
+  'prose-continuity',
+  'hyphen-resolution',
+  'markup-non-promotion',
+  'furniture-exclusion',
+])
 
 const IMAGE_OPERATORS = new Set([
   pdfjs.OPS.paintImageMaskXObject,
@@ -664,10 +670,14 @@ async function renderRendition({
   buildEpub,
   profile,
   document,
+  renditionSource,
   browser,
   root,
 }) {
-  const epub = await buildEpub(document)
+  const epub =
+    renditionSource === 'pdf-reconstruction'
+      ? await buildEpub(document, profile)
+      : await buildEpub(document)
   const archive = unzipSync(epub.bytes)
   const unpacked = await mkdtemp(join(root, 'rendition-'))
   await writeArchive(archive, unpacked)
@@ -727,12 +737,13 @@ async function createViteModules() {
     server: { middlewareMode: true, watch: null },
   })
   try {
-    const [checkpoints, struct, targets] = await Promise.all([
+    const [checkpoints, pdf, struct, targets] = await Promise.all([
       vite.ssrLoadModule('/src/research/source-output-checkpoints.ts'),
+      vite.ssrLoadModule('/src/research/pdf.ts'),
       vite.ssrLoadModule('/src/research/epub.ts'),
       vite.ssrLoadModule('/src/research/targets.ts'),
     ])
-    return { vite, checkpoints, struct, targets }
+    return { vite, checkpoints, pdf, struct, targets }
   } catch (error) {
     await vite.close()
     throw error
@@ -837,6 +848,16 @@ async function run(options) {
       sourceBytes,
       basename(options.document),
     )
+    const reconstruction = privacy.defaultFixture
+      ? await modules.pdf.reconstructPdf(
+          new File([sourceBytes], basename(options.document), {
+            type: 'application/pdf',
+            lastModified: 0,
+          }),
+          undefined,
+          { language: 'en-US' },
+        )
+      : null
     browser = await chromium.launch({ headless: true })
     const browserRoot = await mkdtemp(join(tmpdir(), 'srt-source-output-'))
     const byPair = new Map()
@@ -847,7 +868,12 @@ async function run(options) {
       await mkdir(join(options.output, 'pairs'), { recursive: true })
       for (const checkpoint of checkpoints) {
         const profile = modules.targets.getTargetProfile(checkpoint.profile)
-        const pairKey = `${checkpoint.page}\0${checkpoint.profile}`
+        const renditionSource =
+          reconstruction &&
+          PDF_RECONSTRUCTION_PROPERTIES.has(checkpoint.property)
+            ? 'pdf-reconstruction'
+            : 'struct-document'
+        const pairKey = `${checkpoint.page}\0${checkpoint.profile}\0${renditionSource}`
         let pair = byPair.get(pairKey)
         if (!pair) {
           const source = await renderSourcePage(
@@ -858,7 +884,11 @@ async function run(options) {
           const rendition = await renderRendition({
             buildEpub: modules.struct.buildEpub,
             profile,
-            document,
+            document:
+              renditionSource === 'pdf-reconstruction'
+                ? reconstruction.paper
+                : document,
+            renditionSource,
             browser,
             root: browserRoot,
           })
@@ -873,7 +903,10 @@ async function run(options) {
               text: pair.source.text,
               hasVisual: pair.source.hasVisual,
               furnitureContaminationCount:
-                document.receipt?.conservation?.furnitureContaminationCount,
+                renditionSource === 'pdf-reconstruction'
+                  ? reconstruction.completeness.furnitureContaminationCount
+                  : document.receipt?.conservation
+                      ?.furnitureContaminationCount,
             },
             rendition: {
               profile: checkpoint.profile,
@@ -929,6 +962,7 @@ async function run(options) {
           criterion: checkpoint.criterion,
           sourceExpectation: checkpoint.source,
           outputExpectation: checkpoint.output,
+          renditionSource,
           sourceArtifact: `pairs/${sourceName}`,
           outputArtifact: `pairs/${outputName}`,
           conclusion: reviewerConclusion(checkpoint, result),

--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -912,6 +912,18 @@ async function run(options) {
               profile: checkpoint.profile,
               width: pair.rendition.width,
               html: pair.rendition.html,
+              semanticFlowBoundaryLedgerValid:
+                renditionSource === 'pdf-reconstruction'
+                  ? !reconstruction.diagnostics.some(
+                      (diagnostic) =>
+                        diagnostic.code ===
+                        'INVALID_SOURCE_SEMANTIC_FLOW_BOUNDARY_LEDGER',
+                    )
+                  : undefined,
+              semanticFlowBoundaryDecisions:
+                renditionSource === 'pdf-reconstruction'
+                  ? reconstruction.sourceSemanticFlowBoundaryDecisions
+                  : undefined,
             },
           },
         )

--- a/tools/srt-source-output-evidence.test.mjs
+++ b/tools/srt-source-output-evidence.test.mjs
@@ -48,6 +48,36 @@ function privateFixture() {
 }
 
 describe('source/output evidence privacy boundary', () => {
+  it('renders repository prose checkpoints from the PDF reconstruction path', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'srt-checkpoint-test-'))
+    temporaryDirectories.push(directory)
+    const output = join(directory, 'evidence')
+    const result = spawnSync(
+      process.execPath,
+      [tool, '--output', output],
+      { cwd: root, encoding: 'utf8' },
+    )
+
+    expect(result.status).toBe(0)
+    const manifest = JSON.parse(
+      readFileSync(join(output, 'checkpoint-manifest.json'), 'utf8'),
+    )
+    expect(manifest.result).toBe('passed')
+    expect(
+      manifest.checkpoints
+        .filter(({ property }) =>
+          [
+            'prose-continuity',
+            'hyphen-resolution',
+            'markup-non-promotion',
+          ].includes(property),
+        )
+        .every(
+          ({ renditionSource }) => renditionSource === 'pdf-reconstruction',
+        ),
+    ).toBe(true)
+  }, 30_000)
+
   it('does not fabricate a private rendition without caller-provided STRUCT', () => {
     const paths = privateFixture()
     const result = spawnSync(


### PR DESCRIPTION
Closes #105

## Summary

- prove and ledger source-contiguous prose joins across physical column and page boundaries, including repeated-furniture exclusion
- preserve equation/table/figure ownership and make discretionary hyphen decisions evidence-backed
- keep Markdown-, placeholder-, and ordered-marker-shaped source text literal unless typography or geometry independently proves structure
- replace the tautological prose checkpoint with a generated three-page PDF fixture exercised through `reconstructPdf`

## Root cause

The previous implementation could join several same-page fragments, but cross-page source sequence indexes were compared as though they shared one page-global sequence. The checkpoint fixture also echoed a hand-built STRUCT rendition instead of proving the PDF reconstruction path.

## Validation

- `npx vitest run src/struct/struct.test.ts src/research/pdf-layout.test.ts src/research/epub.test.ts src/research/epub-source-fallback.test.ts` — 464 passed
- `npm run srt:checkpoint-evidence` — passed using the real PDF reconstruction path for issue-specific claims
- GitHub exact-head `agent-evidence` — passed at `20259f39c6894d386f3fbbf83d919f1ac8564af9`, clean checkout
- GitHub `checks`, `secret-scan`, and GitGuardian — passed

Local macOS repository-wide gates also exposed two unchanged environment/baseline failures: Chrome for Testing `149.0.7827.55` is newer than the repository pin `149.0.7827.0`, and the existing staging-root Git pathspec test reports dirty under local Git 2.48. The clean GitHub runner passes both paths.