### PR TITLE
Canonicalize macOS temp paths in publication cleanliness exclusions

### DIFF
--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -779,15 +779,20 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
   const repositoryIdentity = canonicalMacOSTemporaryPath(repositoryRoot)
   const candidate = resolve(excludedPath)
   const candidateIdentity = canonicalMacOSTemporaryPath(candidate)
+  let entry
   try {
     // Only the root-owned macOS temporary aliases above may change a path's
     // spelling. Any other symlink, missing target, or mount boundary fails
     // closed and remains visible to `git status`.
+    entry = lstatSync(candidate)
+    const privateMode = entry.mode & 0o777
     if (
       realpathSync(repositoryRoot) !== repositoryIdentity ||
       realpathSync(candidate) !== candidateIdentity ||
-      !lstatSync(candidate).isDirectory() ||
-      statSync(repositoryIdentity).dev !== statSync(candidateIdentity).dev
+      !entry.isDirectory() ||
+      statSync(repositoryIdentity).dev !== entry.dev ||
+      (typeof process.getuid === 'function' &&
+        (entry.uid !== process.getuid() || privateMode !== 0o700))
     )
       return undefined
   } catch {
@@ -803,27 +808,60 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
     isAbsolute(repositoryRelative)
   )
     return undefined
-  return `:(exclude,top,literal)${repositoryRelative}`
+  return {
+    pathspec: `:(exclude,top,literal)${repositoryRelative}`,
+    candidate,
+    candidateIdentity,
+    identity: {
+      dev: entry.dev,
+      ino: entry.ino,
+      uid: entry.uid,
+      gid: entry.gid,
+      mode: entry.mode,
+    },
+  }
+}
+
+function publicationCleanlinessExclusionIsCurrent(exclusion) {
+  try {
+    if (realpathSync(exclusion.candidate) !== exclusion.candidateIdentity)
+      return false
+    const entry = lstatSync(exclusion.candidate)
+    return (
+      entry.isDirectory() &&
+      entry.dev === exclusion.identity.dev &&
+      entry.ino === exclusion.identity.ino &&
+      entry.uid === exclusion.identity.uid &&
+      entry.gid === exclusion.identity.gid &&
+      entry.mode === exclusion.identity.mode
+    )
+  } catch {
+    return false
+  }
 }
 
 export function publicationRepositoryForCurrentCheckout(excludedPaths = []) {
   const repositoryRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8',
   }).trim()
-  const exclusions = excludedPaths
+  const exclusionReceipts = excludedPaths
     .map((path) => publicationCleanlinessExclusion(repositoryRoot, path))
     .filter(Boolean)
+  const exclusions = exclusionReceipts.map(({ pathspec }) => pathspec)
+  const commit = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  }).trim()
+  const status = execFileSync(
+    'git',
+    ['status', '--short', '--untracked-files=all', '--', '.', ...exclusions],
+    { cwd: repositoryRoot, encoding: 'utf8' },
+  ).trim()
   return {
-    commit: execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: repositoryRoot,
-      encoding: 'utf8',
-    }).trim(),
+    commit,
     dirty:
-      execFileSync(
-        'git',
-        ['status', '--short', '--untracked-files=all', '--', '.', ...exclusions],
-        { cwd: repositoryRoot, encoding: 'utf8' },
-      ).trim().length > 0,
+      status.length > 0 ||
+      !exclusionReceipts.every(publicationCleanlinessExclusionIsCurrent),
   }
 }
 

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -775,6 +775,7 @@ function canonicalMacOSTemporaryPath(value) {
 }
 
 function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
+  if (String(excludedPath).split(/[\\/]+/u).includes('..')) return undefined
   const repositoryIdentity = canonicalMacOSTemporaryPath(repositoryRoot)
   const candidate = resolve(excludedPath)
   const candidateIdentity = canonicalMacOSTemporaryPath(candidate)

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -774,6 +774,12 @@ function canonicalMacOSTemporaryPath(value) {
   return candidate
 }
 
+function currentEffectiveUserId() {
+  if (typeof process.geteuid === 'function') return process.geteuid()
+  if (typeof process.getuid === 'function') return process.getuid()
+  return undefined
+}
+
 function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
   if (String(excludedPath).split(/[\\/]+/u).includes('..')) return undefined
   const repositoryIdentity = canonicalMacOSTemporaryPath(repositoryRoot)
