### PR TITLE
Fix extraction bake-off verification regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pdf:benchmark:extraction": "node tools/pdf-extraction-eval.mjs",
     "pdf:ocr:benchmark": "node tools/pdf-ocr-engine-benchmark.mjs",
     "pdf:benchmark:readiness": "node tools/pdf-benchmark-readiness.mjs",
-    "pdf:extraction:bakeoff": "node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test",
+    "pdf:extraction:bakeoff": "node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test --score-ledger .agent/evidence/pdf-extraction-bakeoff-score-ledger.json",
     "pdf:private-decisions:compose": "node tools/pdf-private-decision-compose.mjs",
     "pdf:private-fidelity": "node tools/pdf-private-fidelity.mjs",
     "pdf:review-sink": "node tools/pdf-review-langfuse-bridge.mjs",

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -4,7 +4,7 @@ import {
   createExtractionArchitectureDecision,
   EXTRACTION_BAKEOFF_SCHEMA_VERSION,
   EXTRACTION_BAKEOFF_STRATA,
-  runExtractionBakeoff,
+  runExtractionBakeoff as runExtractionBakeoffWithLedger,
   validateExtractionBakeoffCorpus,
   type ExtractionBakeoffArm,
   type ExtractionBakeoffCorpus,
@@ -17,6 +17,20 @@ import type {
 
 const hashA = 'a'.repeat(64)
 const hashB = 'b'.repeat(64)
+
+type BakeoffOptions = Omit<
+  Parameters<typeof runExtractionBakeoffWithLedger>[0],
+  'scoredHeldOutKeys'
+> & {
+  scoredHeldOutKeys?: Set<string>
+}
+
+function runExtractionBakeoff(options: BakeoffOptions) {
+  return runExtractionBakeoffWithLedger({
+    ...options,
+    scoredHeldOutKeys: options.scoredHeldOutKeys ?? new Set<string>(),
+  })
+}
 
 function context(
   id: string,
@@ -537,6 +551,45 @@ describe('extraction architecture bake-off', () => {
     ).toBe(true)
   })
 
+  it.each([
+    ['null result', () => null],
+    [
+      'missing metrics',
+      (input: StructuredExtractionContext) => ({ proposal: proposal(input) }),
+    ],
+    [
+      'invalid metrics',
+      (input: StructuredExtractionContext) => ({
+        proposal: proposal(input),
+        metrics: { latencyMs: Number.NaN, costUsd: 0.02 },
+      }),
+    ],
+  ])(
+    'isolates an adapter %s instead of aborting the whole bake-off',
+    async (_name, invalidResult) => {
+      const invalid = arm('llm-authored')
+      invalid.run = async (input) =>
+        input.documentId === 'heldout-one'
+          ? (invalidResult(input) as never)
+          : {
+              proposal: proposal(input),
+              metrics: { latencyMs: 12, costUsd: 0.02 },
+            }
+
+      const report = await runExtractionBakeoff({
+        corpus: corpus(),
+        arms: [arm('geometric-baseline'), invalid, arm('llm-grounded')],
+      })
+      const failed = report.arms['llm-authored'].documents.find(
+        ({ documentId }) => documentId === 'heldout-one',
+      )!
+
+      expect(failed.status).toBe('failed')
+      expect(failed.outputHash).toBeNull()
+      expect(failed.verification.issueCodes).toContain('adapter-failure')
+    },
+  )
+
   it('scopes disagreement detection to the stratum the rows describe', async () => {
     // Comparing whole-document output hashes marks a document as a
     // disagreement for every stratum it appears in, so the report can no
@@ -602,26 +655,107 @@ describe('extraction architecture bake-off', () => {
     ).toEqual(['sectioning'])
   })
 
+  it('detects stratum-local structure changes even when scores are equal', async () => {
+    const inputCorpus = corpus()
+    for (const document of inputCorpus.heldOut) {
+      document.context.sourceRuns.push(
+        {
+          id: `${document.id}-table-anchor`,
+          text: 'Measure',
+          page: 1,
+          order: 3,
+        },
+        {
+          id: `${document.id}-table-cell`,
+          text: '42',
+          page: 1,
+          order: 4,
+        },
+      )
+      const tableCase = document.cases.find(
+        ({ stratum }) => stratum === 'tables',
+      )!
+      tableCase.expectedNodeTypes = ['title', 'paragraph', 'table']
+      tableCase.expectedSourceRunIds = [
+        `${document.id}-title`,
+        `${document.id}-body`,
+        `${document.id}-table-anchor`,
+        `${document.id}-table-cell`,
+      ]
+    }
+    const withScope =
+      (headerScope: 'column' | 'none') =>
+      (input: StructuredExtractionContext) => {
+        const output = proposal(input)
+        output.nodes.push({
+          id: `${input.documentId}-table`,
+          type: 'table',
+          sourceRunIds: [`${input.documentId}-table-anchor`],
+          table: {
+            rows: [
+              {
+                cells: [
+                  {
+                    sourceRunIds: [`${input.documentId}-table-cell`],
+                    headerScope,
+                  },
+                ],
+              },
+            ],
+          },
+        })
+        return output
+      }
+
+    const report = await runExtractionBakeoff({
+      corpus: inputCorpus,
+      arms: [
+        arm('geometric-baseline', withScope('column')),
+        arm('llm-authored', withScope('none')),
+        arm('llm-grounded', withScope('column')),
+      ],
+    })
+
+    expect(
+      report.disagreements
+        .filter(({ layout }) => layout === 'one-column')
+        .map(({ stratum }) => stratum),
+    ).toEqual(['tables'])
+  })
+
   it('does not certify score-once when the same identity is rerun', async () => {
-    // The guard lives in a function-local set, so a second call rescores every
-    // held-out document and still claims compliance.
+    // Receipts for one held-out identity must reject a replay without
+    // colliding with a genuinely changed held-out split that reuses doc IDs.
     const arms = () => [
       arm('geometric-baseline'),
       arm('llm-authored'),
       arm('llm-grounded'),
     ]
     const inputCorpus = corpus()
+    const ledger = new Set<string>()
 
     const first = await runExtractionBakeoff({
       corpus: inputCorpus,
       arms: arms(),
+      scoredHeldOutKeys: ledger,
     })
     expect(first.heldOutScoredOnce).toBe(true)
 
+    const changed = corpus()
+    changed.heldOut[0]!.cases[0]!.expectedNodeTypes = ['paragraph']
     await expect(
       runExtractionBakeoff({
-        corpus: inputCorpus,
+        corpus: changed,
         arms: arms(),
+        scoredHeldOutKeys: ledger,
+      }),
+    ).resolves.toMatchObject({ heldOutScoredOnce: true })
+
+    await expect(
+      runExtractionBakeoff({
+        corpus: structuredClone(inputCorpus),
+        arms: arms(),
+        scoredHeldOutKeys: ledger,
       }),
     ).rejects.toThrow('HELD_OUT_SCORED_MORE_THAN_ONCE')
   })

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -590,6 +590,37 @@ describe('extraction architecture bake-off', () => {
     },
   )
 
+  it('isolates a cyclic adapter proposal instead of aborting the bake-off', async () => {
+    const cyclic = arm('llm-authored')
+    const cyclicProposal: Record<string, unknown> = {
+      schemaVersion: '1.0.0',
+      nodes: [],
+    }
+    cyclicProposal.self = cyclicProposal
+    cyclic.run = async () => ({
+      proposal: cyclicProposal as never,
+      metrics: { latencyMs: 12, costUsd: 0.02 },
+    })
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), cyclic, arm('llm-grounded')],
+    })
+
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status, verification }) =>
+          status === 'failed' &&
+          verification.issueCodes.includes('adapter-failure'),
+      ),
+    ).toBe(true)
+    expect(
+      report.arms['llm-grounded'].documents.every(
+        ({ status }) => status === 'passed',
+      ),
+    ).toBe(true)
+  })
+
   it('scopes disagreement detection to the stratum the rows describe', async () => {
     // Comparing whole-document output hashes marks a document as a
     // disagreement for every stratum it appears in, so the report can no

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   assertNoHeldOutContamination,
   createExtractionArchitectureDecision,
+  EXTRACTION_BAKEOFF_SCHEMA_VERSION,
   EXTRACTION_BAKEOFF_STRATA,
   runExtractionBakeoff,
+  validateExtractionBakeoffCorpus,
   type ExtractionBakeoffArm,
   type ExtractionBakeoffCorpus,
 } from './extraction-bakeoff'
@@ -160,10 +162,15 @@ describe('extraction architecture bake-off', () => {
 
   it('disqualifies a byte-unstable candidate rather than publishing the first result', async () => {
     let invocation = 0
+    // Vary an identifier rather than the node order: reversing the nodes now
+    // fails verification outright on the cross-node source-order check, which
+    // reports `failed` and would no longer exercise byte-instability at all.
     const unstable = arm('llm-authored', (input) => {
       invocation += 1
       const output = proposal(input)
-      if (invocation % 2 === 0) output.nodes.reverse()
+      if (invocation % 2 === 0) {
+        for (const node of output.nodes) node.id = `${node.id}-alt`
+      }
       return output
     })
     const report = await runExtractionBakeoff({
@@ -331,5 +338,291 @@ describe('extraction architecture bake-off', () => {
 
     expect(decision.owner).toBe('pending')
     expect(decision.humanDecisionRequired).toBe(true)
+  })
+
+  it('rejects a document whose split disagrees with the array holding it', () => {
+    // A development-tagged entry under `heldOut` still contributes to the
+    // held-out identity and layout checks but bypasses the contamination
+    // guards and drops out of held-out comparisons.
+    const mislabelled = corpus()
+    const stowaway = context('heldout-two', 'development', 'two-column')
+    mislabelled.heldOut[1] = {
+      id: 'heldout-two',
+      split: 'development',
+      layout: 'two-column',
+      context: stowaway,
+      cases: mislabelled.heldOut[1]!.cases,
+    }
+
+    expect(() => validateExtractionBakeoffCorpus(mislabelled)).toThrow(
+      'INVALID_EXTRACTION_BAKEOFF_DOCUMENT:heldout-two',
+    )
+  })
+
+  it('rejects case labels that do not belong to the document context', () => {
+    for (const mutate of [
+      (input: ExtractionBakeoffCorpus) => {
+        input.heldOut[0]!.cases[0]!.expectedSourceRunIds = ['missing-run']
+      },
+      (input: ExtractionBakeoffCorpus) => {
+        input.heldOut[0]!.cases[0]!.expectedAssetIds = ['missing-asset']
+      },
+      (input: ExtractionBakeoffCorpus) => {
+        input.heldOut[0]!.cases[0]!.expectedExcludedBoilerplateRunIds = [
+          'missing-boilerplate',
+        ]
+      },
+    ]) {
+      const invalid = corpus()
+      mutate(invalid)
+      expect(() => validateExtractionBakeoffCorpus(invalid)).toThrow(
+        'INVALID_EXTRACTION_BAKEOFF_CASE',
+      )
+    }
+  })
+
+  it('scores the expected heading levels a case declares', async () => {
+    // A candidate that emits every heading at the wrong depth publishes a
+    // broken hierarchy; without reading the labels it scores identically to
+    // one that gets the hierarchy right.
+    const levelled = corpus()
+    for (const document of levelled.heldOut) {
+      document.context.sourceRuns.push({
+        id: `${document.id}-heading`,
+        text: 'Section',
+        page: 1,
+        order: 3,
+      })
+      for (const caseInput of document.cases) {
+        caseInput.expectedNodeTypes = ['title', 'paragraph', 'heading']
+        caseInput.expectedHeadingLevels = [2]
+        caseInput.expectedSourceRunIds = [
+          `${document.id}-title`,
+          `${document.id}-body`,
+          `${document.id}-heading`,
+        ]
+      }
+    }
+    const withLevel =
+      (level: number) => (input: StructuredExtractionContext) => {
+        const output = proposal(input)
+        output.nodes.push({
+          id: `${input.documentId}-heading`,
+          type: 'heading',
+          level,
+          sourceRunIds: [`${input.documentId}-heading`],
+          text: 'Section',
+        })
+        return output
+      }
+
+    const report = await runExtractionBakeoff({
+      corpus: levelled,
+      arms: [
+        arm('geometric-baseline', withLevel(2)),
+        arm('llm-authored', withLevel(5)),
+        arm('llm-grounded', withLevel(2)),
+      ],
+    })
+    const row = report.comparison.find(
+      ({ stratum, layout }) =>
+        stratum === 'sectioning' && layout === 'one-column',
+    )!
+
+    expect(row.scores['llm-authored']).toBeLessThan(
+      row.scores['geometric-baseline']!,
+    )
+  })
+
+  it('refuses to derive a decision from a report whose hash no longer binds it', () => {
+    const report = {
+      schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
+      corpusId: 'synthetic-bakeoff',
+      heldOutIdentitySha256: hashA,
+      candidateIdentities: {},
+      heldOutScoredOnce: true,
+      arms: {},
+      comparison: [
+        {
+          stratum: 'sectioning',
+          layout: 'one-column',
+          scores: {
+            'geometric-baseline': 0.1,
+            'llm-authored': 1,
+            'llm-grounded': 0.1,
+          },
+          winner: 'llm-authored',
+          disagreementDocumentIds: [],
+        },
+      ],
+      disagreements: [],
+      reportSha256: hashB,
+    } as unknown as Parameters<
+      typeof createExtractionArchitectureDecision
+    >[0]['report']
+
+    expect(() => createExtractionArchitectureDecision({ report })).toThrow(
+      'EXTRACTION_BAKEOFF_REPORT_HASH_MISMATCH',
+    )
+  })
+
+  it('derives per-page metrics from the document, not from the arm', async () => {
+    // An arm that reports an enormous page count drives its own latency and
+    // cost per page toward zero and wins the operating-profile comparison.
+    const inflated = arm('llm-authored')
+    inflated.run = (input) => ({
+      proposal: proposal(input),
+      metrics: { latencyMs: 12, costUsd: 0.02, pageCount: 100_000 },
+    })
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), inflated, arm('llm-grounded')],
+    })
+
+    expect(report.arms['llm-authored'].documents[0]!.latencyMsPerPage).toBe(
+      report.arms['llm-grounded'].documents[0]!.latencyMsPerPage,
+    )
+  })
+
+  it('stops invoking a contaminated arm for the rest of the held-out split', async () => {
+    // Advancing only to the next document keeps handing held-out papers to an
+    // arm already known to be leaking, widening the leak it was disqualified
+    // for.
+    const seen: string[] = []
+    const leaking = arm('llm-authored', (input) => {
+      seen.push(input.documentId)
+      return { ...proposal(input), goldLabel: ['title'] } as never
+    })
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), leaking, arm('llm-grounded')],
+    })
+
+    expect(report.arms['llm-authored'].disqualified).toBe(true)
+    expect(new Set(seen).size).toBe(1)
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status, outputHash }) =>
+          status === 'disqualified' && outputHash === null,
+      ),
+    ).toBe(true)
+  })
+
+  it('records an adapter failure instead of aborting the whole bake-off', async () => {
+    // A provider error on one document currently rejects the entire run, so no
+    // side-by-side report exists even though the other arms are healthy.
+    const flaky = arm('llm-authored', (input) => {
+      if (input.documentId === 'heldout-one')
+        throw new Error('provider timed out')
+      return proposal(input)
+    })
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), flaky, arm('llm-grounded')],
+    })
+    const failed = report.arms['llm-authored'].documents.find(
+      ({ documentId }) => documentId === 'heldout-one',
+    )!
+
+    expect(failed.status).toBe('failed')
+    expect(failed.outputHash).toBeNull()
+    expect(failed.verification.issueCodes).toContain('adapter-failure')
+    expect(
+      report.arms['llm-grounded'].documents.every(
+        ({ status }) => status === 'passed',
+      ),
+    ).toBe(true)
+  })
+
+  it('scopes disagreement detection to the stratum the rows describe', async () => {
+    // Comparing whole-document output hashes marks a document as a
+    // disagreement for every stratum it appears in, so the report can no
+    // longer say where the architectures actually diverge.
+    const inputCorpus = corpus()
+    for (const document of inputCorpus.heldOut) {
+      document.context.sourceRuns.push({
+        id: `${document.id}-heading`,
+        text: 'Section',
+        page: 1,
+        order: 3,
+      })
+      const sectioning = document.cases.find(
+        ({ stratum }) => stratum === 'sectioning',
+      )!
+      sectioning.expectedNodeTypes = ['title', 'paragraph', 'heading']
+      sectioning.expectedHeadingLevels = [2]
+      sectioning.expectedSourceRunIds = [
+        `${document.id}-title`,
+        `${document.id}-body`,
+        `${document.id}-heading`,
+      ]
+    }
+    const withHeading =
+      (level: number) => (input: StructuredExtractionContext) => {
+        const output = proposal(input)
+        output.nodes.push({
+          id: `${input.documentId}-heading`,
+          type: 'heading',
+          level,
+          sourceRunIds: [`${input.documentId}-heading`],
+          text: 'Section',
+        })
+        return output
+      }
+
+    const report = await runExtractionBakeoff({
+      corpus: inputCorpus,
+      arms: [
+        arm('geometric-baseline', withHeading(2)),
+        arm('llm-authored', withHeading(3)),
+        arm('llm-grounded', withHeading(2)),
+      ],
+    })
+    const rows = report.comparison.filter(
+      ({ layout }) => layout === 'one-column',
+    )
+
+    expect(
+      rows.some(
+        ({ disagreementDocumentIds }) => disagreementDocumentIds.length > 0,
+      ),
+    ).toBe(true)
+    expect(
+      rows.every(
+        ({ disagreementDocumentIds }) => disagreementDocumentIds.length > 0,
+      ),
+    ).toBe(false)
+    expect(
+      report.disagreements
+        .filter(({ layout }) => layout === 'one-column')
+        .map(({ stratum }) => stratum),
+    ).toEqual(['sectioning'])
+  })
+
+  it('does not certify score-once when the same identity is rerun', async () => {
+    // The guard lives in a function-local set, so a second call rescores every
+    // held-out document and still claims compliance.
+    const arms = () => [
+      arm('geometric-baseline'),
+      arm('llm-authored'),
+      arm('llm-grounded'),
+    ]
+    const inputCorpus = corpus()
+
+    const first = await runExtractionBakeoff({
+      corpus: inputCorpus,
+      arms: arms(),
+    })
+    expect(first.heldOutScoredOnce).toBe(true)
+
+    await expect(
+      runExtractionBakeoff({
+        corpus: inputCorpus,
+        arms: arms(),
+      }),
+    ).rejects.toThrow('HELD_OUT_SCORED_MORE_THAN_ONCE')
   })
 })

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -721,6 +721,77 @@ describe('extraction architecture bake-off', () => {
         .filter(({ layout }) => layout === 'one-column')
         .map(({ stratum }) => stratum),
     ).toEqual(['tables'])
+    expect(
+      report.arms['llm-grounded'].documents[0]!.caseScores.find(
+        ({ stratum }) => stratum === 'tables',
+      )?.sourceRecall,
+    ).toBe(1)
+  })
+
+  it('does not leak a stratum-owned node addition into other score rows', async () => {
+    const inputCorpus = corpus()
+    for (const document of inputCorpus.heldOut) {
+      document.context.sourceRuns.push(
+        {
+          id: `${document.id}-table-anchor`,
+          text: 'Measure',
+          page: 1,
+          order: 3,
+        },
+        {
+          id: `${document.id}-table-cell`,
+          text: '42',
+          page: 1,
+          order: 4,
+        },
+      )
+      const tableCase = document.cases.find(
+        ({ stratum }) => stratum === 'tables',
+      )!
+      tableCase.expectedNodeTypes = ['title', 'paragraph', 'table']
+      tableCase.expectedSourceRunIds = [
+        `${document.id}-title`,
+        `${document.id}-body`,
+        `${document.id}-table-anchor`,
+        `${document.id}-table-cell`,
+      ]
+    }
+    const withTable = (input: StructuredExtractionContext) => {
+      const output = proposal(input)
+      output.nodes.push({
+        id: `${input.documentId}-table`,
+        type: 'table',
+        sourceRunIds: [`${input.documentId}-table-anchor`],
+        table: {
+          rows: [
+            {
+              cells: [
+                {
+                  sourceRunIds: [`${input.documentId}-table-cell`],
+                  headerScope: 'column',
+                },
+              ],
+            },
+          ],
+        },
+      })
+      return output
+    }
+
+    const report = await runExtractionBakeoff({
+      corpus: inputCorpus,
+      arms: [
+        arm('geometric-baseline', withTable),
+        arm('llm-authored'),
+        arm('llm-grounded', withTable),
+      ],
+    })
+
+    expect(
+      report.disagreements
+        .filter(({ layout }) => layout === 'one-column')
+        .map(({ stratum }) => stratum),
+    ).toEqual(['tables'])
   })
 
   it('does not certify score-once when the same identity is rerun', async () => {

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -590,6 +590,41 @@ describe('extraction architecture bake-off', () => {
     },
   )
 
+  it('isolates a throwing result accessor instead of aborting the bake-off', async () => {
+    const hostile = arm('llm-authored')
+    hostile.run = async (input) => {
+      const result = { proposal: proposal(input) } as {
+        proposal: StructuredExtractionProposal
+        metrics?: { latencyMs: number; costUsd: number }
+      }
+      Object.defineProperty(result, 'metrics', {
+        enumerable: true,
+        get() {
+          throw new Error('hostile metrics accessor')
+        },
+      })
+      return result as never
+    }
+
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [arm('geometric-baseline'), hostile, arm('llm-grounded')],
+    })
+
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status, verification }) =>
+          status === 'failed' &&
+          verification.issueCodes.includes('adapter-failure'),
+      ),
+    ).toBe(true)
+    expect(
+      report.arms['llm-grounded'].documents.every(
+        ({ status }) => status === 'passed',
+      ),
+    ).toBe(true)
+  })
+
   it('isolates a cyclic adapter proposal instead of aborting the bake-off', async () => {
     const cyclic = arm('llm-authored')
     const cyclicProposal: Record<string, unknown> = {
@@ -703,6 +738,13 @@ describe('extraction architecture bake-off', () => {
           order: 4,
         },
       )
+      document.context.provenArtifacts = [
+        {
+          id: `${document.id}-table-scope`,
+          kind: 'table-scope',
+          sourceRunIds: [`${document.id}-table-cell`],
+        },
+      ]
       const tableCase = document.cases.find(
         ({ stratum }) => stratum === 'tables',
       )!
@@ -776,6 +818,13 @@ describe('extraction architecture bake-off', () => {
           order: 4,
         },
       )
+      document.context.provenArtifacts = [
+        {
+          id: `${document.id}-table-scope`,
+          kind: 'table-scope',
+          sourceRunIds: [`${document.id}-table-cell`],
+        },
+      ]
       const tableCase = document.cases.find(
         ({ stratum }) => stratum === 'tables',
       )!

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -198,20 +198,34 @@ function finiteNonNegative(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
 }
 
-function validExtractionArmResult(
-  value: unknown,
-): value is ExtractionBakeoffArmResult & {
-  metrics: ExtractionBakeoffRunMetrics
-} {
-  if (!value || typeof value !== 'object') return false
-  const metrics = (value as Partial<ExtractionBakeoffArmResult>).metrics
-  return Boolean(
-    metrics &&
-    finiteNonNegative(metrics.latencyMs) &&
-    finiteNonNegative(metrics.costUsd) &&
-    (metrics.pageCount === undefined ||
-      (Number.isSafeInteger(metrics.pageCount) && metrics.pageCount >= 1)),
-  )
+function materializeExtractionArmResult(value: unknown):
+  | (ExtractionBakeoffArmResult & {
+      metrics: ExtractionBakeoffRunMetrics
+    })
+  | null {
+  let materialized: unknown
+  try {
+    // Snapshot the complete adapter result before validation. Structured clone
+    // either strips accessors/prototypes from the value used downstream or
+    // fails here, where the caller can isolate the adapter.
+    materialized = structuredClone(value)
+  } catch {
+    return null
+  }
+  if (!materialized || typeof materialized !== 'object') return null
+  const metrics = (materialized as Partial<ExtractionBakeoffArmResult>).metrics
+  if (
+    !metrics ||
+    !finiteNonNegative(metrics.latencyMs) ||
+    !finiteNonNegative(metrics.costUsd) ||
+    (metrics.pageCount !== undefined &&
+      (!Number.isSafeInteger(metrics.pageCount) || metrics.pageCount < 1))
+  ) {
+    return null
+  }
+  return materialized as ExtractionBakeoffArmResult & {
+    metrics: ExtractionBakeoffRunMetrics
+  }
 }
 
 function stableJson(value: unknown) {
@@ -853,8 +867,8 @@ export async function runExtractionBakeoff({
         if (document.split === 'held-out') identityRunKeys.add(runKey)
         continue
       }
-      const first = firstRun.value
-      if (!validExtractionArmResult(first)) {
+      const first = materializeExtractionArmResult(firstRun.value)
+      if (!first) {
         resultByArm[arm.id].push(
           disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
         )
@@ -897,8 +911,8 @@ export async function runExtractionBakeoff({
         if (document.split === 'held-out') identityRunKeys.add(runKey)
         continue
       }
-      const second = secondRun.value
-      if (!validExtractionArmResult(second)) {
+      const second = materializeExtractionArmResult(secondRun.value)
+      if (!second) {
         resultByArm[arm.id].push(
           disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
         )

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -107,6 +107,8 @@ export type ExtractionBakeoffCaseScore = {
   typeRecall: number
   sourceRecall: number
   assetRecall: number
+  /** Only present when the case declares `expectedHeadingLevels`. */
+  headingLevelRecall?: number
   boilerplateContamination: number
   verification: ExtractionBakeoffVerification
 }
@@ -239,10 +241,26 @@ function unique(values: readonly string[]) {
   return new Set(values).size === values.length
 }
 
+const defaultScoreOnceStores = new WeakMap<
+  ExtractionBakeoffCorpus,
+  Set<string>
+>()
+
+function scoreOnceStoreFor(corpus: ExtractionBakeoffCorpus) {
+  const existing = defaultScoreOnceStores.get(corpus)
+  if (existing) return existing
+  const store = new Set<string>()
+  defaultScoreOnceStores.set(corpus, store)
+  return store
+}
+
 function validateCase(
   caseInput: ExtractionBakeoffCase,
   document: ExtractionBakeoffDocument,
 ) {
+  const sourceRunIds = new Set(document.context.sourceRuns.map(({ id }) => id))
+  const assetIds = new Set(document.context.sourceAssets.map(({ id }) => id))
+  const boilerplateRunIds = new Set(document.context.boilerplateRunIds ?? [])
   if (
     !SAFE_ID.test(caseInput.id) ||
     caseInput.documentId !== document.id ||
@@ -254,7 +272,19 @@ function validateCase(
     ) ||
     !unique(caseInput.expectedAssetIds ?? []) ||
     !unique(caseInput.expectedSourceRunIds ?? []) ||
-    !unique(caseInput.expectedExcludedBoilerplateRunIds ?? [])
+    !unique(caseInput.expectedExcludedBoilerplateRunIds ?? []) ||
+    (caseInput.expectedHeadingLevels ?? []).some(
+      (level) => !Number.isSafeInteger(level) || level < 1 || level > 6,
+    ) ||
+    (caseInput.expectedSourceRunIds ?? []).some(
+      (sourceRunId) => !sourceRunIds.has(sourceRunId),
+    ) ||
+    (caseInput.expectedAssetIds ?? []).some(
+      (assetId) => !assetIds.has(assetId),
+    ) ||
+    (caseInput.expectedExcludedBoilerplateRunIds ?? []).some(
+      (sourceRunId) => !boilerplateRunIds.has(sourceRunId),
+    )
   ) {
     throw new Error(`INVALID_EXTRACTION_BAKEOFF_CASE:${caseInput.id}`)
   }
@@ -268,13 +298,27 @@ export function validateExtractionBakeoffCorpus(
   if (corpus.development.length === 0 || corpus.heldOut.length === 0) {
     throw new Error('EXTRACTION_BAKEOFF_REQUIRES_DEVELOPMENT_AND_HELD_OUT')
   }
-  const documents = [...corpus.development, ...corpus.heldOut]
-  if (!unique(documents.map(({ id }) => id)))
+  // Bind each entry to the array holding it. A development-tagged entry under
+  // `heldOut` still contributes to the held-out identity and layout checks but
+  // bypasses the contamination guards and drops out of held-out comparisons,
+  // and a held-out-tagged development entry is bound by no identity at all.
+  const documents = [
+    ...corpus.development.map((document) => ({
+      document,
+      split: 'development' as const,
+    })),
+    ...corpus.heldOut.map((document) => ({
+      document,
+      split: 'held-out' as const,
+    })),
+  ]
+  if (!unique(documents.map(({ document }) => document.id)))
     throw new Error('DUPLICATE_EXTRACTION_BAKEOFF_DOCUMENT')
-  for (const document of documents) {
+  for (const { document, split } of documents) {
     if (
       !SAFE_ID.test(document.id) ||
       document.context.documentId !== document.id ||
+      document.split !== split ||
       document.context.split !== document.split ||
       document.context.layout !== document.layout
     ) {
@@ -397,16 +441,34 @@ function scoreCase(
   const bodyRuns = [...actualRuns].filter((id) => boilerplate.has(id)).length
   const boilerplateContamination =
     boilerplate.size === 0 ? 0 : ratio(bodyRuns, boilerplate.size)
+  // A sectioning case that declares the expected hierarchy is scored on it.
+  // Without this, a candidate can emit every heading at the wrong depth — a
+  // broken hierarchy — and score exactly as well as one that gets it right.
+  const expectedHeadingLevels = caseInput.expectedHeadingLevels
+  const headingLevelRecall =
+    expectedHeadingLevels === undefined
+      ? undefined
+      : ratio(
+          expectedHeadingLevels.filter(
+            (level, index) =>
+              nodes.filter(({ type }) => type === 'heading')[index]?.level ===
+              level,
+          ).length,
+          expectedHeadingLevels.length,
+        )
   // A failed verifier and a degenerate/no-object answer are both zero. The
   // precision term keeps "every line is a heading" below a useful answer.
+  const terms = [
+    typePrecision,
+    typeRecall,
+    sourceRecall,
+    assetRecall,
+    1 - boilerplateContamination,
+    ...(headingLevelRecall === undefined ? [] : [headingLevelRecall]),
+  ]
   const score =
     verification.status === 'passed' && nodes.length > 0
-      ? (typePrecision +
-          typeRecall +
-          sourceRecall +
-          assetRecall +
-          (1 - boilerplateContamination)) /
-        5
+      ? terms.reduce((sum, term) => sum + term, 0) / terms.length
       : 0
   return {
     caseId: caseInput.id,
@@ -418,6 +480,7 @@ function scoreCase(
     typeRecall,
     sourceRecall,
     assetRecall,
+    ...(headingLevelRecall === undefined ? {} : { headingLevelRecall }),
     boilerplateContamination,
     verification,
   }
@@ -468,6 +531,7 @@ function combinedVerification(
 function disqualifiedDocumentResult(
   document: ExtractionBakeoffDocument,
   issueCode: string,
+  status: ExtractionBakeoffDocumentResult['status'] = 'disqualified',
 ): ExtractionBakeoffDocumentResult {
   const verification: ExtractionBakeoffVerification = {
     status: 'failed',
@@ -478,7 +542,7 @@ function disqualifiedDocumentResult(
     documentId: document.id,
     split: document.split,
     layout: document.layout,
-    status: 'disqualified',
+    status,
     verification,
     outputHash: null,
     byteStable: false,
@@ -587,14 +651,34 @@ function comparisons(
         relevant.flatMap((items) => items.map(({ documentId }) => documentId)),
       ),
     ].sort()
+    // Compare what this row is about. The whole-document output hash differs
+    // whenever the arms diverge anywhere in the document, which marks it a
+    // disagreement for every stratum it appears in and stops the report from
+    // saying where the architectures actually diverge.
     const disagreementDocumentIds = documentIds.filter((documentId) => {
       const states = EXTRACTION_BAKEOFF_ARMS.map((arm) => {
         const result = results[arm].find(
           ({ documentId: id }) => id === documentId,
         )
-        return result
-          ? `${result.status}\u0000${result.outputHash ?? 'none'}\u0000${result.byteStable}`
-          : 'missing'
+        if (!result) return 'missing'
+        const rowScores = result.caseScores
+          .filter(
+            (score) => score.stratum === stratum && score.layout === layout,
+          )
+          .map((score) =>
+            [
+              score.caseId,
+              score.score,
+              score.typePrecision,
+              score.typeRecall,
+              score.sourceRecall,
+              score.assetRecall,
+              score.headingLevelRecall ?? 'none',
+              score.boilerplateContamination,
+            ].join('\u0000'),
+          )
+          .sort()
+        return [result.status, result.byteStable, ...rowScores].join('\u0001')
       })
       return new Set(states).size > 1
     })
@@ -617,10 +701,19 @@ export async function runExtractionBakeoff({
   corpus,
   arms,
   includeDevelopment = false,
+  scoredHeldOutKeys,
 }: {
   corpus: ExtractionBakeoffCorpus
   arms: readonly ExtractionBakeoffArm[]
   includeDevelopment?: boolean
+  /**
+   * Ledger of held-out (identity, document) pairs already scored. A run-local
+   * set cannot substantiate `heldOutScoredOnce`: calling this function again
+   * with the same corpus and identities rescores every held-out document and
+   * claims compliance again. Pass a caller-owned, run-spanning set to make the
+   * guard mean what the report says.
+   */
+  scoredHeldOutKeys?: Set<string>
 }): Promise<ExtractionBakeoffReport> {
   const corpusReceipt = validateExtractionBakeoffCorpus(corpus)
   if (
@@ -641,12 +734,27 @@ export async function runExtractionBakeoff({
     'llm-authored': [],
     'llm-grounded': [],
   } as Record<ExtractionBakeoffArmId, ExtractionBakeoffDocumentResult[]>
-  const identityRunKeys = new Set<string>()
+  const identityRunKeys = scoredHeldOutKeys ?? scoreOnceStoreFor(corpus)
   const documents = includeDevelopment
     ? [...corpus.development, ...corpus.heldOut]
     : corpus.heldOut
 
   for (const arm of arms) {
+    // Once an arm has leaked on the held-out split it must not be handed any
+    // more held-out papers. Advancing only to the next document keeps feeding
+    // held-out input to an adapter already recorded as contaminated, widening
+    // the leak it was disqualified for.
+    let contaminatedOnHeldOut: string | undefined
+    // Isolate the adapter. A provider error, timeout, or adapter exception on
+    // one document must not reject the whole run: the other arms are healthy
+    // and their side-by-side evidence is the point of the bake-off.
+    const runArm = async (input: StructuredExtractionContext) => {
+      try {
+        return { ok: true as const, value: await arm.run(input) }
+      } catch {
+        return { ok: false as const, value: null }
+      }
+    }
     for (const document of documents) {
       const runKey = `${structuredExtractionHash(arm.identity)}\u0000${document.id}`
       if (document.split === 'held-out' && identityRunKeys.has(runKey))
@@ -658,10 +766,18 @@ export async function runExtractionBakeoff({
       if (document.split === 'held-out') {
         if (!identityValid(arm.identity))
           throw new Error(`INVALID_EXTRACTION_MODEL_IDENTITY:${arm.id}`)
+        if (contaminatedOnHeldOut) {
+          resultByArm[arm.id].push(
+            disqualifiedDocumentResult(document, contaminatedOnHeldOut),
+          )
+          identityRunKeys.add(runKey)
+          continue
+        }
         const staticContamination =
           !arm.tunedOn.every((value) => value === 'development') ||
           Boolean(arm.usedHeldOutForTuning)
         if (staticContamination) {
+          contaminatedOnHeldOut = 'held-out-contamination'
           resultByArm[arm.id].push(
             disqualifiedDocumentResult(document, 'held-out-contamination'),
           )
@@ -673,7 +789,15 @@ export async function runExtractionBakeoff({
         document.context,
         inputArm,
       )
-      const first = await arm.run(firstInput)
+      const firstRun = await runArm(firstInput)
+      if (!firstRun.ok) {
+        resultByArm[arm.id].push(
+          disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+        )
+        identityRunKeys.add(runKey)
+        continue
+      }
+      const first = firstRun.value
       if (!first || typeof first !== 'object')
         throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
       if (document.split === 'held-out') {
@@ -682,6 +806,7 @@ export async function runExtractionBakeoff({
         } catch (error) {
           const issueCode = heldOutContaminationCode(error)
           if (!issueCode) throw error
+          contaminatedOnHeldOut = issueCode
           resultByArm[arm.id].push(
             disqualifiedDocumentResult(document, issueCode),
           )
@@ -697,7 +822,15 @@ export async function runExtractionBakeoff({
         document.context,
         inputArm,
       )
-      const second = await arm.run(secondInput)
+      const secondRun = await runArm(secondInput)
+      if (!secondRun.ok) {
+        resultByArm[arm.id].push(
+          disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+        )
+        identityRunKeys.add(runKey)
+        continue
+      }
+      const second = secondRun.value
       if (!second || typeof second !== 'object')
         throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
       if (document.split === 'held-out') {
@@ -706,6 +839,7 @@ export async function runExtractionBakeoff({
         } catch (error) {
           const issueCode = heldOutContaminationCode(error)
           if (!issueCode) throw error
+          contaminatedOnHeldOut = issueCode
           resultByArm[arm.id].push(
             disqualifiedDocumentResult(document, issueCode),
           )
@@ -736,7 +870,11 @@ export async function runExtractionBakeoff({
           (!Number.isSafeInteger(metrics.pageCount) || metrics.pageCount < 1))
       )
         throw new Error(`INVALID_EXTRACTION_RUN_METRICS:${arm.id}`)
-      const pages = metrics.pageCount ?? pageCount(document.context)
+      // Derive the denominator from the document, never from the arm. An arm
+      // that reports its own page count can drive latency and cost per page
+      // arbitrarily close to zero and win the operating-profile comparison on
+      // nothing. `metrics.pageCount` stays validated above but is not used.
+      const pages = pageCount(document.context)
       const output =
         firstVerification.status === 'passed' &&
         secondVerification.status === 'passed' &&
@@ -770,59 +908,37 @@ export async function runExtractionBakeoff({
   }
 
   const comparison = comparisons(corpus, resultByArm)
-  const disagreements = comparison.flatMap((row) => {
-    const armResults = EXTRACTION_BAKEOFF_ARMS.map((arm) =>
-      resultByArm[arm]
-        .filter(({ split }) => split === 'held-out')
-        .filter((result) =>
-          result.caseScores.some(
-            (score) =>
-              score.stratum === row.stratum && score.layout === row.layout,
-          ),
-        ),
-    )
-    const ids = [
-      ...new Set(
-        armResults.flatMap((items) =>
-          items.map(({ documentId }) => documentId),
-        ),
-      ),
-    ].sort()
-    return ids.flatMap((documentId) => {
+  const disagreements = comparison.flatMap((row) =>
+    row.disagreementDocumentIds.map((documentId) => {
       const states = EXTRACTION_BAKEOFF_ARMS.map((arm) => {
         const result = resultByArm[arm].find(
           (item) => item.documentId === documentId && item.split === 'held-out',
         )
-        return {
-          arm,
-          result,
-          state: result
-            ? `${result.status}\u0000${result.outputHash ?? 'none'}\u0000${result.byteStable}`
-            : 'missing',
-        }
-      })
-      if (new Set(states.map(({ state }) => state)).size === 1) return []
-      const matches = states
-        .filter(({ result }) =>
-          result?.caseScores.some(
+        const rowScores =
+          result?.caseScores.filter(
             (score) =>
               score.stratum === row.stratum && score.layout === row.layout,
-          ),
-        )
-        .map(({ arm }) => arm)
-      return [
-        {
-          documentId,
-          stratum: row.stratum,
-          layout: row.layout,
-          arms: matches,
-          reason: states.some(({ result }) => result?.status !== 'passed')
-            ? ('verification' as const)
+          ) ?? []
+        return { arm, result, rowScores }
+      })
+      const scores = states.map(({ rowScores }) =>
+        stableJson(rowScores.map(({ score }) => score)),
+      )
+      return {
+        documentId,
+        stratum: row.stratum,
+        layout: row.layout,
+        arms: states
+          .filter(({ rowScores }) => rowScores.length > 0)
+          .map(({ arm }) => arm),
+        reason: states.some(({ result }) => result?.status !== 'passed')
+          ? ('verification' as const)
+          : new Set(scores).size > 1
+            ? ('score' as const)
             : ('structure' as const),
-        },
-      ]
-    })
-  })
+      }
+    }),
+  )
   const reportWithoutHash = {
     schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
     corpusId: corpus.id,
@@ -857,6 +973,14 @@ export function createExtractionArchitectureDecision({
   report: ExtractionBakeoffReport
   decisionId?: string
 }): ExtractionArchitectureDecision {
+  // The decision copies `reportSha256` forward as the binding between the
+  // recorded owner and the rows it was derived from. Verify that binding
+  // before reading the rows, or a mutated report yields a decision that
+  // presents the old hash as vouching for the altered comparison.
+  const { reportSha256, ...reportWithoutHash } = report
+  if (structuredExtractionHash(reportWithoutHash) !== reportSha256) {
+    throw new Error('EXTRACTION_BAKEOFF_REPORT_HASH_MISMATCH')
+  }
   const perStratum: Record<string, ExtractionBakeoffArmId | 'tie' | 'pending'> =
     {}
   for (const row of report.comparison) {

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -402,14 +402,42 @@ function ratio(numerator: number, denominator: number) {
     : Math.max(0, Math.min(1, numerator / denominator))
 }
 
+function verifiedNodeSourceRunIds(
+  node: VerifiedStructuredExtraction['nodes'][number],
+) {
+  return [
+    ...node.sourceRunIds,
+    ...(node.table?.rows.flatMap(({ cells }) =>
+      cells.flatMap(({ sourceRunIds }) => sourceRunIds),
+    ) ?? []),
+  ]
+}
+
 function scoreCase(
   caseInput: ExtractionBakeoffCase,
   output: VerifiedStructuredExtraction | null,
   verification: ExtractionBakeoffVerification,
 ): ExtractionBakeoffCaseScore {
-  const nodes = output?.nodes ?? []
-  const actualTypes = nodes.map(({ type }) => type)
   const expectedTypes = [...caseInput.expectedNodeTypes]
+  const expectedRuns = new Set(caseInput.expectedSourceRunIds ?? [])
+  const expectedAssets = new Set(caseInput.expectedAssetIds ?? [])
+  const boilerplate = new Set(caseInput.expectedExcludedBoilerplateRunIds ?? [])
+  const caseRunIds = new Set([...expectedRuns, ...boilerplate])
+  const nodes = (output?.nodes ?? []).filter((node) => {
+    if (
+      verifiedNodeSourceRunIds(node).some((sourceRunId) =>
+        caseRunIds.has(sourceRunId),
+      )
+    )
+      return true
+    if (node.assetId && expectedAssets.has(node.assetId)) return true
+    return (
+      caseRunIds.size === 0 &&
+      expectedAssets.size === 0 &&
+      expectedTypes.includes(node.type)
+    )
+  })
+  const actualTypes = nodes.map(({ type }) => type)
   const matchedTypes = expectedTypes.filter(
     (type, index) => actualTypes[index] === type,
   ).length
@@ -430,19 +458,16 @@ function scoreCase(
     actualTypes.length,
   )
   const typeRecall = ratio(matchedTypes, expectedTypes.length)
-  const expectedRuns = new Set(caseInput.expectedSourceRunIds ?? [])
-  const actualRuns = new Set(nodes.flatMap(({ sourceRunIds }) => sourceRunIds))
+  const actualRuns = new Set(nodes.flatMap(verifiedNodeSourceRunIds))
   const sourceRecall = ratio(
     [...expectedRuns].filter((id) => actualRuns.has(id)).length,
     expectedRuns.size,
   )
-  const expectedAssets = new Set(caseInput.expectedAssetIds ?? [])
   const actualAssets = new Set(output?.assetIds ?? [])
   const assetRecall = ratio(
     [...expectedAssets].filter((id) => actualAssets.has(id)).length,
     expectedAssets.size,
   )
-  const boilerplate = new Set(caseInput.expectedExcludedBoilerplateRunIds ?? [])
   const bodyRuns = [...actualRuns].filter((id) => boilerplate.has(id)).length
   const boilerplateContamination =
     boilerplate.size === 0 ? 0 : ratio(bodyRuns, boilerplate.size)
@@ -475,24 +500,9 @@ function scoreCase(
     verification.status === 'passed' && nodes.length > 0
       ? terms.reduce((sum, term) => sum + term, 0) / terms.length
       : 0
-  const relevantNodes = output?.nodes.filter((node) => {
-    const ownedRunIds = [
-      ...node.sourceRunIds,
-      ...(node.table?.rows.flatMap(({ cells }) =>
-        cells.flatMap(({ sourceRunIds }) => sourceRunIds),
-      ) ?? []),
-    ]
-    if (ownedRunIds.some((id) => expectedRuns.has(id))) return true
-    if (node.assetId && expectedAssets.has(node.assetId)) return true
-    return (
-      expectedRuns.size === 0 &&
-      expectedAssets.size === 0 &&
-      expectedTypes.includes(node.type)
-    )
-  })
   const structureHash = output
     ? structuredExtractionHash({
-        nodes: relevantNodes,
+        nodes,
         assetIds: output.assetIds.filter((id) => expectedAssets.has(id)),
         excludedBoilerplateRunIds: output.excludedBoilerplateRunIds.filter(
           (id) => boilerplate.has(id),

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -228,31 +228,46 @@ function identityValid(identity: ExtractionBakeoffModelIdentity) {
   )
 }
 
-function hasForbiddenGroundTruth(value: unknown, path = ''): string | null {
-  if (Array.isArray(value)) {
-    for (const [index, item] of value.entries()) {
-      const found = hasForbiddenGroundTruth(item, `${path}[${index}]`)
+function hasForbiddenGroundTruth(
+  value: unknown,
+  path = '',
+  ancestors = new WeakSet<object>(),
+): string | null {
+  if (!value || typeof value !== 'object') return null
+  if (ancestors.has(value))
+    throw new Error('INVALID_EXTRACTION_ARM_RESULT:cyclic-proposal')
+  ancestors.add(value)
+  try {
+    if (Array.isArray(value)) {
+      for (const [index, item] of value.entries()) {
+        const found = hasForbiddenGroundTruth(
+          item,
+          `${path}[${index}]`,
+          ancestors,
+        )
+        if (found) return found
+      }
+      return null
+    }
+    for (const [key, child] of Object.entries(value)) {
+      const normalizedKey = key
+        .normalize('NFKC')
+        .replace(/[^A-Za-z0-9]/gu, '')
+        .toLowerCase()
+      if (
+        FORBIDDEN_GROUND_TRUTH_KEYS.has(normalizedKey) ||
+        /^(?:gold|groundtruth|expected|labels?|reviewer|targetbox)/u.test(
+          normalizedKey,
+        )
+      )
+        return `${path}.${key}`
+      const found = hasForbiddenGroundTruth(child, `${path}.${key}`, ancestors)
       if (found) return found
     }
     return null
+  } finally {
+    ancestors.delete(value)
   }
-  if (!value || typeof value !== 'object') return null
-  for (const [key, child] of Object.entries(value)) {
-    const normalizedKey = key
-      .normalize('NFKC')
-      .replace(/[^A-Za-z0-9]/gu, '')
-      .toLowerCase()
-    if (
-      FORBIDDEN_GROUND_TRUTH_KEYS.has(normalizedKey) ||
-      /^(?:gold|groundtruth|expected|labels?|reviewer|targetbox)/u.test(
-        normalizedKey,
-      )
-    )
-      return `${path}.${key}`
-    const found = hasForbiddenGroundTruth(child, `${path}.${key}`)
-    if (found) return found
-  }
-  return null
 }
 
 function unique(values: readonly string[]) {
@@ -851,7 +866,13 @@ export async function runExtractionBakeoff({
           assertNoHeldOutContamination(arm, first.proposal, document.split)
         } catch (error) {
           const issueCode = heldOutContaminationCode(error)
-          if (!issueCode) throw error
+          if (!issueCode) {
+            resultByArm[arm.id].push(
+              disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+            )
+            identityRunKeys.add(runKey)
+            continue
+          }
           contaminatedOnHeldOut = issueCode
           resultByArm[arm.id].push(
             disqualifiedDocumentResult(document, issueCode),
@@ -889,7 +910,13 @@ export async function runExtractionBakeoff({
           assertNoHeldOutContamination(arm, second.proposal, document.split)
         } catch (error) {
           const issueCode = heldOutContaminationCode(error)
-          if (!issueCode) throw error
+          if (!issueCode) {
+            resultByArm[arm.id].push(
+              disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+            )
+            identityRunKeys.add(runKey)
+            continue
+          }
           contaminatedOnHeldOut = issueCode
           resultByArm[arm.id].push(
             disqualifiedDocumentResult(document, issueCode),

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -110,6 +110,8 @@ export type ExtractionBakeoffCaseScore = {
   /** Only present when the case declares `expectedHeadingLevels`. */
   headingLevelRecall?: number
   boilerplateContamination: number
+  /** Hash of the verified structure owned by this case's source labels. */
+  structureHash: string | null
   verification: ExtractionBakeoffVerification
 }
 
@@ -196,6 +198,22 @@ function finiteNonNegative(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
 }
 
+function validExtractionArmResult(
+  value: unknown,
+): value is ExtractionBakeoffArmResult & {
+  metrics: ExtractionBakeoffRunMetrics
+} {
+  if (!value || typeof value !== 'object') return false
+  const metrics = (value as Partial<ExtractionBakeoffArmResult>).metrics
+  return Boolean(
+    metrics &&
+    finiteNonNegative(metrics.latencyMs) &&
+    finiteNonNegative(metrics.costUsd) &&
+    (metrics.pageCount === undefined ||
+      (Number.isSafeInteger(metrics.pageCount) && metrics.pageCount >= 1)),
+  )
+}
+
 function stableJson(value: unknown) {
   return structuredExtractionStableJson(value)
 }
@@ -239,19 +257,6 @@ function hasForbiddenGroundTruth(value: unknown, path = ''): string | null {
 
 function unique(values: readonly string[]) {
   return new Set(values).size === values.length
-}
-
-const defaultScoreOnceStores = new WeakMap<
-  ExtractionBakeoffCorpus,
-  Set<string>
->()
-
-function scoreOnceStoreFor(corpus: ExtractionBakeoffCorpus) {
-  const existing = defaultScoreOnceStores.get(corpus)
-  if (existing) return existing
-  const store = new Set<string>()
-  defaultScoreOnceStores.set(corpus, store)
-  return store
 }
 
 function validateCase(
@@ -470,6 +475,30 @@ function scoreCase(
     verification.status === 'passed' && nodes.length > 0
       ? terms.reduce((sum, term) => sum + term, 0) / terms.length
       : 0
+  const relevantNodes = output?.nodes.filter((node) => {
+    const ownedRunIds = [
+      ...node.sourceRunIds,
+      ...(node.table?.rows.flatMap(({ cells }) =>
+        cells.flatMap(({ sourceRunIds }) => sourceRunIds),
+      ) ?? []),
+    ]
+    if (ownedRunIds.some((id) => expectedRuns.has(id))) return true
+    if (node.assetId && expectedAssets.has(node.assetId)) return true
+    return (
+      expectedRuns.size === 0 &&
+      expectedAssets.size === 0 &&
+      expectedTypes.includes(node.type)
+    )
+  })
+  const structureHash = output
+    ? structuredExtractionHash({
+        nodes: relevantNodes,
+        assetIds: output.assetIds.filter((id) => expectedAssets.has(id)),
+        excludedBoilerplateRunIds: output.excludedBoilerplateRunIds.filter(
+          (id) => boilerplate.has(id),
+        ),
+      })
+    : null
   return {
     caseId: caseInput.id,
     documentId: caseInput.documentId,
@@ -482,6 +511,7 @@ function scoreCase(
     assetRecall,
     ...(headingLevelRecall === undefined ? {} : { headingLevelRecall }),
     boilerplateContamination,
+    structureHash,
     verification,
   }
 }
@@ -675,6 +705,7 @@ function comparisons(
               score.assetRecall,
               score.headingLevelRecall ?? 'none',
               score.boilerplateContamination,
+              score.structureHash ?? 'none',
             ].join('\u0000'),
           )
           .sort()
@@ -713,7 +744,7 @@ export async function runExtractionBakeoff({
    * claims compliance again. Pass a caller-owned, run-spanning set to make the
    * guard mean what the report says.
    */
-  scoredHeldOutKeys?: Set<string>
+  scoredHeldOutKeys: Set<string>
 }): Promise<ExtractionBakeoffReport> {
   const corpusReceipt = validateExtractionBakeoffCorpus(corpus)
   if (
@@ -734,7 +765,7 @@ export async function runExtractionBakeoff({
     'llm-authored': [],
     'llm-grounded': [],
   } as Record<ExtractionBakeoffArmId, ExtractionBakeoffDocumentResult[]>
-  const identityRunKeys = scoredHeldOutKeys ?? scoreOnceStoreFor(corpus)
+  const identityRunKeys = scoredHeldOutKeys
   const documents = includeDevelopment
     ? [...corpus.development, ...corpus.heldOut]
     : corpus.heldOut
@@ -756,7 +787,7 @@ export async function runExtractionBakeoff({
       }
     }
     for (const document of documents) {
-      const runKey = `${structuredExtractionHash(arm.identity)}\u0000${document.id}`
+      const runKey = `${corpusReceipt.heldOutIdentitySha256}\u0000${structuredExtractionHash(arm.identity)}\u0000${document.id}`
       if (document.split === 'held-out' && identityRunKeys.has(runKey))
         throw new Error(
           `HELD_OUT_SCORED_MORE_THAN_ONCE:${arm.id}:${document.id}`,
@@ -794,12 +825,17 @@ export async function runExtractionBakeoff({
         resultByArm[arm.id].push(
           disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
         )
-        identityRunKeys.add(runKey)
+        if (document.split === 'held-out') identityRunKeys.add(runKey)
         continue
       }
       const first = firstRun.value
-      if (!first || typeof first !== 'object')
-        throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
+      if (!validExtractionArmResult(first)) {
+        resultByArm[arm.id].push(
+          disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+        )
+        if (document.split === 'held-out') identityRunKeys.add(runKey)
+        continue
+      }
       if (document.split === 'held-out') {
         try {
           assertNoHeldOutContamination(arm, first.proposal, document.split)
@@ -827,12 +863,17 @@ export async function runExtractionBakeoff({
         resultByArm[arm.id].push(
           disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
         )
-        identityRunKeys.add(runKey)
+        if (document.split === 'held-out') identityRunKeys.add(runKey)
         continue
       }
       const second = secondRun.value
-      if (!second || typeof second !== 'object')
-        throw new Error(`INVALID_EXTRACTION_ARM_RESULT:${arm.id}`)
+      if (!validExtractionArmResult(second)) {
+        resultByArm[arm.id].push(
+          disqualifiedDocumentResult(document, 'adapter-failure', 'failed'),
+        )
+        if (document.split === 'held-out') identityRunKeys.add(runKey)
+        continue
+      }
       if (document.split === 'held-out') {
         try {
           assertNoHeldOutContamination(arm, second.proposal, document.split)
@@ -862,14 +903,6 @@ export async function runExtractionBakeoff({
         byteStable,
       )
       const metrics = first.metrics
-      if (!metrics) throw new Error(`MISSING_EXTRACTION_RUN_METRICS:${arm.id}`)
-      if (
-        !finiteNonNegative(metrics.latencyMs) ||
-        !finiteNonNegative(metrics.costUsd) ||
-        (metrics.pageCount !== undefined &&
-          (!Number.isSafeInteger(metrics.pageCount) || metrics.pageCount < 1))
-      )
-        throw new Error(`INVALID_EXTRACTION_RUN_METRICS:${arm.id}`)
       // Derive the denominator from the document, never from the arm. An arm
       // that reports its own page count can drive latency and cost per page
       // arbitrarily close to zero and win the operating-profile comparison on
@@ -924,6 +957,9 @@ export async function runExtractionBakeoff({
       const scores = states.map(({ rowScores }) =>
         stableJson(rowScores.map(({ score }) => score)),
       )
+      const structures = states.map(({ rowScores }) =>
+        stableJson(rowScores.map(({ structureHash }) => structureHash)),
+      )
       return {
         documentId,
         stratum: row.stratum,
@@ -933,9 +969,11 @@ export async function runExtractionBakeoff({
           .map(({ arm }) => arm),
         reason: states.some(({ result }) => result?.status !== 'passed')
           ? ('verification' as const)
-          : new Set(scores).size > 1
-            ? ('score' as const)
-            : ('structure' as const),
+          : new Set(structures).size > 1
+            ? ('structure' as const)
+            : new Set(scores).size > 1
+              ? ('score' as const)
+              : ('structure' as const),
       }
     }),
   )

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -304,6 +304,40 @@ describe('source-backed structured extraction verifier', () => {
     }
   })
 
+  it('does not invent line breaks between code fragments on the same source line', () => {
+    const base = context()
+    base.sourceRuns.push(
+      {
+        id: 'code-fragment-a',
+        text: '  const value = ',
+        page: 2,
+        order: 8,
+        lineId: 'code-line-1',
+      } as never,
+      {
+        id: 'code-fragment-b',
+        text: '42',
+        page: 2,
+        order: 9,
+        lineId: 'code-line-1',
+      } as never,
+    )
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'fragmented-listing',
+      type: 'code',
+      sourceRunIds: ['code-fragment-a', 'code-fragment-b'],
+      text: '  const value = 42',
+    })
+
+    const result = verifyStructuredExtraction(base, candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.nodes.at(-1)?.text).toBe('  const value = 42')
+    }
+  })
+
   it('rejects a table node that carries no semantic cells', () => {
     // `verifyNodeTable` returns early when `table` is absent, so a candidate
     // can label a source span a table, score as one, and publish a table with
@@ -378,6 +412,44 @@ describe('source-backed structured extraction verifier', () => {
     }
   })
 
+  it('includes table-cell provenance when enforcing order across nodes', () => {
+    const input = context()
+    input.sourceRuns.find(({ id }) => id === 'table-value')!.order = 9
+    input.sourceRuns.push({
+      id: 'after-table',
+      text: 'After the table.',
+      page: 2,
+      order: 8,
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'late-table',
+        type: 'table',
+        sourceRunIds: ['table-head'],
+        table: {
+          rows: [
+            {
+              cells: [{ sourceRunIds: ['table-value'], headerScope: 'none' }],
+            },
+          ],
+        },
+      },
+      {
+        id: 'after-table',
+        type: 'paragraph',
+        sourceRunIds: ['after-table'],
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unverified-span')
+    }
+  })
+
   it('preserves note and citation targets with reciprocal backlinks', () => {
     const input = context()
     input.sourceRuns.push(
@@ -385,6 +457,20 @@ describe('source-backed structured extraction verifier', () => {
       { id: 'note-body', text: 'A note.', page: 2, order: 9 },
       { id: 'citation-marker', text: '[1]', page: 2, order: 10 },
       { id: 'reference', text: 'A reference.', page: 2, order: 11 },
+    )
+    input.provenArtifacts!.push(
+      {
+        id: 'note-link',
+        kind: 'note-relationship',
+        sourceRunIds: ['note-marker'],
+        targetSourceRunIds: ['note-body'],
+      },
+      {
+        id: 'citation-link',
+        kind: 'citation-relationship',
+        sourceRunIds: ['citation-marker'],
+        targetSourceRunIds: ['reference'],
+      },
     )
     const candidate = validProposal()
     candidate.nodes.push(
@@ -421,6 +507,50 @@ describe('source-backed structured extraction verifier', () => {
       expect(result.output.nodes.at(-1)?.relationships?.backlinks).toEqual([
         'citation-marker',
       ])
+    }
+  })
+
+  it('rejects a reciprocal note link to the wrong proven source target', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'note-marker', text: '1', page: 2, order: 8 },
+      { id: 'right-note', text: 'Right note.', page: 2, order: 9 },
+      { id: 'wrong-note', text: 'Wrong note.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'note-link-1',
+      kind: 'note-relationship',
+      sourceRunIds: ['note-marker'],
+      targetSourceRunIds: ['right-note'],
+    } as never)
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'note-marker',
+        type: 'paragraph',
+        sourceRunIds: ['note-marker'],
+        relationships: { noteTargetNodeIds: ['wrong-note'] },
+      },
+      {
+        id: 'right-note',
+        type: 'footnote',
+        sourceRunIds: ['right-note'],
+      },
+      {
+        id: 'wrong-note',
+        type: 'footnote',
+        sourceRunIds: ['wrong-note'],
+        relationships: { backlinks: ['note-marker'] },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
     }
   })
 

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -148,6 +148,12 @@ describe('source-backed structured extraction verifier', () => {
   })
 
   it('keeps table cell provenance source-backed', () => {
+    const input = context()
+    input.provenArtifacts!.push({
+      id: 'table-scope',
+      kind: 'table-scope',
+      sourceRunIds: ['table-head', 'table-value'],
+    })
     const candidate = validProposal()
     candidate.nodes.push({
       id: 'table',
@@ -160,7 +166,7 @@ describe('source-backed structured extraction verifier', () => {
         ],
       },
     })
-    const result = verifyStructuredExtraction(context(), candidate)
+    const result = verifyStructuredExtraction(input, candidate)
 
     expect(result.status).toBe('passed')
     if (result.status === 'passed') {
@@ -586,6 +592,102 @@ describe('source-backed structured extraction verifier', () => {
     }
   })
 
+  it('rejects a semantic table whose cells omit deterministic scope provenance', () => {
+    const input = context()
+    input.provenArtifacts!.push({
+      id: 'incomplete-table-scope',
+      kind: 'table-scope',
+      sourceRunIds: ['table-head', 'table-value'],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'incomplete-table',
+      type: 'table',
+      sourceRunIds: ['table-head', 'table-value'],
+      table: {
+        rows: [
+          {
+            cells: [{ sourceRunIds: ['table-head'], headerScope: 'column' }],
+          },
+        ],
+      },
+    })
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('invalid-table')
+    }
+  })
+
+  it('rejects a semantic table with ambiguous deterministic scope ownership', () => {
+    const input = context()
+    input.provenArtifacts!.push(
+      {
+        id: 'ambiguous-table-scope-a',
+        kind: 'table-scope',
+        sourceRunIds: ['table-head', 'table-value'],
+      },
+      {
+        id: 'ambiguous-table-scope-b',
+        kind: 'table-scope',
+        sourceRunIds: ['table-head', 'table-value'],
+      },
+    )
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'ambiguous-table',
+      type: 'table',
+      sourceRunIds: ['table-head', 'table-value'],
+      table: {
+        rows: [
+          { cells: [{ sourceRunIds: ['table-head'] }] },
+          { cells: [{ sourceRunIds: ['table-value'] }] },
+        ],
+      },
+    })
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('invalid-table')
+    }
+  })
+
+  it('rejects table cells emitted out of flattened source order', () => {
+    const input = context()
+    input.provenArtifacts!.push({
+      id: 'reversed-table-scope',
+      kind: 'table-scope',
+      sourceRunIds: ['table-head', 'table-value'],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'reversed-rows',
+      type: 'table',
+      sourceRunIds: ['table-head', 'table-value'],
+      table: {
+        rows: [
+          {
+            cells: [{ sourceRunIds: ['table-value'], headerScope: 'none' }],
+          },
+          {
+            cells: [{ sourceRunIds: ['table-head'], headerScope: 'column' }],
+          },
+        ],
+      },
+    })
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unverified-span')
+    }
+  })
+
   it('preserves note and citation targets with reciprocal backlinks', () => {
     const input = context()
     input.sourceRuns.push(
@@ -811,6 +913,133 @@ describe('source-backed structured extraction verifier', () => {
     const result = verifyStructuredExtraction(input, candidate)
 
     expect(result.status).toBe('passed')
+  })
+
+  it('rejects omitted relationships for deterministic note provenance', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'omitted-marker', text: '1', page: 2, order: 8 },
+      { id: 'omitted-note', text: 'A note.', page: 2, order: 9 },
+    )
+    input.provenArtifacts!.push({
+      id: 'omitted-note-link',
+      kind: 'note-relationship',
+      sourceRunIds: ['omitted-marker'],
+      targetSourceRunIdGroups: [['omitted-note']],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'omitted-marker',
+        type: 'paragraph',
+        sourceRunIds: ['omitted-marker'],
+      },
+      {
+        id: 'omitted-note',
+        type: 'footnote',
+        sourceRunIds: ['omitted-note'],
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
+    }
+  })
+
+  it('requires every deterministic citation target group in the proposal', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'partial-citation-marker', text: '[1, 2]', page: 2, order: 8 },
+      { id: 'partial-reference-a', text: 'Reference A.', page: 2, order: 9 },
+      { id: 'partial-reference-b', text: 'Reference B.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'partial-citation-link',
+      kind: 'citation-relationship',
+      sourceRunIds: ['partial-citation-marker'],
+      targetSourceRunIdGroups: [
+        ['partial-reference-a'],
+        ['partial-reference-b'],
+      ],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'partial-citation-marker',
+        type: 'paragraph',
+        sourceRunIds: ['partial-citation-marker'],
+        relationships: {
+          citationTargetNodeIds: ['partial-reference-a'],
+        },
+      },
+      {
+        id: 'partial-reference-a',
+        type: 'reference',
+        sourceRunIds: ['partial-reference-a'],
+        relationships: { backlinks: ['partial-citation-marker'] },
+      },
+      {
+        id: 'partial-reference-b',
+        type: 'reference',
+        sourceRunIds: ['partial-reference-b'],
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
+    }
+  })
+
+  it('rejects relationship provenance hidden in cells on a non-table target', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'smuggled-marker', text: '1', page: 2, order: 8 },
+      { id: 'smuggled-note-a', text: 'First half.', page: 2, order: 9 },
+      { id: 'smuggled-note-b', text: 'Second half.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'smuggled-note-link',
+      kind: 'note-relationship',
+      sourceRunIds: ['smuggled-marker'],
+      targetSourceRunIdGroups: [['smuggled-note-a', 'smuggled-note-b']],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'smuggled-marker',
+        type: 'paragraph',
+        sourceRunIds: ['smuggled-marker'],
+        relationships: { noteTargetNodeIds: ['smuggled-note'] },
+      },
+      {
+        id: 'smuggled-note',
+        type: 'footnote',
+        sourceRunIds: ['smuggled-note-a'],
+        relationships: { backlinks: ['smuggled-marker'] },
+        table: {
+          rows: [{ cells: [{ sourceRunIds: ['smuggled-note-b'] }] }],
+        },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toEqual(
+        expect.arrayContaining(['invalid-table', 'invalid-relationship']),
+      )
+    }
   })
 
   it('rejects a relationship without a reciprocal backlink', () => {

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -273,11 +273,13 @@ describe('source-backed structured extraction verifier', () => {
   it('does not freeze or alias caller-owned relationship provenance', () => {
     const inputContext = context()
     const targetSourceRunIds = ['body-run']
+    const targetSourceRunIdGroup = ['body-run']
     inputContext.provenArtifacts!.push({
       id: 'note-link',
       kind: 'note-relationship',
       sourceRunIds: ['title-run'],
       targetSourceRunIds,
+      targetSourceRunIdGroups: [targetSourceRunIdGroup],
     })
 
     const input = modelInputForStructuredExtraction(
@@ -291,7 +293,11 @@ describe('source-backed structured extraction verifier', () => {
     expect(input.provenArtifacts?.at(-1)?.targetSourceRunIds).not.toBe(
       targetSourceRunIds,
     )
+    expect(
+      input.provenArtifacts?.at(-1)?.targetSourceRunIdGroups?.[0],
+    ).not.toBe(targetSourceRunIdGroup)
     expect(Object.isFrozen(targetSourceRunIds)).toBe(false)
+    expect(Object.isFrozen(targetSourceRunIdGroup)).toBe(false)
   })
 
   it('stays byte-stable for repeated verified output', () => {
@@ -337,15 +343,22 @@ describe('source-backed structured extraction verifier', () => {
         page: 2,
         order: 8,
         lineId: 'code-line-1',
-      } as never,
+      },
       {
         id: 'code-fragment-b',
         text: '42',
         page: 2,
         order: 9,
         lineId: 'code-line-1',
-      } as never,
+      },
     )
+    base.sourceLines = [
+      {
+        id: 'code-line-1',
+        text: '  const value = 42',
+        sourceRunIds: ['code-fragment-a', 'code-fragment-b'],
+      },
+    ]
     const candidate = validProposal()
     candidate.nodes.push({
       id: 'fragmented-listing',
@@ -359,6 +372,46 @@ describe('source-backed structured extraction verifier', () => {
     expect(result.status).toBe('passed')
     if (result.status === 'passed') {
       expect(result.output.nodes.at(-1)?.text).toBe('  const value = 42')
+    }
+  })
+
+  it('uses canonical line spacing between code fragments', () => {
+    const base = context()
+    base.sourceRuns.push(
+      {
+        id: 'spaced-code-a',
+        text: 'const',
+        page: 2,
+        order: 8,
+        lineId: 'spaced-code-line',
+      },
+      {
+        id: 'spaced-code-b',
+        text: 'value = 42',
+        page: 2,
+        order: 9,
+        lineId: 'spaced-code-line',
+      },
+    )
+    base.sourceLines = [
+      {
+        id: 'spaced-code-line',
+        text: 'const value = 42',
+        sourceRunIds: ['spaced-code-a', 'spaced-code-b'],
+      },
+    ]
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'spaced-listing',
+      type: 'code',
+      sourceRunIds: ['spaced-code-a', 'spaced-code-b'],
+    })
+
+    const result = verifyStructuredExtraction(base, candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.nodes.at(-1)?.text).toBe('const value = 42')
     }
   })
 
@@ -498,6 +551,34 @@ describe('source-backed structured extraction verifier', () => {
     )
 
     const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unverified-span')
+    }
+  })
+
+  it('rejects source runs reversed inside a table cell', () => {
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'reversed-table',
+      type: 'table',
+      sourceRunIds: ['table-head'],
+      table: {
+        rows: [
+          {
+            cells: [
+              {
+                sourceRunIds: ['table-value', 'table-head'],
+                headerScope: 'none',
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const result = verifyStructuredExtraction(context(), candidate)
 
     expect(result.status).toBe('failed')
     if (result.status === 'failed') {
@@ -646,6 +727,90 @@ describe('source-backed structured extraction verifier', () => {
         'invalid-relationship',
       )
     }
+  })
+
+  it('rejects a proven note target missing part of its exact provenance', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'partial-marker', text: '1', page: 2, order: 8 },
+      { id: 'note-part-a', text: 'First half.', page: 2, order: 9 },
+      { id: 'note-part-b', text: 'Second half.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'partial-note-link',
+      kind: 'note-relationship',
+      sourceRunIds: ['partial-marker'],
+      targetSourceRunIdGroups: [['note-part-a', 'note-part-b']],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'partial-marker',
+        type: 'paragraph',
+        sourceRunIds: ['partial-marker'],
+        relationships: { noteTargetNodeIds: ['partial-note'] },
+      },
+      {
+        id: 'partial-note',
+        type: 'footnote',
+        sourceRunIds: ['note-part-a'],
+        relationships: { backlinks: ['partial-marker'] },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
+    }
+  })
+
+  it('matches each citation target against its own provenance group', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'grouped-marker', text: '[1, 2]', page: 2, order: 8 },
+      { id: 'grouped-reference-a', text: 'Reference A.', page: 2, order: 9 },
+      { id: 'grouped-reference-b', text: 'Reference B.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'grouped-citation-link',
+      kind: 'citation-relationship',
+      sourceRunIds: ['grouped-marker'],
+      targetSourceRunIdGroups: [
+        ['grouped-reference-a'],
+        ['grouped-reference-b'],
+      ],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'grouped-marker',
+        type: 'paragraph',
+        sourceRunIds: ['grouped-marker'],
+        relationships: {
+          citationTargetNodeIds: ['grouped-reference-a', 'grouped-reference-b'],
+        },
+      },
+      {
+        id: 'grouped-reference-a',
+        type: 'reference',
+        sourceRunIds: ['grouped-reference-a'],
+        relationships: { backlinks: ['grouped-marker'] },
+      },
+      {
+        id: 'grouped-reference-b',
+        type: 'reference',
+        sourceRunIds: ['grouped-reference-b'],
+        relationships: { backlinks: ['grouped-marker'] },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('passed')
   })
 
   it('rejects a relationship without a reciprocal backlink', () => {

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -242,15 +242,216 @@ describe('source-backed structured extraction verifier', () => {
     }
   })
 
-  it('only exposes proved artifacts to the grounded arm and stays byte-stable', () => {
-    const input = modelInputForStructuredExtraction(context(), 'llm-grounded')
+  it('shares page evidence without leaking deterministic labels to the authored arm', () => {
+    const inputContext = context()
+    inputContext.pageRenditions = [
+      {
+        page: 1,
+        mediaType: 'image/png',
+        width: 1200,
+        height: 1600,
+        bytesSha256: '3'.repeat(64),
+        reference: 'owner-local-page-1',
+      },
+    ]
+    const input = modelInputForStructuredExtraction(
+      inputContext,
+      'llm-grounded',
+    )
     expect(input.provenArtifacts).toHaveLength(1)
     expect(input).not.toHaveProperty('groundTruth')
+    expect(input.pageRenditions).toEqual(inputContext.pageRenditions)
+    const authored = modelInputForStructuredExtraction(
+      inputContext,
+      'llm-authored',
+    )
+    expect(authored.pageRenditions).toEqual(inputContext.pageRenditions)
+    expect(authored).not.toHaveProperty('boilerplateRunIds')
+    expect(input).toHaveProperty('boilerplateRunIds', ['running-head'])
+  })
+
+  it('stays byte-stable for repeated verified output', () => {
     const first = verifyStructuredExtraction(context(), validProposal())
     const second = verifyStructuredExtraction(
       context(),
       structuredClone(validProposal()),
     )
     expect(first).toEqual(second)
+  })
+
+  it('preserves the preformatted structure of a source-backed code listing', () => {
+    // Prose normalization collapses every run of whitespace to one space. A
+    // code listing that survives that has lost the indentation and line breaks
+    // that make it a listing, so the verified document no longer preserves the
+    // source.
+    const listing = 'function main() {\n  return 42\n}'
+    const base = context()
+    base.sourceRuns.push({ id: 'code-run', text: listing, page: 2, order: 8 })
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'listing',
+      type: 'code',
+      sourceRunIds: ['code-run'],
+      text: listing,
+    })
+
+    const result = verifyStructuredExtraction(base, candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      const code = result.output.nodes.find(({ id }) => id === 'listing')!
+      expect(code.text).toBe(listing)
+    }
+  })
+
+  it('rejects a table node that carries no semantic cells', () => {
+    // `verifyNodeTable` returns early when `table` is absent, so a candidate
+    // can label a source span a table, score as one, and publish a table with
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'table',
+      type: 'table',
+      sourceRunIds: ['table-head', 'table-value'],
+    })
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('invalid-table')
+      expect(result.output).toBeNull()
+    }
+  })
+
+  it('rejects a figure that references no deterministic asset', () => {
+    // `verifyAsset` returns immediately without an `assetId`, so every
+    // figure-specific check — bounded asset, caption, caption-derived alt text
+    // — is skipped for a figure that simply omits one.
+    const candidate = validProposal()
+    delete candidate.nodes[2]!.assetId
+    delete candidate.nodes[2]!.captionNodeId
+    delete candidate.nodes[2]!.altText
+    delete candidate.nodes[2]!.altTextSource
+    candidate.assetIds = []
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unknown-asset')
+      expect(result.output).toBeNull()
+    }
+  })
+
+  it('rejects model-authored alt text on a node that is not a figure', () => {
+    // The alt-text checks are figure-only, but the verified node is built with
+    // an unconditional `altText` copy, so a paragraph can carry invented text
+    // into the supposedly source-backed document.
+    const candidate = validProposal()
+    candidate.nodes[3]!.altText = 'invented'
+    candidate.nodes[3]!.altTextSource = 'model'
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'model-authored-alt-text',
+      )
+      expect(result.output).toBeNull()
+    }
+  })
+
+  it('rejects nodes emitted out of source order relative to one another', () => {
+    // Each node's own run IDs stay sorted, so the per-node order check passes
+    // while the document reads back to front.
+    const candidate = validProposal()
+    const [title, caption, figure, body] = candidate.nodes
+    candidate.nodes = [body!, title!, caption!, figure!]
+
+    const result = verifyStructuredExtraction(context(), candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unverified-span')
+      expect(result.output).toBeNull()
+    }
+  })
+
+  it('preserves note and citation targets with reciprocal backlinks', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'note-marker', text: '1', page: 2, order: 8 },
+      { id: 'note-body', text: 'A note.', page: 2, order: 9 },
+      { id: 'citation-marker', text: '[1]', page: 2, order: 10 },
+      { id: 'reference', text: 'A reference.', page: 2, order: 11 },
+    )
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'note-marker',
+        type: 'paragraph',
+        sourceRunIds: ['note-marker'],
+        relationships: { noteTargetNodeIds: ['note-body'] },
+      },
+      {
+        id: 'note-body',
+        type: 'footnote',
+        sourceRunIds: ['note-body'],
+        relationships: { backlinks: ['note-marker'] },
+      },
+      {
+        id: 'citation-marker',
+        type: 'paragraph',
+        sourceRunIds: ['citation-marker'],
+        relationships: { citationTargetNodeIds: ['reference'] },
+      },
+      {
+        id: 'reference',
+        type: 'reference',
+        sourceRunIds: ['reference'],
+        relationships: { backlinks: ['citation-marker'] },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.nodes.at(-1)?.relationships?.backlinks).toEqual([
+        'citation-marker',
+      ])
+    }
+  })
+
+  it('rejects a relationship without a reciprocal backlink', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'note-marker', text: '1', page: 2, order: 8 },
+      { id: 'note-body', text: 'A note.', page: 2, order: 9 },
+    )
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'note-marker',
+        type: 'paragraph',
+        sourceRunIds: ['note-marker'],
+        relationships: { noteTargetNodeIds: ['note-body'] },
+      },
+      {
+        id: 'note-body',
+        type: 'footnote',
+        sourceRunIds: ['note-body'],
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
+    }
   })
 })

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -270,6 +270,30 @@ describe('source-backed structured extraction verifier', () => {
     expect(input).toHaveProperty('boilerplateRunIds', ['running-head'])
   })
 
+  it('does not freeze or alias caller-owned relationship provenance', () => {
+    const inputContext = context()
+    const targetSourceRunIds = ['body-run']
+    inputContext.provenArtifacts!.push({
+      id: 'note-link',
+      kind: 'note-relationship',
+      sourceRunIds: ['title-run'],
+      targetSourceRunIds,
+    })
+
+    const input = modelInputForStructuredExtraction(
+      inputContext,
+      'llm-grounded',
+    )
+
+    expect(input.provenArtifacts?.at(-1)?.targetSourceRunIds).toEqual([
+      'body-run',
+    ])
+    expect(input.provenArtifacts?.at(-1)?.targetSourceRunIds).not.toBe(
+      targetSourceRunIds,
+    )
+    expect(Object.isFrozen(targetSourceRunIds)).toBe(false)
+  })
+
   it('stays byte-stable for repeated verified output', () => {
     const first = verifyStructuredExtraction(context(), validProposal())
     const second = verifyStructuredExtraction(
@@ -335,6 +359,37 @@ describe('source-backed structured extraction verifier', () => {
     expect(result.status).toBe('passed')
     if (result.status === 'passed') {
       expect(result.output.nodes.at(-1)?.text).toBe('  const value = 42')
+    }
+  })
+
+  it('rejects ambiguous multi-run code without deterministic line ownership', () => {
+    const base = context()
+    base.sourceRuns.push(
+      {
+        id: 'legacy-code-line-a',
+        text: 'const value = 42',
+        page: 2,
+        order: 8,
+      },
+      {
+        id: 'legacy-code-line-b',
+        text: 'return value',
+        page: 2,
+        order: 9,
+      },
+    )
+    const candidate = validProposal()
+    candidate.nodes.push({
+      id: 'legacy-listing',
+      type: 'code',
+      sourceRunIds: ['legacy-code-line-a', 'legacy-code-line-b'],
+    })
+
+    const result = verifyStructuredExtraction(base, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('unverified-span')
     }
   })
 
@@ -540,6 +595,45 @@ describe('source-backed structured extraction verifier', () => {
         id: 'wrong-note',
         type: 'footnote',
         sourceRunIds: ['wrong-note'],
+        relationships: { backlinks: ['note-marker'] },
+      },
+    )
+
+    const result = verifyStructuredExtraction(input, candidate)
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-relationship',
+      )
+    }
+  })
+
+  it('rejects a proven note target contaminated with unrelated source runs', () => {
+    const input = context()
+    input.sourceRuns.push(
+      { id: 'note-marker', text: '1', page: 2, order: 8 },
+      { id: 'right-note', text: 'Right note.', page: 2, order: 9 },
+      { id: 'wrong-note', text: 'Unrelated wrong note.', page: 2, order: 10 },
+    )
+    input.provenArtifacts!.push({
+      id: 'note-link-1',
+      kind: 'note-relationship',
+      sourceRunIds: ['note-marker'],
+      targetSourceRunIds: ['right-note'],
+    })
+    const candidate = validProposal()
+    candidate.nodes.push(
+      {
+        id: 'note-marker',
+        type: 'paragraph',
+        sourceRunIds: ['note-marker'],
+        relationships: { noteTargetNodeIds: ['merged-note'] },
+      },
+      {
+        id: 'merged-note',
+        type: 'footnote',
+        sourceRunIds: ['right-note', 'wrong-note'],
         relationships: { backlinks: ['note-marker'] },
       },
     )

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -632,9 +632,11 @@ function nodeTextForRunIds(
 function nodeOwnedSourceRunIds(node: StructuredExtractionNode) {
   return [
     ...node.sourceRunIds,
-    ...(node.table?.rows.flatMap(({ cells }) =>
-      cells.flatMap(({ sourceRunIds }) => sourceRunIds),
-    ) ?? []),
+    ...(node.type === 'table'
+      ? (node.table?.rows.flatMap(({ cells }) =>
+          cells.flatMap(({ sourceRunIds }) => sourceRunIds),
+        ) ?? [])
+      : []),
   ]
 }
 
@@ -649,6 +651,7 @@ function issue(
 function verifyNodeTable(
   node: StructuredExtractionNode,
   runsById: ReadonlyMap<string, StructuredSourceRun>,
+  provenArtifacts: readonly StructuredProvenArtifact[],
   claimed: Set<string>,
   issues: StructuredExtractionVerificationIssue[],
   boilerplate: ReadonlySet<string>,
@@ -672,6 +675,60 @@ function verifyNodeTable(
     )
     return undefined
   }
+  const cellSourceRunIds = node.table.rows.flatMap(({ cells }) =>
+    cells.flatMap(({ sourceRunIds }) => sourceRunIds),
+  )
+  const cellSourceRunCounts = new Map<string, number>()
+  for (const sourceRunId of cellSourceRunIds) {
+    cellSourceRunCounts.set(
+      sourceRunId,
+      (cellSourceRunCounts.get(sourceRunId) ?? 0) + 1,
+    )
+  }
+  const matchingScopes = provenArtifacts.filter((artifact) => {
+    if (
+      artifact.kind !== 'table-scope' ||
+      artifact.sourceRunIds.length !== cellSourceRunIds.length
+    ) {
+      return false
+    }
+    const scopeCounts = new Map<string, number>()
+    for (const sourceRunId of artifact.sourceRunIds) {
+      scopeCounts.set(sourceRunId, (scopeCounts.get(sourceRunId) ?? 0) + 1)
+    }
+    return (
+      scopeCounts.size === cellSourceRunCounts.size &&
+      [...scopeCounts].every(
+        ([sourceRunId, count]) =>
+          cellSourceRunCounts.get(sourceRunId) === count,
+      )
+    )
+  })
+  if (matchingScopes.length !== 1) {
+    issues.push(
+      issue(
+        'invalid-table',
+        'Semantic table cells must exactly match one deterministic table scope.',
+        { nodeId: node.id },
+      ),
+    )
+  }
+  const cellSourceOrders = cellSourceRunIds
+    .map((sourceRunId) => runsById.get(sourceRunId)?.order)
+    .filter((order): order is number => order !== undefined)
+  if (
+    cellSourceOrders.some(
+      (order, index) => index > 0 && order < cellSourceOrders[index - 1]!,
+    )
+  ) {
+    issues.push(
+      issue(
+        'unverified-span',
+        'Table cells and rows must follow deterministic source order.',
+        { nodeId: node.id },
+      ),
+    )
+  }
   const rows: VerifiedStructuredExtractionNode['table'] = { rows: [] }
   for (const row of node.table.rows) {
     if (row.cells.length === 0) {
@@ -684,22 +741,6 @@ function verifyNodeTable(
     }
     const cells = []
     for (const cell of row.cells) {
-      const sourceOrders = cell.sourceRunIds
-        .map((sourceRunId) => runsById.get(sourceRunId)?.order)
-        .filter((order): order is number => order !== undefined)
-      if (
-        sourceOrders.some(
-          (order, index) => index > 0 && order < sourceOrders[index - 1]!,
-        )
-      ) {
-        issues.push(
-          issue(
-            'unverified-span',
-            'Table cell source runs must follow deterministic source order.',
-            { nodeId: node.id },
-          ),
-        )
-      }
       const cellText = sourceTextForRunIds(cell.sourceRunIds, runsById)
       if (!cellText) {
         issues.push(
@@ -1003,30 +1044,45 @@ function verifyRelationships(
   issues: StructuredExtractionVerificationIssue[],
 ) {
   const provenArtifacts = context.provenArtifacts ?? []
+  const targetGroupsForArtifact = (artifact: StructuredProvenArtifact) => [
+    ...(artifact.targetSourceRunIdGroups ?? []),
+    ...(artifact.targetSourceRunIds ? [artifact.targetSourceRunIds] : []),
+  ]
+  const targetMatchesGroup = (
+    target: StructuredExtractionNode,
+    group: readonly string[],
+  ) => {
+    const targetRuns = new Set(nodeOwnedSourceRunIds(target))
+    const artifactTargetRuns = new Set(group)
+    return (
+      targetRuns.size > 0 &&
+      artifactTargetRuns.size === targetRuns.size &&
+      [...targetRuns].every((id) => artifactTargetRuns.has(id))
+    )
+  }
+  const sourceMatchesArtifact = (
+    source: StructuredExtractionNode,
+    artifact: StructuredProvenArtifact,
+  ) => {
+    const sourceRuns = new Set(nodeOwnedSourceRunIds(source))
+    const artifactSourceRuns = new Set(artifact.sourceRunIds)
+    return (
+      sourceRuns.size > 0 &&
+      [...sourceRuns].every((id) => artifactSourceRuns.has(id))
+    )
+  }
   const relationshipIsProven = (
     source: StructuredExtractionNode,
     target: StructuredExtractionNode,
     kind: 'note-relationship' | 'citation-relationship',
   ) => {
-    const sourceRuns = new Set(nodeOwnedSourceRunIds(source))
-    const targetRuns = new Set(nodeOwnedSourceRunIds(target))
     return provenArtifacts.some((artifact) => {
       if (artifact.kind !== kind) return false
-      const artifactSourceRuns = new Set(artifact.sourceRunIds)
-      const targetGroups =
-        artifact.targetSourceRunIdGroups ??
-        (artifact.targetSourceRunIds ? [artifact.targetSourceRunIds] : [])
       return (
-        sourceRuns.size > 0 &&
-        targetRuns.size > 0 &&
-        [...sourceRuns].every((id) => artifactSourceRuns.has(id)) &&
-        targetGroups.some((group) => {
-          const artifactTargetRuns = new Set(group)
-          return (
-            artifactTargetRuns.size === targetRuns.size &&
-            [...targetRuns].every((id) => artifactTargetRuns.has(id))
-          )
-        })
+        sourceMatchesArtifact(source, artifact) &&
+        targetGroupsForArtifact(artifact).some((group) =>
+          targetMatchesGroup(target, group),
+        )
       )
     })
   }
@@ -1097,6 +1153,36 @@ function verifyRelationships(
             'invalid-relationship',
             `Backlink ${backlinkId} must point to ${node.id}.`,
             { nodeId: node.id },
+          ),
+        )
+      }
+    }
+  }
+
+  for (const artifact of provenArtifacts) {
+    if (
+      artifact.kind !== 'note-relationship' &&
+      artifact.kind !== 'citation-relationship'
+    ) {
+      continue
+    }
+    for (const targetGroup of targetGroupsForArtifact(artifact)) {
+      const represented = proposal.nodes.some((source) => {
+        if (!sourceMatchesArtifact(source, artifact)) return false
+        const targetIds =
+          artifact.kind === 'note-relationship'
+            ? (source.relationships?.noteTargetNodeIds ?? [])
+            : (source.relationships?.citationTargetNodeIds ?? [])
+        return targetIds.some((targetId) => {
+          const target = nodesById.get(targetId)
+          return target ? targetMatchesGroup(target, targetGroup) : false
+        })
+      })
+      if (!represented) {
+        issues.push(
+          issue(
+            'invalid-relationship',
+            `Deterministic relationship ${artifact.id} is missing a proven target from the proposal.`,
           ),
         )
       }
@@ -1252,6 +1338,15 @@ export function verifyStructuredExtraction(
         ),
       )
     }
+    if (node.type !== 'table' && node.table !== undefined) {
+      issues.push(
+        issue(
+          'invalid-table',
+          `Only a table node may carry semantic cells; ${node.id} is a ${node.type}.`,
+          { nodeId: node.id },
+        ),
+      )
+    }
     const claimedBeforeNode = new Set(claimed)
     const text = validateNodeText(node, runsById, linesById, claimed, issues)
     for (const sourceRunId of node.sourceRunIds) {
@@ -1273,6 +1368,7 @@ export function verifyStructuredExtraction(
     const table = verifyNodeTable(
       node,
       runsById,
+      context.provenArtifacts ?? [],
       tableClaimed,
       issues,
       boilerplate,

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -45,6 +45,8 @@ export type StructuredSourceRun = {
   text: string
   page: number
   order: number
+  /** Stable deterministic line ownership for whitespace-sensitive material. */
+  lineId?: string
   /** A source run is already normalized by the deterministic extractor. */
   layout?: StructuredExtractionLayout
   stratum?: string
@@ -87,6 +89,8 @@ export type StructuredProvenArtifact = {
     | 'citation-relationship'
     | 'source-run-provenance'
   sourceRunIds: string[]
+  /** Deterministic destination ownership for note/citation relationships. */
+  targetSourceRunIds?: string[]
 }
 
 export type StructuredExtractionContext = {
@@ -222,6 +226,7 @@ const sourceRunSchema = z
     text: z.string(),
     page: z.number().int().positive(),
     order: z.number().int().nonnegative(),
+    lineId: idSchema.optional(),
     layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS).optional(),
     stratum: z.string().min(1).optional(),
   })
@@ -274,6 +279,7 @@ const sourceArtifactSchema = z
       'source-run-provenance',
     ]),
     sourceRunIds: z.array(idSchema),
+    targetSourceRunIds: z.array(idSchema).optional(),
   })
   .strict()
 
@@ -376,6 +382,7 @@ export function structuredExtractionContextFromReconstruction({
           text: run.text,
           page: run.page,
           order: order++,
+          lineId: `${region.id}:${line.id}`,
           layout,
           ...(stratum ? { stratum } : {}),
         })
@@ -393,6 +400,12 @@ export function structuredExtractionContextFromReconstruction({
         .filter(Boolean),
     )
   }
+  const runIdsForNode = (nodeId: string | null) =>
+    nodeId
+      ? (reconstruction.provenance[nodeId]?.regionIds ?? []).flatMap(
+          runIdsForRegion,
+        )
+      : []
   const sourceAssets: StructuredSourceAsset[] = reconstruction.assets.map(
     (asset) => {
       const relationship = reconstruction.visualRelationships.find(
@@ -452,11 +465,13 @@ export function structuredExtractionContextFromReconstruction({
       id: relationship.id,
       kind: 'note-relationship' as const,
       sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
+      targetSourceRunIds: runIdsForNode(relationship.targetNoteId),
     })),
     ...reconstruction.citationRelationships.map((relationship) => ({
       id: relationship.id,
       kind: 'citation-relationship' as const,
       sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
+      targetSourceRunIds: relationship.targetNodeIds.flatMap(runIdsForNode),
     })),
     {
       id: 'source-run-provenance',
@@ -553,11 +568,31 @@ function nodeTextForRunIds(
 ) {
   if (!PREFORMATTED_NODE_TYPES.has(type))
     return sourceTextForRunIds(sourceRunIds, runsById)
-  return sourceRunIds
-    .map((id) => runsById.get(id)?.text ?? '')
-    .filter((text) => text.length > 0)
-    .join('\n')
+  const runs = sourceRunIds
+    .map((id) => runsById.get(id))
+    .filter((run): run is StructuredSourceRun => run !== undefined)
+  return runs
+    .map((run, index) => {
+      const previous = runs[index - 1]
+      const lineBreak =
+        previous?.lineId !== undefined &&
+        run.lineId !== undefined &&
+        previous.lineId !== run.lineId
+          ? '\n'
+          : ''
+      return `${lineBreak}${run.text}`
+    })
+    .join('')
     .normalize('NFKC')
+}
+
+function nodeOwnedSourceRunIds(node: StructuredExtractionNode) {
+  return [
+    ...node.sourceRunIds,
+    ...(node.table?.rows.flatMap(({ cells }) =>
+      cells.flatMap(({ sourceRunIds }) => sourceRunIds),
+    ) ?? []),
+  ]
 }
 
 function issue(
@@ -855,10 +890,26 @@ function captionTextForNode(
 }
 
 function verifyRelationships(
+  context: StructuredExtractionContext,
   proposal: StructuredExtractionProposal,
   nodesById: ReadonlyMap<string, StructuredExtractionNode>,
   issues: StructuredExtractionVerificationIssue[],
 ) {
+  const provenArtifacts = context.provenArtifacts ?? []
+  const relationshipIsProven = (
+    source: StructuredExtractionNode,
+    target: StructuredExtractionNode,
+    kind: 'note-relationship' | 'citation-relationship',
+  ) => {
+    const sourceRuns = new Set(nodeOwnedSourceRunIds(source))
+    const targetRuns = new Set(nodeOwnedSourceRunIds(target))
+    return provenArtifacts.some(
+      (artifact) =>
+        artifact.kind === kind &&
+        artifact.sourceRunIds.some((id) => sourceRuns.has(id)) &&
+        (artifact.targetSourceRunIds ?? []).some((id) => targetRuns.has(id)),
+    )
+  }
   const targetLists = (node: StructuredExtractionNode) => [
     ...(node.relationships?.noteTargetNodeIds ?? []),
     ...(node.relationships?.citationTargetNodeIds ?? []),
@@ -884,12 +935,13 @@ function verifyRelationships(
       const target = nodesById.get(targetId)
       if (
         target?.type !== 'footnote' ||
-        !target.relationships?.backlinks?.includes(node.id)
+        !target.relationships?.backlinks?.includes(node.id) ||
+        !relationshipIsProven(node, target, 'note-relationship')
       ) {
         issues.push(
           issue(
             'invalid-relationship',
-            `Note target ${targetId} must be a footnote with a reciprocal backlink.`,
+            `Note target ${targetId} must be a deterministically proven footnote with a reciprocal backlink.`,
             { nodeId: node.id },
           ),
         )
@@ -900,12 +952,13 @@ function verifyRelationships(
       const target = nodesById.get(targetId)
       if (
         target?.type !== 'reference' ||
-        !target.relationships?.backlinks?.includes(node.id)
+        !target.relationships?.backlinks?.includes(node.id) ||
+        !relationshipIsProven(node, target, 'citation-relationship')
       ) {
         issues.push(
           issue(
             'invalid-relationship',
-            `Citation target ${targetId} must be a reference with a reciprocal backlink.`,
+            `Citation target ${targetId} must be a deterministically proven reference with a reciprocal backlink.`,
             { nodeId: node.id },
           ),
         )
@@ -1007,7 +1060,7 @@ export function verifyStructuredExtraction(
   // node boundaries too.
   let previousNodeOrder: { id: string; order: number } | undefined
   for (const node of proposal.nodes) {
-    const nodeOrders = node.sourceRunIds
+    const nodeOrders = nodeOwnedSourceRunIds(node)
       .map((sourceRunId) => runsById.get(sourceRunId)?.order)
       .filter((order): order is number => order !== undefined)
     if (nodeOrders.length > 0) {
@@ -1155,7 +1208,7 @@ export function verifyStructuredExtraction(
     })
   }
 
-  verifyRelationships(proposal, nodesById, issues)
+  verifyRelationships(context, proposal, nodesById, issues)
 
   for (const sourceRunId of excluded) {
     if (!boilerplate.has(sourceRunId)) {

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -52,6 +52,13 @@ export type StructuredSourceRun = {
   stratum?: string
 }
 
+export type StructuredSourceLine = {
+  id: string
+  /** Canonical deterministic line text, including inferred run boundaries. */
+  text: string
+  sourceRunIds: string[]
+}
+
 export type StructuredSourceAsset = {
   id: string
   kind: 'figure' | 'diagram' | 'table' | 'equation'
@@ -91,6 +98,8 @@ export type StructuredProvenArtifact = {
   sourceRunIds: string[]
   /** Deterministic destination ownership for note/citation relationships. */
   targetSourceRunIds?: string[]
+  /** One exact destination group per deterministic relationship target. */
+  targetSourceRunIdGroups?: string[][]
 }
 
 export type StructuredExtractionContext = {
@@ -99,6 +108,7 @@ export type StructuredExtractionContext = {
   split: StructuredExtractionSplit
   layout: StructuredExtractionLayout
   sourceRuns: StructuredSourceRun[]
+  sourceLines?: StructuredSourceLine[]
   sourceAssets: StructuredSourceAsset[]
   pageRenditions?: StructuredExtractionPageRendition[]
   provenArtifacts?: StructuredProvenArtifact[]
@@ -251,6 +261,14 @@ const sourceAssetSchema = z
   })
   .strict()
 
+const sourceLineSchema = z
+  .object({
+    id: idSchema,
+    text: z.string(),
+    sourceRunIds: z.array(idSchema).min(1),
+  })
+  .strict()
+
 const pageRenditionSchema = z
   .object({
     id: idSchema.optional(),
@@ -280,6 +298,7 @@ const sourceArtifactSchema = z
     ]),
     sourceRunIds: z.array(idSchema),
     targetSourceRunIds: z.array(idSchema).optional(),
+    targetSourceRunIdGroups: z.array(z.array(idSchema).min(1)).optional(),
   })
   .strict()
 
@@ -290,6 +309,7 @@ const contextSchema = z
     split: z.enum(STRUCTURED_EXTRACTION_SPLITS),
     layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS),
     sourceRuns: z.array(sourceRunSchema),
+    sourceLines: z.array(sourceLineSchema).optional(),
     sourceAssets: z.array(sourceAssetSchema),
     pageRenditions: z.array(pageRenditionSchema).min(1).optional(),
     provenArtifacts: z.array(sourceArtifactSchema).optional(),
@@ -370,22 +390,29 @@ export function structuredExtractionContextFromReconstruction({
   pageRenditions?: StructuredExtractionPageRendition[]
 }): StructuredExtractionContext {
   const sourceRuns: StructuredSourceRun[] = []
+  const sourceLines: StructuredSourceLine[] = []
   const runIdsByKey = new Map<string, string>()
   let order = 0
   for (const region of reconstruction.regions) {
     for (const line of region.lines) {
+      const lineId = `${region.id}:${line.id}`
+      const sourceRunIds: string[] = []
       for (const [runIndex, run] of line.runs.entries()) {
         const id = `r-${region.id}-${line.id}-${runIndex}`
+        sourceRunIds.push(id)
         runIdsByKey.set(`${region.id}\u0000${line.id}\u0000${runIndex}`, id)
         sourceRuns.push({
           id,
           text: run.text,
           page: run.page,
           order: order++,
-          lineId: `${region.id}:${line.id}`,
+          lineId,
           layout,
           ...(stratum ? { stratum } : {}),
         })
+      }
+      if (sourceRunIds.length > 0) {
+        sourceLines.push({ id: lineId, text: line.text, sourceRunIds })
       }
     }
   }
@@ -465,13 +492,15 @@ export function structuredExtractionContextFromReconstruction({
       id: relationship.id,
       kind: 'note-relationship' as const,
       sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
-      targetSourceRunIds: runIdsForNode(relationship.targetNoteId),
+      targetSourceRunIdGroups: relationship.targetNoteId
+        ? [runIdsForNode(relationship.targetNoteId)]
+        : [],
     })),
     ...reconstruction.citationRelationships.map((relationship) => ({
       id: relationship.id,
       kind: 'citation-relationship' as const,
       sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
-      targetSourceRunIds: relationship.targetNodeIds.flatMap(runIdsForNode),
+      targetSourceRunIdGroups: relationship.targetNodeIds.map(runIdsForNode),
     })),
     {
       id: 'source-run-provenance',
@@ -485,6 +514,7 @@ export function structuredExtractionContextFromReconstruction({
     split,
     layout,
     sourceRuns,
+    sourceLines,
     sourceAssets,
     ...(pageRenditions ? { pageRenditions } : {}),
     provenArtifacts,
@@ -565,12 +595,25 @@ function nodeTextForRunIds(
   type: StructuredExtractionNodeType,
   sourceRunIds: readonly string[],
   runsById: ReadonlyMap<string, StructuredSourceRun>,
+  linesById: ReadonlyMap<string, StructuredSourceLine>,
 ) {
   if (!PREFORMATTED_NODE_TYPES.has(type))
     return sourceTextForRunIds(sourceRunIds, runsById)
   const runs = sourceRunIds
     .map((id) => runsById.get(id))
     .filter((run): run is StructuredSourceRun => run !== undefined)
+  if (
+    runs.length > 0 &&
+    runs.every((run) => run.lineId !== undefined && linesById.has(run.lineId))
+  ) {
+    const lineIds = runs.flatMap(({ lineId }, index) =>
+      lineId !== runs[index - 1]?.lineId ? [lineId!] : [],
+    )
+    return lineIds
+      .map((lineId) => linesById.get(lineId)!.text)
+      .join('\n')
+      .normalize('NFKC')
+  }
   return runs
     .map((run, index) => {
       const previous = runs[index - 1]
@@ -641,6 +684,22 @@ function verifyNodeTable(
     }
     const cells = []
     for (const cell of row.cells) {
+      const sourceOrders = cell.sourceRunIds
+        .map((sourceRunId) => runsById.get(sourceRunId)?.order)
+        .filter((order): order is number => order !== undefined)
+      if (
+        sourceOrders.some(
+          (order, index) => index > 0 && order < sourceOrders[index - 1]!,
+        )
+      ) {
+        issues.push(
+          issue(
+            'unverified-span',
+            'Table cell source runs must follow deterministic source order.',
+            { nodeId: node.id },
+          ),
+        )
+      }
       const cellText = sourceTextForRunIds(cell.sourceRunIds, runsById)
       if (!cellText) {
         issues.push(
@@ -692,6 +751,7 @@ function verifyNodeTable(
 function validateNodeText(
   node: StructuredExtractionNode,
   runsById: ReadonlyMap<string, StructuredSourceRun>,
+  linesById: ReadonlyMap<string, StructuredSourceLine>,
   claimed: Set<string>,
   issues: StructuredExtractionVerificationIssue[],
 ) {
@@ -722,7 +782,37 @@ function validateNodeText(
       ),
     )
   }
-  const text = nodeTextForRunIds(node.type, node.sourceRunIds, runsById)
+  if (node.type === 'code') {
+    const selectedByLineId = new Map<string, string[]>()
+    for (const run of knownRuns) {
+      if (!run.lineId) continue
+      const selected = selectedByLineId.get(run.lineId) ?? []
+      selected.push(run.id)
+      selectedByLineId.set(run.lineId, selected)
+    }
+    for (const [lineId, selected] of selectedByLineId) {
+      const sourceLine = linesById.get(lineId)
+      if (
+        !sourceLine ||
+        sourceLine.sourceRunIds.length !== selected.length ||
+        sourceLine.sourceRunIds.some((id, index) => id !== selected[index])
+      ) {
+        issues.push(
+          issue(
+            'unverified-span',
+            `Code line ${lineId} requires complete canonical line ownership.`,
+            { nodeId: node.id },
+          ),
+        )
+      }
+    }
+  }
+  const text = nodeTextForRunIds(
+    node.type,
+    node.sourceRunIds,
+    runsById,
+    linesById,
+  )
   if (!text) {
     issues.push(
       issue('unverified-span', 'A node references no readable source text.', {
@@ -920,19 +1010,25 @@ function verifyRelationships(
   ) => {
     const sourceRuns = new Set(nodeOwnedSourceRunIds(source))
     const targetRuns = new Set(nodeOwnedSourceRunIds(target))
-    return provenArtifacts.some(
-      (artifact) => {
-        if (artifact.kind !== kind) return false
-        const artifactSourceRuns = new Set(artifact.sourceRunIds)
-        const artifactTargetRuns = new Set(artifact.targetSourceRunIds ?? [])
-        return (
-          sourceRuns.size > 0 &&
-          targetRuns.size > 0 &&
-          [...sourceRuns].every((id) => artifactSourceRuns.has(id)) &&
-          [...targetRuns].every((id) => artifactTargetRuns.has(id))
-        )
-      },
-    )
+    return provenArtifacts.some((artifact) => {
+      if (artifact.kind !== kind) return false
+      const artifactSourceRuns = new Set(artifact.sourceRunIds)
+      const targetGroups =
+        artifact.targetSourceRunIdGroups ??
+        (artifact.targetSourceRunIds ? [artifact.targetSourceRunIds] : [])
+      return (
+        sourceRuns.size > 0 &&
+        targetRuns.size > 0 &&
+        [...sourceRuns].every((id) => artifactSourceRuns.has(id)) &&
+        targetGroups.some((group) => {
+          const artifactTargetRuns = new Set(group)
+          return (
+            artifactTargetRuns.size === targetRuns.size &&
+            [...targetRuns].every((id) => artifactTargetRuns.has(id))
+          )
+        })
+      )
+    })
   }
   const targetLists = (node: StructuredExtractionNode) => [
     ...(node.relationships?.noteTargetNodeIds ?? []),
@@ -1041,6 +1137,9 @@ export function verifyStructuredExtraction(
 
   const issues: StructuredExtractionVerificationIssue[] = []
   const runsById = new Map(context.sourceRuns.map((run) => [run.id, run]))
+  const linesById = new Map(
+    (context.sourceLines ?? []).map((line) => [line.id, line]),
+  )
   const assetsById = new Map(
     context.sourceAssets.map((asset) => [asset.id, asset]),
   )
@@ -1062,6 +1161,35 @@ export function verifyStructuredExtraction(
         'Source run identifiers and source order positions must be unique.',
       ),
     )
+  }
+  if (linesById.size !== (context.sourceLines ?? []).length) {
+    issues.push(
+      issue('invalid-output', 'Deterministic source line IDs must be unique.'),
+    )
+  }
+  const lineOwnedRunIds = new Set<string>()
+  for (const line of context.sourceLines ?? []) {
+    if (new Set(line.sourceRunIds).size !== line.sourceRunIds.length) {
+      issues.push(
+        issue(
+          'invalid-output',
+          `Source line ${line.id} run ownership must be unique.`,
+        ),
+      )
+    }
+    for (const sourceRunId of line.sourceRunIds) {
+      const run = runsById.get(sourceRunId)
+      if (!run || run.lineId !== line.id || lineOwnedRunIds.has(sourceRunId)) {
+        issues.push(
+          issue(
+            'invalid-output',
+            `Source line ${line.id} has invalid run ownership.`,
+            { sourceRunId },
+          ),
+        )
+      }
+      lineOwnedRunIds.add(sourceRunId)
+    }
   }
   if (
     new Set(context.sourceAssets.map(({ id }) => id)).size !==
@@ -1125,7 +1253,7 @@ export function verifyStructuredExtraction(
       )
     }
     const claimedBeforeNode = new Set(claimed)
-    const text = validateNodeText(node, runsById, claimed, issues)
+    const text = validateNodeText(node, runsById, linesById, claimed, issues)
     for (const sourceRunId of node.sourceRunIds) {
       if (boilerplate.has(sourceRunId)) {
         issues.push(
@@ -1333,6 +1461,14 @@ export function modelInputForStructuredExtraction(
     split: context.split,
     layout: context.layout,
     sourceRuns: context.sourceRuns.map((run) => ({ ...run })),
+    ...(context.sourceLines
+      ? {
+          sourceLines: context.sourceLines.map((line) => ({
+            ...line,
+            sourceRunIds: [...line.sourceRunIds],
+          })),
+        }
+      : {}),
     sourceAssets: context.sourceAssets.map((asset) => ({
       ...asset,
       bounds: { ...asset.bounds },
@@ -1358,6 +1494,13 @@ export function modelInputForStructuredExtraction(
       sourceRunIds: [...artifact.sourceRunIds],
       ...(artifact.targetSourceRunIds
         ? { targetSourceRunIds: [...artifact.targetSourceRunIds] }
+        : {}),
+      ...(artifact.targetSourceRunIdGroups
+        ? {
+            targetSourceRunIdGroups: artifact.targetSourceRunIdGroups.map(
+              (group) => [...group],
+            ),
+          }
         : {}),
     }))
   }

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -705,6 +705,23 @@ function validateNodeText(
     )
     return ''
   }
+  const knownRuns = node.sourceRunIds
+    .map((sourceRunId) => runsById.get(sourceRunId))
+    .filter((run): run is StructuredSourceRun => run !== undefined)
+  if (
+    node.type === 'code' &&
+    node.sourceRunIds.length > 1 &&
+    knownRuns.length === node.sourceRunIds.length &&
+    knownRuns.some(({ lineId }) => lineId === undefined)
+  ) {
+    issues.push(
+      issue(
+        'unverified-span',
+        'Multi-run code requires deterministic line ownership.',
+        { nodeId: node.id },
+      ),
+    )
+  }
   const text = nodeTextForRunIds(node.type, node.sourceRunIds, runsById)
   if (!text) {
     issues.push(
@@ -904,10 +921,17 @@ function verifyRelationships(
     const sourceRuns = new Set(nodeOwnedSourceRunIds(source))
     const targetRuns = new Set(nodeOwnedSourceRunIds(target))
     return provenArtifacts.some(
-      (artifact) =>
-        artifact.kind === kind &&
-        artifact.sourceRunIds.some((id) => sourceRuns.has(id)) &&
-        (artifact.targetSourceRunIds ?? []).some((id) => targetRuns.has(id)),
+      (artifact) => {
+        if (artifact.kind !== kind) return false
+        const artifactSourceRuns = new Set(artifact.sourceRunIds)
+        const artifactTargetRuns = new Set(artifact.targetSourceRunIds ?? [])
+        return (
+          sourceRuns.size > 0 &&
+          targetRuns.size > 0 &&
+          [...sourceRuns].every((id) => artifactSourceRuns.has(id)) &&
+          [...targetRuns].every((id) => artifactTargetRuns.has(id))
+        )
+      },
     )
   }
   const targetLists = (node: StructuredExtractionNode) => [
@@ -1332,6 +1356,9 @@ export function modelInputForStructuredExtraction(
     base.provenArtifacts = (context.provenArtifacts ?? []).map((artifact) => ({
       ...artifact,
       sourceRunIds: [...artifact.sourceRunIds],
+      ...(artifact.targetSourceRunIds
+        ? { targetSourceRunIds: [...artifact.targetSourceRunIds] }
+        : {}),
     }))
   }
   return deepFreeze(base)

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -65,6 +65,18 @@ export type StructuredSourceAsset = {
   captionRunIds?: string[]
 }
 
+/** Owner-local page evidence shared by every extraction arm. */
+export type StructuredExtractionPageRendition = {
+  id?: string
+  page: number
+  mediaType?: string
+  width?: number
+  height?: number
+  bytesSha256?: string
+  reference?: string
+  data?: string
+}
+
 export type StructuredProvenArtifact = {
   id: string
   kind:
@@ -84,6 +96,7 @@ export type StructuredExtractionContext = {
   layout: StructuredExtractionLayout
   sourceRuns: StructuredSourceRun[]
   sourceAssets: StructuredSourceAsset[]
+  pageRenditions?: StructuredExtractionPageRendition[]
   provenArtifacts?: StructuredProvenArtifact[]
   /** These runs remain accounted for but may not enter body flow. */
   boilerplateRunIds?: string[]
@@ -100,6 +113,12 @@ export type StructuredExtractionTable = {
   rows: Array<{ cells: StructuredExtractionTableCell[] }>
 }
 
+export type StructuredExtractionRelationships = {
+  noteTargetNodeIds?: string[]
+  citationTargetNodeIds?: string[]
+  backlinks?: string[]
+}
+
 export type StructuredExtractionNode = {
   id: string
   type: StructuredExtractionNodeType
@@ -112,6 +131,7 @@ export type StructuredExtractionNode = {
   altText?: string
   altTextSource?: 'caption' | 'model' | 'image'
   table?: StructuredExtractionTable
+  relationships?: StructuredExtractionRelationships
 }
 
 export type StructuredExtractionProposal = {
@@ -172,6 +192,7 @@ export type StructuredExtractionVerificationIssueCode =
   | 'model-authored-alt-text'
   | 'invalid-heading-level'
   | 'invalid-table'
+  | 'invalid-relationship'
 
 export type StructuredExtractionVerificationIssue = {
   code: StructuredExtractionVerificationIssueCode
@@ -225,6 +246,22 @@ const sourceAssetSchema = z
   })
   .strict()
 
+const pageRenditionSchema = z
+  .object({
+    id: idSchema.optional(),
+    page: z.number().int().positive(),
+    mediaType: z.string().min(1).optional(),
+    width: z.number().finite().positive().optional(),
+    height: z.number().finite().positive().optional(),
+    bytesSha256: sha256Schema.optional(),
+    reference: z.string().min(1).optional(),
+    data: z.string().min(1).optional(),
+  })
+  .strict()
+  .refine(
+    ({ reference, data }) => reference !== undefined || data !== undefined,
+  )
+
 const sourceArtifactSchema = z
   .object({
     id: idSchema,
@@ -248,6 +285,7 @@ const contextSchema = z
     layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS),
     sourceRuns: z.array(sourceRunSchema),
     sourceAssets: z.array(sourceAssetSchema),
+    pageRenditions: z.array(pageRenditionSchema).min(1).optional(),
     provenArtifacts: z.array(sourceArtifactSchema).optional(),
     boilerplateRunIds: z.array(idSchema).optional(),
   })
@@ -262,6 +300,20 @@ const tableCellSchema = z
   })
   .strict()
 
+const relationshipsSchema = z
+  .object({
+    noteTargetNodeIds: z.array(idSchema).min(1).optional(),
+    citationTargetNodeIds: z.array(idSchema).min(1).optional(),
+    backlinks: z.array(idSchema).min(1).optional(),
+  })
+  .strict()
+  .refine(
+    ({ noteTargetNodeIds, citationTargetNodeIds, backlinks }) =>
+      noteTargetNodeIds !== undefined ||
+      citationTargetNodeIds !== undefined ||
+      backlinks !== undefined,
+  )
+
 const nodeSchema = z
   .object({
     id: idSchema,
@@ -273,6 +325,7 @@ const nodeSchema = z
     captionNodeId: idSchema.optional(),
     altText: z.string().optional(),
     altTextSource: z.enum(['caption', 'model', 'image']).optional(),
+    relationships: relationshipsSchema.optional(),
     table: z
       .object({ rows: z.array(z.object({ cells: z.array(tableCellSchema) })) })
       .strict()
@@ -301,12 +354,14 @@ export function structuredExtractionContextFromReconstruction({
   split,
   layout,
   stratum,
+  pageRenditions,
 }: {
   reconstruction: PdfReconstruction
   documentId?: string
   split: StructuredExtractionSplit
   layout: StructuredExtractionLayout
   stratum?: string
+  pageRenditions?: StructuredExtractionPageRendition[]
 }): StructuredExtractionContext {
   const sourceRuns: StructuredSourceRun[] = []
   const runIdsByKey = new Map<string, string>()
@@ -416,6 +471,7 @@ export function structuredExtractionContextFromReconstruction({
     layout,
     sourceRuns,
     sourceAssets,
+    ...(pageRenditions ? { pageRenditions } : {}),
     provenArtifacts,
     boilerplateRunIds,
   }
@@ -481,6 +537,29 @@ function sourceTextForRunIds(
   )
 }
 
+/**
+ * A code listing's whitespace *is* its structure. Prose normalization collapses
+ * every run of whitespace to one space, which republishes a source-backed
+ * listing as a single flattened line, so preformatted nodes keep their source
+ * bytes (NFKC-normalized, like prose) and are joined by line rather than space.
+ */
+const PREFORMATTED_NODE_TYPES: ReadonlySet<StructuredExtractionNodeType> =
+  new Set(['code'])
+
+function nodeTextForRunIds(
+  type: StructuredExtractionNodeType,
+  sourceRunIds: readonly string[],
+  runsById: ReadonlyMap<string, StructuredSourceRun>,
+) {
+  if (!PREFORMATTED_NODE_TYPES.has(type))
+    return sourceTextForRunIds(sourceRunIds, runsById)
+  return sourceRunIds
+    .map((id) => runsById.get(id)?.text ?? '')
+    .filter((text) => text.length > 0)
+    .join('\n')
+    .normalize('NFKC')
+}
+
 function issue(
   code: StructuredExtractionVerificationIssueCode,
   message: string,
@@ -496,7 +575,17 @@ function verifyNodeTable(
   issues: StructuredExtractionVerificationIssue[],
   boilerplate: ReadonlySet<string>,
 ) {
-  if (!node.table || node.type !== 'table') return undefined
+  if (node.type !== 'table') return undefined
+  // A table node without semantic cells publishes no rows, header scopes, or
+  // per-cell provenance, yet would score as a table. It is not a table.
+  if (!node.table) {
+    issues.push(
+      issue('invalid-table', 'A table must carry its semantic cells.', {
+        nodeId: node.id,
+      }),
+    )
+    return undefined
+  }
   if (node.table.rows.length === 0) {
     issues.push(
       issue('invalid-table', 'A table must contain at least one row.', {
@@ -581,7 +670,7 @@ function validateNodeText(
     )
     return ''
   }
-  const text = sourceTextForRunIds(node.sourceRunIds, runsById)
+  const text = nodeTextForRunIds(node.type, node.sourceRunIds, runsById)
   if (!text) {
     issues.push(
       issue('unverified-span', 'A node references no readable source text.', {
@@ -589,7 +678,12 @@ function validateNodeText(
       }),
     )
   }
-  if (node.text !== undefined && normalizedText(node.text) !== text) {
+  const proposedText = PREFORMATTED_NODE_TYPES.has(node.type)
+    ? node.text?.normalize('NFKC')
+    : node.text === undefined
+      ? undefined
+      : normalizedText(node.text)
+  if (node.text !== undefined && proposedText !== text) {
     issues.push(
       issue(
         'source-text-mismatch',
@@ -643,7 +737,21 @@ function verifyAsset(
   nodesById: ReadonlyMap<string, StructuredExtractionNode>,
   issues: StructuredExtractionVerificationIssue[],
 ) {
-  if (!node.assetId) return
+  if (!node.assetId) {
+    // Returning here for a figure skips every figure-specific check, so a
+    // proposal that simply omits `assetId` publishes a figure with no bounded
+    // asset, no caption, and no caption-derived alt text.
+    if (node.type === 'figure') {
+      issues.push(
+        issue(
+          'unknown-asset',
+          `Figure ${node.id} must reference a deterministic asset.`,
+          { nodeId: node.id },
+        ),
+      )
+    }
+    return
+  }
   const asset = assetsById.get(node.assetId)
   if (!asset) {
     issues.push(
@@ -746,6 +854,83 @@ function captionTextForNode(
     : undefined
 }
 
+function verifyRelationships(
+  proposal: StructuredExtractionProposal,
+  nodesById: ReadonlyMap<string, StructuredExtractionNode>,
+  issues: StructuredExtractionVerificationIssue[],
+) {
+  const targetLists = (node: StructuredExtractionNode) => [
+    ...(node.relationships?.noteTargetNodeIds ?? []),
+    ...(node.relationships?.citationTargetNodeIds ?? []),
+  ]
+
+  for (const node of proposal.nodes) {
+    const relationships = node.relationships
+    if (!relationships) continue
+    const lists = [
+      relationships.noteTargetNodeIds ?? [],
+      relationships.citationTargetNodeIds ?? [],
+      relationships.backlinks ?? [],
+    ]
+    if (lists.some((ids) => new Set(ids).size !== ids.length)) {
+      issues.push(
+        issue('invalid-relationship', 'Relationship targets must be unique.', {
+          nodeId: node.id,
+        }),
+      )
+    }
+
+    for (const targetId of relationships.noteTargetNodeIds ?? []) {
+      const target = nodesById.get(targetId)
+      if (
+        target?.type !== 'footnote' ||
+        !target.relationships?.backlinks?.includes(node.id)
+      ) {
+        issues.push(
+          issue(
+            'invalid-relationship',
+            `Note target ${targetId} must be a footnote with a reciprocal backlink.`,
+            { nodeId: node.id },
+          ),
+        )
+      }
+    }
+
+    for (const targetId of relationships.citationTargetNodeIds ?? []) {
+      const target = nodesById.get(targetId)
+      if (
+        target?.type !== 'reference' ||
+        !target.relationships?.backlinks?.includes(node.id)
+      ) {
+        issues.push(
+          issue(
+            'invalid-relationship',
+            `Citation target ${targetId} must be a reference with a reciprocal backlink.`,
+            { nodeId: node.id },
+          ),
+        )
+      }
+    }
+
+    for (const backlinkId of relationships.backlinks ?? []) {
+      const backlink = nodesById.get(backlinkId)
+      if (
+        !['footnote', 'reference'].includes(node.type) ||
+        !backlink ||
+        !targetLists(backlink).includes(node.id)
+      ) {
+        issues.push(
+          issue(
+            'invalid-relationship',
+            `Backlink ${backlinkId} must point to ${node.id}.`,
+            { nodeId: node.id },
+          ),
+        )
+      }
+    }
+  }
+}
+
 /**
  * Verify and materialize a model proposal.  On any violation this function
  * returns no document; callers must use the deterministic fallback instead of
@@ -816,7 +1001,28 @@ export function verifyStructuredExtraction(
   if (nodesById.size !== proposal.nodes.length) {
     issues.push(issue('invalid-output', 'Node identifiers must be unique.'))
   }
+  // `validateNodeText` only orders the runs *within* one node, so two nodes can
+  // be supplied back to front with each one internally sorted. The proposal
+  // order is what the verified document publishes, so it has to hold across
+  // node boundaries too.
+  let previousNodeOrder: { id: string; order: number } | undefined
   for (const node of proposal.nodes) {
+    const nodeOrders = node.sourceRunIds
+      .map((sourceRunId) => runsById.get(sourceRunId)?.order)
+      .filter((order): order is number => order !== undefined)
+    if (nodeOrders.length > 0) {
+      const first = Math.min(...nodeOrders)
+      if (previousNodeOrder && first < previousNodeOrder.order) {
+        issues.push(
+          issue(
+            'unverified-span',
+            `Node ${node.id} is emitted after ${previousNodeOrder.id} but starts earlier in source order.`,
+            { nodeId: node.id },
+          ),
+        )
+      }
+      previousNodeOrder = { id: node.id, order: Math.max(...nodeOrders) }
+    }
     if (
       node.type === 'heading' &&
       (node.level === undefined || node.level < 1 || node.level > 6)
@@ -825,6 +1031,18 @@ export function verifyStructuredExtraction(
         issue(
           'invalid-heading-level',
           'Headings require a level from 1 through 6.',
+          { nodeId: node.id },
+        ),
+      )
+    }
+    // The alt-text checks below are figure-only, but the verified node copies
+    // `altText` unconditionally. Without this, a paragraph carrying
+    // `altTextSource: 'model'` lands invented text in a source-backed document.
+    if (node.type !== 'figure' && node.altText !== undefined) {
+      issues.push(
+        issue(
+          'model-authored-alt-text',
+          `Only a figure may carry alt text; ${node.id} is a ${node.type}.`,
           { nodeId: node.id },
         ),
       )
@@ -909,10 +1127,35 @@ export function verifyStructuredExtraction(
       ...(node.altTextSource === 'caption'
         ? { altTextSource: 'caption' as const }
         : {}),
+      ...(node.relationships
+        ? {
+            relationships: {
+              ...(node.relationships.noteTargetNodeIds
+                ? {
+                    noteTargetNodeIds: [
+                      ...node.relationships.noteTargetNodeIds,
+                    ],
+                  }
+                : {}),
+              ...(node.relationships.citationTargetNodeIds
+                ? {
+                    citationTargetNodeIds: [
+                      ...node.relationships.citationTargetNodeIds,
+                    ],
+                  }
+                : {}),
+              ...(node.relationships.backlinks
+                ? { backlinks: [...node.relationships.backlinks] }
+                : {}),
+            },
+          }
+        : {}),
       provenance: { sourceRunIds: [...node.sourceRunIds] },
       ...(table ? { table } : {}),
     })
   }
+
+  verifyRelationships(proposal, nodesById, issues)
 
   for (const sourceRunId of excluded) {
     if (!boilerplate.has(sourceRunId)) {
@@ -1021,7 +1264,14 @@ export function modelInputForStructuredExtraction(
         ? { captionRunIds: [...asset.captionRunIds] }
         : {}),
     })),
-    ...(context.boilerplateRunIds
+    ...(context.pageRenditions
+      ? {
+          pageRenditions: context.pageRenditions.map((rendition) => ({
+            ...rendition,
+          })),
+        }
+      : {}),
+    ...(arm !== 'llm-authored' && context.boilerplateRunIds
       ? { boilerplateRunIds: [...context.boilerplateRunIds] }
       : {}),
   }

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -9,6 +9,7 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import {
   createExtractionArchitectureDecision,
   EXTRACTION_BAKEOFF_STRATA,
@@ -41,7 +42,32 @@ async function loadScoreLedger(path) {
   return new Set(value.scoredHeldOutKeys)
 }
 
-async function withScoreLedger(pathInput, run) {
+async function persistScoreLedger(path, scoredHeldOutKeys) {
+  const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`
+  try {
+    await writeFile(
+      temporaryPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: SCORE_LEDGER_SCHEMA_VERSION,
+          scoredHeldOutKeys: [...scoredHeldOutKeys].sort(),
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    await rename(temporaryPath, path)
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined)
+  }
+}
+
+export async function withScoreLedger(
+  pathInput,
+  run,
+  persist = persistScoreLedger,
+) {
   const path = resolve(pathInput)
   await mkdir(dirname(path), { recursive: true })
   const lockPath = `${path}.lock`
@@ -58,24 +84,15 @@ async function withScoreLedger(pathInput, run) {
     scoredHeldOutKeys = await loadScoreLedger(path)
     return await run(scoredHeldOutKeys)
   } finally {
-    if (scoredHeldOutKeys) {
-      const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`
-      await writeFile(
-        temporaryPath,
-        `${JSON.stringify(
-          {
-            schemaVersion: SCORE_LEDGER_SCHEMA_VERSION,
-            scoredHeldOutKeys: [...scoredHeldOutKeys].sort(),
-          },
-          null,
-          2,
-        )}\n`,
-        { encoding: 'utf8', mode: 0o600 },
-      )
-      await rename(temporaryPath, path)
+    try {
+      if (scoredHeldOutKeys) await persist(path, scoredHeldOutKeys)
+    } finally {
+      try {
+        await lock.close()
+      } finally {
+        await unlink(lockPath).catch(() => undefined)
+      }
     }
-    await lock.close()
-    await unlink(lockPath).catch(() => undefined)
   }
 }
 
@@ -226,9 +243,14 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(
-    `${error instanceof Error ? error.message : 'Extraction bake-off failed.'}\n`,
-  )
-  process.exitCode = 1
-})
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : 'Extraction bake-off failed.'}\n`,
+    )
+    process.exitCode = 1
+  })
+}

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -42,6 +42,17 @@ async function loadScoreLedger(path) {
   return new Set(value.scoredHeldOutKeys)
 }
 
+async function fileExists(path) {
+  try {
+    await readFile(path)
+    return true
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT')
+      return false
+    throw error
+  }
+}
+
 async function persistScoreLedger(path, scoredHeldOutKeys) {
   const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`
   try {
@@ -71,6 +82,7 @@ export async function withScoreLedger(
   const path = resolve(pathInput)
   await mkdir(dirname(path), { recursive: true })
   const lockPath = `${path}.lock`
+  const failurePath = `${path}.failed`
   let lock
   try {
     lock = await open(lockPath, 'wx', 0o600)
@@ -80,17 +92,31 @@ export async function withScoreLedger(
     throw error
   }
   let scoredHeldOutKeys
+  let persistenceFailed = false
   try {
+    // Inspect the failure receipt only after acquiring the lock so a process
+    // cannot race past a receipt being installed by the previous owner.
+    if (await fileExists(failurePath))
+      throw new Error('EXTRACTION_SCORE_LEDGER_RECOVERY_REQUIRED')
     scoredHeldOutKeys = await loadScoreLedger(path)
     return await run(scoredHeldOutKeys)
   } finally {
     try {
       if (scoredHeldOutKeys) await persist(path, scoredHeldOutKeys)
+    } catch (error) {
+      persistenceFailed = true
+      await lock.close().catch(() => undefined)
+      // A distinct failure receipt is not an active lock, but it keeps every
+      // future process fail-closed until an owner reconciles the held-out run.
+      await rename(lockPath, failurePath).catch(() => undefined)
+      throw error
     } finally {
-      try {
-        await lock.close()
-      } finally {
-        await unlink(lockPath).catch(() => undefined)
+      if (!persistenceFailed) {
+        try {
+          await lock.close()
+        } finally {
+          await unlink(lockPath).catch(() => undefined)
+        }
       }
     }
   }

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
-import { writeFile } from 'node:fs/promises'
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
 import {
   createExtractionArchitectureDecision,
   EXTRACTION_BAKEOFF_STRATA,
@@ -9,6 +17,67 @@ import {
 
 const SHA_A = 'a'.repeat(64)
 const SHA_B = 'b'.repeat(64)
+const SCORE_LEDGER_SCHEMA_VERSION = '1.0.0'
+
+async function loadScoreLedger(path) {
+  let value
+  try {
+    value = JSON.parse(await readFile(path, 'utf8'))
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT')
+      return new Set()
+    throw new Error('INVALID_EXTRACTION_SCORE_LEDGER')
+  }
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    value.schemaVersion !== SCORE_LEDGER_SCHEMA_VERSION ||
+    !Array.isArray(value.scoredHeldOutKeys) ||
+    !value.scoredHeldOutKeys.every((key) => typeof key === 'string') ||
+    new Set(value.scoredHeldOutKeys).size !== value.scoredHeldOutKeys.length
+  ) {
+    throw new Error('INVALID_EXTRACTION_SCORE_LEDGER')
+  }
+  return new Set(value.scoredHeldOutKeys)
+}
+
+async function withScoreLedger(pathInput, run) {
+  const path = resolve(pathInput)
+  await mkdir(dirname(path), { recursive: true })
+  const lockPath = `${path}.lock`
+  let lock
+  try {
+    lock = await open(lockPath, 'wx', 0o600)
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'EEXIST')
+      throw new Error('EXTRACTION_SCORE_LEDGER_LOCKED')
+    throw error
+  }
+  let scoredHeldOutKeys
+  try {
+    scoredHeldOutKeys = await loadScoreLedger(path)
+    return await run(scoredHeldOutKeys)
+  } finally {
+    if (scoredHeldOutKeys) {
+      const temporaryPath = `${path}.${process.pid}.${Date.now()}.tmp`
+      await writeFile(
+        temporaryPath,
+        `${JSON.stringify(
+          {
+            schemaVersion: SCORE_LEDGER_SCHEMA_VERSION,
+            scoredHeldOutKeys: [...scoredHeldOutKeys].sort(),
+          },
+          null,
+          2,
+        )}\n`,
+        { encoding: 'utf8', mode: 0o600 },
+      )
+      await rename(temporaryPath, path)
+    }
+    await lock.close()
+    await unlink(lockPath).catch(() => undefined)
+  }
+}
 
 function context(id, split, layout) {
   return {
@@ -109,15 +178,26 @@ async function main() {
   const args = process.argv.slice(2)
   if (!args.includes('--self-test')) {
     process.stderr.write(
-      'Usage: node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test [--out <path>]\n',
+      'Usage: node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test --score-ledger <path> [--out <path>]\n',
     )
     process.exitCode = 2
     return
   }
-  const report = await runExtractionBakeoff({
-    corpus: makeCorpus(),
-    arms: [arm('geometric-baseline'), arm('llm-authored'), arm('llm-grounded')],
-  })
+  const scoreLedgerIndex = args.indexOf('--score-ledger')
+  const scoreLedgerPath = args[scoreLedgerIndex + 1]
+  if (scoreLedgerIndex < 0 || !scoreLedgerPath)
+    throw new Error('--score-ledger requires a path')
+  const report = await withScoreLedger(scoreLedgerPath, (scoredHeldOutKeys) =>
+    runExtractionBakeoff({
+      corpus: makeCorpus(),
+      arms: [
+        arm('geometric-baseline'),
+        arm('llm-authored'),
+        arm('llm-grounded'),
+      ],
+      scoredHeldOutKeys,
+    }),
+  )
   const decision = createExtractionArchitectureDecision({ report })
   const payload = `${JSON.stringify({ report, decision }, null, 2)}\n`
   const outIndex = args.indexOf('--out')

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { withScoreLedger } from './pdf-extraction-bakeoff.mjs'
 
 describe('extraction bake-off CLI', () => {
   it('runs the privacy-safe synthetic held-out smoke benchmark', () => {
@@ -52,6 +53,23 @@ describe('extraction bake-off CLI', () => {
     expect(first.status, first.stderr).toBe(0)
     expect(second.status).toBe(1)
     expect(second.stderr).toContain('HELD_OUT_SCORED_MORE_THAN_ONCE')
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('releases the score-ledger lock when persistence fails', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const ledger = join(directory, 'score-ledger.json')
+
+    await expect(
+      withScoreLedger(
+        ledger,
+        async (scoredHeldOutKeys) => scoredHeldOutKeys.add('scored-key'),
+        async () => {
+          throw new Error('simulated persistence failure')
+        },
+      ),
+    ).rejects.toThrow('simulated persistence failure')
+    expect(existsSync(`${ledger}.lock`)).toBe(false)
     rmSync(directory, { recursive: true, force: true })
   })
 })

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -56,7 +56,7 @@ describe('extraction bake-off CLI', () => {
     rmSync(directory, { recursive: true, force: true })
   })
 
-  it('releases the score-ledger lock when persistence fails', async () => {
+  it('fails closed without stranding the active lock when persistence fails', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
     const ledger = join(directory, 'score-ledger.json')
 
@@ -70,6 +70,15 @@ describe('extraction bake-off CLI', () => {
       ),
     ).rejects.toThrow('simulated persistence failure')
     expect(existsSync(`${ledger}.lock`)).toBe(false)
+    expect(existsSync(`${ledger}.failed`)).toBe(true)
+
+    let replayed = false
+    await expect(
+      withScoreLedger(ledger, async () => {
+        replayed = true
+      }),
+    ).rejects.toThrow('EXTRACTION_SCORE_LEDGER_RECOVERY_REQUIRED')
+    expect(replayed).toBe(false)
     rmSync(directory, { recursive: true, force: true })
   })
 })

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -1,14 +1,20 @@
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 describe('extraction bake-off CLI', () => {
   it('runs the privacy-safe synthetic held-out smoke benchmark', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
     const result = spawnSync(
       process.execPath,
       [
         '--experimental-strip-types',
         'tools/pdf-extraction-bakeoff.mjs',
         '--self-test',
+        '--score-ledger',
+        join(directory, 'score-ledger.json'),
       ],
       { encoding: 'utf8', timeout: 30_000 },
     )
@@ -21,5 +27,31 @@ describe('extraction bake-off CLI', () => {
     ).toMatch(/^[a-f0-9]{64}$/u)
     expect(payload.decision.owner).toBe('llm-grounded')
     expect(payload.report).not.toHaveProperty('sourceText')
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('persists score-once receipts across CLI processes', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const ledger = join(directory, 'score-ledger.json')
+    const run = () =>
+      spawnSync(
+        process.execPath,
+        [
+          '--experimental-strip-types',
+          'tools/pdf-extraction-bakeoff.mjs',
+          '--self-test',
+          '--score-ledger',
+          ledger,
+        ],
+        { encoding: 'utf8', timeout: 30_000 },
+      )
+
+    const first = run()
+    const second = run()
+
+    expect(first.status, first.stderr).toBe(0)
+    expect(second.status).toBe(1)
+    expect(second.stderr).toContain('HELD_OUT_SCORED_MORE_THAN_ONCE')
+    rmSync(directory, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
Fixes #134

## What changed

- make score-once receipts durable, held-out-identity scoped, and replay-safe after persistence failure
- require complete bidirectional note/citation coverage for every deterministic target group
- bind semantic table cells exactly to one deterministic `table-scope` multiset and preserve full row/cell/run order
- preserve geometry-derived canonical code-line spacing and fail closed on incomplete line ownership
- scope every disagreement metric to the active stratum
- materialize hostile adapter results before validation so thrown accessors, cycles, nulls, and invalid metrics isolate per arm/document
- deep-copy nested relationship provenance before freezing model inputs

## Why

Four independent review passes reproduced twenty gaps that the initially green suites missed. Each counterexample is now a regression test; no review finding is waived.

## Validation

- latest focused repaired seams: 61/61 passed
- full suite: 3,031 passed, 3 skipped across 139 files
- association audit passed
- production publication matrix passed structural, accessibility, EPUBCheck, and PDF checks; Astro check has 0 errors/warnings
- exact-head evidence passed at `2fb4d9ada61aa0ed477af829a14220bbfd4c8a69` with `dirty=false`, no caveats, and no required failures
- exact-head secret scans and `git diff --check` passed

The PR remains draft until a fresh independent exact-head review and hosted checks complete.