### PR TITLE
Repair PDF furniture findings from #132

### DIFF
--- a/src/research/pdf-regions.test.ts
+++ b/src/research/pdf-regions.test.ts
@@ -4,6 +4,8 @@ import { buildEpub, buildReadableEpub, inspectEpub } from './epub'
 import type { PdfPageAnalysis, PdfSourceRun } from './import-types'
 import { reconstructPageAnalyses } from './pdf-layout'
 import {
+  classifyPdfFurniture,
+  digitValue,
   evaluateReadingOrder,
   hasAcceptedCycle,
   noteLabelFromText,
@@ -6854,6 +6856,237 @@ describe('deterministic scholarly page regions', () => {
       ),
     ).toBe(true)
     expect(first.regions).toEqual(second.regions)
+  })
+
+  it('splits a reviewable margin run from an adjacent first-page title run', async () => {
+    const result = await reconstruct([
+      page(1, [
+        run(1, 'Submitted for bounded source review', 0.1, 0.03, 0.3, 8),
+        run(1, 'Synthetic title block', 0.41, 0.03, 0.16, 14),
+        run(
+          1,
+          'Canonical body prose establishes the page font.',
+          0.12,
+          0.2,
+          0.72,
+        ),
+        run(
+          1,
+          'A second body line stabilizes the source geometry.',
+          0.12,
+          0.24,
+          0.72,
+        ),
+      ]),
+    ])
+
+    expect(
+      result.regions.find(
+        (region) => region.text === 'Submitted for bounded source review',
+      ),
+    ).toMatchObject({
+      furnitureReview: { reason: 'single-occurrence-margin' },
+      includedInReadingOrder: true,
+    })
+    expect(
+      result.regions.find((region) => region.text === 'Synthetic title block'),
+    ).toMatchObject({ includedInReadingOrder: true })
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'FURNITURE_REVIEW_REQUIRED',
+          severity: 'error',
+        }),
+      ]),
+    )
+  })
+
+  it('keeps short unproven margin lines on the bounded header path', () => {
+    const result = reconstructPageRegions([
+      page(1, [
+        run(
+          1,
+          'Canonical body prose establishes the page font.',
+          0.12,
+          0.2,
+          0.72,
+        ),
+        run(
+          1,
+          'A second body line stabilizes the source geometry.',
+          0.12,
+          0.24,
+          0.72,
+        ),
+        run(1, 'DRAFT', 0.2, 0.03, 0.08, 8.5),
+      ]),
+    ])
+
+    expect(
+      result.regions.find((region) => region.text === 'DRAFT'),
+    ).toMatchObject({
+      kind: 'header',
+      confidence: 0.78,
+      includedInReadingOrder: false,
+    })
+  })
+
+  it('does not attach furniture evidence to protected repeated-margin headings', () => {
+    const prefixForms = [
+      (ordinal: number) => `A.${ordinal}.`,
+      (ordinal: number) => `A.1.${ordinal}`,
+    ]
+
+    for (const prefix of prefixForms) {
+      const headingPage = (pageNumber: number, ordinal: number) =>
+        page(pageNumber, [
+          {
+            ...run(pageNumber, prefix(ordinal), 0.1, 0.08, 0.05, 14),
+            fontName: 'Synthetic-Bold',
+            bold: true,
+          },
+          {
+            ...run(
+              pageNumber,
+              `Repeated Section ${ordinal}`,
+              0.155,
+              0.08,
+              0.5,
+              14,
+            ),
+            fontName: 'Synthetic-Bold',
+            bold: true,
+          },
+          run(
+            pageNumber,
+            `Canonical body prose on page ${pageNumber}.`,
+            0.12,
+            0.2,
+            0.72,
+          ),
+        ])
+      const result = reconstructPageRegions([
+        page(1, [
+          {
+            ...run(1, 'A Parent Heading', 0.12, 0.04, 0.3, 14),
+            fontName: 'Synthetic-Bold',
+            bold: true,
+          },
+          run(1, 'Canonical body prose on page 1.', 0.12, 0.2, 0.72),
+        ]),
+        headingPage(2, 1),
+        headingPage(3, 2),
+        headingPage(4, 3),
+      ])
+
+      const headings = result.regions.filter((region) =>
+        region.text.includes('Repeated Section'),
+      )
+      expect(headings).toHaveLength(3)
+      expect(
+        headings.every(
+          (region) =>
+            region.kind === 'body' &&
+            region.furniture === undefined &&
+            region.includedInReadingOrder,
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it('protects a narrow first-page title-block run while later repeats remain furniture', () => {
+    const titlePage = (pageNumber: number) =>
+      page(pageNumber, [
+        run(pageNumber, 'Ada Lovelace', 0.12, 0.09, 0.22, 9),
+        run(
+          pageNumber,
+          `Canonical body prose on page ${pageNumber}.`,
+          0.12,
+          0.2,
+          0.72,
+        ),
+        run(
+          pageNumber,
+          `A second body line stabilizes page ${pageNumber}.`,
+          0.12,
+          0.24,
+          0.72,
+        ),
+      ])
+    const result = reconstructPageRegions([
+      titlePage(1),
+      titlePage(2),
+      titlePage(3),
+    ])
+    const titleRegions = result.regions.filter(
+      (region) => region.text === 'Ada Lovelace',
+    )
+
+    expect(titleRegions).toHaveLength(3)
+    expect(titleRegions[0]).toMatchObject({
+      kind: 'body',
+      includedInReadingOrder: true,
+    })
+    expect(titleRegions[0].furniture).toBeUndefined()
+    expect(
+      titleRegions
+        .slice(1)
+        .every(
+          (region) =>
+            region.kind === 'header' &&
+            region.includedInReadingOrder === false &&
+            region.furniture?.classification === 'repeated-text',
+        ),
+    ).toBe(true)
+  })
+
+  it('recognizes every Unicode decimal digit supported by the runtime', () => {
+    const missing: string[] = []
+    for (let codePoint = 0; codePoint <= 0x10ffff; codePoint += 1) {
+      const character = String.fromCodePoint(codePoint)
+      if (!/^\p{Nd}$/u.test(character)) continue
+      if (digitValue(character) === null) {
+        missing.push(`U+${codePoint.toString(16).toUpperCase()}`)
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+
+  it('classifies a newly assigned decimal digit range as incrementing folios', () => {
+    const folio = (index: number) => String.fromCodePoint(0x10d40 + index)
+    const result = reconstructPageRegions(
+      [1, 2, 3].map((pageNumber, index) =>
+        page(pageNumber, [
+          run(
+            pageNumber,
+            `Canonical body prose on page ${pageNumber}.`,
+            0.12,
+            0.2,
+            0.72,
+          ),
+          run(pageNumber, folio(index), 0.48, 0.95, 0.03, 8),
+        ]),
+      ),
+    )
+
+    expect(
+      result.regions
+        .filter((region) =>
+          [folio(0), folio(1), folio(2)].includes(region.text),
+        )
+        .map((region) => ({
+          text: region.text,
+          kind: region.kind,
+          classification: region.furniture?.classification,
+        })),
+    ).toEqual(
+      [folio(0), folio(1), folio(2)].map((text) => ({
+        text,
+        kind: 'page-number',
+        classification: 'incrementing-numeral',
+      })),
+    )
   })
 
   it('keeps raised Unicode note markers linked while margin numerals remain furniture', async () => {

--- a/src/research/pdf-regions.ts
+++ b/src/research/pdf-regions.ts
@@ -351,7 +351,7 @@ function furnitureRunKey(run: PdfSourceRun) {
   ].join('\u001f')
 }
 
-function digitValue(character: string) {
+export function digitValue(character: string) {
   const codePoint = character.codePointAt(0) ?? -1
   const ranges = [
     [0x30, 0x39],
@@ -392,6 +392,7 @@ function digitValue(character: string) {
     [0xabf0, 0xabf9],
     [0x104a0, 0x104a9],
     [0x10d30, 0x10d39],
+    [0x10d40, 0x10d49],
     [0x11066, 0x1106f],
     [0x110f0, 0x110f9],
     [0x11136, 0x1113f],
@@ -401,18 +402,28 @@ function digitValue(character: string) {
     [0x114d0, 0x114d9],
     [0x11650, 0x11659],
     [0x116c0, 0x116c9],
+    [0x116d0, 0x116d9],
+    [0x116da, 0x116e3],
     [0x11730, 0x11739],
     [0x118e0, 0x118e9],
     [0x11950, 0x11959],
+    [0x11bf0, 0x11bf9],
     [0x11c50, 0x11c59],
     [0x11d50, 0x11d59],
     [0x11da0, 0x11da9],
+    [0x11de0, 0x11de9],
+    [0x11f50, 0x11f59],
+    [0x16130, 0x16139],
     [0x16a60, 0x16a69],
     [0x16ac0, 0x16ac9],
     [0x16b50, 0x16b59],
+    [0x16d70, 0x16d79],
+    [0x1ccf0, 0x1ccf9],
     [0x1d7ce, 0x1d7ff],
     [0x1e140, 0x1e149],
     [0x1e2f0, 0x1e2f9],
+    [0x1e4f0, 0x1e4f9],
+    [0x1e5f1, 0x1e5fa],
     [0x1e950, 0x1e959],
     [0x1fbf0, 0x1fbf9],
     [0xff10, 0xff19],
@@ -482,7 +493,9 @@ function firstPageTitleBlockRun(run: PdfSourceRun, bodyFontSize: number) {
   if (run.y < 0.08 && run.fontSize < bodyFontSize * 1.2 && run.width < 0.55) {
     return false
   }
-  return run.width >= 0.28 || run.fontSize >= bodyFontSize * 0.92
+  return (
+    run.y >= 0.08 || run.width >= 0.28 || run.fontSize >= bodyFontSize * 0.92
+  )
 }
 
 function furniturePatternProven(occurrences: FurnitureRunOccurrence[]) {
@@ -1825,6 +1838,7 @@ function splitRepeatedMarginSourceRuns(
   repeated: ReadonlySet<string>,
   protectedLines: ReadonlySet<PdfTextLine> = new Set(),
   furnitureByRunKey: ReadonlyMap<string, PdfFurnitureEvidence> = new Map(),
+  furnitureReviewByRunKey: ReadonlyMap<string, PdfFurnitureReview> = new Map(),
 ) {
   return lines.flatMap((line) => {
     if (
@@ -1839,6 +1853,7 @@ function splitRepeatedMarginSourceRuns(
     const repeatedIndexes = orderedRuns.flatMap((run, index) =>
       marginBand(run) &&
       (furnitureByRunKey.has(furnitureRunKey(run)) ||
+        furnitureReviewByRunKey.has(furnitureRunKey(run)) ||
         repeated.has(normalizeMarginText(run.text)))
         ? [index]
         : [],
@@ -5836,6 +5851,13 @@ export function reconstructPageRegions(
   )
   const protectedRepeatedMarginHeadings =
     sourceProvenRepeatedMarginHeadingLines(groupedLines, repeated)
+  const protectedRepeatedMarginHeadingRunKeys = new Set(
+    [...protectedRepeatedMarginHeadings].flatMap((line) =>
+      line.runs
+        .filter((run) => run.text.trim())
+        .map((run) => furnitureRunKey(run)),
+    ),
+  )
   const rawLines = groupedLines.map((lines) =>
     splitDetachedMathExtensionProseRuns(
       splitSourceStackedInlineFormulaLines(
@@ -5844,6 +5866,7 @@ export function reconstructPageRegions(
           repeated,
           protectedRepeatedMarginHeadings,
           furnitureAssessment.byRunKey,
+          furnitureAssessment.reviewByRunKey,
         ),
       ),
     ),
@@ -5857,6 +5880,13 @@ export function reconstructPageRegions(
   const lineFurniture = (line: PdfTextLine) => {
     const visibleRuns = line.runs.filter((run) => run.text.trim())
     if (visibleRuns.length === 0) return undefined
+    if (
+      visibleRuns.every((run) =>
+        protectedRepeatedMarginHeadingRunKeys.has(furnitureRunKey(run)),
+      )
+    ) {
+      return undefined
+    }
     const evidences = visibleRuns.flatMap((run) => {
       const evidence = furnitureAssessment.byRunKey.get(furnitureRunKey(run))
       return evidence ? [evidence] : []
@@ -5919,6 +5949,9 @@ export function reconstructPageRegions(
         )
         const { label, explicitFootnote, renderedFootnote } = noteEvidence
         const inlineStackedFragment = inlineStackedFragmentParts(line)
+        const firstPageTitleBlockLine = line.runs.some((run) =>
+          firstPageTitleBlockRun(run, fontSize),
+        )
         let kind: PdfRegionKind = 'body'
         let confidence = 0.9
         if (inEndnotes && label !== null) {
@@ -5957,13 +5990,15 @@ export function reconstructPageRegions(
                   : 'footer'
           confidence = 0.99
         } else if (
+          !firstPageTitleBlockLine &&
           marginBand(line) &&
           repeated.has(normalizeMarginText(line.text))
         ) {
           kind = line.y < 0.5 ? 'header' : 'footer'
           confidence = 0.99
         } else if (
-          furniture &&
+          !furnitureReview &&
+          !firstPageTitleBlockLine &&
           (line.y <= 0.08 || line.y + line.height >= 0.92) &&
           line.fontSize <= fontSize * 0.9
         ) {


### PR DESCRIPTION
Fixes #133

## What changed

- harden PDF furniture-region detection and filtering across the remaining post-#132 review cases
- add regression coverage for the repaired header/footer and page-region behavior

## Why

The PDF-to-EPUB pipeline could misclassify repeated page furniture, degrading the reconstructed document before EPUB generation. This completes findings 1, 2, 3, 5, and 6; finding 4 was already resolved by #168.

## Validation

- focused seam: 590/590 passed
- full suite: 2,995 passed, 3 skipped across 139 files
- production build, publication matrix, accessibility, EPUBCheck, and PDF checks passed
- staged secret scans passed
- exact-head evidence manifest passed with `dirty=false`, no caveats, and no required failures