@@ -786,13 +792,14 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
     // closed and remains visible to `git status`.
     entry = lstatSync(candidate)
     const privateMode = entry.mode & 0o777
+    const effectiveUserId = currentEffectiveUserId()
     if (
       realpathSync(repositoryRoot) !== repositoryIdentity ||
       realpathSync(candidate) !== candidateIdentity ||
       !entry.isDirectory() ||
       statSync(repositoryIdentity).dev !== entry.dev ||
-      (typeof process.getuid === 'function' &&
-        (entry.uid !== process.getuid() || privateMode !== 0o700))
+      (effectiveUserId !== undefined &&
+        (entry.uid !== effectiveUserId || privateMode !== 0o700))
     )
       return undefined
   } catch {
@@ -827,8 +834,10 @@ function publicationCleanlinessExclusionIsCurrent(exclusion) {
     if (realpathSync(exclusion.candidate) !== exclusion.candidateIdentity)
       return false
     const entry = lstatSync(exclusion.candidate)
+    const effectiveUserId = currentEffectiveUserId()
     return (
       entry.isDirectory() &&
+      (effectiveUserId === undefined || entry.uid === effectiveUserId) &&
       entry.dev === exclusion.identity.dev &&
       entry.ino === exclusion.identity.ino &&
       entry.uid === exclusion.identity.uid &&

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -781,10 +781,24 @@ function currentEffectiveUserId() {
 }
 
 function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
-  if (String(excludedPath).split(/[\\/]+/u).includes('..')) return undefined
   const repositoryIdentity = canonicalMacOSTemporaryPath(repositoryRoot)
   const candidate = resolve(excludedPath)
   const candidateIdentity = canonicalMacOSTemporaryPath(candidate)
+  const repositoryRelative = relative(repositoryIdentity, candidateIdentity)
+    .split(sep)
+    .join('/')
+  if (
+    repositoryRelative === '..' ||
+    repositoryRelative.startsWith('../') ||
+    isAbsolute(repositoryRelative)
+  )
+    return undefined
+  const rejected = { rejected: true }
+  if (
+    !repositoryRelative ||
+    String(excludedPath).split(/[\\/]+/u).includes('..')
+  )
+    return rejected
   let entry
   try {
     // Only the root-owned macOS temporary aliases above may change a path's
@@ -801,21 +815,12 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
       (effectiveUserId !== undefined &&
         (entry.uid !== BigInt(effectiveUserId) || privateMode !== 0o700n))
     )
-      return undefined
+      return rejected
   } catch {
-    return undefined
+    return rejected
   }
-  const repositoryRelative = relative(repositoryIdentity, candidateIdentity)
-    .split(sep)
-    .join('/')
-  if (
-    !repositoryRelative ||
-    repositoryRelative === '..' ||
-    repositoryRelative.startsWith('../') ||
-    isAbsolute(repositoryRelative)
-  )
-    return undefined
   return {
+    rejected: false,
     pathspec: `:(exclude,top,literal)${repositoryRelative}`,
     candidate,
     candidateIdentity,
@@ -854,9 +859,12 @@ export function publicationRepositoryForCurrentCheckout(excludedPaths = []) {
   const repositoryRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8',
   }).trim()
-  const exclusionReceipts = excludedPaths
+  const requestedExclusions = excludedPaths
     .map((path) => publicationCleanlinessExclusion(repositoryRoot, path))
     .filter(Boolean)
+  const exclusionReceipts = requestedExclusions.filter(
+    ({ rejected }) => !rejected,
+  )
   const exclusions = exclusionReceipts.map(({ pathspec }) => pathspec)
   const commit = execFileSync('git', ['rev-parse', 'HEAD'], {
     cwd: repositoryRoot,
@@ -871,6 +879,7 @@ export function publicationRepositoryForCurrentCheckout(excludedPaths = []) {
     commit,
     dirty:
       status.length > 0 ||
+      requestedExclusions.some(({ rejected }) => rejected) ||
       !exclusionReceipts.every(publicationCleanlinessExclusionIsCurrent),
   }
 }

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -803,7 +803,7 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
     isAbsolute(repositoryRelative)
   )
     return undefined
-  return `:(exclude,top)${repositoryRelative}`
+  return `:(exclude,top,literal)${repositoryRelative}`
 }
 
 export function publicationRepositoryForCurrentCheckout(excludedPaths = []) {

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
-import { existsSync, lstatSync, realpathSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync, statSync } from 'node:fs'
 import {
   lstat,
   mkdir,
@@ -746,20 +746,72 @@ export function publicationReceiptDigest(receipt) {
   return createHash('sha256').update(receipt).digest('hex')
 }
 
+function canonicalMacOSTemporaryPath(value) {
+  const candidate = resolve(value)
+  if (process.platform !== 'darwin') return candidate
+  for (const [aliasRoot, canonicalRoot] of [
+    ['/var', '/private/var'],
+    ['/tmp', '/private/tmp'],
+  ]) {
+    if (
+      candidate !== aliasRoot &&
+      !candidate.startsWith(`${aliasRoot}${sep}`)
+    )
+      continue
+    try {
+      const alias = lstatSync(aliasRoot)
+      if (
+        !alias.isSymbolicLink() ||
+        alias.uid !== 0 ||
+        realpathSync(aliasRoot) !== canonicalRoot
+      )
+        return candidate
+    } catch {
+      return candidate
+    }
+    return resolve(canonicalRoot, relative(aliasRoot, candidate))
+  }
+  return candidate
+}
+
+function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
+  const repositoryIdentity = canonicalMacOSTemporaryPath(repositoryRoot)
+  const candidate = resolve(excludedPath)
+  const candidateIdentity = canonicalMacOSTemporaryPath(candidate)
+  try {
+    // Only the root-owned macOS temporary aliases above may change a path's
+    // spelling. Any other symlink, missing target, or mount boundary fails
+    // closed and remains visible to `git status`.
+    if (
+      realpathSync(repositoryRoot) !== repositoryIdentity ||
+      realpathSync(candidate) !== candidateIdentity ||
+      !lstatSync(candidate).isDirectory() ||
+      statSync(repositoryIdentity).dev !== statSync(candidateIdentity).dev
+    )
+      return undefined
+  } catch {
+    return undefined
+  }
+  const repositoryRelative = relative(repositoryIdentity, candidateIdentity)
+    .split(sep)
+    .join('/')
+  if (
+    !repositoryRelative ||
+    repositoryRelative === '..' ||
+    repositoryRelative.startsWith('../') ||
+    isAbsolute(repositoryRelative)
+  )
+    return undefined
+  return `:(exclude,top)${repositoryRelative}`
+}
+
 export function publicationRepositoryForCurrentCheckout(excludedPaths = []) {
   const repositoryRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
     encoding: 'utf8',
   }).trim()
   const exclusions = excludedPaths
-    .map((path) => relative(repositoryRoot, resolve(path)).split(sep).join('/'))
-    .filter(
-      (path) =>
-        path &&
-        path !== '..' &&
-        !path.startsWith('../') &&
-        !isAbsolute(path),
-    )
-    .map((path) => `:(exclude,top)${path}`)
+    .map((path) => publicationCleanlinessExclusion(repositoryRoot, path))
+    .filter(Boolean)
   return {
     commit: execFileSync('git', ['rev-parse', 'HEAD'], {
       cwd: repositoryRoot,

--- a/tools/publication-build.mjs
+++ b/tools/publication-build.mjs
@@ -790,16 +790,16 @@ function publicationCleanlinessExclusion(repositoryRoot, excludedPath) {
     // Only the root-owned macOS temporary aliases above may change a path's
     // spelling. Any other symlink, missing target, or mount boundary fails
     // closed and remains visible to `git status`.
-    entry = lstatSync(candidate)
-    const privateMode = entry.mode & 0o777
+    entry = lstatSync(candidate, { bigint: true })
+    const privateMode = entry.mode & 0o777n
     const effectiveUserId = currentEffectiveUserId()
     if (
       realpathSync(repositoryRoot) !== repositoryIdentity ||
       realpathSync(candidate) !== candidateIdentity ||
       !entry.isDirectory() ||
-      statSync(repositoryIdentity).dev !== entry.dev ||
+      statSync(repositoryIdentity, { bigint: true }).dev !== entry.dev ||
       (effectiveUserId !== undefined &&
-        (entry.uid !== effectiveUserId || privateMode !== 0o700))
+        (entry.uid !== BigInt(effectiveUserId) || privateMode !== 0o700n))
     )
       return undefined
   } catch {
@@ -833,11 +833,12 @@ function publicationCleanlinessExclusionIsCurrent(exclusion) {
   try {
     if (realpathSync(exclusion.candidate) !== exclusion.candidateIdentity)
       return false
-    const entry = lstatSync(exclusion.candidate)
+    const entry = lstatSync(exclusion.candidate, { bigint: true })
     const effectiveUserId = currentEffectiveUserId()
     return (
       entry.isDirectory() &&
-      (effectiveUserId === undefined || entry.uid === effectiveUserId) &&
+      (effectiveUserId === undefined ||
+        entry.uid === BigInt(effectiveUserId)) &&
       entry.dev === exclusion.identity.dev &&
       entry.ino === exclusion.identity.ino &&
       entry.uid === exclusion.identity.uid &&

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1137,6 +1137,42 @@ describe('publication staging and publish helpers', () => {
       await rm(temporaryRoot, { recursive: true, force: true })
     }
   })
+
+  it('treats an owned staging path as a literal Git pathspec', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-literal-pathspec-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.publication-staging-*')
+      await mkdir(staging)
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      await writeFile(
+        resolve(temporaryRoot, '.publication-staging-unrelated.txt'),
+        'must remain visible\n',
+      )
+      process.chdir(temporaryRoot)
+
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
+    } finally {
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('publication output safety', () => {

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto'
 import { constants as fsConstants } from 'node:fs'
 import {
   access,
+  chmod,
   link,
   lstat,
   mkdir,
@@ -990,7 +991,7 @@ describe('publication staging and publish helpers', () => {
         cwd: temporaryRoot,
       })
       const staging = resolve(temporaryRoot, '.publication-staging-owned')
-      await mkdir(staging)
+      await mkdir(staging, { mode: 0o700 })
       await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
       process.chdir(nestedDirectory)
 
@@ -1049,7 +1050,7 @@ describe('publication staging and publish helpers', () => {
             cwd: temporaryRoot,
           })
           const staging = resolve(temporaryRoot, '.publication-staging-owned')
-          await mkdir(staging)
+          await mkdir(staging, { mode: 0o700 })
           await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
           process.chdir(temporaryRoot)
 
@@ -1123,7 +1124,7 @@ describe('publication staging and publish helpers', () => {
         cwd: temporaryRoot,
       })
       const staging = resolve(temporaryRoot, '.publication-staging-owned')
-      await mkdir(staging)
+      await mkdir(staging, { mode: 0o700 })
       await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
       process.chdir(temporaryRoot)
 
@@ -1157,7 +1158,7 @@ describe('publication staging and publish helpers', () => {
         cwd: temporaryRoot,
       })
       const staging = resolve(temporaryRoot, '.publication-staging-*')
-      await mkdir(staging)
+      await mkdir(staging, { mode: 0o700 })
       await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
       await writeFile(
         resolve(temporaryRoot, '.publication-staging-unrelated.txt'),
@@ -1171,6 +1172,106 @@ describe('publication staging and publish helpers', () => {
     } finally {
       process.chdir(previousDirectory)
       await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses a staging exclusion that is writable by other users', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-shared-exclusion-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.publication-staging-shared')
+      await mkdir(staging, { mode: 0o700 })
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      await chmod(staging, 0o777)
+      process.chdir(temporaryRoot)
+
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
+    } finally {
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('fails closed when an owned staging directory changes during status collection', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-identity-change-'),
+    )
+    const wrapperRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-git-wrapper-'),
+    )
+    const previousDirectory = process.cwd()
+    const previousPath = process.env.PATH
+    try {
+      const realGit = execFileSync('sh', ['-c', 'command -v git'], {
+        encoding: 'utf8',
+      }).trim()
+      execFileSync(realGit, ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync(realGit, ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync(realGit, ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync(realGit, ['add', '.'], { cwd: temporaryRoot })
+      execFileSync(realGit, ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.publication-staging-owned')
+      await mkdir(staging, { mode: 0o700 })
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      const wrapper = resolve(wrapperRoot, 'git')
+      await writeFile(
+        wrapper,
+        `#!/usr/bin/env node
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+const args = process.argv.slice(2)
+const staging = process.env.PUBLICATION_TEST_STAGING
+const held = process.env.PUBLICATION_TEST_HELD
+if (args[0] === 'status' && staging && held) {
+  renameSync(staging, held)
+  mkdirSync(staging, { mode: 0o700 })
+  writeFileSync(resolve(staging, 'replacement.txt'), 'must remain visible\\n')
+}
+const result = spawnSync(${JSON.stringify(realGit)}, args, { stdio: 'inherit' })
+process.exit(result.status ?? 1)
+`,
+      )
+      await chmod(wrapper, 0o700)
+      process.env.PATH = `${wrapperRoot}:${previousPath}`
+      process.env.PUBLICATION_TEST_STAGING = staging
+      process.env.PUBLICATION_TEST_HELD = resolve(wrapperRoot, 'held')
+      process.chdir(temporaryRoot)
+
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
+    } finally {
+      process.chdir(previousDirectory)
+      if (previousPath === undefined) delete process.env.PATH
+      else process.env.PATH = previousPath
+      delete process.env.PUBLICATION_TEST_STAGING
+      delete process.env.PUBLICATION_TEST_HELD
+      await rm(temporaryRoot, { recursive: true, force: true })
+      await rm(wrapperRoot, { recursive: true, force: true })
     }
   })
 })

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1255,6 +1255,84 @@ describe('publication staging and publish helpers', () => {
     }
   })
 
+  it('preserves full-width staging identities across status collection', async () => {
+    const originalChildProcess = await import('node:child_process')
+    const originalFs = await import('node:fs')
+    const repositoryRoot = '/Users/publication-cleanliness-bigint'
+    const staging = resolve(repositoryRoot, '.publication-staging-owned')
+    const owner = BigInt(process.geteuid?.() ?? process.getuid?.() ?? 0)
+    const originalIdentity = {
+      dev: 9_007_199_254_740_992n,
+      ino: 9_007_199_254_740_992n,
+    }
+    const replacementIdentity = {
+      dev: 9_007_199_254_740_993n,
+      ino: 9_007_199_254_740_993n,
+    }
+    const identityModes = []
+    let replaced = false
+
+    const stagingStats = (identity, bigint) => ({
+      dev: bigint ? identity.dev : Number(identity.dev),
+      ino: bigint ? identity.ino : Number(identity.ino),
+      uid: bigint ? owner : Number(owner),
+      gid: bigint ? 20n : 20,
+      mode: bigint ? 0o40700n : 0o40700,
+      isDirectory: () => true,
+    })
+
+    vi.resetModules()
+    vi.doMock('node:fs', () => ({
+      ...originalFs,
+      lstatSync: (path, options) => {
+        expect(resolve(path)).toBe(staging)
+        const bigint = options?.bigint === true
+        identityModes.push(bigint)
+        return stagingStats(
+          replaced ? replacementIdentity : originalIdentity,
+          bigint,
+        )
+      },
+      realpathSync: (path) => resolve(path),
+      statSync: (_path, options) => {
+        const bigint = options?.bigint === true
+        return {
+          dev: bigint
+            ? originalIdentity.dev
+            : Number(originalIdentity.dev),
+        }
+      },
+    }))
+    vi.doMock('node:child_process', () => ({
+      ...originalChildProcess,
+      execFileSync: (_command, args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--show-toplevel')
+          return `${repositoryRoot}\n`
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'fixture\n'
+        if (args[0] === 'status') {
+          replaced = true
+          return ''
+        }
+        throw new Error(`Unexpected Git invocation: ${args.join(' ')}`)
+      },
+    }))
+
+    try {
+      const { publicationRepositoryForCurrentCheckout: repositoryReceipt } =
+        await import('./publication-build.mjs')
+
+      expect(repositoryReceipt([staging])).toEqual({
+        commit: 'fixture',
+        dirty: true,
+      })
+      expect(identityModes).toEqual([true, true])
+    } finally {
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('node:fs')
+      vi.resetModules()
+    }
+  })
+
   it('fails closed when an owned staging directory changes during status collection', async () => {
     const temporaryRoot = await mkdtemp(
       resolve(tmpdir(), 'publication-cleanliness-identity-change-'),

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -43,6 +43,19 @@ import * as publicationBuildTools from './publication-build.mjs'
 
 const SENTINEL = 'sentinel-untouched\n'
 
+function macOSTemporaryAliasCases(processTemporaryDirectory) {
+  const aliases = [['/tmp', '/private/tmp']]
+  if (
+    processTemporaryDirectory === '/var' ||
+    processTemporaryDirectory.startsWith('/var/')
+  )
+    aliases.unshift([
+      processTemporaryDirectory,
+      `/private${processTemporaryDirectory}`,
+    ])
+  return aliases
+}
+
 function payloadBuildArgs(output) {
   return [
     '--adapter',
@@ -1021,10 +1034,15 @@ describe('publication staging and publish helpers', () => {
     'canonicalizes root-owned /var and /tmp aliases for the repository and staging root',
     async () => {
       const previousDirectory = process.cwd()
-      for (const [aliasRoot, canonicalRoot] of [
-        [tmpdir(), `/private${tmpdir()}`],
+      expect(macOSTemporaryAliasCases('/private/var/folders/custom')).toEqual([
         ['/tmp', '/private/tmp'],
-      ]) {
+      ])
+      expect(macOSTemporaryAliasCases('/Users/custom/tmp')).toEqual([
+        ['/tmp', '/private/tmp'],
+      ])
+      for (const [aliasRoot, canonicalRoot] of macOSTemporaryAliasCases(
+        tmpdir(),
+      )) {
         const temporaryRoot = await mkdtemp(
           resolve(aliasRoot, 'publication-cleanliness-macos-alias-'),
         )

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1208,6 +1208,43 @@ describe('publication staging and publish helpers', () => {
     }
   })
 
+  it('marks rejected repository-local ignored exclusions dirty', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-ignored-rejection-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, '.gitignore'), '.agent/evidence/\n')
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.agent/evidence')
+      await mkdir(staging, { recursive: true, mode: 0o700 })
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      process.chdir(temporaryRoot)
+
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        false,
+      )
+      await chmod(staging, 0o777)
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
+    } finally {
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
   it.runIf(
     typeof process.getuid === 'function' &&
       typeof process.geteuid === 'function',

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1010,6 +1010,92 @@ describe('publication staging and publish helpers', () => {
       await rm(temporaryRoot, { recursive: true, force: true })
     }
   })
+
+  it.runIf(process.platform === 'darwin')(
+    'canonicalizes root-owned /var and /tmp aliases for the repository and staging root',
+    async () => {
+      const previousDirectory = process.cwd()
+      for (const [aliasRoot, canonicalRoot] of [
+        [tmpdir(), `/private${tmpdir()}`],
+        ['/tmp', '/private/tmp'],
+      ]) {
+        const temporaryRoot = await mkdtemp(
+          resolve(aliasRoot, 'publication-cleanliness-macos-alias-'),
+        )
+        try {
+          expect(temporaryRoot.startsWith(`${aliasRoot}/`)).toBe(true)
+          expect(
+            execFileSync('python3', [
+              '-c',
+              'import os,sys; print(os.path.realpath(sys.argv[1]))',
+              temporaryRoot,
+            ], { encoding: 'utf8' }).trim().startsWith(`${canonicalRoot}/`),
+          ).toBe(true)
+          execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+          execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+            cwd: temporaryRoot,
+          })
+          execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+            cwd: temporaryRoot,
+          })
+          await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+          execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+          execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+            cwd: temporaryRoot,
+          })
+          const staging = resolve(temporaryRoot, '.publication-staging-owned')
+          await mkdir(staging)
+          await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+          process.chdir(temporaryRoot)
+
+          expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+            false,
+          )
+        } finally {
+          process.chdir(previousDirectory)
+          await rm(temporaryRoot, { recursive: true, force: true })
+        }
+      }
+    },
+  )
+
+  it('does not let a repository symlink masquerade as an owned staging root', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-symlink-exclusion-'),
+    )
+    const externalRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-external-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const stagingLink = resolve(
+        temporaryRoot,
+        '.publication-staging-attacker-link',
+      )
+      await symlink(externalRoot, stagingLink, 'dir')
+      process.chdir(temporaryRoot)
+
+      expect(
+        publicationRepositoryForCurrentCheckout([stagingLink]).dirty,
+      ).toBe(true)
+    } finally {
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
+      await rm(externalRoot, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('publication output safety', () => {

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1208,6 +1208,53 @@ describe('publication staging and publish helpers', () => {
     }
   })
 
+  it.runIf(
+    typeof process.getuid === 'function' &&
+      typeof process.geteuid === 'function',
+  )('binds staging ownership to the effective user ID', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-effective-owner-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.publication-staging-owned')
+      await mkdir(staging, { mode: 0o700 })
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      const owner = (await stat(staging)).uid
+      process.chdir(temporaryRoot)
+
+      const realUid = vi.spyOn(process, 'getuid').mockReturnValue(owner + 1)
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        false,
+      )
+      realUid.mockRestore()
+
+      const effectiveUid = vi
+        .spyOn(process, 'geteuid')
+        .mockReturnValue(owner + 1)
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
+      effectiveUid.mockRestore()
+    } finally {
+      vi.restoreAllMocks()
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  })
+
   it('fails closed when an owned staging directory changes during status collection', async () => {
     const temporaryRoot = await mkdtemp(
       resolve(tmpdir(), 'publication-cleanliness-identity-change-'),

--- a/tools/publication-build.test.mjs
+++ b/tools/publication-build.test.mjs
@@ -1005,6 +1005,11 @@ describe('publication staging and publish helpers', () => {
       expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
         true,
       )
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      await writeFile(resolve(temporaryRoot, 'unrelated-output.txt'), 'dirty\n')
+      expect(publicationRepositoryForCurrentCheckout([staging]).dirty).toBe(
+        true,
+      )
     } finally {
       process.chdir(previousDirectory)
       await rm(temporaryRoot, { recursive: true, force: true })
@@ -1094,6 +1099,42 @@ describe('publication staging and publish helpers', () => {
       process.chdir(previousDirectory)
       await rm(temporaryRoot, { recursive: true, force: true })
       await rm(externalRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not normalize traversal into an owned staging exclusion', async () => {
+    const temporaryRoot = await mkdtemp(
+      resolve(tmpdir(), 'publication-cleanliness-traversal-exclusion-'),
+    )
+    const previousDirectory = process.cwd()
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: temporaryRoot })
+      execFileSync('git', ['config', 'user.email', 'tests@example.invalid'], {
+        cwd: temporaryRoot,
+      })
+      execFileSync('git', ['config', 'user.name', 'Publication Tests'], {
+        cwd: temporaryRoot,
+      })
+      await writeFile(resolve(temporaryRoot, 'tracked.txt'), 'tracked\n')
+      const nestedDirectory = resolve(temporaryRoot, 'nested')
+      await mkdir(nestedDirectory)
+      execFileSync('git', ['add', '.'], { cwd: temporaryRoot })
+      execFileSync('git', ['commit', '--quiet', '-m', 'fixture'], {
+        cwd: temporaryRoot,
+      })
+      const staging = resolve(temporaryRoot, '.publication-staging-owned')
+      await mkdir(staging)
+      await writeFile(resolve(staging, 'candidate.txt'), 'candidate\n')
+      process.chdir(temporaryRoot)
+
+      expect(
+        publicationRepositoryForCurrentCheckout([
+          `${nestedDirectory}/../.publication-staging-owned`,
+        ]).dirty,
+      ).toBe(true)
+    } finally {
+      process.chdir(previousDirectory)
+      await rm(temporaryRoot, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
Fixes #172

## What changed
- canonicalize only verified root-owned macOS /var and /tmp aliases before repository-relative comparisons
- reject missing targets, arbitrary symlinks, traversal, cross-device roots, and paths outside the checkout from cleanliness exclusions
- preserve dirty receipts for unrelated tracked and untracked repository output

## Validation
- RED reproduced on current main for both macOS aliases and traversal
- focused alias, symlink-safety, traversal, and dirty-output tests pass
- full npm test: 2,873 passed, 3 skipped, 0 failed
- npm run build passed, including EPUBCheck and the four-profile publication matrix
- scripts/agent-evidence passed on exact head 21f8fcfe8adebfe97881b44c62cb640f0cd4c872
- diff check and secret scan passed

Local EPUBCheck requires the already-installed Homebrew JDK on PATH; the initial no-JDK run was classified as an environment-only failure and the exact-head rerun passed.