### PR TITLE
Add guarded source-to-EPUB refinement contracts

### DIFF
--- a/src/research/reconstruction-attempt-trace.test.ts
+++ b/src/research/reconstruction-attempt-trace.test.ts
@@ -1,0 +1,712 @@
+import { describe, expect, it } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+  canonicalTraceJson,
+  createReconstructionAttemptTrace,
+  encodeCanonicalObservationPayload,
+  hashAppliedRepairBinding,
+  hashEpubBytes,
+  hashReconstructionAttemptTrace,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  serializeReconstructionAttemptTrace,
+  toRefinementTraceBinding,
+  validateReconstructionAttemptTrace,
+  validateReconstructionAttemptTraceLineage,
+  verifyEpubArtifactBytes,
+  type ReconstructionAttemptTraceCore,
+  type RenderedEpubEvidence,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+
+const digest = (value: string | Uint8Array) => sha256HexSync(value)
+const epubBytes = new TextEncoder().encode('exact downloadable epub bytes')
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const source = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 20, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+const source2 = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 140, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-2'],
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-paragraph-1'],
+    })),
+  })
+  return { sha256: digest(bytes), byteLength: bytes.byteLength }
+}
+
+function coreFixture(
+  status: 'publication-ready' | 'failed' = 'publication-ready',
+): ReconstructionAttemptTraceCore {
+  const sourcePdfSha256 = digest('source-pdf')
+  const evidenceGraphSha256 = digest('evidence-graph')
+  const structSha256 = digest('struct-artifact')
+  const epubSha256 = hashEpubBytes(epubBytes)
+  const evidenceCandidates = [
+    {
+      referenceSha256: digest('provider-neutral-candidate'),
+      bindingSha256: digest('provider-neutral-candidate-binding'),
+    },
+  ]
+  const sourceRegions = [
+    { id: 'region-1', source },
+    { id: 'region-2', source: source2 },
+  ]
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures' ? ['source-figure'] : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1', 'region-2'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashSourceExpectedObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-expected-observation-set'),
+        }),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures'
+          ? status === 'failed'
+            ? []
+            : ['source-figure']
+          : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: status === 'failed' && check === 'figures' ? 0 : 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-actual-observation-set'),
+        }),
+      }
+    },
+  )
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '198.1.0',
+    sourcePdfSha256,
+    evidenceGraphSha256,
+    candidateSetSha256: hashTraceValue(evidenceCandidates),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashSourceEvidenceReceipt({
+      ...sourceEvidenceWithoutReceipt,
+      receiptSha256: digest('pending-source-evidence'),
+    }),
+  }
+  const renderedEpub: RenderedEpubEvidence = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1.0.0',
+      executableSha256: digest('chromium'),
+      configurationSha256: digest('render-configuration'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: digest('rendered-dom'), byteLength: 200 },
+        anchors: ['struct-paragraph-1', 'struct-paragraph-2'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screenshot-1',
+        spineHref: 'EPUB/content.xhtml',
+        domSha256: digest('rendered-dom'),
+        image: { sha256: digest('screenshot'), byteLength: 400 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: digest('pending-render-receipt'),
+  }
+  renderedEpub.receiptSha256 = hashRenderedEpubEvidence(renderedEpub)
+  const mappings = [
+    {
+      id: 'mapping-1',
+      obligationId: 'obligation-1',
+      source,
+      output: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'struct-paragraph-1',
+          rendered: {
+            screenshotId: 'screenshot-1',
+            viewport,
+            rect: { x: 10, y: 20, width: 100, height: 80 },
+          },
+        },
+      ],
+      status: 'mapped' as const,
+    },
+    {
+      id: 'mapping-2',
+      obligationId: 'obligation-2',
+      source: source2,
+      output: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'struct-paragraph-2',
+          rendered: {
+            screenshotId: 'screenshot-1',
+            viewport,
+            rect: { x: 10, y: 140, width: 100, height: 80 },
+          },
+        },
+      ],
+      status: 'mapped' as const,
+    },
+  ]
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: digest(`observation-${check}`),
+      check,
+      source,
+      mappingIds: ['mapping-1'],
+      expectedSetReceiptSha256: expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: 'document-1',
+    sourcePdfSha256,
+    artifact: { sha256: structSha256, byteLength: 600 },
+    generatedSha256: digest('generated-struct'),
+    assets: [
+      { id: 'asset-1', sha256: digest('asset-bytes'), byteLength: 100 },
+    ],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+    mediaType: 'application/epub+zip' as const,
+    structSha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: digest('epubcheck-report'),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256,
+    sourceEvidence,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations,
+  })
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256,
+    evidenceGraphSha256,
+    candidateSetSha256: sourceEvidence.candidateSetSha256,
+    structSha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  const codexIdentity = {
+    server: {
+      id: 'owner-local-codex-server',
+      version: '1.0.0',
+      transport: 'http://127.0.0.1:4500/v1',
+      executableSha256: digest('codex-server'),
+    },
+    model: {
+      id: 'gpt-5.6-sol',
+      version: '2026.08.01',
+      sha256: digest('codex-model'),
+    },
+    prompt: {
+      id: 'reconstruction-reconciliation',
+      version: '1.0.0',
+      sha256: digest('codex-prompt'),
+    },
+    tool: { id: 'codex', version: '0.99.0' },
+  }
+  return {
+    schemaVersion: RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+    attemptId: 'attempt-0',
+    lineage: {
+      attemptIndex: 0,
+      parentTraceSha256: null,
+      immutablePriorTraceSha256: null,
+      appliedRepair: null,
+    },
+    sourcePdf: {
+      artifact: { sha256: sourcePdfSha256, byteLength: 1_000 },
+      pageCount: 1,
+      pageRenders: [
+        {
+          page: 1,
+          sourcePdfSha256,
+          image: { sha256: digest('source-page-1'), byteLength: 500 },
+          mediaType: 'image/png',
+          width: 600,
+          height: 800,
+        },
+      ],
+    },
+    evidenceGraph: {
+      schemaVersion: '198.1.0',
+      artifact: { sha256: evidenceGraphSha256, byteLength: 800 },
+      sourcePdfSha256,
+    },
+    sourceEvidence,
+    evidenceCandidates,
+    structure,
+    epub,
+    renderedEpub,
+    mappings,
+    comparisonEvidence: { sourceRegions, observations },
+    providerReceipts: [
+      {
+        id: 'provider-source-evidence',
+        role: 'source-evidence',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'provider-neutral-source-evidence',
+        receiptSha256: digest('provider-source-evidence-receipt'),
+        inputSha256: sourcePdfSha256,
+        outputSha256: sourceEvidence.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-render',
+        role: 'actual-render',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-chromium',
+        receiptSha256: digest('provider-render-receipt'),
+        inputSha256: epubSha256,
+        outputSha256: renderedEpub.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-codex-reconciliation',
+        role: 'owner-local-codex-reconciliation',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-codex-server',
+        identitySha256: hashTraceValue(codexIdentity),
+        receiptSha256: digest('provider-codex-reconciliation-receipt'),
+        inputSha256: reconciliationInputSha256,
+        outputSha256: hashTraceValue(comparator),
+        ...codexIdentity,
+        status: 'succeeded',
+      },
+    ],
+    comparator,
+    critiqueRepair: null,
+    budget: {
+      policy: {
+        maxRefinements: 3,
+        maxFreshTasks: 1,
+        maxTokens: 24_000,
+        maxDurationMs: 1_800_000,
+        repairPolicySha256: digest('repair-policy'),
+      },
+      usage: { refinements: 0, freshTasks: 0, tokens: 0, durationMs: 0 },
+    },
+    terminalState: status,
+  }
+}
+
+function childCoreFixture(
+  parent: ReturnType<typeof createReconstructionAttemptTrace>,
+) {
+  const child = coreFixture('publication-ready')
+  const resultingStructSha256 = digest('struct-artifact-child')
+  child.attemptId = 'attempt-1'
+  child.structure.artifact = {
+    sha256: resultingStructSha256,
+    byteLength: 620,
+  }
+  child.epub.structSha256 = resultingStructSha256
+  child.comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    sourceEvidence: child.sourceEvidence,
+    structure: child.structure,
+    epub: child.epub,
+    renderedEpub: child.renderedEpub,
+    sourceRegions: child.comparisonEvidence.sourceRegions,
+    mappings: child.mappings,
+    observations: child.comparisonEvidence.observations,
+  })
+  const proposalProjection = {
+    schemaVersion: '1.0.0' as const,
+    documentId: child.structure.documentId,
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    sourceEvidenceGraphSha256: child.evidenceGraph.artifact.sha256,
+    baseStructSha256: parent.structure.artifact.sha256,
+    priorTraceSha256: parent.traceSha256,
+    taskIdSha256: digest('fresh-task'),
+    operations: [
+      {
+        op: 'select-evidence-candidate' as const,
+        targetKind: 'relationship' as const,
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256:
+          child.evidenceCandidates[0]!.referenceSha256,
+      },
+    ],
+  }
+  const proposal = {
+    ...proposalProjection,
+    proposalSha256: hashTraceValue(proposalProjection),
+  }
+  const applicationProjection = {
+    proposalSha256: proposal.proposalSha256,
+    baseStructSha256: parent.structure.artifact.sha256,
+    resultingStructSha256,
+    applicationReceiptSha256: digest('materialized-application-receipt'),
+    groundedVerifierReceiptSha256: digest('grounded-verifier-receipt'),
+  }
+  child.lineage = {
+    attemptIndex: 1,
+    parentTraceSha256: parent.traceSha256,
+    immutablePriorTraceSha256: parent.traceSha256,
+    appliedRepair: {
+      ...applicationProjection,
+      applicationSha256: hashAppliedRepairBinding(applicationProjection),
+    },
+  }
+  child.critiqueRepair = {
+    providerReceiptId: 'provider-codex-repair',
+    priorComparatorSha256: hashTraceValue(parent.comparator),
+    priorFirstCauseFailureId: parent.comparator.firstCauseFailureId!,
+    critiqueSha256: digest('critique'),
+    proposal,
+    disposition: 'verified',
+  }
+  const reconciliation = child.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-reconciliation',
+  )!
+  reconciliation.inputSha256 = hashTraceValue({
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    evidenceGraphSha256: child.evidenceGraph.artifact.sha256,
+    candidateSetSha256: child.sourceEvidence.candidateSetSha256,
+    structSha256: child.structure.artifact.sha256,
+    epubSha256: child.epub.bytes.sha256,
+    renderObservationReceiptSha256: child.renderedEpub.receiptSha256,
+  })
+  reconciliation.outputSha256 = hashTraceValue(child.comparator)
+  child.providerReceipts.push({
+    ...reconciliation,
+    id: 'provider-codex-repair',
+    role: 'owner-local-codex-repair',
+    receiptSha256: digest('provider-codex-repair-receipt'),
+    inputSha256: hashTraceValue(parent.comparator),
+    outputSha256: proposal.proposalSha256,
+  })
+  child.budget.usage = {
+    refinements: 1,
+    freshTasks: 1,
+    tokens: 100,
+    durationMs: 10,
+  }
+  return child
+}
+
+describe('reconstruction attempt trace', () => {
+  it('canonically hashes, serializes, and verifies exact EPUB bytes', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture())
+
+    expect(validateReconstructionAttemptTrace(trace)).toEqual([])
+    expect(trace.traceSha256).toBe(hashReconstructionAttemptTrace(trace))
+    expect(JSON.parse(serializeReconstructionAttemptTrace(trace))).toEqual(trace)
+    expect(verifyEpubArtifactBytes(trace.epub.bytes, epubBytes)).toBe(true)
+    expect(
+      verifyEpubArtifactBytes(
+        trace.epub.bytes,
+        new TextEncoder().encode('different epub'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects hidden or noncanonical array properties and unsupported values', () => {
+    const hidden = [1]
+    Object.defineProperty(hidden, 'privateSource', { value: 'secret' })
+    expect(() => canonicalTraceJson(hidden)).toThrow(/noncanonical/iu)
+
+    const enumerable = [1] as number[] & { extra?: number }
+    enumerable.extra = 2
+    expect(() => canonicalTraceJson(enumerable)).toThrow(/noncanonical/iu)
+    expect(() => canonicalTraceJson({ missing: undefined })).toThrow()
+    expect(() => canonicalTraceJson(new Date())).toThrow()
+  })
+
+  it('rejects stale renderer, missing reconciliation, warnings, and bad locators', () => {
+    const stale = coreFixture()
+    stale.renderedEpub.epubSha256 = digest('stale-epub')
+    expect(() => createReconstructionAttemptTrace(stale)).toThrow(
+      /exact EPUB bytes/u,
+    )
+
+    const missing = coreFixture()
+    missing.providerReceipts = missing.providerReceipts.filter(
+      ({ role }) => role !== 'owner-local-codex-reconciliation',
+    )
+    expect(() => createReconstructionAttemptTrace(missing)).toThrow(
+      /owner-local-codex-reconciliation/u,
+    )
+
+    const warning = coreFixture()
+    warning.epub.epubCheck.warningCount = 1
+    expect(() => createReconstructionAttemptTrace(warning)).toThrow(
+      /Publication-ready/u,
+    )
+
+    const missingAnchor = coreFixture()
+    missingAnchor.mappings[0]!.output[0]!.anchorId = 'not-rendered'
+    expect(() => createReconstructionAttemptTrace(missingAnchor)).toThrow(
+      /anchor/u,
+    )
+  })
+
+  it('fails closed on uncalibrated judge input and unavailable reconciliation', () => {
+    const judge = coreFixture()
+    judge.comparator.judgeResults.push({ id: 'untrusted-judge' } as never)
+    expect(() => createReconstructionAttemptTrace(judge)).toThrow()
+
+    const unavailable = coreFixture()
+    unavailable.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-reconciliation',
+    )!.status = 'available'
+    expect(() => createReconstructionAttemptTrace(unavailable)).toThrow(
+      /reconciliation must succeed/iu,
+    )
+  })
+
+  it('exports only opaque allowlisted non-promotion bindings', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture('failed'))
+    const binding = toRefinementTraceBinding(trace)
+
+    expect(Object.keys(binding).sort()).toEqual(
+      [
+        'attemptIndex',
+        'canonicalStructSha256',
+        'evidenceCandidateReferences',
+        'firstCause',
+        'parentTraceSha256',
+        'policy',
+        'sourceEvidenceGraphSha256',
+        'sourcePdfSha256',
+        'terminalStatus',
+        'traceSha256',
+        'usage',
+      ].sort(),
+    )
+    expect(binding.firstCause?.failureReferenceSha256).toBe(
+      hashTraceValue({
+        kind: 'first-cause',
+        failureId: trace.comparator.firstCauseFailureId!,
+      }),
+    )
+    expect(JSON.stringify(binding)).not.toMatch(
+      /failure-missing|providerReceipts|mappings|pageRenders|source-figure/u,
+    )
+  })
+
+  it('validates private lineage and rejects hash tampering', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture())
+
+    expect(validateReconstructionAttemptTraceLineage([trace])).toEqual([])
+    expect(toRefinementTraceBinding(trace)).toMatchObject({
+      traceSha256: trace.traceSha256,
+      terminalStatus: 'publication-ready',
+      firstCause: null,
+      evidenceCandidateReferences: [digest('provider-neutral-candidate')],
+    })
+    expect(() =>
+      toRefinementTraceBinding({ ...trace, attemptId: 'tampered' }),
+    ).toThrow(/Trace hash/u)
+  })
+
+  it('rejects a child that shrinks the frozen source-obligation sets', () => {
+    const parent = createReconstructionAttemptTrace(coreFixture('failed'))
+    const child = createReconstructionAttemptTrace(childCoreFixture(parent))
+
+    expect(validateReconstructionAttemptTraceLineage([parent, child])).toEqual(
+      [],
+    )
+
+    const shrunkCore = childCoreFixture(parent)
+    shrunkCore.comparisonEvidence.sourceRegions =
+      shrunkCore.comparisonEvidence.sourceRegions.slice(0, 1)
+    shrunkCore.mappings = shrunkCore.mappings.slice(0, 1)
+    const obligationProjection = {
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      obligationsSha256: hashTraceValue(
+        shrunkCore.comparisonEvidence.sourceRegions,
+      ),
+      obligationCount: 1,
+    }
+    shrunkCore.sourceEvidence.sourceObligations = {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    }
+    shrunkCore.sourceEvidence.expectedObservationSets =
+      shrunkCore.sourceEvidence.expectedObservationSets.map((set) => {
+        const projection = { ...set, sourceRegionIds: ['region-1'] }
+        return {
+          ...projection,
+          receiptSha256: hashSourceExpectedObservationSet(projection),
+        }
+      })
+    shrunkCore.sourceEvidence.receiptSha256 = hashSourceEvidenceReceipt({
+      ...shrunkCore.sourceEvidence,
+      receiptSha256: digest('pending-shrunk-source-evidence'),
+    })
+    shrunkCore.renderedEpub.sourceObligations = {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    }
+    shrunkCore.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+      shrunkCore.renderedEpub,
+    )
+    shrunkCore.comparisonEvidence.observations =
+      shrunkCore.comparisonEvidence.observations.map((observation) =>
+        createDeterministicObservationReceipt({
+          idSha256: observation.idSha256,
+          check: observation.check,
+          source: observation.source,
+          mappingIds: observation.mappingIds,
+          expectedSetReceiptSha256:
+            shrunkCore.sourceEvidence.expectedObservationSets.find(
+              (set) => set.check === observation.check,
+            )!.receiptSha256,
+          actualSetReceiptSha256: observation.actualSetReceiptSha256,
+        }),
+      )
+    shrunkCore.comparator = compareSourceToRenderedEpub({
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      sourceEvidence: shrunkCore.sourceEvidence,
+      structure: shrunkCore.structure,
+      epub: shrunkCore.epub,
+      renderedEpub: shrunkCore.renderedEpub,
+      sourceRegions: shrunkCore.comparisonEvidence.sourceRegions,
+      mappings: shrunkCore.mappings,
+      observations: shrunkCore.comparisonEvidence.observations,
+    })
+    const sourceReceipt = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'source-evidence',
+    )!
+    sourceReceipt.outputSha256 = shrunkCore.sourceEvidence.receiptSha256
+    const renderReceipt = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'actual-render',
+    )!
+    renderReceipt.outputSha256 = shrunkCore.renderedEpub.receiptSha256
+    const reconciliation = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-reconciliation',
+    )!
+    reconciliation.inputSha256 = hashTraceValue({
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      evidenceGraphSha256: shrunkCore.evidenceGraph.artifact.sha256,
+      candidateSetSha256: shrunkCore.sourceEvidence.candidateSetSha256,
+      structSha256: shrunkCore.structure.artifact.sha256,
+      epubSha256: shrunkCore.epub.bytes.sha256,
+      renderObservationReceiptSha256: shrunkCore.renderedEpub.receiptSha256,
+    })
+    reconciliation.outputSha256 = hashTraceValue(shrunkCore.comparator)
+    const shrunk = createReconstructionAttemptTrace(shrunkCore)
+
+    expect(
+      validateReconstructionAttemptTraceLineage([parent, shrunk]).some(
+        ({ path }) => path.includes('evidenceGraph'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects repair identity drift from the frozen reconciliation identity', () => {
+    const parent = createReconstructionAttemptTrace(coreFixture('failed'))
+    const child = childCoreFixture(parent)
+    const repairReceipt = child.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-repair',
+    )!
+    repairReceipt.model = {
+      ...repairReceipt.model!,
+      version: '2026.08.02',
+    }
+    repairReceipt.identitySha256 = hashTraceValue({
+      server: repairReceipt.server,
+      model: repairReceipt.model,
+      prompt: repairReceipt.prompt,
+      tool: repairReceipt.tool,
+    })
+
+    expect(() => createReconstructionAttemptTrace(child)).toThrow(
+      /driver-compatible Codex patch/iu,
+    )
+  })
+})

--- a/src/research/reconstruction-attempt-trace.ts
+++ b/src/research/reconstruction-attempt-trace.ts
@@ -1,0 +1,2238 @@
+import { z } from 'zod'
+import type { StructBox } from '../struct/types'
+import { sha256HexSync } from '../struct/sha256'
+
+/**
+ * Closed, content-addressed evidence for one source-PDF reconstruction attempt.
+ *
+ * The trace deliberately stores hashes and stable identifiers, not document
+ * bytes, DOM text, screenshots, prompts, or provider output. Private artifacts
+ * remain owner-local and can be verified against these bindings.
+ */
+export const RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION = '1.0.0' as const
+export const SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION = '1.0.0' as const
+
+export const DETERMINISTIC_CHECK_IDS = [
+  'render-binding',
+  'epub-package',
+  'source-region-conservation',
+  'text-exactness',
+  'reading-order',
+  'hierarchy',
+  'object-counts',
+  'table-cells',
+  'table-spans',
+  'table-headers',
+  'figures',
+  'diagrams',
+  'captions',
+  'formulas',
+  'code-preformatted',
+  'notes',
+  'citations',
+  'links',
+  'asset-bytes',
+  'clipping',
+  'overflow',
+  'dangling-targets',
+] as const
+
+export type DeterministicCheckId = (typeof DETERMINISTIC_CHECK_IDS)[number]
+
+export const SOURCE_EPUB_OBSERVATION_CHECK_IDS = [
+  'text-exactness',
+  'reading-order',
+  'hierarchy',
+  'object-counts',
+  'table-cells',
+  'table-spans',
+  'table-headers',
+  'figures',
+  'diagrams',
+  'captions',
+  'formulas',
+  'code-preformatted',
+  'notes',
+  'citations',
+  'links',
+  'asset-bytes',
+  'clipping',
+  'overflow',
+  'dangling-targets',
+] as const satisfies readonly DeterministicCheckId[]
+
+export type SourceEpubObservationCheckId =
+  (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number]
+
+export const RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET = {
+  maxRefinements: 3,
+  maxFreshTasks: 1,
+  maxTokens: 24_000,
+  maxDurationMs: 30 * 60 * 1_000,
+} as const
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/u)
+const nonEmptyStringSchema = z.string().trim().min(1).max(512)
+const nonNegativeIntegerSchema = z.number().int().min(0)
+const positiveIntegerSchema = z.number().int().positive()
+const finiteNumberSchema = z.number().finite()
+const rasterMediaTypeSchema = z.enum(['image/png', 'image/webp', 'image/jpeg'])
+
+const hashedArtifactSchema = z
+  .object({
+    sha256: sha256Schema,
+    byteLength: nonNegativeIntegerSchema,
+  })
+  .strict()
+
+const nonEmptyHashedArtifactSchema = hashedArtifactSchema.refine(
+  ({ byteLength }) => byteLength > 0,
+  'Artifact bytes cannot be empty.',
+)
+
+const boxSchema = z
+  .object({
+    page: positiveIntegerSchema,
+    x: finiteNumberSchema,
+    y: finiteNumberSchema,
+    width: finiteNumberSchema.nonnegative(),
+    height: finiteNumberSchema.nonnegative(),
+    rotation: finiteNumberSchema,
+  })
+  .strict()
+
+export const sourceLocationSchema = z
+  .object({
+    page: positiveIntegerSchema,
+    boxes: z.array(boxSchema),
+    sourceRegionIds: z.array(nonEmptyStringSchema).min(1),
+  })
+  .strict()
+
+const viewportSchema = z
+  .object({
+    width: positiveIntegerSchema,
+    height: positiveIntegerSchema,
+    deviceScaleFactor: finiteNumberSchema.positive(),
+  })
+  .strict()
+
+const rectSchema = z
+  .object({
+    x: finiteNumberSchema,
+    y: finiteNumberSchema,
+    width: finiteNumberSchema.nonnegative(),
+    height: finiteNumberSchema.nonnegative(),
+  })
+  .strict()
+
+const renderedLocatorSchema = z
+  .object({
+    screenshotId: nonEmptyStringSchema,
+    viewport: viewportSchema,
+    rect: rectSchema,
+    scrollOffset: z
+      .object({ x: finiteNumberSchema, y: finiteNumberSchema })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const epubLocationSchema = z
+  .object({
+    spineHref: nonEmptyStringSchema,
+    anchorId: nonEmptyStringSchema,
+    /** Advisory only; the stable spine href and anchor id are authoritative. */
+    domPath: nonEmptyStringSchema.optional(),
+    /** Hash-bound visual locator for offline review, never an identity key. */
+    rendered: renderedLocatorSchema.optional(),
+  })
+  .strict()
+
+export const sourceOutputMappingSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    obligationId: nonEmptyStringSchema,
+    source: sourceLocationSchema,
+    output: z.array(epubLocationSchema),
+    status: z.enum(['mapped', 'missing', 'duplicate']),
+  })
+  .strict()
+
+export const sourceRegionObligationSchema = z
+  .object({ id: nonEmptyStringSchema, source: sourceLocationSchema })
+  .strict()
+
+export const canonicalObservationItemSchema = z
+  .object({
+    idSha256: sha256Schema,
+    valueSha256: sha256Schema,
+    anchorIds: z.array(nonEmptyStringSchema),
+  })
+  .strict()
+
+export const canonicalObservationPayloadSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    items: z.array(canonicalObservationItemSchema),
+  })
+  .strict()
+
+export const sourceExpectedObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256Schema,
+    itemCount: nonNegativeIntegerSchema,
+    payload: nonEmptyHashedArtifactSchema,
+    sourceRegionIds: z.array(nonEmptyStringSchema),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const renderedActualObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256Schema,
+    itemCount: nonNegativeIntegerSchema,
+    payload: nonEmptyHashedArtifactSchema,
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const observationReceiptCoreSchema = z
+  .object({
+    idSha256: sha256Schema,
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    source: sourceLocationSchema.optional(),
+    mappingIds: z.array(nonEmptyStringSchema).min(1),
+    expectedSetReceiptSha256: sha256Schema,
+    actualSetReceiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const observationReceiptSchema = observationReceiptCoreSchema
+  .extend({ receiptSha256: sha256Schema })
+  .strict()
+
+const comparisonEvidenceSchema = z
+  .object({
+    sourceRegions: z.array(sourceRegionObligationSchema).min(1),
+    observations: z.array(observationReceiptSchema).min(1),
+  })
+  .strict()
+
+const sourcePdfSchema = z
+  .object({
+    artifact: hashedArtifactSchema,
+    pageCount: positiveIntegerSchema,
+    pageRenders: z
+      .array(
+        z
+          .object({
+            page: positiveIntegerSchema,
+            sourcePdfSha256: sha256Schema,
+            image: hashedArtifactSchema,
+            mediaType: rasterMediaTypeSchema,
+            width: positiveIntegerSchema,
+            height: positiveIntegerSchema,
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict()
+
+const evidenceGraphSchema = z
+  .object({
+    /** #198 owns the graph schema; this module treats it as an opaque blob. */
+    schemaVersion: nonEmptyStringSchema,
+    artifact: hashedArtifactSchema,
+    sourcePdfSha256: sha256Schema,
+  })
+  .strict()
+
+export const sourceEvidenceReceiptSchema = z
+  .object({
+    schemaVersion: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    evidenceGraphSha256: sha256Schema,
+    candidateSetSha256: sha256Schema,
+    sourceObligations: z
+      .object({
+        obligationsSha256: sha256Schema,
+        obligationCount: positiveIntegerSchema,
+        receiptSha256: sha256Schema,
+      })
+      .strict(),
+    expectedObservationSets: z
+      .array(sourceExpectedObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+const evidenceCandidateReferenceSchema = z
+  .object({
+    referenceSha256: sha256Schema,
+    bindingSha256: sha256Schema,
+  })
+  .strict()
+
+export const structBindingSchema = z
+  .object({
+    schemaVersion: nonEmptyStringSchema,
+    documentId: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    artifact: hashedArtifactSchema,
+    generatedSha256: sha256Schema,
+    assets: z.array(
+      z
+        .object({
+          id: nonEmptyStringSchema,
+          sha256: sha256Schema,
+          byteLength: nonNegativeIntegerSchema,
+        })
+        .strict(),
+    ),
+  })
+  .strict()
+
+export const epubBindingSchema = z
+  .object({
+    bytes: nonEmptyHashedArtifactSchema,
+    mediaType: z.literal('application/epub+zip'),
+    structSha256: sha256Schema,
+    epubCheck: z
+      .object({
+        toolId: nonEmptyStringSchema,
+        toolVersion: nonEmptyStringSchema,
+        reportSha256: sha256Schema,
+        status: z.enum(['passed', 'failed', 'not-run']),
+        errorCount: nonNegativeIntegerSchema,
+        warningCount: nonNegativeIntegerSchema,
+      })
+      .strict(),
+  })
+  .strict()
+
+export const renderedEpubSchema = z
+  .object({
+    epubSha256: sha256Schema,
+    download: z
+      .object({
+        artifact: nonEmptyHashedArtifactSchema,
+        verificationReceiptSha256: sha256Schema,
+      })
+      .strict(),
+    sourceObligations: z
+      .object({
+        sourcePdfSha256: sha256Schema,
+        obligationsSha256: sha256Schema,
+        obligationCount: positiveIntegerSchema,
+        receiptSha256: sha256Schema,
+      })
+      .strict(),
+    actualObservationSets: z
+      .array(renderedActualObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    renderer: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        executableSha256: sha256Schema.optional(),
+        configurationSha256: sha256Schema,
+      })
+      .strict(),
+    domSnapshots: z
+      .array(
+        z
+          .object({
+            spineHref: nonEmptyStringSchema,
+            dom: hashedArtifactSchema,
+            anchors: z.array(nonEmptyStringSchema).min(1),
+          })
+          .strict(),
+      )
+      .min(1),
+    screenshots: z
+      .array(
+        z
+          .object({
+            id: nonEmptyStringSchema,
+            spineHref: nonEmptyStringSchema,
+            domSha256: sha256Schema,
+            image: nonEmptyHashedArtifactSchema,
+            mediaType: rasterMediaTypeSchema,
+            width: positiveIntegerSchema,
+            height: positiveIntegerSchema,
+            viewport: viewportSchema,
+            fullPage: z.boolean(),
+          })
+          .strict(),
+      )
+      .min(1),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+const providerReceiptSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    role: z.enum([
+      'source-evidence',
+      'actual-render',
+      'owner-local-codex-reconciliation',
+      'owner-local-codex-repair',
+      'optional',
+    ]),
+    required: z.boolean(),
+    enabledBeforeRun: z.boolean(),
+    providerId: nonEmptyStringSchema,
+    identitySha256: sha256Schema.optional(),
+    receiptSha256: sha256Schema,
+    inputSha256: sha256Schema,
+    outputSha256: sha256Schema,
+    prompt: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        sha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    tool: z
+      .object({ id: nonEmptyStringSchema, version: nonEmptyStringSchema })
+      .strict()
+      .optional(),
+    model: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        sha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    server: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        transport: nonEmptyStringSchema,
+        executableSha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    status: z.enum([
+      'available',
+      'succeeded',
+      'failed',
+      'abstained',
+      'disabled',
+    ]),
+  })
+  .strict()
+
+const comparatorCheckResultSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    check: z.enum(DETERMINISTIC_CHECK_IDS),
+    origin: z.enum(['deterministic', 'judge']),
+    judgeResultId: nonEmptyStringSchema.optional(),
+    status: z.enum(['passed', 'failed']),
+    expectedSha256: sha256Schema,
+    actualSha256: sha256Schema,
+    mappingIds: z.array(nonEmptyStringSchema),
+    source: sourceLocationSchema.optional(),
+    message: nonEmptyStringSchema,
+    failureId: nonEmptyStringSchema.optional(),
+  })
+  .strict()
+
+const comparisonFailureSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    check: z.enum(DETERMINISTIC_CHECK_IDS),
+    origin: z.enum(['deterministic', 'judge']),
+    judgeResultId: nonEmptyStringSchema.optional(),
+    message: nonEmptyStringSchema,
+    mappingIds: z.array(nonEmptyStringSchema),
+    source: sourceLocationSchema.optional(),
+    output: z.array(epubLocationSchema),
+  })
+  .strict()
+
+// Interpretive judges are intentionally fail-closed in the core trace. A
+// separately calibrated judge slice may replace this empty contract only after
+// its frozen human labels and held-out thresholds are available.
+const comparatorJudgeResultSchema = z.never()
+
+const comparatorResultSchema = z
+  .object({
+    schemaVersion: z.literal(SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION),
+    sourcePdfSha256: sha256Schema,
+    structSha256: sha256Schema,
+    epubSha256: sha256Schema,
+    renderObservationReceiptSha256: sha256Schema,
+    observationSetSha256: sha256Schema,
+    status: z.enum(['publication-ready', 'failed']),
+    denominator: nonNegativeIntegerSchema,
+    passed: nonNegativeIntegerSchema,
+    failed: nonNegativeIntegerSchema,
+    checkResults: z.array(comparatorCheckResultSchema).min(1),
+    judgeResults: z.array(comparatorJudgeResultSchema).max(0),
+    failures: z.array(comparisonFailureSchema),
+    firstCauseFailureId: nonEmptyStringSchema.nullable(),
+  })
+  .strict()
+
+export const structEvidencePatchOperationSchema = z
+  .object({
+    op: z.literal('select-evidence-candidate'),
+    targetKind: z.enum(['block', 'asset', 'relationship']),
+    targetId: nonEmptyStringSchema,
+    candidateReferenceSha256: sha256Schema,
+  })
+  .strict()
+
+export const structEvidencePatchSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    documentId: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    sourceEvidenceGraphSha256: sha256Schema,
+    baseStructSha256: sha256Schema,
+    priorTraceSha256: sha256Schema,
+    taskIdSha256: sha256Schema,
+    operations: z.array(structEvidencePatchOperationSchema).min(1),
+    proposalSha256: sha256Schema,
+  })
+  .strict()
+
+const critiqueRepairSchema = z
+  .object({
+    providerReceiptId: nonEmptyStringSchema,
+    priorComparatorSha256: sha256Schema,
+    priorFirstCauseFailureId: nonEmptyStringSchema,
+    critiqueSha256: sha256Schema,
+    proposal: structEvidencePatchSchema,
+    disposition: z.enum(['proposed', 'verified', 'rejected']),
+  })
+  .strict()
+
+const budgetSchema = z
+  .object({
+    policy: z
+      .object({
+        maxRefinements: nonNegativeIntegerSchema,
+        maxFreshTasks: positiveIntegerSchema,
+        maxTokens: positiveIntegerSchema,
+        maxDurationMs: positiveIntegerSchema,
+        repairPolicySha256: sha256Schema,
+      })
+      .strict(),
+    usage: z
+      .object({
+        refinements: nonNegativeIntegerSchema,
+        freshTasks: nonNegativeIntegerSchema,
+        tokens: nonNegativeIntegerSchema,
+        durationMs: nonNegativeIntegerSchema,
+      })
+      .strict(),
+  })
+  .strict()
+
+const traceCoreSchema = z
+  .object({
+    schemaVersion: z.literal(RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION),
+    attemptId: nonEmptyStringSchema,
+    lineage: z
+      .object({
+        attemptIndex: nonNegativeIntegerSchema,
+        parentTraceSha256: sha256Schema.nullable(),
+        immutablePriorTraceSha256: sha256Schema.nullable(),
+        appliedRepair: z
+          .object({
+            proposalSha256: sha256Schema,
+            baseStructSha256: sha256Schema,
+            resultingStructSha256: sha256Schema,
+            applicationReceiptSha256: sha256Schema,
+            groundedVerifierReceiptSha256: sha256Schema,
+            applicationSha256: sha256Schema,
+          })
+          .strict()
+          .nullable(),
+      })
+      .strict(),
+    sourcePdf: sourcePdfSchema,
+    evidenceGraph: evidenceGraphSchema,
+    sourceEvidence: sourceEvidenceReceiptSchema,
+    evidenceCandidates: z.array(evidenceCandidateReferenceSchema).min(1),
+    structure: structBindingSchema,
+    epub: epubBindingSchema,
+    renderedEpub: renderedEpubSchema,
+    mappings: z.array(sourceOutputMappingSchema).min(1),
+    comparisonEvidence: comparisonEvidenceSchema,
+    providerReceipts: z.array(providerReceiptSchema),
+    comparator: comparatorResultSchema,
+    critiqueRepair: critiqueRepairSchema.nullable(),
+    budget: budgetSchema,
+    terminalState: z.enum(['publication-ready', 'failed']),
+  })
+  .strict()
+
+const traceSchema = traceCoreSchema
+  .extend({ traceSha256: sha256Schema })
+  .strict()
+
+export type HashedArtifact = z.infer<typeof hashedArtifactSchema>
+export type SourceLocation = Omit<
+  z.infer<typeof sourceLocationSchema>,
+  'boxes'
+> & { boxes: StructBox[] }
+export type EpubLocation = z.infer<typeof epubLocationSchema>
+export type SourceOutputMapping = z.infer<typeof sourceOutputMappingSchema>
+export type SourceRegionObligation = z.infer<
+  typeof sourceRegionObligationSchema
+>
+export type CanonicalObservationPayload = z.infer<
+  typeof canonicalObservationPayloadSchema
+>
+export type SourceExpectedObservationSet = z.infer<
+  typeof sourceExpectedObservationSetSchema
+>
+export type RenderedActualObservationSet = z.infer<
+  typeof renderedActualObservationSetSchema
+>
+export type DeterministicComparisonObservation = z.infer<
+  typeof observationReceiptSchema
+>
+export type SourcePdfBinding = z.infer<typeof sourcePdfSchema>
+export type EvidenceGraphBinding = z.infer<typeof evidenceGraphSchema>
+export type SourceEvidenceReceiptBinding = z.infer<
+  typeof sourceEvidenceReceiptSchema
+>
+export type EvidenceCandidateReference = z.infer<
+  typeof evidenceCandidateReferenceSchema
+>
+export type StructArtifactBinding = z.infer<typeof structBindingSchema>
+export type EpubArtifactBinding = z.infer<typeof epubBindingSchema>
+export type RenderedEpubEvidence = z.infer<typeof renderedEpubSchema>
+export type ProviderReceiptBinding = z.infer<typeof providerReceiptSchema>
+export type ComparatorCheckResult = z.infer<typeof comparatorCheckResultSchema>
+export type ComparisonFailure = z.infer<typeof comparisonFailureSchema>
+export type ComparatorJudgeResult = z.infer<typeof comparatorJudgeResultSchema>
+export type SourceEpubComparatorResult = z.infer<typeof comparatorResultSchema>
+export type StructEvidencePatchOperation = z.infer<
+  typeof structEvidencePatchOperationSchema
+>
+export type StructEvidencePatch = z.infer<typeof structEvidencePatchSchema>
+export type CritiqueRepairBinding = z.infer<typeof critiqueRepairSchema>
+export type ReconstructionAttemptBudget = z.infer<typeof budgetSchema>
+export type ReconstructionAttemptTraceCore = z.infer<typeof traceCoreSchema>
+export type ReconstructionAttemptTrace = z.infer<typeof traceSchema>
+
+export type TraceValidationIssue = {
+  code:
+    | 'invalid-schema'
+    | 'hash-mismatch'
+    | 'binding-mismatch'
+    | 'invalid-lineage'
+    | 'invalid-page-render-set'
+    | 'invalid-mapping'
+    | 'invalid-comparator'
+    | 'invalid-budget'
+    | 'invalid-repair'
+    | 'duplicate-id'
+  path: string
+  message: string
+}
+
+export class ReconstructionAttemptTraceValidationError extends Error {
+  constructor(public readonly issues: TraceValidationIssue[]) {
+    super(issues.map((issue) => `${issue.path}: ${issue.message}`).join('\n'))
+    this.name = 'ReconstructionAttemptTraceValidationError'
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/** Stable, locale-independent JSON used by all trace commitments. */
+export function canonicalTraceJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Only finite numbers hash')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    const expectedOwnKeys = new Set([
+      'length',
+      ...Array.from({ length: value.length }, (_, index) => String(index)),
+    ])
+    if (
+      Reflect.ownKeys(value).some(
+        (key) => typeof key !== 'string' || !expectedOwnKeys.has(key),
+      ) ||
+      Reflect.ownKeys(value).length !== expectedOwnKeys.size ||
+      Array.from({ length: value.length }, (_, index) =>
+        descriptors[String(index)],
+      ).some((descriptor) => !descriptor?.enumerable || !('value' in descriptor))
+    ) {
+      throw new TypeError(
+        'Arrays with holes or noncanonical own properties cannot be committed to a trace',
+      )
+    }
+    return `[${Array.from({ length: value.length }, (_, index) =>
+      canonicalTraceJson(descriptors[String(index)]!.value),
+    ).join(',')}]`
+  }
+  if (isPlainObject(value)) {
+    const ownKeys = Reflect.ownKeys(value)
+    if (ownKeys.some((key) => typeof key !== 'string')) {
+      throw new TypeError('Symbol keys cannot be committed to a trace')
+    }
+    const keys = ownKeys as string[]
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    if (
+      keys.some((key) => {
+        const descriptor = descriptors[key]
+        return !descriptor?.enumerable || !('value' in descriptor)
+      })
+    ) {
+      throw new TypeError(
+        'Only enumerable data properties can be committed to a trace',
+      )
+    }
+    return `{${keys
+      .sort(compareCodeUnits)
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${canonicalTraceJson(descriptors[key]!.value)}`,
+      )
+      .join(',')}}`
+  }
+  throw new TypeError('Only plain JSON values can be committed to a trace')
+}
+
+export function hashTraceValue(value: unknown) {
+  return sha256HexSync(canonicalTraceJson(value))
+}
+
+export function encodeCanonicalObservationPayload(
+  input: CanonicalObservationPayload,
+) {
+  const payload = canonicalObservationPayloadSchema.parse(input)
+  const bytes = new TextEncoder().encode(canonicalTraceJson(payload))
+  parseCanonicalObservationPayloadBytes(bytes)
+  return bytes
+}
+
+export function parseCanonicalObservationPayloadBytes(bytes: Uint8Array) {
+  let text: string
+  let parsed: unknown
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    parsed = JSON.parse(text)
+  } catch {
+    throw new TypeError('INVALID_CANONICAL_OBSERVATION_PAYLOAD')
+  }
+  const payload = canonicalObservationPayloadSchema.parse(parsed)
+  const sortedItems = [...payload.items].sort((left, right) =>
+    compareCodeUnits(left.idSha256, right.idSha256),
+  )
+  if (
+    text !== canonicalTraceJson(payload) ||
+    new Set(payload.items.map(({ idSha256 }) => idSha256)).size !==
+      payload.items.length ||
+    hashTraceValue(payload.items) !== hashTraceValue(sortedItems) ||
+    payload.items.some(
+      ({ anchorIds }) =>
+        new Set(anchorIds).size !== anchorIds.length ||
+        anchorIds.some(
+          (anchorId, index) =>
+            index > 0 &&
+            compareCodeUnits(anchorIds[index - 1]!, anchorId) >= 0,
+        ),
+    )
+  ) {
+    throw new TypeError('INVALID_CANONICAL_OBSERVATION_PAYLOAD')
+  }
+  return payload
+}
+
+export function hashSourceExpectedObservationSet(
+  value: SourceExpectedObservationSet,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function hashRenderedActualObservationSet(
+  value: RenderedActualObservationSet,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function hashSourceEvidenceReceipt(
+  value: SourceEvidenceReceiptBinding,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function codexProviderIdentityProjection(
+  value: ProviderReceiptBinding,
+) {
+  return {
+    server: value.server ?? null,
+    model: value.model ?? null,
+    prompt: value.prompt ?? null,
+    tool: value.tool ?? null,
+  }
+}
+
+export function hashCodexProviderIdentity(value: ProviderReceiptBinding) {
+  return hashTraceValue(codexProviderIdentityProjection(value))
+}
+
+/** Commit the exact downloadable EPUB bytes with the browser-safe hasher. */
+export function hashEpubBytes(bytes: Uint8Array) {
+  return sha256HexSync(bytes)
+}
+
+export function verifyEpubArtifactBytes(
+  artifact: HashedArtifact,
+  bytes: Uint8Array,
+) {
+  return (
+    artifact.byteLength === bytes.byteLength &&
+    artifact.sha256 === hashEpubBytes(bytes)
+  )
+}
+
+/** Hash the complete renderer receipt independently of the EPUB byte hash. */
+export function hashRenderedEpubEvidence(evidence: RenderedEpubEvidence) {
+  const { receiptSha256: _receiptSha256, ...projection } = evidence
+  return hashTraceValue(projection)
+}
+
+export function hashRepairProposal(
+  proposal: Omit<CritiqueRepairBinding['proposal'], 'proposalSha256'>,
+) {
+  return hashTraceValue(proposal)
+}
+
+export function parseStructEvidencePatch(input: unknown): StructEvidencePatch {
+  const proposal = structEvidencePatchSchema.parse(input)
+  const { proposalSha256, ...projection } = proposal
+  if (proposalSha256 !== hashTraceValue(projection)) {
+    throw new TypeError('Repair proposal hash does not match its content.')
+  }
+  return proposal
+}
+
+export function hashAppliedRepairBinding(input: {
+  proposalSha256: string
+  baseStructSha256: string
+  resultingStructSha256: string
+  applicationReceiptSha256: string
+  groundedVerifierReceiptSha256: string
+}) {
+  return hashTraceValue(input)
+}
+
+const DETERMINISTIC_CHECK_PRIORITY: Readonly<
+  Record<DeterministicCheckId, number>
+> = {
+  'render-binding': 0,
+  'epub-package': 1,
+  'source-region-conservation': 2,
+  figures: 3,
+  diagrams: 4,
+  captions: 5,
+  'table-cells': 6,
+  'table-spans': 7,
+  'table-headers': 8,
+  formulas: 9,
+  'code-preformatted': 10,
+  notes: 11,
+  citations: 12,
+  links: 13,
+  'text-exactness': 14,
+  'reading-order': 15,
+  hierarchy: 16,
+  'object-counts': 17,
+  'asset-bytes': 18,
+  clipping: 19,
+  overflow: 20,
+  'dangling-targets': 21,
+}
+
+function compareCodeUnits(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+/** Stable order used to select the single first actionable cause. */
+export function compareComparisonFailures(
+  left: ComparisonFailure,
+  right: ComparisonFailure,
+) {
+  // A judge can add a narrow failure but can never outrank deterministic
+  // evidence, even when its semantic category has an earlier display order.
+  if (left.origin !== right.origin)
+    return left.origin === 'deterministic' ? -1 : 1
+  const checkDifference =
+    DETERMINISTIC_CHECK_PRIORITY[left.check] -
+    DETERMINISTIC_CHECK_PRIORITY[right.check]
+  if (checkDifference !== 0) return checkDifference
+  const pageDifference =
+    (left.source?.page ?? Number.MAX_SAFE_INTEGER) -
+    (right.source?.page ?? Number.MAX_SAFE_INTEGER)
+  if (pageDifference !== 0) return pageDifference
+  const leftBox = left.source?.boxes[0]
+  const rightBox = right.source?.boxes[0]
+  const yDifference =
+    (leftBox?.y ?? Number.MAX_SAFE_INTEGER) -
+    (rightBox?.y ?? Number.MAX_SAFE_INTEGER)
+  if (yDifference !== 0) return yDifference
+  const xDifference =
+    (leftBox?.x ?? Number.MAX_SAFE_INTEGER) -
+    (rightBox?.x ?? Number.MAX_SAFE_INTEGER)
+  if (xDifference !== 0) return xDifference
+  return compareCodeUnits(left.id, right.id)
+}
+
+function uniqueIssues(
+  values: readonly string[],
+  path: string,
+): TraceValidationIssue[] {
+  const seen = new Set<string>()
+  const duplicate = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) duplicate.add(value)
+    seen.add(value)
+  }
+  return [...duplicate].sort().map((value) => ({
+    code: 'duplicate-id' as const,
+    path,
+    message: `Duplicate id ${value}.`,
+  }))
+}
+
+function isOwnerLocalTransport(transport: string) {
+  if (transport.startsWith('unix://')) {
+    const path = transport.slice('unix://'.length)
+    return path.startsWith('/') && !path.includes('\0') && !path.split('/').includes('..')
+  }
+  try {
+    const url = new URL(transport)
+    return (
+      ['http:', 'https:'].includes(url.protocol) &&
+      ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname) &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+function coreInvariantIssues(
+  trace: ReconstructionAttemptTraceCore,
+): TraceValidationIssue[] {
+  const issues: TraceValidationIssue[] = []
+  const sourceSha256 = trace.sourcePdf.artifact.sha256
+
+  const renderedPages = trace.sourcePdf.pageRenders.map((render) => render.page)
+  const expectedPages = Array.from(
+    { length: trace.sourcePdf.pageCount },
+    (_, index) => index + 1,
+  )
+  if (
+    renderedPages.length !== expectedPages.length ||
+    [...renderedPages]
+      .sort((a, b) => a - b)
+      .some((page, index) => page !== expectedPages[index])
+  ) {
+    issues.push({
+      code: 'invalid-page-render-set',
+      path: 'sourcePdf.pageRenders',
+      message: 'Page renders must contain every source page exactly once.',
+    })
+  }
+  for (const [index, render] of trace.sourcePdf.pageRenders.entries()) {
+    if (render.sourcePdfSha256 !== sourceSha256) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `sourcePdf.pageRenders.${index}.sourcePdfSha256`,
+        message: 'Page render is not bound to the source PDF.',
+      })
+    }
+  }
+
+  const sourceBindings: Array<[string, string]> = [
+    ['evidenceGraph.sourcePdfSha256', trace.evidenceGraph.sourcePdfSha256],
+    [
+      'sourceEvidence.sourcePdfSha256',
+      trace.sourceEvidence.sourcePdfSha256,
+    ],
+    ['structure.sourcePdfSha256', trace.structure.sourcePdfSha256],
+  ]
+  for (const [path, actual] of sourceBindings) {
+    if (actual !== sourceSha256) {
+      issues.push({
+        code: 'binding-mismatch',
+        path,
+        message: 'Artifact is not bound to the source PDF.',
+      })
+    }
+  }
+  if (
+    trace.sourceEvidence.evidenceGraphSha256 !==
+    trace.evidenceGraph.artifact.sha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'sourceEvidence.evidenceGraphSha256',
+      message: 'Source-evidence receipt is not bound to the evidence graph.',
+    })
+  }
+  if (
+    trace.sourceEvidence.candidateSetSha256 !==
+    hashTraceValue(trace.evidenceCandidates)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'sourceEvidence.candidateSetSha256',
+      message:
+        'Source-evidence receipt is not bound to the provider-neutral candidate references.',
+    })
+  }
+  if (
+    trace.sourceEvidence.receiptSha256 !==
+    hashSourceEvidenceReceipt(trace.sourceEvidence)
+  ) {
+    issues.push({
+      code: 'hash-mismatch',
+      path: 'sourceEvidence.receiptSha256',
+      message: 'Source-evidence receipt hash does not match its content.',
+    })
+  }
+  const expectedChecks = trace.sourceEvidence.expectedObservationSets.map(
+    ({ check }) => check,
+  )
+  if (
+    new Set(expectedChecks).size !== SOURCE_EPUB_OBSERVATION_CHECK_IDS.length ||
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) => !expectedChecks.includes(check),
+    )
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'sourceEvidence.expectedObservationSets',
+      message:
+        'Source evidence must commit exactly one expected set for every observation category.',
+    })
+  }
+  const sourceRegionIds = new Set(
+    trace.comparisonEvidence.sourceRegions.map(({ id }) => id),
+  )
+  for (const [index, expected] of
+    trace.sourceEvidence.expectedObservationSets.entries()) {
+    if (
+      expected.receiptSha256 !== hashSourceExpectedObservationSet(expected) ||
+      expected.setSha256 !== expected.payload.sha256 ||
+      new Set(expected.sourceRegionIds).size !== expected.sourceRegionIds.length ||
+      expected.sourceRegionIds.some((id) => !sourceRegionIds.has(id)) ||
+      (expected.sourceRegionIds.length > 0 && expected.itemCount === 0)
+    ) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `sourceEvidence.expectedObservationSets.${index}`,
+        message:
+          'Expected category sets must be hash-bound to known source obligations and cannot self-attest zero items for source-bearing evidence.',
+      })
+    }
+  }
+  const actualChecks = trace.renderedEpub.actualObservationSets.map(
+    ({ check }) => check,
+  )
+  if (
+    new Set(actualChecks).size !== SOURCE_EPUB_OBSERVATION_CHECK_IDS.length ||
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) => !actualChecks.includes(check),
+    )
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'renderedEpub.actualObservationSets',
+      message:
+        'Actual renderer evidence must commit exactly one set for every observation category.',
+    })
+  }
+  for (const [index, actual] of
+    trace.renderedEpub.actualObservationSets.entries()) {
+    if (
+      actual.receiptSha256 !== hashRenderedActualObservationSet(actual) ||
+      actual.setSha256 !== actual.payload.sha256
+    ) {
+      issues.push({
+        code: 'hash-mismatch',
+        path: `renderedEpub.actualObservationSets.${index}.receiptSha256`,
+        message: 'Actual renderer category-set receipt is stale.',
+      })
+    }
+  }
+  if (trace.epub.structSha256 !== trace.structure.artifact.sha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'epub.structSha256',
+      message: 'EPUB is not bound to this serialized STRUCT artifact.',
+    })
+  }
+  if (trace.renderedEpub.epubSha256 !== trace.epub.bytes.sha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'renderedEpub.epubSha256',
+      message: 'Rendered evidence is not from the exact EPUB bytes.',
+    })
+  }
+  if (
+    hashTraceValue(trace.renderedEpub.download.artifact) !==
+      hashTraceValue(trace.epub.bytes) ||
+    trace.renderedEpub.receiptSha256 !==
+      hashRenderedEpubEvidence(trace.renderedEpub) ||
+    trace.renderedEpub.sourceObligations.sourcePdfSha256 !== sourceSha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'renderedEpub',
+      message:
+        'Actual-render receipt must bind the downloaded EPUB artifact, source obligations, and complete renderer observation.',
+    })
+  }
+
+  if (trace.lineage.attemptIndex === 0) {
+    if (
+      trace.lineage.parentTraceSha256 !== null ||
+      trace.lineage.immutablePriorTraceSha256 !== null ||
+      trace.lineage.appliedRepair !== null ||
+      trace.critiqueRepair !== null
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: 'lineage',
+        message: 'The first attempt cannot have a parent trace.',
+      })
+    }
+  } else if (
+    trace.lineage.parentTraceSha256 === null ||
+    trace.lineage.immutablePriorTraceSha256 !==
+      trace.lineage.parentTraceSha256 ||
+    trace.lineage.appliedRepair === null ||
+    trace.critiqueRepair === null
+  ) {
+    issues.push({
+      code: 'invalid-lineage',
+      path: 'lineage',
+      message:
+        'A refinement must name the same immutable parent trace in both lineage fields.',
+    })
+  }
+  if (trace.lineage.appliedRepair) {
+    const application = trace.lineage.appliedRepair
+    if (
+      application.resultingStructSha256 !== trace.structure.artifact.sha256 ||
+      application.applicationSha256 !==
+        hashAppliedRepairBinding({
+          proposalSha256: application.proposalSha256,
+          baseStructSha256: application.baseStructSha256,
+          resultingStructSha256: application.resultingStructSha256,
+          applicationReceiptSha256: application.applicationReceiptSha256,
+          groundedVerifierReceiptSha256:
+            application.groundedVerifierReceiptSha256,
+        })
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: 'lineage.appliedRepair',
+        message:
+          'Repair application must commit its parent, proposal, base STRUCT, and exact resulting STRUCT.',
+      })
+    }
+  }
+
+  issues.push(
+    ...uniqueIssues(
+      trace.evidenceCandidates.map((candidate) => candidate.referenceSha256),
+      'evidenceCandidates',
+    ),
+    ...uniqueIssues(
+      trace.structure.assets.map((asset) => asset.id),
+      'structure.assets',
+    ),
+    ...uniqueIssues(
+      trace.renderedEpub.domSnapshots.map((snapshot) => snapshot.spineHref),
+      'renderedEpub.domSnapshots',
+    ),
+    ...uniqueIssues(
+      trace.renderedEpub.screenshots.map((screenshot) => screenshot.id),
+      'renderedEpub.screenshots',
+    ),
+    ...uniqueIssues(
+      trace.mappings.map((mapping) => mapping.id),
+      'mappings',
+    ),
+    ...uniqueIssues(
+      trace.mappings.map((mapping) => mapping.obligationId),
+      'mappings.obligationId',
+    ),
+    ...uniqueIssues(
+      trace.comparisonEvidence.sourceRegions.map((region) => region.id),
+      'comparisonEvidence.sourceRegions',
+    ),
+    ...uniqueIssues(
+      trace.comparisonEvidence.observations.map(
+        (observation) => observation.idSha256,
+      ),
+      'comparisonEvidence.observations',
+    ),
+    ...uniqueIssues(
+      trace.providerReceipts.map((receipt) => receipt.id),
+      'providerReceipts',
+    ),
+    ...uniqueIssues(
+      trace.comparator.checkResults.map((result) => result.id),
+      'comparator.checkResults',
+    ),
+    ...uniqueIssues(
+      trace.comparator.failures.map((failure) => failure.id),
+      'comparator.failures',
+    ),
+  )
+
+  const requiredProviderRoles: ProviderReceiptBinding['role'][] = [
+    'source-evidence',
+    'actual-render',
+    'owner-local-codex-reconciliation',
+    ...(trace.critiqueRepair ? ['owner-local-codex-repair' as const] : []),
+  ]
+  const requiredReceipts = new Map<
+    ProviderReceiptBinding['role'],
+    ProviderReceiptBinding[]
+  >(
+    requiredProviderRoles.map((role) => [
+      role,
+      trace.providerReceipts.filter((receipt) => receipt.role === role),
+    ] as const),
+  )
+  for (const role of requiredProviderRoles) {
+    const receipts = requiredReceipts.get(role) ?? []
+    if (receipts.length !== 1) {
+      issues.push({
+        code: receipts.length === 0 ? 'invalid-schema' : 'duplicate-id',
+        path: 'providerReceipts',
+        message: `Required provider role ${role} must appear exactly once.`,
+      })
+      continue
+    }
+    const receipt = receipts[0]!
+    if (!receipt.required || !receipt.enabledBeforeRun) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `providerReceipts.${receipt.id}`,
+        message: `Required provider role ${role} must be enabled before the run.`,
+      })
+    }
+  }
+  for (const receipt of trace.providerReceipts) {
+    if (receipt.role === 'optional') {
+      if (receipt.required) {
+        issues.push({
+          code: 'binding-mismatch',
+          path: `providerReceipts.${receipt.id}.required`,
+          message: 'An optional provider arm cannot be marked required.',
+        })
+      }
+      if (
+        (!receipt.enabledBeforeRun && receipt.status !== 'disabled') ||
+        (receipt.enabledBeforeRun && receipt.status === 'disabled')
+      ) {
+        issues.push({
+          code: 'binding-mismatch',
+          path: `providerReceipts.${receipt.id}.status`,
+          message:
+            'Optional provider status must preserve whether it was enabled before the run.',
+        })
+      }
+    } else if (!receipt.required) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `providerReceipts.${receipt.id}.required`,
+        message: 'Core provider roles are required.',
+      })
+    }
+  }
+  const deterministicReceipt = requiredReceipts.get('source-evidence')?.[0]
+  if (
+    deterministicReceipt &&
+    (deterministicReceipt.status !== 'succeeded' ||
+      deterministicReceipt.inputSha256 !== sourceSha256 ||
+      deterministicReceipt.outputSha256 !== trace.sourceEvidence.receiptSha256)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${deterministicReceipt.id}`,
+      message:
+        'Source-evidence provider must bind the source PDF to its graph and candidate receipt.',
+    })
+  }
+  const renderReceipt = requiredReceipts.get('actual-render')?.[0]
+  const renderedEvidenceSha256 = hashRenderedEpubEvidence(trace.renderedEpub)
+  if (
+    renderReceipt &&
+    (renderReceipt.status !== 'succeeded' ||
+      renderReceipt.inputSha256 !== trace.epub.bytes.sha256 ||
+      renderReceipt.outputSha256 !== renderedEvidenceSha256 ||
+      trace.renderedEpub.receiptSha256 !== renderedEvidenceSha256)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${renderReceipt.id}`,
+      message:
+        'Actual EPUB renderer must bind the exact EPUB bytes to its complete evidence receipt.',
+    })
+  }
+  const codexReceipt = requiredReceipts.get(
+    'owner-local-codex-reconciliation',
+  )?.[0]
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256: sourceSha256,
+    evidenceGraphSha256: trace.evidenceGraph.artifact.sha256,
+    candidateSetSha256: trace.sourceEvidence.candidateSetSha256,
+    structSha256: trace.structure.artifact.sha256,
+    epubSha256: trace.epub.bytes.sha256,
+    renderObservationReceiptSha256: trace.renderedEpub.receiptSha256,
+  })
+  if (
+    codexReceipt &&
+    (codexReceipt.status !== 'succeeded' ||
+      codexReceipt.inputSha256 !== reconciliationInputSha256 ||
+      codexReceipt.outputSha256 !== hashTraceValue(trace.comparator))
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${codexReceipt.id}`,
+      message:
+        'Owner-local Codex reconciliation must succeed and bind the exact render input to the comparator result.',
+    })
+  }
+  if (
+    codexReceipt &&
+    (!codexReceipt.server ||
+      !codexReceipt.model ||
+      !codexReceipt.prompt ||
+      !codexReceipt.tool ||
+      codexReceipt.identitySha256 !==
+        hashCodexProviderIdentity(codexReceipt) ||
+      !isOwnerLocalTransport(codexReceipt.server.transport))
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${codexReceipt.id}.server`,
+      message:
+        'Owner-local Codex requires an identified local server transport.',
+    })
+  }
+
+  const doms = new Map(
+    trace.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot,
+    ]),
+  )
+  const screenshots = new Map(
+    trace.renderedEpub.screenshots.map((screenshot) => [
+      screenshot.id,
+      screenshot,
+    ]),
+  )
+  for (const [mappingIndex, mapping] of trace.mappings.entries()) {
+    if (mapping.source.page > trace.sourcePdf.pageCount) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.source.page`,
+        message: 'Mapping page is outside the source PDF.',
+      })
+    }
+    if (
+      new Set(mapping.source.sourceRegionIds).size !==
+      mapping.source.sourceRegionIds.length
+    ) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.source.sourceRegionIds`,
+        message: 'A mapping cannot repeat a source region id.',
+      })
+    }
+    for (const [boxIndex, box] of mapping.source.boxes.entries()) {
+      if (box.page !== mapping.source.page) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.source.boxes.${boxIndex}.page`,
+          message: 'Every source box must be on the mapping source page.',
+        })
+      }
+    }
+    if (mapping.status === 'missing' && mapping.output.length !== 0) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message: 'A missing mapping cannot claim output locations.',
+      })
+    }
+    if (mapping.status === 'mapped' && mapping.output.length !== 1) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message: 'A mapped obligation must have exactly one output location.',
+      })
+    }
+    if (mapping.status === 'duplicate' && mapping.output.length < 2) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message:
+          'A duplicate obligation must have at least two output locations.',
+      })
+    }
+    for (const [outputIndex, output] of mapping.output.entries()) {
+      if (!output.rendered) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.rendered`,
+          message:
+            'Every output locator must include hash-bound screenshot geometry.',
+        })
+      }
+      const dom = doms.get(output.spineHref)
+      if (!dom) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.spineHref`,
+          message: 'Output location does not exist in rendered DOM evidence.',
+        })
+      }
+      if (dom && !dom.anchors.includes(output.anchorId)) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.anchorId`,
+          message: 'Output anchor does not exist in rendered DOM evidence.',
+        })
+      }
+      if (output.rendered) {
+        const screenshot = screenshots.get(output.rendered.screenshotId)
+        if (!screenshot || screenshot.spineHref !== output.spineHref) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.screenshotId`,
+            message:
+              'Rendered locator must reference a screenshot of the same spine item.',
+          })
+        } else if (
+          output.rendered.viewport.width !== screenshot.viewport.width ||
+          output.rendered.viewport.height !== screenshot.viewport.height ||
+          output.rendered.viewport.deviceScaleFactor !==
+            screenshot.viewport.deviceScaleFactor
+        ) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.viewport`,
+            message: 'Rendered locator viewport does not match its screenshot.',
+          })
+        }
+        const { rect, viewport } = output.rendered
+        if (
+          rect.x < 0 ||
+          rect.y < 0 ||
+          rect.width <= 0 ||
+          rect.height <= 0 ||
+          rect.x + rect.width > viewport.width ||
+          rect.y + rect.height > viewport.height
+        ) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.rect`,
+            message:
+              'Rendered locator must have positive area inside its screenshot viewport.',
+          })
+        }
+      }
+    }
+  }
+
+  const domHashes = new Map(
+    trace.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot.dom.sha256,
+    ]),
+  )
+  for (const [index, screenshot] of trace.renderedEpub.screenshots.entries()) {
+    if (screenshot.domSha256 !== domHashes.get(screenshot.spineHref)) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `renderedEpub.screenshots.${index}.domSha256`,
+        message: 'Screenshot is not bound to its rendered DOM snapshot.',
+      })
+    }
+  }
+
+  const sortedSourceRegions = [...trace.comparisonEvidence.sourceRegions].sort(
+    (left, right) => compareCodeUnits(left.id, right.id),
+  )
+  const sourceObligationProjection = {
+    sourcePdfSha256: sourceSha256,
+    obligationsSha256: hashTraceValue(sortedSourceRegions),
+    obligationCount: sortedSourceRegions.length,
+  }
+  const sourceObligationReceiptSha256 = hashTraceValue(
+    sourceObligationProjection,
+  )
+  if (
+    trace.sourceEvidence.sourceObligations.obligationsSha256 !==
+      sourceObligationProjection.obligationsSha256 ||
+    trace.sourceEvidence.sourceObligations.obligationCount !==
+      sourceObligationProjection.obligationCount ||
+    trace.sourceEvidence.sourceObligations.receiptSha256 !==
+      sourceObligationReceiptSha256 ||
+    trace.renderedEpub.sourceObligations.obligationsSha256 !==
+      sourceObligationProjection.obligationsSha256 ||
+    trace.renderedEpub.sourceObligations.obligationCount !==
+      sourceObligationProjection.obligationCount ||
+    trace.renderedEpub.sourceObligations.receiptSha256 !==
+      sourceObligationReceiptSha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'comparisonEvidence.sourceRegions',
+      message:
+        'Private comparison evidence must match the authoritative source-evidence obligation receipt and renderer copy.',
+    })
+  }
+  const expectedSets = new Map(
+    trace.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    trace.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  for (const [index, observation] of trace.comparisonEvidence.observations.entries()) {
+    const { receiptSha256, ...core } = observation
+    if (
+      receiptSha256 !== hashTraceValue(core) ||
+      observation.expectedSetReceiptSha256 !==
+        expectedSets.get(observation.check)?.receiptSha256 ||
+      observation.actualSetReceiptSha256 !==
+        actualSets.get(observation.check)?.receiptSha256
+    ) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `comparisonEvidence.observations.${index}`,
+        message:
+          'Observation must select the authoritative source-expected and renderer-actual category receipts.',
+      })
+    }
+  }
+
+  const comparator = trace.comparator
+  const comparatorBindings: Array<[string, string, string]> = [
+    ['sourcePdfSha256', comparator.sourcePdfSha256, sourceSha256],
+    ['structSha256', comparator.structSha256, trace.structure.artifact.sha256],
+    ['epubSha256', comparator.epubSha256, trace.epub.bytes.sha256],
+    [
+      'renderObservationReceiptSha256',
+      comparator.renderObservationReceiptSha256,
+      trace.renderedEpub.receiptSha256,
+    ],
+  ]
+  for (const [field, actual, expected] of comparatorBindings) {
+    if (actual !== expected) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `comparator.${field}`,
+        message: 'Comparator result is stale for this attempt.',
+      })
+    }
+  }
+  const expectedObservationSetSha256 = hashTraceValue(
+    [...trace.comparisonEvidence.observations].sort((left, right) =>
+      compareCodeUnits(left.idSha256, right.idSha256),
+    ),
+  )
+  if (comparator.observationSetSha256 !== expectedObservationSetSha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'comparator.observationSetSha256',
+      message: 'Comparator is not bound to the private observation receipt set.',
+    })
+  }
+  if (
+    comparator.denominator !== comparator.checkResults.length ||
+    comparator.passed !==
+      comparator.checkResults.filter((result) => result.status === 'passed')
+        .length ||
+    comparator.failed !==
+      comparator.checkResults.filter((result) => result.status === 'failed')
+        .length ||
+    comparator.denominator !== comparator.passed + comparator.failed
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator',
+      message: 'Comparator totals do not match its check results.',
+    })
+  }
+
+  const evaluatedChecks = new Set(
+    comparator.checkResults
+      .filter((result) => result.origin === 'deterministic')
+      .map((result) => result.check),
+  )
+  if (DETERMINISTIC_CHECK_IDS.some((check) => !evaluatedChecks.has(check))) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.checkResults',
+      message: 'Comparator omitted a required deterministic check category.',
+    })
+  }
+
+  const failureById = new Map(
+    comparator.failures.map((failure) => [failure.id, failure]),
+  )
+  for (const result of comparator.checkResults) {
+    if (
+      (result.status === 'passed' && result.failureId !== undefined) ||
+      (result.status === 'failed' &&
+        (!result.failureId || !failureById.has(result.failureId)))
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}`,
+        message: 'Failed checks and failure records must reference each other.',
+      })
+    }
+    if (
+      result.origin === 'deterministic' &&
+      result.status === 'passed' &&
+      result.check !== 'render-binding' &&
+      result.check !== 'epub-package' &&
+      result.check !== 'source-region-conservation' &&
+      (result.mappingIds.length === 0 ||
+        result.mappingIds.some((id) => {
+          const mapping = trace.mappings.find(
+            (candidate) => candidate.id === id,
+          )
+          return (
+            !mapping ||
+            mapping.status !== 'mapped' ||
+            mapping.output.length !== 1
+          )
+        }))
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}.mappingIds`,
+        message:
+          'A passing semantic observation requires known one-to-one mapping evidence.',
+      })
+    }
+  }
+  for (const result of comparator.checkResults) {
+    if (
+      result.origin !== 'deterministic' ||
+      result.judgeResultId !== undefined
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}.origin`,
+        message:
+          'Interpretive judges cannot enter the core trace until their separately calibrated contract is enabled.',
+      })
+    }
+  }
+  const referencedFailureIds = new Set(
+    comparator.checkResults.flatMap((result) =>
+      result.failureId ? [result.failureId] : [],
+    ),
+  )
+  for (const failure of comparator.failures) {
+    const citedMappings = failure.mappingIds.map((id) =>
+      trace.mappings.find((mapping) => mapping.id === id),
+    )
+    if (
+      failure.mappingIds.length === 0 ||
+      !failure.source ||
+      citedMappings.some((mapping) => !mapping) ||
+      !citedMappings.some(
+        (mapping) =>
+          mapping &&
+          hashTraceValue(mapping.source) === hashTraceValue(failure.source),
+      )
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.failures.${failure.id}`,
+        message:
+          'Every failure must cite a known mapping and source location for browser navigation.',
+      })
+    }
+  }
+  if (
+    comparator.failures.some((failure) => !referencedFailureIds.has(failure.id))
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.failures',
+      message: 'Every failure must be referenced by a failed check.',
+    })
+  }
+  if (comparator.failures.length !== comparator.failed) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.failures',
+      message: 'Every failed check must have exactly one failure record.',
+    })
+  }
+  if (comparator.status === 'publication-ready') {
+    if (
+      comparator.failed !== 0 ||
+      comparator.failures.length !== 0 ||
+      comparator.firstCauseFailureId !== null ||
+      trace.epub.epubCheck.status !== 'passed' ||
+      trace.epub.epubCheck.errorCount !== 0 ||
+      trace.epub.epubCheck.warningCount !== 0 ||
+      [...requiredReceipts.values()].some(
+        ([receipt]) =>
+          !receipt || receipt.status !== 'succeeded',
+      )
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: 'comparator.status',
+        message:
+          'Publication-ready requires every check and EPUBCheck to pass.',
+      })
+    }
+  } else if (
+    comparator.failed === 0 ||
+    comparator.failures.length === 0 ||
+    comparator.firstCauseFailureId === null ||
+    !failureById.has(comparator.firstCauseFailureId)
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.firstCauseFailureId',
+      message: 'A failed comparison requires a valid first cause.',
+    })
+  }
+  if (
+    comparator.firstCauseFailureId !== null &&
+    [...comparator.failures].sort(compareComparisonFailures)[0]?.id !==
+      comparator.firstCauseFailureId
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.firstCauseFailureId',
+      message: 'First cause is not the deterministic earliest failure.',
+    })
+  }
+  if (trace.terminalState !== comparator.status) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'terminalState',
+      message: 'Only the comparator may declare publication-ready.',
+    })
+  }
+
+  const { policy, usage } = trace.budget
+  if (
+    usage.refinements > policy.maxRefinements ||
+    usage.freshTasks > policy.maxFreshTasks ||
+    usage.tokens > policy.maxTokens ||
+    usage.durationMs > policy.maxDurationMs ||
+    usage.refinements !== trace.lineage.attemptIndex
+  ) {
+    issues.push({
+      code: 'invalid-budget',
+      path: 'budget',
+      message: 'Attempt usage exceeds its frozen policy or lineage index.',
+    })
+  }
+
+  if (trace.critiqueRepair) {
+    const repair = trace.critiqueRepair
+    const receipt = trace.providerReceipts.find(
+      (candidate) => candidate.id === repair.providerReceiptId,
+    )
+    const candidateIds = new Set(
+      trace.evidenceCandidates.map((candidate) => candidate.referenceSha256),
+    )
+    const hasUnknownEvidenceCandidate = repair.proposal.operations.some(
+      (operation) =>
+        !candidateIds.has(operation.candidateReferenceSha256),
+    )
+    const { proposalSha256, ...proposalProjection } = repair.proposal
+    const application = trace.lineage.appliedRepair
+    if (
+      repair.disposition !== 'verified' ||
+      repair.proposal.documentId !== trace.structure.documentId ||
+      repair.proposal.sourcePdfSha256 !== sourceSha256 ||
+      repair.proposal.sourceEvidenceGraphSha256 !==
+        trace.evidenceGraph.artifact.sha256 ||
+      repair.proposal.priorTraceSha256 !== trace.lineage.parentTraceSha256 ||
+      repair.proposal.baseStructSha256 !== application?.baseStructSha256 ||
+      repair.proposal.proposalSha256 !== application?.proposalSha256 ||
+      repair.proposal.proposalSha256 !==
+        hashRepairProposal(proposalProjection) ||
+      !receipt ||
+      receipt.role !== 'owner-local-codex-repair' ||
+      receipt.status !== 'succeeded' ||
+      !receipt.server ||
+      !receipt.model ||
+      !receipt.prompt ||
+      !receipt.tool ||
+      receipt.identitySha256 !== hashCodexProviderIdentity(receipt) ||
+      receipt.identitySha256 !== codexReceipt?.identitySha256 ||
+      receipt.inputSha256 !== repair.priorComparatorSha256 ||
+      receipt.outputSha256 !== repair.proposal.proposalSha256 ||
+      hasUnknownEvidenceCandidate
+    ) {
+      issues.push({
+        code: 'invalid-repair',
+        path: 'critiqueRepair',
+        message:
+          'Child repair must be a verified driver-compatible Codex patch bound to its parent, evidence, and applied STRUCT.',
+      })
+    }
+  }
+
+  return issues
+}
+
+function schemaIssues(error: z.ZodError): TraceValidationIssue[] {
+  return error.issues.map((issue) => ({
+    code: 'invalid-schema',
+    path: issue.path.join('.') || 'trace',
+    message: issue.message,
+  }))
+}
+
+export function validateReconstructionAttemptTrace(
+  input: unknown,
+): TraceValidationIssue[] {
+  const parsed = traceSchema.safeParse(input)
+  if (!parsed.success) return schemaIssues(parsed.error)
+  const issues = coreInvariantIssues(parsed.data)
+  const expectedTraceSha256 = hashReconstructionAttemptTrace(parsed.data)
+  if (parsed.data.traceSha256 !== expectedTraceSha256) {
+    issues.push({
+      code: 'hash-mismatch',
+      path: 'traceSha256',
+      message: 'Trace hash does not match its canonical content.',
+    })
+  }
+  return issues
+}
+
+export function parseReconstructionAttemptTrace(
+  input: unknown,
+): ReconstructionAttemptTrace {
+  const parsed = traceSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new ReconstructionAttemptTraceValidationError(
+      schemaIssues(parsed.error),
+    )
+  }
+  const issues = validateReconstructionAttemptTrace(parsed.data)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return parsed.data
+}
+
+export function hashReconstructionAttemptTrace(
+  input: ReconstructionAttemptTrace | ReconstructionAttemptTraceCore,
+) {
+  const { traceSha256: _traceSha256, ...candidateCore } = input as
+    | ReconstructionAttemptTrace
+    | (ReconstructionAttemptTraceCore & { traceSha256?: string })
+  const core = traceCoreSchema.parse(candidateCore)
+  return hashTraceValue(core)
+}
+
+export function createReconstructionAttemptTrace(
+  input: ReconstructionAttemptTraceCore,
+): ReconstructionAttemptTrace {
+  const core = traceCoreSchema.parse(input)
+  const issues = coreInvariantIssues(core)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return parseReconstructionAttemptTrace({
+    ...core,
+    traceSha256: hashReconstructionAttemptTrace(core),
+  })
+}
+
+export function serializeReconstructionAttemptTrace(
+  trace: ReconstructionAttemptTrace,
+) {
+  return canonicalTraceJson(parseReconstructionAttemptTrace(trace))
+}
+
+function providerIdentityProjection(
+  trace: ReconstructionAttemptTrace,
+  role: ProviderReceiptBinding['role'],
+) {
+  const receipt = trace.providerReceipts.find(
+    (candidate) => candidate.role === role,
+  )
+  if (!receipt) return null
+  return {
+    role: receipt.role,
+    required: receipt.required,
+    enabledBeforeRun: receipt.enabledBeforeRun,
+    providerId: receipt.providerId,
+    identitySha256: receipt.identitySha256 ?? null,
+    prompt: receipt.prompt ?? null,
+    tool: receipt.tool ?? null,
+    model: receipt.model ?? null,
+    server: receipt.server ?? null,
+  }
+}
+
+function executionIdentityProjection(trace: ReconstructionAttemptTrace) {
+  const requiredRoles: ProviderReceiptBinding['role'][] = [
+    'source-evidence',
+    'actual-render',
+    'owner-local-codex-reconciliation',
+  ]
+  return {
+    providers: requiredRoles.map((role) =>
+      providerIdentityProjection(trace, role),
+    ),
+    renderer: trace.renderedEpub.renderer,
+    epubCheck: {
+      toolId: trace.epub.epubCheck.toolId,
+      toolVersion: trace.epub.epubCheck.toolVersion,
+    },
+  }
+}
+
+/**
+ * Validate deterministic resume/replay across the complete ordered history.
+ * A child cannot establish this property by naming an arbitrary parent hash;
+ * callers must retain and validate every immutable prior trace.
+ */
+export function validateReconstructionAttemptTraceLineage(
+  input: readonly unknown[],
+): TraceValidationIssue[] {
+  if (input.length === 0) {
+    return [
+      {
+        code: 'invalid-lineage',
+        path: 'traces',
+        message: 'A replay lineage must contain at least one attempt.',
+      },
+    ]
+  }
+
+  const issues: TraceValidationIssue[] = []
+  const traces: Array<ReconstructionAttemptTrace | undefined> = input.map(
+    (candidate, index) => {
+      const parsed = traceSchema.safeParse(candidate)
+      if (!parsed.success) {
+        issues.push(
+          ...schemaIssues(parsed.error).map((issue) => ({
+            ...issue,
+            path: `traces.${index}.${issue.path}`,
+          })),
+        )
+        return undefined
+      }
+      issues.push(
+        ...validateReconstructionAttemptTrace(parsed.data).map((issue) => ({
+          ...issue,
+          path: `traces.${index}.${issue.path}`,
+        })),
+      )
+      return parsed.data
+    },
+  )
+
+  const first = traces[0]
+  if (!first) return issues
+  const frozenSourceSha256 = hashTraceValue(first.sourcePdf)
+  const frozenEvidenceSha256 = hashTraceValue({
+    evidenceGraph: first.evidenceGraph,
+    sourceEvidence: first.sourceEvidence,
+    evidenceCandidates: first.evidenceCandidates,
+  })
+  const frozenPolicySha256 = hashTraceValue(first.budget.policy)
+  const frozenExecutionIdentitySha256 = hashTraceValue(
+    executionIdentityProjection(first),
+  )
+  const documentId = first.structure.documentId
+  const seenAttemptIds = new Set<string>()
+
+  for (const [index, trace] of traces.entries()) {
+    if (!trace) continue
+    if (seenAttemptIds.has(trace.attemptId)) {
+      issues.push({
+        code: 'duplicate-id',
+        path: `traces.${index}.attemptId`,
+        message: 'Attempt ids must be unique across a replay lineage.',
+      })
+    }
+    seenAttemptIds.add(trace.attemptId)
+
+    if (trace.lineage.attemptIndex !== index) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.lineage.attemptIndex`,
+        message: 'Attempt indexes must be contiguous and ordered from zero.',
+      })
+    }
+    const previous = index > 0 ? traces[index - 1] : undefined
+    const expectedParentSha256 = previous?.traceSha256 ?? null
+    if (
+      trace.lineage.parentTraceSha256 !== expectedParentSha256 ||
+      trace.lineage.immutablePriorTraceSha256 !== expectedParentSha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.lineage`,
+        message:
+          'Parent and immutable-prior hashes must name the immediately preceding trace.',
+      })
+    }
+    if (previous) {
+      const application = trace.lineage.appliedRepair
+      const repair = trace.critiqueRepair
+      if (
+        previous.terminalState !== 'failed' ||
+        !application ||
+        !repair ||
+        repair.priorComparatorSha256 !== hashTraceValue(previous.comparator) ||
+        repair.priorFirstCauseFailureId !==
+          previous.comparator.firstCauseFailureId ||
+        repair.proposal.priorTraceSha256 !== previous.traceSha256 ||
+        repair.proposal.baseStructSha256 !==
+          previous.structure.artifact.sha256 ||
+        application.proposalSha256 !== repair.proposal.proposalSha256 ||
+        application.baseStructSha256 !== previous.structure.artifact.sha256 ||
+        application.resultingStructSha256 !== trace.structure.artifact.sha256 ||
+        application.resultingStructSha256 === application.baseStructSha256
+      ) {
+        issues.push({
+          code: 'invalid-lineage',
+          path: `traces.${index}.lineage.appliedRepair`,
+          message:
+            'A child requires its verified proposal for the exact failed parent comparator to produce a changed STRUCT.',
+        })
+      }
+    }
+    if (
+      hashTraceValue(trace.sourcePdf) !== frozenSourceSha256 ||
+      trace.structure.documentId !== documentId
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.sourcePdf`,
+        message: 'Source identity changed during replay.',
+      })
+    }
+    if (
+      hashTraceValue({
+        evidenceGraph: trace.evidenceGraph,
+        sourceEvidence: trace.sourceEvidence,
+        evidenceCandidates: trace.evidenceCandidates,
+      }) !== frozenEvidenceSha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.evidenceGraph`,
+        message: 'Extraction evidence changed during replay.',
+      })
+    }
+    if (hashTraceValue(trace.budget.policy) !== frozenPolicySha256) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.budget.policy`,
+        message: 'The refinement policy changed during replay.',
+      })
+    }
+    if (
+      hashTraceValue(executionIdentityProjection(trace)) !==
+      frozenExecutionIdentitySha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.providerReceipts`,
+        message:
+          'Required provider, tool, renderer, EPUBCheck, model, server, or prompt identity changed during replay.',
+      })
+    }
+    if (
+      previous &&
+      (trace.budget.usage.freshTasks < previous.budget.usage.freshTasks ||
+        trace.budget.usage.tokens < previous.budget.usage.tokens ||
+        trace.budget.usage.durationMs < previous.budget.usage.durationMs)
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.budget.usage`,
+        message: 'Replay usage counters cannot move backwards.',
+      })
+    }
+  }
+  return issues
+}
+
+export function parseReconstructionAttemptTraceLineage(
+  input: readonly unknown[],
+): ReconstructionAttemptTrace[] {
+  const issues = validateReconstructionAttemptTraceLineage(input)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return input.map((trace) => parseReconstructionAttemptTrace(trace))
+}
+
+const reconstructionAttemptRefinementTraceBindingSchema = z
+  .object({
+    traceSha256: sha256Schema,
+    sourcePdfSha256: sha256Schema,
+    sourceEvidenceGraphSha256: sha256Schema,
+    canonicalStructSha256: sha256Schema,
+    attemptIndex: nonNegativeIntegerSchema,
+    parentTraceSha256: sha256Schema.nullable(),
+    terminalStatus: z.enum(['publication-ready', 'failed']),
+    firstCause: z
+      .object({
+        failureReferenceSha256: sha256Schema,
+        code: z.enum(DETERMINISTIC_CHECK_IDS),
+      })
+      .strict()
+      .nullable(),
+    evidenceCandidateReferences: z.array(sha256Schema).min(1),
+    policy: budgetSchema.shape.policy,
+    usage: budgetSchema.shape.usage,
+  })
+  .strict()
+
+/** Public, allowlisted receipt projection; it never contains source text or bytes. */
+export type ReconstructionAttemptRefinementTraceBinding = z.infer<
+  typeof reconstructionAttemptRefinementTraceBindingSchema
+>
+
+export function parseReconstructionAttemptRefinementTraceBinding(
+  input: unknown,
+): ReconstructionAttemptRefinementTraceBinding {
+  return reconstructionAttemptRefinementTraceBindingSchema.parse(input)
+}
+
+/** Validate the public projection without requiring private owner-local payloads. */
+export function validateReconstructionAttemptRefinementTraceBindingLineage(
+  input: readonly unknown[],
+) {
+  const parsed = input.map((value) =>
+    reconstructionAttemptRefinementTraceBindingSchema.safeParse(value),
+  )
+  if (parsed.length === 0 || parsed.some((result) => !result.success)) {
+    return false
+  }
+  const bindings = parsed.flatMap((result) =>
+    result.success ? [result.data] : [],
+  )
+  const first = bindings[0]!
+  const policySha256 = hashTraceValue(first.policy)
+  for (const [index, binding] of bindings.entries()) {
+    const previous = bindings[index - 1]
+    if (
+      binding.attemptIndex !== index ||
+      binding.parentTraceSha256 !== (previous?.traceSha256 ?? null) ||
+      binding.sourcePdfSha256 !== first.sourcePdfSha256 ||
+      binding.sourceEvidenceGraphSha256 !==
+        first.sourceEvidenceGraphSha256 ||
+      hashTraceValue(binding.policy) !== policySha256 ||
+      new Set(binding.evidenceCandidateReferences).size !==
+        binding.evidenceCandidateReferences.length ||
+      (binding.terminalStatus === 'publication-ready') !==
+        (binding.firstCause === null) ||
+      binding.usage.refinements > binding.policy.maxRefinements ||
+      binding.usage.refinements !== binding.attemptIndex ||
+      binding.usage.freshTasks > binding.policy.maxFreshTasks ||
+      binding.usage.tokens > binding.policy.maxTokens ||
+      binding.usage.durationMs > binding.policy.maxDurationMs ||
+      (previous !== undefined &&
+        (binding.usage.refinements < previous.usage.refinements ||
+          binding.usage.freshTasks < previous.usage.freshTasks ||
+          binding.usage.tokens < previous.usage.tokens ||
+          binding.usage.durationMs < previous.usage.durationMs))
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Bind the generic bounded-refinement loop to one fully verified trace. */
+export function toRefinementTraceBinding(
+  input: unknown,
+): ReconstructionAttemptRefinementTraceBinding {
+  const trace = parseReconstructionAttemptTrace(input)
+  const firstCause = trace.comparator.firstCauseFailureId
+    ? trace.comparator.failures.find(
+        (failure) => failure.id === trace.comparator.firstCauseFailureId,
+      )
+    : undefined
+  return parseReconstructionAttemptRefinementTraceBinding({
+    traceSha256: trace.traceSha256,
+    sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+    sourceEvidenceGraphSha256: trace.evidenceGraph.artifact.sha256,
+    canonicalStructSha256: trace.structure.artifact.sha256,
+    attemptIndex: trace.lineage.attemptIndex,
+    parentTraceSha256: trace.lineage.parentTraceSha256,
+    terminalStatus: trace.terminalState,
+    firstCause: firstCause
+      ? {
+          failureReferenceSha256: hashTraceValue({
+            kind: 'first-cause',
+            failureId: firstCause.id,
+          }),
+          code: firstCause.check,
+        }
+      : null,
+    evidenceCandidateReferences: trace.evidenceCandidates
+      .map((candidate) => candidate.referenceSha256)
+      .sort(compareCodeUnits),
+    policy: trace.budget.policy,
+    usage: trace.budget.usage,
+  })
+}
+
+export function assertSha256(value: string, label = 'sha256') {
+  if (!sha256Schema.safeParse(value).success) {
+    throw new TypeError(`${label} must be a lowercase SHA-256 digest`)
+  }
+}

--- a/src/research/reconstruction-refinement.test.ts
+++ b/src/research/reconstruction-refinement.test.ts
@@ -1,0 +1,1510 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+  createReconstructionAttemptTrace,
+  encodeCanonicalObservationPayload,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  type ReconstructionAttemptTraceCore,
+  type ReconstructionAttemptTrace,
+  type RenderedEpubEvidence,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+import {
+  createReconstructionCandidateBinding,
+  createReconstructionCandidateContract,
+  createStructEvidencePatch,
+  deriveStructRepairProjections,
+  parseMaterializedRepairApplicationReceipt,
+  reconstructionRefinementHash,
+  replayPrivateRefinementRun,
+  replayRefinementRun,
+  runReconstructionRefinement,
+  type MaterializedRepairApplicationReceipt,
+  type MaterializationVerificationAuthorities,
+  type OwnerLocalCodexIdentity,
+  type OwnerLocalArtifactResolutionRequest,
+  type OwnerLocalArtifactResolver,
+  type PrivateReplayAuthorities,
+  type ReconstructionCandidate,
+  type ReconstructionCandidateContract,
+  type RefinementRunReceipt,
+  type StructEvidencePatch,
+} from './reconstruction-refinement'
+
+const digest = (value: string | Uint8Array) => sha256HexSync(value)
+const sourcePdfSha256 = digest('source-pdf')
+const sourceEvidenceGraphSha256 = digest('source-evidence-graph')
+const candidateReferenceSha256 = digest('provider-neutral-candidate-reference')
+const source = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 20, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+const sourceRegions = [{ id: 'region-1', source }]
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const mappings = [
+  {
+    id: 'mapping-1',
+    obligationId: 'obligation-1',
+    source,
+    output: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        anchorId: 'struct-paragraph-1',
+        rendered: {
+          screenshotId: 'screenshot-1',
+          viewport,
+          rect: { x: 10, y: 20, width: 100, height: 80 },
+        },
+      },
+    ],
+    status: 'mapped' as const,
+  },
+]
+
+function observationPayloadBytes(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  return encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-paragraph-1'],
+    })),
+  })
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = observationPayloadBytes(check, labels)
+  return { sha256: digest(bytes), byteLength: bytes.byteLength }
+}
+
+const identity: OwnerLocalCodexIdentity = {
+  server: {
+    id: 'owner-local-codex-server',
+    version: '2026.08.1',
+    transport: 'http://127.0.0.1:4500/v1',
+    executableSha256: digest('codex-server'),
+  },
+  model: {
+    id: 'gpt-5.6-sol',
+    version: '2026-08-01',
+    sha256: digest('codex-model'),
+  },
+  prompt: {
+    id: 'reconstruction-first-cause-repair',
+    version: '1.0.0',
+    sha256: digest('prompt'),
+  },
+  tool: { id: 'codex', version: '0.99.0' },
+}
+const verifierIdentity = {
+  id: 'owner-local-grounded-verifier',
+  version: '2026.08.1',
+  configurationSha256: digest('verifier-configuration'),
+  executableSha256: digest('verifier-executable'),
+}
+const artifactResolverIdentity = {
+  id: 'owner-local-artifact-resolver',
+  version: '2026.08.1',
+  configurationSha256: digest('artifact-resolver-configuration'),
+}
+const sourceEvidenceVerifierIdentity = {
+  id: 'source-evidence-verifier',
+  version: '198.1.0',
+  configurationSha256: digest('source-evidence-verifier-configuration'),
+  executableSha256: digest('source-evidence-verifier-executable'),
+}
+const renderObservationExtractorIdentity = {
+  id: 'render-observation-extractor',
+  version: '1.0.0',
+  configurationSha256: digest('render-observation-configuration'),
+  executableSha256: digest('render-observation-executable'),
+}
+
+function contract(
+  budget: Partial<ReconstructionCandidateContract['budget']> = {},
+) {
+  return createReconstructionCandidateContract({
+    schemaVersion: '1.0.0',
+    runId: 'run-document-a',
+    documentId: 'document-a',
+    sourcePdfSha256,
+    sourceEvidenceGraph: {
+      schemaVersion: '1.0.0',
+      sha256: sourceEvidenceGraphSha256,
+    },
+    authorities: {
+      codex: {
+        identity,
+        identitySha256: hashTraceValue(identity),
+      },
+      groundedVerifier: {
+        identity: verifierIdentity,
+        identitySha256: hashTraceValue(verifierIdentity),
+      },
+      artifactResolver: {
+        identity: artifactResolverIdentity,
+        identitySha256: hashTraceValue(artifactResolverIdentity),
+      },
+      sourceEvidenceVerifier: {
+        identity: sourceEvidenceVerifierIdentity,
+        identitySha256: hashTraceValue(sourceEvidenceVerifierIdentity),
+      },
+      renderObservationExtractor: {
+        identity: renderObservationExtractorIdentity,
+        identitySha256: hashTraceValue(renderObservationExtractorIdentity),
+      },
+    },
+    budget: {
+      maxRefinements: 1,
+      maxFreshTasks: 1,
+      maxTokens: 1_000,
+      maxDurationMs: 10_000,
+      repairPolicySha256: digest('repair-policy'),
+      ...budget,
+    },
+    repairScope: [
+      {
+        targetKind: 'relationship',
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256s: [candidateReferenceSha256],
+      },
+    ],
+  })
+}
+
+function initialCandidate(): ReconstructionCandidate {
+  const canonicalStructBytes = new TextEncoder().encode(
+    '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"unresolved"}]}',
+  )
+  return {
+    binding: createReconstructionCandidateBinding({
+      schemaVersion: '1.0.0',
+      sourcePdfSha256,
+      sourceEvidenceGraphSha256,
+      canonicalStruct: {
+        sha256: digest(canonicalStructBytes),
+        byteLength: canonicalStructBytes.byteLength,
+      },
+      selections: [],
+    }),
+    canonicalStructBytes,
+  }
+}
+
+function renderer(
+  epubSha256: string,
+  actualObservationSets: RenderedEpubEvidence['actualObservationSets'],
+): RenderedEpubEvidence {
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const evidence: RenderedEpubEvidence = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: 4 },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1.0.0',
+      executableSha256: digest('chromium'),
+      configurationSha256: digest('render-configuration'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: digest('dom'), byteLength: 3 },
+        anchors: ['struct-paragraph-1'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screenshot-1',
+        spineHref: 'EPUB/content.xhtml',
+        domSha256: digest('dom'),
+        image: { sha256: digest('screenshot'), byteLength: 10 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: digest('pending-render-receipt'),
+  }
+  evidence.receiptSha256 = hashRenderedEpubEvidence(evidence)
+  return evidence
+}
+
+function attemptTrace(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+  usage: ReconstructionAttemptTraceCore['budget']['usage'],
+  terminalState: 'failed' | 'publication-ready' = 'failed',
+) {
+  const epubSha256 = digest('epub')
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures' ? ['source-figure'] : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashSourceExpectedObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-expected-set'),
+        }),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures'
+          ? terminalState === 'failed'
+            ? []
+            : ['source-figure']
+          : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount:
+          terminalState === 'failed' && check === 'figures' ? 0 : 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-actual-set'),
+        }),
+      }
+    },
+  )
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256,
+    evidenceGraphSha256: sourceEvidenceGraphSha256,
+    candidateSetSha256: hashTraceValue([
+      {
+        referenceSha256: candidateReferenceSha256,
+        bindingSha256: digest('candidate-binding'),
+      },
+    ]),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashTraceValue(sourceEvidenceWithoutReceipt),
+  }
+  const renderedEpub = renderer(epubSha256, actualObservationSets)
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: digest(`observation-${check}`),
+      check,
+      source,
+      mappingIds: ['mapping-1'],
+      expectedSetReceiptSha256: expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: candidateContract.documentId,
+    sourcePdfSha256,
+    artifact: candidate.binding.canonicalStruct,
+    generatedSha256: digest('generated-struct'),
+    assets: [],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: 4 },
+    mediaType: 'application/epub+zip' as const,
+    structSha256: structure.artifact.sha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: digest('epubcheck-report'),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256,
+    sourceEvidence,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations,
+  })
+  const evidenceCandidates = [
+    {
+      referenceSha256: candidateReferenceSha256,
+      bindingSha256: digest('candidate-binding'),
+    },
+  ]
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256,
+    evidenceGraphSha256: sourceEvidenceGraphSha256,
+    candidateSetSha256: sourceEvidence.candidateSetSha256,
+    structSha256: structure.artifact.sha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  return createReconstructionAttemptTrace({
+    schemaVersion: RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+    attemptId: 'attempt-document-a-0',
+    lineage: {
+      attemptIndex: 0,
+      parentTraceSha256: null,
+      immutablePriorTraceSha256: null,
+      appliedRepair: null,
+    },
+    sourcePdf: {
+      artifact: { sha256: sourcePdfSha256, byteLength: 1_000 },
+      pageCount: 1,
+      pageRenders: [
+        {
+          page: 1,
+          sourcePdfSha256,
+          image: { sha256: digest('source-page-1'), byteLength: 500 },
+          mediaType: 'image/png',
+          width: 600,
+          height: 800,
+        },
+      ],
+    },
+    evidenceGraph: {
+      schemaVersion: '1.0.0',
+      artifact: {
+        sha256: sourceEvidenceGraphSha256,
+        byteLength: new TextEncoder().encode('source-evidence-graph').byteLength,
+      },
+      sourcePdfSha256,
+    },
+    sourceEvidence,
+    evidenceCandidates,
+    structure,
+    epub,
+    renderedEpub,
+    mappings,
+    comparisonEvidence: { sourceRegions, observations },
+    providerReceipts: [
+      {
+        id: 'provider-source-evidence',
+        role: 'source-evidence',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'provider-neutral-evidence-adapter',
+        receiptSha256: digest('provider-source-receipt'),
+        inputSha256: sourcePdfSha256,
+        outputSha256: sourceEvidence.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-actual-render',
+        role: 'actual-render',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-chromium',
+        receiptSha256: digest('provider-render-receipt'),
+        inputSha256: epubSha256,
+        outputSha256: renderedEpub.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-codex-reconciliation',
+        role: 'owner-local-codex-reconciliation',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: identity.server.id,
+        identitySha256: hashTraceValue(identity),
+        receiptSha256: digest('provider-codex-reconciliation-receipt'),
+        inputSha256: reconciliationInputSha256,
+        outputSha256: hashTraceValue(comparator),
+        prompt: identity.prompt,
+        tool: identity.tool,
+        model: identity.model,
+        server: identity.server,
+        status: 'succeeded',
+      },
+    ],
+    comparator,
+    critiqueRepair: null,
+    budget: { policy: candidateContract.budget, usage },
+    terminalState,
+  })
+}
+
+function patchFor(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+): StructEvidencePatch {
+  return createStructEvidencePatch({
+    schemaVersion: '1.0.0',
+    documentId: candidateContract.documentId,
+    sourcePdfSha256,
+    sourceEvidenceGraphSha256,
+    baseStructSha256: candidate.binding.canonicalStruct.sha256,
+    priorTraceSha256: digest('prior-trace'),
+    taskIdSha256: digest('fresh-task'),
+    operations: [
+      {
+        op: 'select-evidence-candidate',
+        targetKind: 'relationship',
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256,
+      },
+    ],
+  })
+}
+
+function applicationFor(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+  proposal: StructEvidencePatch,
+  resultingStructJson =
+    '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"resolved"}]}',
+) {
+  const resultingCanonicalStructBytes = new TextEncoder().encode(
+    resultingStructJson,
+  )
+  const resultingCanonicalStruct = {
+    sha256: digest(resultingCanonicalStructBytes),
+    byteLength: resultingCanonicalStructBytes.byteLength,
+  }
+  const beforeProjections = deriveStructRepairProjections(
+    candidate.canonicalStructBytes,
+    proposal.operations,
+  )
+  const resultingProjections = deriveStructRepairProjections(
+    resultingCanonicalStructBytes,
+    proposal.operations,
+  )
+  const operationTargetSetSha256 = hashTraceValue(
+    proposal.operations.map(({ targetKind, targetId }) => ({
+      targetKind,
+      targetId,
+    })),
+  )
+  const candidateReferenceSetSha256 = hashTraceValue(
+    proposal.operations.map(({ candidateReferenceSha256: reference }) =>
+      reference,
+    ),
+  )
+  const candidateBindingSha256 = digest('candidate-binding')
+  const candidatePayloadBytes = new TextEncoder().encode(
+    '{"selectedStatus":"resolved"}',
+  )
+  const candidatePayload = {
+    sha256: digest(candidatePayloadBytes),
+    byteLength: candidatePayloadBytes.byteLength,
+  }
+  const candidateRequest = {
+    schemaVersion: '1.0.0' as const,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    referenceSha256: candidateReferenceSha256,
+    bindingSha256: candidateBindingSha256,
+  }
+  const candidateResolutionProjection = {
+    schemaVersion: '1.0.0' as const,
+    verifierIdentity: sourceEvidenceVerifierIdentity,
+    verifierIdentitySha256: hashTraceValue(sourceEvidenceVerifierIdentity),
+    requestSha256: hashTraceValue(candidateRequest),
+    referenceSha256: candidateReferenceSha256,
+    bindingSha256: candidateBindingSha256,
+    payload: candidatePayload,
+    status: 'succeeded' as const,
+  }
+  const candidateResolution = {
+    ...candidateResolutionProjection,
+    payloadBytes: candidatePayloadBytes,
+    receiptSha256: hashTraceValue(candidateResolutionProjection),
+  }
+  const candidatePayloadSetSha256 = hashTraceValue([
+    {
+      ...candidateResolution,
+      payloadBytes: undefined,
+    },
+  ].map(({ payloadBytes: _payloadBytes, ...value }) => value))
+  const groundingRequestProjection = {
+    schemaVersion: '1.0.0' as const,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: candidate.binding.canonicalStruct,
+    resultingCanonicalStruct,
+    beforeSelectedProjection: beforeProjections.selected,
+    resultingSelectedProjection: resultingProjections.selected,
+    candidatePayloads: [candidateResolution].map(
+      ({ payloadBytes: _payloadBytes, ...value }) => value,
+    ),
+  }
+  const groundedProjection = {
+    schemaVersion: '1.0.0' as const,
+    verifierIdentity,
+    verifierIdentitySha256:
+      candidateContract.authorities.groundedVerifier.identitySha256,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operationTargetSetSha256,
+    candidateReferenceSetSha256,
+    candidatePayloadSetSha256,
+    beforeStructSha256: candidate.binding.canonicalStruct.sha256,
+    resultingStructSha256: resultingCanonicalStruct.sha256,
+    beforeSelectedProjectionSha256: beforeProjections.selected.sha256,
+    beforeUnselectedProjectionSha256: beforeProjections.unselected.sha256,
+    resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+    resultingUnselectedProjectionSha256:
+      resultingProjections.unselected.sha256,
+    inputSha256: hashTraceValue(groundingRequestProjection),
+    outputSha256: hashTraceValue({
+      resultingStructSha256: resultingCanonicalStruct.sha256,
+      resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+      resultingUnselectedProjectionSha256:
+        resultingProjections.unselected.sha256,
+    }),
+    status: 'succeeded' as const,
+  }
+  const unchangedProjection = {
+    schemaVersion: '1.0.0' as const,
+    beforeSha256: beforeProjections.unselected.sha256,
+    afterSha256: resultingProjections.unselected.sha256,
+  }
+  const groundedVerifier = {
+    ...groundedProjection,
+    receiptSha256: hashTraceValue(groundedProjection),
+  }
+  const unchangedUnselected = {
+    ...unchangedProjection,
+    receiptSha256: hashTraceValue(unchangedProjection),
+  }
+  const projection = {
+    schemaVersion: '1.0.0' as const,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: candidate.binding.canonicalStruct,
+    beforeSelectedProjection: beforeProjections.selected,
+    beforeUnselectedProjection: beforeProjections.unselected,
+    resultingCanonicalStruct,
+    resultingSelectedProjection: resultingProjections.selected,
+    resultingUnselectedProjection: resultingProjections.unselected,
+    groundedVerifier,
+    unchangedUnselected,
+  }
+  const application: MaterializedRepairApplicationReceipt = {
+    ...projection,
+    beforeCanonicalStructBytes: candidate.canonicalStructBytes,
+    resultingCanonicalStructBytes,
+    receiptSha256: hashTraceValue(projection),
+  }
+  const authorities: MaterializationVerificationAuthorities = {
+    evidenceCandidates: [
+      {
+        referenceSha256: candidateReferenceSha256,
+        bindingSha256: candidateBindingSha256,
+      },
+    ],
+    sourceEvidenceVerifier: {
+      identity: sourceEvidenceVerifierIdentity,
+      verifyExpected: () => {
+        throw new Error('expected-source verification is not used here')
+      },
+      resolveCandidate: () => candidateResolution,
+    },
+    groundedVerifier: {
+      identity: verifierIdentity,
+      verifySelected: () => groundedVerifier,
+    },
+  }
+  return { application, authorities }
+}
+
+function artifactResolver(
+  mutate?: (
+    request: OwnerLocalArtifactResolutionRequest,
+    bytes: Uint8Array,
+  ) => Uint8Array | null,
+): OwnerLocalArtifactResolver {
+  return {
+    identity: artifactResolverIdentity,
+    resolve: (request) => {
+      const source =
+        request.kind === 'epub-download'
+          ? 'epub'
+          : request.kind === 'dom-snapshot'
+            ? 'dom'
+            : 'screenshot'
+      const originalBytes = new TextEncoder().encode(source)
+      const bytes = mutate ? mutate(request, originalBytes) : originalBytes
+      if (bytes === null) return null
+      const projection = {
+        schemaVersion: '1.0.0' as const,
+        resolverIdentity: artifactResolverIdentity,
+        resolverIdentitySha256: hashTraceValue(artifactResolverIdentity),
+        requestSha256: hashTraceValue(request),
+        artifact: request.artifact,
+        status: 'succeeded' as const,
+      }
+      return {
+        ...projection,
+        bytes,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  }
+}
+
+function privateReplayAuthorities(
+  trace: ReconstructionAttemptTrace,
+  mode?: 'lying-source-count' | 'lying-render-count' | 'unrelated-render',
+  resolvedArtifacts = artifactResolver(),
+): PrivateReplayAuthorities {
+  return {
+    artifactResolver: resolvedArtifacts,
+    sourceEvidenceVerifier: {
+      identity: sourceEvidenceVerifierIdentity,
+      verifyExpected: (request) => {
+        const expectedObservationSets =
+          trace.sourceEvidence.expectedObservationSets.map((set, index) => {
+            const labels =
+              set.check === 'figures'
+                ? ['source-figure']
+                : [`value-${set.check}`]
+            let payloadBytes = observationPayloadBytes(set.check, labels)
+            let verifiedSet = { ...set, payloadBytes }
+            if (mode === 'lying-source-count' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 1,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashSourceExpectedObservationSet(verifiedSet)
+            }
+            return verifiedSet
+          })
+        const projection = {
+          schemaVersion: '1.0.0' as const,
+          verifierIdentity: sourceEvidenceVerifierIdentity,
+          verifierIdentitySha256: hashTraceValue(
+            sourceEvidenceVerifierIdentity,
+          ),
+          requestSha256: hashTraceValue(request),
+          evidenceGraph: trace.evidenceGraph.artifact,
+          expectedObservationSets: expectedObservationSets.map(
+            ({ payloadBytes: _payloadBytes, ...set }) => set,
+          ),
+          status: 'succeeded' as const,
+        }
+        return {
+          ...projection,
+          evidenceGraphBytes: new TextEncoder().encode(
+            'source-evidence-graph',
+          ),
+          expectedObservationSets,
+          receiptSha256: hashTraceValue(projection),
+        }
+      },
+      resolveCandidate: () => {
+        throw new Error('candidate resolution is not used by this replay')
+      },
+    },
+    renderObservationExtractor: {
+      identity: renderObservationExtractorIdentity,
+      extract: (request) => {
+        const actualObservationSets =
+          trace.renderedEpub.actualObservationSets.map((set, index) => {
+            const labels =
+              set.itemCount === 0
+                ? []
+                : set.check === 'figures'
+                  ? ['source-figure']
+                  : [`value-${set.check}`]
+            let payloadBytes = observationPayloadBytes(set.check, labels)
+            let verifiedSet = { ...set, payloadBytes }
+            if (mode === 'lying-render-count' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 1,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashRenderedActualObservationSet(verifiedSet)
+            } else if (mode === 'unrelated-render' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 0,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashRenderedActualObservationSet(verifiedSet)
+            }
+            return verifiedSet
+          })
+        const requestProjection = {
+          ...request,
+          artifacts: request.artifacts.map(
+            ({ bytes: _bytes, ...artifact }) => artifact,
+          ),
+        }
+        const anchorInventorySha256 = hashTraceValue(
+          trace.renderedEpub.domSnapshots
+            .map(({ spineHref, anchors }) => ({
+              spineHref,
+              anchors: [...anchors].sort(),
+            }))
+            .sort((left, right) =>
+              left.spineHref.localeCompare(right.spineHref),
+            ),
+        )
+        const projection = {
+          schemaVersion: '1.0.0' as const,
+          extractorIdentity: renderObservationExtractorIdentity,
+          extractorIdentitySha256: hashTraceValue(
+            renderObservationExtractorIdentity,
+          ),
+          requestSha256: hashTraceValue(requestProjection),
+          anchorInventorySha256,
+          actualObservationSets: actualObservationSets.map(
+            ({ payloadBytes: _payloadBytes, ...set }) => set,
+          ),
+          status: 'succeeded' as const,
+        }
+        return {
+          ...projection,
+          actualObservationSets,
+          receiptSha256: hashTraceValue(projection),
+        }
+      },
+    },
+    groundedVerifier: {
+      identity: verifierIdentity,
+      verifySelected: () => {
+        throw new Error('selected grounding is not used without applications')
+      },
+    },
+  }
+}
+
+describe('bounded reconstruction refinement', () => {
+  it('rejects a malformed runtime contract before budget access', async () => {
+    const result = await runReconstructionRefinement({
+      contract: { budget: null } as unknown as ReconstructionCandidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {} as never,
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      status: 'failed',
+      failureCode: 'invalid-candidate-contract',
+    })
+  })
+
+  it('rejects public garbage without inspecting events', () => {
+    expect(replayRefinementRun(null)).toBe(false)
+    expect(replayRefinementRun({ events: null })).toBe(false)
+    expect(replayRefinementRun({ events: 'private-source-text' })).toBe(false)
+  })
+
+  it('rejects a coordinator client identity mismatch before evaluation', async () => {
+    const candidateContract = contract()
+    const evaluate = vi.fn(async () => {
+      throw new Error('must not evaluate with a drifted Codex client')
+    })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => {
+          throw new Error('must not materialize')
+        },
+        codex: {
+          identity: {
+            ...identity,
+            model: { ...identity.model, version: '2026-08-02' },
+          },
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(result.publicReceipt.failureCode).toBe('codex-identity-mismatch')
+    expect(evaluate).not.toHaveBeenCalled()
+  })
+
+  it('maps malformed unknown Codex output to a failed receipt without materialization', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const materializeRepair = vi.fn(async () => {
+      throw new Error('must not materialize malformed output')
+    })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(candidateContract, candidate, context.usage),
+        materializeRepair,
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async (request) => ({
+            taskIdSha256: digest('fresh-task'),
+            documentId: candidateContract.documentId,
+            runId: candidateContract.runId,
+            fresh: true,
+            parentTaskId: null,
+            contextPolicy: 'immutable-prior-trace-only',
+            acceptedTraceSha256: request.priorTraceSha256,
+            identity,
+          }),
+          proposeRepair: async () => ({ proposal: null, usage: 'not-usage' }),
+        },
+      },
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      status: 'failed',
+      failureCode: 'invalid-repair-proposal',
+    })
+    expect(materializeRepair).not.toHaveBeenCalled()
+  })
+
+  it('rejects an internally consistent invented public success receipt', () => {
+    const candidateContract = contract()
+    const traceSha256 = digest('invented-trace')
+    const projection: Omit<RefinementRunReceipt, 'receiptSha256'> = {
+      schemaVersion: '1.0.0',
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      contractSha256: candidateContract.contractSha256,
+      status: 'publication-ready',
+      failureCode: null,
+      attempts: [
+        {
+          traceSha256,
+          sourcePdfSha256,
+          sourceEvidenceGraphSha256,
+          canonicalStructSha256: digest('invented-struct'),
+          attemptIndex: 0,
+          parentTraceSha256: null,
+          terminalStatus: 'publication-ready',
+          firstCause: null,
+          evidenceCandidateReferences: [candidateReferenceSha256],
+          policy: candidateContract.budget,
+          usage: {
+            refinements: 0,
+            freshTasks: 0,
+            tokens: 0,
+            durationMs: 0,
+          },
+        },
+      ],
+      proposalSha256s: [],
+      freshTaskCount: 0,
+      refinementCount: 0,
+      usage: { inputTokens: 0, outputTokens: 0, elapsedMs: 0 },
+      events: [
+        {
+          sequence: 0,
+          kind: 'server-verified',
+          attemptIndex: 0,
+          taskIdentitySha256: digest('invented-codex-identity'),
+        },
+        {
+          sequence: 1,
+          kind: 'rendered-and-compared',
+          attemptIndex: 0,
+          traceSha256,
+        },
+        {
+          sequence: 2,
+          kind: 'publication-ready',
+          attemptIndex: 0,
+          traceSha256,
+        },
+      ],
+    }
+    const receipt: RefinementRunReceipt = {
+      ...projection,
+      receiptSha256: reconstructionRefinementHash(projection),
+    }
+
+    expect(replayRefinementRun(receipt)).toBe(false)
+  })
+
+  it('accepts a closed grounded materialization receipt and rejects a fully rehashed whole-document replacement', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+    const { application, authorities } = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+    )
+
+    expect(
+      parseMaterializedRepairApplicationReceipt(
+        application,
+        candidate,
+        proposal,
+        candidateContract,
+        authorities,
+      ),
+    ).toEqual(application)
+
+    const tamperedFixture = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+      '{"assets":[],"blocks":[{"id":"unselected-replacement"}],"relationships":[{"id":"figure-relationship-1","status":"resolved"}]}',
+    )
+    const tampered = tamperedFixture.application
+    const unchangedProjection = {
+      schemaVersion: '1.0.0' as const,
+      beforeSha256: tampered.beforeUnselectedProjection.sha256,
+      afterSha256: tampered.beforeUnselectedProjection.sha256,
+    }
+    tampered.unchangedUnselected = {
+      ...unchangedProjection,
+      receiptSha256: hashTraceValue(unchangedProjection),
+    }
+    const { receiptSha256: _receiptSha256, ...tamperedProjection } = tampered
+    delete (tamperedProjection as Partial<typeof tamperedProjection>)
+      .beforeCanonicalStructBytes
+    delete (tamperedProjection as Partial<typeof tamperedProjection>)
+      .resultingCanonicalStructBytes
+    tampered.receiptSha256 = hashTraceValue(tamperedProjection)
+
+    expect(() =>
+      parseMaterializedRepairApplicationReceipt(
+        tampered,
+        candidate,
+        proposal,
+        candidateContract,
+        tamperedFixture.authorities,
+      ),
+    ).toThrow(/INVALID_MATERIALIZED/iu)
+  })
+
+  it('rejects self-hashed copied verifier identity over hallucinated selected JSON', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+    const trusted = applicationFor(candidateContract, candidate, proposal)
+    const hallucinated = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+      '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"hallucinated"}]}',
+    )
+
+    expect(() =>
+      parseMaterializedRepairApplicationReceipt(
+        hallucinated.application,
+        candidate,
+        proposal,
+        candidateContract,
+        trusted.authorities,
+      ),
+    ).toThrow(/INVALID_MATERIALIZED/iu)
+  })
+
+  it('reopens and rehashes private EPUB, DOM, and screenshot artifacts before replay', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(
+            candidateContract,
+            candidate,
+            context.usage,
+            'publication-ready',
+          ),
+        materializeRepair: async () => {
+          throw new Error('publication-ready must not materialize')
+        },
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      status: 'publication-ready',
+      failureCode: null,
+    })
+    expect(
+      replayPrivateRefinementRun(
+        candidateContract,
+        result,
+        privateReplayAuthorities(result.privateEvidence.traces[0]!),
+      ),
+    ).toBe(true)
+
+    for (const kind of [
+      'epub-download',
+      'dom-snapshot',
+      'screenshot',
+    ] as const) {
+      expect(
+        replayPrivateRefinementRun(
+          candidateContract,
+          result,
+          privateReplayAuthorities(
+            result.privateEvidence.traces[0]!,
+            undefined,
+            artifactResolver((request) =>
+              request.kind === kind
+                ? new TextEncoder().encode(`tampered-${kind}`)
+                : new TextEncoder().encode(
+                    request.kind === 'epub-download'
+                      ? 'epub'
+                      : request.kind === 'dom-snapshot'
+                        ? 'dom'
+                        : 'screenshot',
+                  ),
+            ),
+          ),
+        ),
+      ).toBe(false)
+    }
+    expect(
+      replayPrivateRefinementRun(
+        candidateContract,
+        result,
+        privateReplayAuthorities(
+          result.privateEvidence.traces[0]!,
+          undefined,
+          artifactResolver((request, bytes) =>
+            request.kind === 'epub-download' ? null : bytes,
+          ),
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects lying source or render counts and observations derived from unrelated DOM', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(
+            candidateContract,
+            candidate,
+            context.usage,
+            'publication-ready',
+          ),
+        materializeRepair: async () => {
+          throw new Error('publication-ready must not materialize')
+        },
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    const trace = result.privateEvidence.traces[0]!
+
+    for (const mode of [
+      'lying-source-count',
+      'lying-render-count',
+      'unrelated-render',
+    ] as const) {
+      expect(
+        replayPrivateRefinementRun(
+          candidateContract,
+          result,
+          privateReplayAuthorities(trace, mode),
+        ),
+      ).toBe(false)
+    }
+  })
+
+  it('enforces the coordinator deadline across the initial Codex probe', async () => {
+    const candidateContract = contract({ maxDurationMs: 5 })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {
+        evaluate: async () => {
+          throw new Error('must not evaluate after a timed-out probe')
+        },
+        materializeRepair: async () => {
+          throw new Error('must not materialize after a timed-out probe')
+        },
+        codex: {
+          identity,
+          probe: async (signal, lease) =>
+            new Promise(() => {
+              signal.addEventListener(
+                'abort',
+                () => lease.acknowledgeAbort(),
+                { once: true },
+              )
+            }),
+          createFreshTask: async () => {
+            throw new Error('must not create a task after a timed-out probe')
+          },
+          proposeRepair: async () => {
+            throw new Error('must not propose after a timed-out probe')
+          },
+        },
+      },
+    })
+
+    expect(result.publicReceipt.failureCode).toBe('codex-probe-timeout')
+  })
+
+  it('fences a concurrent duplicate run without invoking a second coordinator', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const firstController = new AbortController()
+    let blockedLease: import('./reconstruction-refinement').CoordinatorStageLease | undefined
+    let releaseProbe: (() => void) | undefined
+    const evaluate = vi.fn(async () => {
+      throw new Error('a blocked probe must not evaluate')
+    })
+    const first = runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      signal: firstController.signal,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async (_signal, lease) =>
+            new Promise((resolve) => {
+              blockedLease = lease
+              releaseProbe = () => resolve({ available: true })
+            }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    const duplicate = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(duplicate.publicReceipt.failureCode).toBe('concurrent-run')
+    expect(duplicate.privateEvidence.traces).toEqual([])
+    expect(evaluate).not.toHaveBeenCalled()
+    firstController.abort()
+    expect((await first).publicReceipt.failureCode).toBe('interrupted')
+    expect(blockedLease!.tryCommit()).toBe(false)
+
+    const stillFenced = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async () => ({ available: false }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    expect(stillFenced.publicReceipt.failureCode).toBe('concurrent-run')
+
+    const priorGenerationSha256 = blockedLease!.generationSha256
+    releaseProbe!()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    let retryGenerationSha256: string | undefined
+    const retry = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async (_signal, lease) => {
+            retryGenerationSha256 = lease.generationSha256
+            return { available: false }
+          },
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    expect(retry.publicReceipt.failureCode).toBe('codex-server-unavailable')
+    expect(retryGenerationSha256).not.toBe(priorGenerationSha256)
+  })
+
+  it.each([
+    ['evaluate', 'evaluation-timeout'],
+    ['createFreshTask', 'fresh-task-timeout'],
+    ['proposeRepair', 'repair-proposal-timeout'],
+    ['materialize', 'repair-application-timeout'],
+  ] as const)(
+    'uses the cumulative deadline for %s and ignores its late result',
+    async (stage, expectedFailureCode) => {
+      vi.useFakeTimers()
+      try {
+        const candidateContract = contract({ maxDurationMs: 50 })
+        const candidate = initialCandidate()
+        let lateLease: import('./reconstruction-refinement').CoordinatorStageLease | undefined
+        let releaseLateResult: (() => void) | undefined
+        const lateResult = new Promise<unknown>((resolve) => {
+          releaseLateResult = () => resolve(null)
+        })
+        const run = runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async (_candidate, context) => {
+              if (stage === 'evaluate') {
+                lateLease = context.lease
+                return lateResult as Promise<ReconstructionAttemptTrace>
+              }
+              return attemptTrace(candidateContract, candidate, context.usage)
+            },
+            materializeRepair: async (_candidate, _proposal, _signal, lease) => {
+              if (stage === 'materialize') {
+                lateLease = lease
+                return lateResult
+              }
+              return null
+            },
+            codex: {
+              identity,
+              probe: async () => ({ available: true }),
+              createFreshTask: async (request, _signal, lease) => {
+                if (stage === 'createFreshTask') {
+                  lateLease = lease
+                  return lateResult
+                }
+                return {
+                      taskIdSha256: digest('fresh-task'),
+                      documentId: candidateContract.documentId,
+                      runId: candidateContract.runId,
+                      fresh: true,
+                      parentTaskId: null,
+                      contextPolicy: 'immutable-prior-trace-only',
+                      acceptedTraceSha256: request.priorTraceSha256,
+                      identity,
+                    }
+              },
+              proposeRepair: async (request, _signal, lease) => {
+                if (stage === 'proposeRepair') {
+                  lateLease = lease
+                  return lateResult
+                }
+                return {
+                      proposal: createStructEvidencePatch({
+                        schemaVersion: '1.0.0',
+                        documentId: candidateContract.documentId,
+                        sourcePdfSha256,
+                        sourceEvidenceGraphSha256,
+                        baseStructSha256:
+                          candidate.binding.canonicalStruct.sha256,
+                        priorTraceSha256: request.priorTraceSha256,
+                        taskIdSha256: request.task.taskIdSha256,
+                        operations: [
+                          {
+                            op: 'select-evidence-candidate',
+                            targetKind: 'relationship',
+                            targetId: 'figure-relationship-1',
+                            candidateReferenceSha256,
+                          },
+                        ],
+                      }),
+                      usage: {
+                        inputTokens: 1,
+                        outputTokens: 1,
+                        elapsedMs: 1,
+                      },
+                    }
+              },
+            },
+          },
+        })
+
+        await vi.advanceTimersByTimeAsync(51)
+        const result = await run
+        expect(result.publicReceipt.failureCode).toBe(expectedFailureCode)
+        const frozenResultSha256 = hashTraceValue(result.publicReceipt)
+        expect(lateLease!.tryCommit()).toBe(false)
+
+        const duplicate = await runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async () => {
+              throw new Error('fenced duplicate must not evaluate')
+            },
+            materializeRepair: async () => null,
+            codex: {
+              identity,
+              probe: async () => ({ available: false }),
+              createFreshTask: async () => null,
+              proposeRepair: async () => null,
+            },
+          },
+        })
+        expect(duplicate.publicReceipt.failureCode).toBe('concurrent-run')
+
+        const expiredGenerationSha256 = lateLease!.generationSha256
+        releaseLateResult!()
+        await vi.runAllTimersAsync()
+        expect(hashTraceValue(result.publicReceipt)).toBe(frozenResultSha256)
+        expect(result.privateEvidence.applications).toEqual([])
+        if (stage === 'evaluate') {
+          expect(result.privateEvidence.traces).toEqual([])
+        } else if (stage === 'createFreshTask') {
+          expect(result.publicReceipt.freshTaskCount).toBe(0)
+        } else if (stage === 'proposeRepair') {
+          expect(result.publicReceipt.proposalSha256s).toEqual([])
+        } else {
+          expect(result.publicReceipt.refinementCount).toBe(0)
+        }
+
+        let retryGenerationSha256: string | undefined
+        const retry = await runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async () => {
+              throw new Error('unavailable retry must not evaluate')
+            },
+            materializeRepair: async () => null,
+            codex: {
+              identity,
+              probe: async (_signal, lease) => {
+                retryGenerationSha256 = lease.generationSha256
+                return { available: false }
+              },
+              createFreshTask: async () => null,
+              proposeRepair: async () => null,
+            },
+          },
+        })
+        expect(retry.publicReceipt.failureCode).toBe(
+          'codex-server-unavailable',
+        )
+        expect(retryGenerationSha256).not.toBe(expiredGenerationSha256)
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
+
+  it('keeps candidate references provider-neutral and opaque', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+
+    expect(candidateContract.repairScope[0]!.candidateReferenceSha256s).toEqual(
+      [candidateReferenceSha256],
+    )
+    expect(proposal.operations[0]!.candidateReferenceSha256).toBe(
+      candidateReferenceSha256,
+    )
+    expect(JSON.stringify({ candidateContract, proposal })).not.toMatch(
+      /mineru|candidateId|privateSource/iu,
+    )
+  })
+})

--- a/src/research/reconstruction-refinement.ts
+++ b/src/research/reconstruction-refinement.ts
@@ -1,0 +1,2939 @@
+import { z } from 'zod'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET,
+  canonicalTraceJson,
+  hashTraceValue,
+  parseCanonicalObservationPayloadBytes,
+  parseStructEvidencePatch,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  structEvidencePatchOperationSchema,
+  parseReconstructionAttemptTrace,
+  parseReconstructionAttemptTraceLineage,
+  toRefinementTraceBinding,
+  validateReconstructionAttemptRefinementTraceBindingLineage,
+  type HashedArtifact,
+  type RenderedActualObservationSet,
+  type ReconstructionAttemptBudget,
+  type ReconstructionAttemptRefinementTraceBinding,
+  type ReconstructionAttemptTrace,
+  type StructEvidencePatch,
+  type StructEvidencePatchOperation,
+  type SourceExpectedObservationSet,
+} from './reconstruction-attempt-trace'
+import { compareSourceToRenderedEpub } from './source-epub-comparator'
+
+export const RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION = '1.0.0' as const
+export const STRUCT_EVIDENCE_PATCH_SCHEMA_VERSION = '1.0.0' as const
+
+export const DEFAULT_RECONSTRUCTION_REFINEMENT_BUDGET =
+  RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/+\-]{0,191}$/u
+const PLACEHOLDER_IDENTITY_PATTERN =
+  /(?:^|[._:@/+\-])(demo|dummy|fake|fixture|mock|placeholder|recorded-stub|sample|stub|synthetic|test|unknown)(?:$|[._:@/+\-])/iu
+
+export type ReconstructionRefinementBudget =
+  ReconstructionAttemptBudget['policy']
+
+export type StructRepairTargetKind = 'block' | 'asset' | 'relationship'
+
+export type StructRepairScope = {
+  targetKind: StructRepairTargetKind
+  targetId: string
+  candidateReferenceSha256s: string[]
+}
+
+export type ReconstructionCandidateContract = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  runId: string
+  documentId: string
+  sourcePdfSha256: string
+  sourceEvidenceGraph: {
+    schemaVersion: string
+    sha256: string
+  }
+  authorities: {
+    codex: {
+      identity: OwnerLocalCodexIdentity
+      identitySha256: string
+    }
+    groundedVerifier: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+    artifactResolver: {
+      identity: OwnerLocalArtifactResolverIdentity
+      identitySha256: string
+    }
+    sourceEvidenceVerifier: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+    renderObservationExtractor: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+  }
+  budget: ReconstructionRefinementBudget
+  repairScope: StructRepairScope[]
+  contractSha256: string
+}
+
+export type { StructEvidencePatch, StructEvidencePatchOperation }
+
+export type ReconstructionCandidateBinding = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  sourcePdfSha256: string
+  sourceEvidenceGraphSha256: string
+  canonicalStruct: HashedArtifact
+  selections: StructEvidencePatchOperation[]
+  bindingSha256: string
+}
+
+export type ReconstructionCandidate = {
+  binding: ReconstructionCandidateBinding
+  canonicalStructBytes: Uint8Array
+}
+
+export type GroundedVerifierIdentity = {
+  id: string
+  version: string
+  configurationSha256: string
+  executableSha256: string
+}
+
+export type OwnerLocalArtifactResolverIdentity = {
+  id: string
+  version: string
+  configurationSha256: string
+}
+
+export type OwnerLocalArtifactKind =
+  | 'epub-download'
+  | 'dom-snapshot'
+  | 'screenshot'
+
+export type OwnerLocalArtifactResolutionRequest = {
+  schemaVersion: '1.0.0'
+  runId: string
+  attemptTraceSha256: string
+  kind: OwnerLocalArtifactKind
+  logicalId: string
+  artifact: HashedArtifact
+}
+
+export type OwnerLocalArtifactVerificationReceipt = {
+  schemaVersion: '1.0.0'
+  resolverIdentity: OwnerLocalArtifactResolverIdentity
+  resolverIdentitySha256: string
+  requestSha256: string
+  artifact: HashedArtifact
+  bytes: Uint8Array
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type OwnerLocalArtifactResolver = {
+  identity: OwnerLocalArtifactResolverIdentity
+  resolve: (request: OwnerLocalArtifactResolutionRequest) => unknown
+}
+
+type VerifiedObservationSet<
+  TSet extends SourceExpectedObservationSet | RenderedActualObservationSet,
+> = TSet & { payloadBytes: Uint8Array }
+
+export type SourceEvidenceVerificationRequest = {
+  schemaVersion: '1.0.0'
+  sourcePdfSha256: string
+  evidenceGraph: HashedArtifact
+  sourceObligationsSha256: string
+}
+
+export type SourceEvidenceVerificationReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  requestSha256: string
+  evidenceGraph: HashedArtifact
+  evidenceGraphBytes: Uint8Array
+  expectedObservationSets: Array<
+    VerifiedObservationSet<SourceExpectedObservationSet>
+  >
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type EvidenceCandidateResolutionRequest = {
+  schemaVersion: '1.0.0'
+  sourceEvidenceGraphSha256: string
+  referenceSha256: string
+  bindingSha256: string
+}
+
+export type EvidenceCandidateResolutionReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  requestSha256: string
+  referenceSha256: string
+  bindingSha256: string
+  payload: HashedArtifact
+  payloadBytes: Uint8Array
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type SourceEvidenceVerifier = {
+  identity: GroundedVerifierIdentity
+  verifyExpected: (request: SourceEvidenceVerificationRequest) => unknown
+  resolveCandidate: (request: EvidenceCandidateResolutionRequest) => unknown
+}
+
+export type SelectedGroundingVerificationRequest = {
+  schemaVersion: '1.0.0'
+  sourceEvidenceGraphSha256: string
+  proposalSha256: string
+  operations: StructEvidencePatchOperation[]
+  beforeCanonicalStruct: HashedArtifact
+  beforeCanonicalStructBytes: Uint8Array
+  resultingCanonicalStruct: HashedArtifact
+  resultingCanonicalStructBytes: Uint8Array
+  beforeSelectedProjection: HashedArtifact
+  beforeSelectedProjectionBytes: Uint8Array
+  resultingSelectedProjection: HashedArtifact
+  resultingSelectedProjectionBytes: Uint8Array
+  candidatePayloads: EvidenceCandidateResolutionReceipt[]
+}
+
+export type SelectedGroundingVerifier = {
+  identity: GroundedVerifierIdentity
+  verifySelected: (request: SelectedGroundingVerificationRequest) => unknown
+}
+
+export type MaterializationVerificationAuthorities = {
+  sourceEvidenceVerifier: SourceEvidenceVerifier
+  groundedVerifier: SelectedGroundingVerifier
+  evidenceCandidates: Array<{
+    referenceSha256: string
+    bindingSha256: string
+  }>
+}
+
+export type ResolvedRenderArtifact = OwnerLocalArtifactResolutionRequest & {
+  bytes: Uint8Array
+  verificationReceiptSha256: string
+}
+
+export type RenderObservationExtractionRequest = {
+  schemaVersion: '1.0.0'
+  runId: string
+  attemptTraceSha256: string
+  renderedEpubReceiptSha256: string
+  artifacts: ResolvedRenderArtifact[]
+}
+
+export type RenderObservationExtractionReceipt = {
+  schemaVersion: '1.0.0'
+  extractorIdentity: GroundedVerifierIdentity
+  extractorIdentitySha256: string
+  requestSha256: string
+  anchorInventorySha256: string
+  actualObservationSets: Array<
+    VerifiedObservationSet<RenderedActualObservationSet>
+  >
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type RenderObservationExtractor = {
+  identity: GroundedVerifierIdentity
+  extract: (request: RenderObservationExtractionRequest) => unknown
+}
+
+export type PrivateReplayAuthorities = {
+  artifactResolver: OwnerLocalArtifactResolver
+  sourceEvidenceVerifier: SourceEvidenceVerifier
+  renderObservationExtractor: RenderObservationExtractor
+  groundedVerifier: SelectedGroundingVerifier
+}
+
+export type GroundedVerifierReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  sourceEvidenceGraphSha256: string
+  proposalSha256: string
+  operationTargetSetSha256: string
+  candidateReferenceSetSha256: string
+  candidatePayloadSetSha256: string
+  beforeStructSha256: string
+  resultingStructSha256: string
+  beforeSelectedProjectionSha256: string
+  beforeUnselectedProjectionSha256: string
+  resultingSelectedProjectionSha256: string
+  resultingUnselectedProjectionSha256: string
+  inputSha256: string
+  outputSha256: string
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type UnchangedUnselectedProof = {
+  schemaVersion: '1.0.0'
+  beforeSha256: string
+  afterSha256: string
+  receiptSha256: string
+}
+
+export type MaterializedRepairApplicationReceipt = {
+  schemaVersion: '1.0.0'
+  proposalSha256: string
+  operations: StructEvidencePatchOperation[]
+  beforeCanonicalStruct: HashedArtifact
+  beforeCanonicalStructBytes: Uint8Array
+  beforeSelectedProjection: HashedArtifact
+  beforeUnselectedProjection: HashedArtifact
+  resultingCanonicalStruct: HashedArtifact
+  resultingCanonicalStructBytes: Uint8Array
+  resultingSelectedProjection: HashedArtifact
+  resultingUnselectedProjection: HashedArtifact
+  groundedVerifier: GroundedVerifierReceipt
+  unchangedUnselected: UnchangedUnselectedProof
+  receiptSha256: string
+}
+
+export type OwnerLocalCodexIdentity = {
+  server: {
+    id: string
+    version: string
+    transport: string
+    executableSha256: string
+  }
+  model: {
+    id: string
+    version: string
+    sha256: string
+  }
+  prompt: {
+    id: string
+    version: string
+    sha256: string
+  }
+  tool: {
+    id: 'codex'
+    version: string
+  }
+}
+
+export type RefinementTraceBinding =
+  ReconstructionAttemptRefinementTraceBinding
+
+export type RefinementTask = {
+  taskIdSha256: string
+  documentId: string
+  runId: string
+  fresh: true
+  parentTaskId: null
+  contextPolicy: 'immutable-prior-trace-only'
+  acceptedTraceSha256: string
+  identity: OwnerLocalCodexIdentity
+}
+
+export type RefinementUsage = {
+  inputTokens: number
+  outputTokens: number
+  elapsedMs: number
+}
+
+export type CoordinatorStageLease = {
+  runId: string
+  generationSha256: string
+  stageSha256: string
+  tryCommit: () => boolean
+  acknowledgeAbort: () => boolean
+}
+
+export type RefinementEvent = {
+  sequence: number
+  kind:
+    | 'server-verified'
+    | 'rendered-and-compared'
+    | 'fresh-task-created'
+    | 'repair-proposed'
+    | 'repair-verified'
+    | 'repair-applied'
+    | 'publication-ready'
+    | 'failed'
+  attemptIndex: number
+  traceSha256?: string
+  firstCauseCode?: string
+  taskIdentitySha256?: string
+  proposalSha256?: string
+  failureCode?: RefinementFailureCode
+}
+
+export type RefinementFailureCode =
+  | 'invalid-candidate-contract'
+  | 'codex-server-unavailable'
+  | 'codex-identity-mismatch'
+  | 'concurrent-run'
+  | 'codex-probe-timeout'
+  | 'evaluation-timeout'
+  | 'fresh-task-timeout'
+  | 'repair-proposal-timeout'
+  | 'repair-application-timeout'
+  | 'evaluation-failed'
+  | 'stale-trace'
+  | 'missing-first-cause'
+  | 'fresh-task-budget-exhausted'
+  | 'fresh-task-invalid'
+  | 'task-timeout'
+  | 'token-budget-exhausted'
+  | 'invalid-repair-proposal'
+  | 'repair-application-failed'
+  | 'refinement-budget-exhausted'
+  | 'interrupted'
+
+const REFINEMENT_FAILURE_CODES: readonly RefinementFailureCode[] = [
+  'invalid-candidate-contract',
+  'codex-server-unavailable',
+  'codex-identity-mismatch',
+  'concurrent-run',
+  'codex-probe-timeout',
+  'evaluation-timeout',
+  'fresh-task-timeout',
+  'repair-proposal-timeout',
+  'repair-application-timeout',
+  'evaluation-failed',
+  'stale-trace',
+  'missing-first-cause',
+  'fresh-task-budget-exhausted',
+  'fresh-task-invalid',
+  'task-timeout',
+  'token-budget-exhausted',
+  'invalid-repair-proposal',
+  'repair-application-failed',
+  'refinement-budget-exhausted',
+  'interrupted',
+]
+
+export type RefinementRunReceipt = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  authority: 'diagnostic-only'
+  promotionAllowed: false
+  contractSha256: string
+  status: 'publication-ready' | 'failed'
+  failureCode: RefinementFailureCode | null
+  attempts: ReconstructionAttemptRefinementTraceBinding[]
+  proposalSha256s: string[]
+  freshTaskCount: number
+  refinementCount: number
+  usage: RefinementUsage
+  events: RefinementEvent[]
+  receiptSha256: string
+}
+
+export type RefinementCodexClient = {
+  identity: OwnerLocalCodexIdentity
+  probe: (
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<{ available: boolean }>
+  createFreshTask: (
+    request: {
+      documentId: string
+      runId: string
+      immutablePriorTrace: Readonly<ReconstructionAttemptTrace>
+      priorTraceSha256: string
+      firstCause: NonNullable<RefinementTraceBinding['firstCause']>
+      budget: ReconstructionRefinementBudget
+    },
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+  proposeRepair: (
+    request: {
+      task: RefinementTask
+      immutablePriorTrace: Readonly<ReconstructionAttemptTrace>
+      priorTraceSha256: string
+      firstCause: NonNullable<RefinementTraceBinding['firstCause']>
+      remainingTokens: number
+      remainingTimeMs: number
+    },
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+}
+
+export type ReconstructionRefinementDependencies = {
+  evaluate: (
+    candidate: ReconstructionCandidate,
+    context: {
+      attemptIndex: number
+      parentTraceSha256: string | null
+      usage: Readonly<RefinementTraceBinding['usage']>
+      signal: AbortSignal
+      lease: CoordinatorStageLease
+    },
+  ) => Promise<ReconstructionAttemptTrace>
+  materializeRepair: (
+    candidate: Readonly<ReconstructionCandidate>,
+    proposal: StructEvidencePatch,
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+  codex?: RefinementCodexClient
+  materializationVerification?: Omit<
+    MaterializationVerificationAuthorities,
+    'evidenceCandidates'
+  >
+}
+
+export type PrivateRefinementRunEvidence = {
+  initialCandidate: ReconstructionCandidate
+  traces: ReconstructionAttemptTrace[]
+  applications: MaterializedRepairApplicationReceipt[]
+}
+
+export type ReconstructionRefinementRunResult = {
+  publicReceipt: RefinementRunReceipt
+  privateEvidence: PrivateRefinementRunEvidence
+}
+
+export function reconstructionRefinementHash(value: unknown) {
+  return hashTraceValue(value)
+}
+
+const sha256ValueSchema = z.string().regex(SHA256_PATTERN)
+const hashedArtifactValueSchema = z
+  .object({
+    sha256: sha256ValueSchema,
+    byteLength: z.number().int().nonnegative(),
+  })
+  .strict()
+const refinementUsageSchema = z
+  .object({
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    elapsedMs: z.number().finite().nonnegative(),
+  })
+  .strict()
+const refinementTaskSchema = z
+  .object({
+    taskIdSha256: sha256ValueSchema,
+    documentId: z.string().regex(SAFE_ID_PATTERN),
+    runId: z.string().regex(SAFE_ID_PATTERN),
+    fresh: z.literal(true),
+    parentTaskId: z.null(),
+    contextPolicy: z.literal('immutable-prior-trace-only'),
+    acceptedTraceSha256: sha256ValueSchema,
+    identity: z.unknown(),
+  })
+  .strict()
+const groundedVerifierReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: z
+      .object({
+        id: z.string().regex(SAFE_ID_PATTERN),
+        version: z.string().regex(SAFE_ID_PATTERN),
+        configurationSha256: sha256ValueSchema,
+        executableSha256: sha256ValueSchema,
+      })
+      .strict(),
+    verifierIdentitySha256: sha256ValueSchema,
+    sourceEvidenceGraphSha256: sha256ValueSchema,
+    proposalSha256: sha256ValueSchema,
+    operationTargetSetSha256: sha256ValueSchema,
+    candidateReferenceSetSha256: sha256ValueSchema,
+    candidatePayloadSetSha256: sha256ValueSchema,
+    beforeStructSha256: sha256ValueSchema,
+    resultingStructSha256: sha256ValueSchema,
+    beforeSelectedProjectionSha256: sha256ValueSchema,
+    beforeUnselectedProjectionSha256: sha256ValueSchema,
+    resultingSelectedProjectionSha256: sha256ValueSchema,
+    resultingUnselectedProjectionSha256: sha256ValueSchema,
+    inputSha256: sha256ValueSchema,
+    outputSha256: sha256ValueSchema,
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const unchangedUnselectedProofSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    beforeSha256: sha256ValueSchema,
+    afterSha256: sha256ValueSchema,
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const materializedRepairApplicationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    proposalSha256: sha256ValueSchema,
+    operations: z.array(structEvidencePatchOperationSchema).min(1),
+    beforeCanonicalStruct: hashedArtifactValueSchema,
+    beforeCanonicalStructBytes: z.instanceof(Uint8Array),
+    beforeSelectedProjection: hashedArtifactValueSchema,
+    beforeUnselectedProjection: hashedArtifactValueSchema,
+    resultingCanonicalStruct: hashedArtifactValueSchema,
+    resultingCanonicalStructBytes: z.instanceof(Uint8Array),
+    resultingSelectedProjection: hashedArtifactValueSchema,
+    resultingUnselectedProjection: hashedArtifactValueSchema,
+    groundedVerifier: groundedVerifierReceiptSchema,
+    unchangedUnselected: unchangedUnselectedProofSchema,
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const ownerLocalArtifactVerificationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    resolverIdentity: z
+      .object({
+        id: z.string().regex(SAFE_ID_PATTERN),
+        version: z.string().regex(SAFE_ID_PATTERN),
+        configurationSha256: sha256ValueSchema,
+      })
+      .strict(),
+    resolverIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    artifact: hashedArtifactValueSchema,
+    bytes: z.instanceof(Uint8Array),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const frozenExecutionIdentitySchema = z
+  .object({
+    id: z.string().regex(SAFE_ID_PATTERN),
+    version: z.string().regex(SAFE_ID_PATTERN),
+    configurationSha256: sha256ValueSchema,
+    executableSha256: sha256ValueSchema,
+  })
+  .strict()
+const verifiedExpectedObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256ValueSchema,
+    itemCount: z.number().int().nonnegative(),
+    payload: hashedArtifactValueSchema,
+    sourceRegionIds: z.array(z.string().regex(SAFE_ID_PATTERN)),
+    receiptSha256: sha256ValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+  })
+  .strict()
+const verifiedActualObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256ValueSchema,
+    itemCount: z.number().int().nonnegative(),
+    payload: hashedArtifactValueSchema,
+    receiptSha256: sha256ValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+  })
+  .strict()
+const sourceEvidenceVerificationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: frozenExecutionIdentitySchema,
+    verifierIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    evidenceGraph: hashedArtifactValueSchema,
+    evidenceGraphBytes: z.instanceof(Uint8Array),
+    expectedObservationSets: z
+      .array(verifiedExpectedObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const evidenceCandidateResolutionReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: frozenExecutionIdentitySchema,
+    verifierIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    referenceSha256: sha256ValueSchema,
+    bindingSha256: sha256ValueSchema,
+    payload: hashedArtifactValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const renderObservationExtractionReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    extractorIdentity: frozenExecutionIdentitySchema,
+    extractorIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    anchorInventorySha256: sha256ValueSchema,
+    actualObservationSets: z
+      .array(verifiedActualObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const codexProposalResponseSchema = z
+  .object({ proposal: z.unknown(), usage: refinementUsageSchema })
+  .strict()
+const refinementEventEnvelopeSchema = z
+  .object({
+    sequence: z.number().int().nonnegative(),
+    kind: z.enum([
+      'server-verified',
+      'rendered-and-compared',
+      'fresh-task-created',
+      'repair-proposed',
+      'repair-verified',
+      'repair-applied',
+      'publication-ready',
+      'failed',
+    ]),
+    attemptIndex: z.number().int().nonnegative(),
+    traceSha256: sha256ValueSchema.optional(),
+    firstCauseCode: z.string().regex(SAFE_ID_PATTERN).optional(),
+    taskIdentitySha256: sha256ValueSchema.optional(),
+    proposalSha256: sha256ValueSchema.optional(),
+    failureCode: z.enum(REFINEMENT_FAILURE_CODES as [
+      RefinementFailureCode,
+      ...RefinementFailureCode[],
+    ]).optional(),
+  })
+  .strict()
+const refinementRunReceiptEnvelopeSchema = z
+  .object({
+    schemaVersion: z.literal(RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION),
+    authority: z.literal('diagnostic-only'),
+    promotionAllowed: z.literal(false),
+    contractSha256: sha256ValueSchema,
+    status: z.enum(['publication-ready', 'failed']),
+    failureCode: z
+      .enum(REFINEMENT_FAILURE_CODES as [
+        RefinementFailureCode,
+        ...RefinementFailureCode[],
+      ])
+      .nullable(),
+    attempts: z.array(z.unknown()),
+    proposalSha256s: z.array(sha256ValueSchema),
+    freshTaskCount: z.number().int().nonnegative(),
+    refinementCount: z.number().int().nonnegative(),
+    usage: refinementUsageSchema,
+    events: z.array(refinementEventEnvelopeSchema),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+
+function exactKeys(value: unknown, keys: readonly string[]) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const actual = Object.keys(value).sort()
+  const expected = [...keys].sort()
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  )
+}
+
+function safeId(value: unknown): value is string {
+  return typeof value === 'string' && SAFE_ID_PATTERN.test(value)
+}
+
+function sha256(value: unknown): value is string {
+  return typeof value === 'string' && SHA256_PATTERN.test(value)
+}
+
+function positiveInteger(value: unknown) {
+  return Number.isSafeInteger(value) && Number(value) > 0
+}
+
+function nonNegativeInteger(value: unknown) {
+  return Number.isSafeInteger(value) && Number(value) >= 0
+}
+
+export function validateReconstructionRefinementBudget(
+  input: unknown,
+) {
+  if (!exactKeys(input, [
+    'maxRefinements',
+    'maxFreshTasks',
+    'maxTokens',
+    'maxDurationMs',
+    'repairPolicySha256',
+  ])) return false
+  const value = input as ReconstructionRefinementBudget
+  return (
+    nonNegativeInteger(value.maxRefinements) &&
+    positiveInteger(value.maxFreshTasks) &&
+    positiveInteger(value.maxTokens) &&
+    positiveInteger(value.maxDurationMs) &&
+    sha256(value.repairPolicySha256)
+  )
+}
+
+function candidateContractProjection(
+  value: Omit<ReconstructionCandidateContract, 'contractSha256'>,
+) {
+  return value
+}
+
+export function createReconstructionCandidateContract(
+  input: Omit<ReconstructionCandidateContract, 'contractSha256'>,
+): ReconstructionCandidateContract {
+  const contract = {
+    ...structuredClone(input),
+    contractSha256: reconstructionRefinementHash(
+      candidateContractProjection(input),
+    ),
+  }
+  if (!validateReconstructionCandidateContract(contract)) {
+    throw new Error('INVALID_RECONSTRUCTION_CANDIDATE_CONTRACT')
+  }
+  return contract
+}
+
+export function validateReconstructionCandidateContract(
+  input: unknown,
+) {
+  if (!exactKeys(input, [
+    'schemaVersion',
+    'runId',
+    'documentId',
+    'sourcePdfSha256',
+    'sourceEvidenceGraph',
+    'authorities',
+    'budget',
+    'repairScope',
+    'contractSha256',
+  ])) return false
+  const value = input as ReconstructionCandidateContract
+  if (
+    value.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    !safeId(value.runId) ||
+    !safeId(value.documentId) ||
+    !sha256(value.sourcePdfSha256) ||
+    !exactKeys(value.sourceEvidenceGraph, ['schemaVersion', 'sha256']) ||
+    !safeId(value.sourceEvidenceGraph.schemaVersion) ||
+    !sha256(value.sourceEvidenceGraph.sha256) ||
+    !exactKeys(value.authorities, [
+      'codex',
+      'groundedVerifier',
+      'artifactResolver',
+      'sourceEvidenceVerifier',
+      'renderObservationExtractor',
+    ]) ||
+    !exactKeys(value.authorities.codex, ['identity', 'identitySha256']) ||
+    !validateOwnerLocalCodexIdentity(value.authorities.codex.identity) ||
+    value.authorities.codex.identitySha256 !==
+      reconstructionRefinementHash(value.authorities.codex.identity) ||
+    !validGroundedVerifierAuthority(value.authorities.groundedVerifier) ||
+    !validArtifactResolverAuthority(value.authorities.artifactResolver) ||
+    !validGroundedVerifierAuthority(
+      value.authorities.sourceEvidenceVerifier,
+    ) ||
+    !validGroundedVerifierAuthority(
+      value.authorities.renderObservationExtractor,
+    ) ||
+    !validateReconstructionRefinementBudget(value.budget) ||
+    !Array.isArray(value.repairScope) ||
+    !sha256(value.contractSha256)
+  ) {
+    return false
+  }
+  const targets = new Set<string>()
+  for (const scope of value.repairScope) {
+    if (
+      !exactKeys(scope, [
+        'targetKind',
+        'targetId',
+        'candidateReferenceSha256s',
+      ]) ||
+      !['block', 'asset', 'relationship'].includes(scope.targetKind) ||
+      !safeId(scope.targetId) ||
+      !Array.isArray(scope.candidateReferenceSha256s) ||
+      scope.candidateReferenceSha256s.length < 1 ||
+      scope.candidateReferenceSha256s.some((candidate) => !sha256(candidate)) ||
+      new Set(scope.candidateReferenceSha256s).size !==
+        scope.candidateReferenceSha256s.length
+    ) {
+      return false
+    }
+    const target = `${scope.targetKind}:${scope.targetId}`
+    if (targets.has(target)) return false
+    targets.add(target)
+  }
+  const { contractSha256, ...projection } = value
+  return contractSha256 === reconstructionRefinementHash(projection)
+}
+
+function selectionKey(value: StructEvidencePatchOperation) {
+  return `${value.targetKind}:${value.targetId}`
+}
+
+function compareSelections(
+  left: StructEvidencePatchOperation,
+  right: StructEvidencePatchOperation,
+) {
+  const leftKey = `${selectionKey(left)}:${left.candidateReferenceSha256}`
+  const rightKey = `${selectionKey(right)}:${right.candidateReferenceSha256}`
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+}
+
+export function createReconstructionCandidateBinding(
+  input: Omit<ReconstructionCandidateBinding, 'bindingSha256'>,
+): ReconstructionCandidateBinding {
+  const projection = structuredClone(input)
+  projection.selections.sort(compareSelections)
+  return {
+    ...projection,
+    bindingSha256: reconstructionRefinementHash(projection),
+  }
+}
+
+export function validateReconstructionCandidateBinding(
+  value: ReconstructionCandidateBinding,
+  contract: ReconstructionCandidateContract,
+) {
+  if (
+    !exactKeys(value, [
+      'schemaVersion',
+      'sourcePdfSha256',
+      'sourceEvidenceGraphSha256',
+      'canonicalStruct',
+      'selections',
+      'bindingSha256',
+    ]) ||
+    value.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    value.sourcePdfSha256 !== contract.sourcePdfSha256 ||
+    value.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    !hashedArtifactValueSchema.safeParse(value.canonicalStruct).success ||
+    !sha256(value.bindingSha256) ||
+    !Array.isArray(value.selections)
+  ) {
+    return false
+  }
+  const keys = new Set<string>()
+  for (const selection of value.selections) {
+    if (
+      !structEvidencePatchOperationSchema.safeParse(selection).success
+    ) {
+      return false
+    }
+    const scope = contract.repairScope.find(
+      (candidate) =>
+        candidate.targetKind === selection.targetKind &&
+        candidate.targetId === selection.targetId,
+    )
+    const key = selectionKey(selection)
+    if (
+      !scope?.candidateReferenceSha256s.includes(
+        selection.candidateReferenceSha256,
+      ) ||
+      keys.has(key)
+    ) {
+      return false
+    }
+    keys.add(key)
+  }
+  const { bindingSha256, ...projection } = value
+  return (
+    value.selections.every(
+      (selection, index) =>
+        index === 0 ||
+        compareSelections(value.selections[index - 1]!, selection) < 0,
+    ) &&
+    bindingSha256 === reconstructionRefinementHash(projection)
+  )
+}
+
+export function validateReconstructionCandidate(
+  value: ReconstructionCandidate,
+  contract: ReconstructionCandidateContract,
+) {
+  return (
+    exactKeys(value, ['binding', 'canonicalStructBytes']) &&
+    value.canonicalStructBytes instanceof Uint8Array &&
+    validateReconstructionCandidateBinding(value.binding, contract) &&
+    value.binding.canonicalStruct.byteLength ===
+      value.canonicalStructBytes.byteLength &&
+    value.binding.canonicalStruct.sha256 ===
+      sha256HexSync(value.canonicalStructBytes)
+  )
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array) {
+  return (
+    left.byteLength === right.byteLength &&
+    left.every((byte, index) => byte === right[index])
+  )
+}
+
+function projectionArtifact(value: unknown) {
+  const bytes = new TextEncoder().encode(canonicalTraceJson(value))
+  return {
+    artifact: { sha256: sha256HexSync(bytes), byteLength: bytes.byteLength },
+    bytes,
+  }
+}
+
+function parseCanonicalStructBytes(bytes: Uint8Array) {
+  let text: string
+  let value: unknown
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    value = JSON.parse(text)
+  } catch {
+    throw new TypeError('INVALID_CANONICAL_STRUCT_BYTES')
+  }
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    canonicalTraceJson(value) !== text
+  ) {
+    throw new TypeError('INVALID_CANONICAL_STRUCT_BYTES')
+  }
+  return value as Record<string, unknown>
+}
+
+/** #200 may use this exact projection algorithm when materializing a patch. */
+export function deriveStructRepairProjections(
+  bytes: Uint8Array,
+  operations: readonly StructEvidencePatchOperation[],
+) {
+  const value = parseCanonicalStructBytes(bytes)
+  const unselected = structuredClone(value)
+  const selected: Array<{
+    targetKind: StructRepairTargetKind
+    targetId: string
+    value: unknown
+  }> = []
+  const collectionNames: Record<StructRepairTargetKind, string> = {
+    block: 'blocks',
+    asset: 'assets',
+    relationship: 'relationships',
+  }
+  for (const operation of [...operations].sort(compareSelections)) {
+    const collectionName = collectionNames[operation.targetKind]
+    const collection = value[collectionName]
+    const unselectedCollection = unselected[collectionName]
+    if (!Array.isArray(collection) || !Array.isArray(unselectedCollection)) {
+      throw new TypeError('INVALID_CANONICAL_STRUCT_TARGET_COLLECTION')
+    }
+    const matches = collection.flatMap((candidate, index) =>
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).id === operation.targetId
+        ? [index]
+        : [],
+    )
+    if (matches.length !== 1) {
+      throw new TypeError('INVALID_CANONICAL_STRUCT_TARGET')
+    }
+    const index = matches[0]!
+    selected.push({
+      targetKind: operation.targetKind,
+      targetId: operation.targetId,
+      value: collection[index],
+    })
+    unselectedCollection[index] = {
+      __selectedRepairTarget__: `${operation.targetKind}:${operation.targetId}`,
+    }
+  }
+  const selectedProjection = projectionArtifact(selected)
+  const unselectedProjection = projectionArtifact(unselected)
+  return {
+    selected: selectedProjection.artifact,
+    selectedBytes: selectedProjection.bytes,
+    unselected: unselectedProjection.artifact,
+    unselectedBytes: unselectedProjection.bytes,
+  }
+}
+
+function applicationReceiptProjection(
+  receipt: MaterializedRepairApplicationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    proposalSha256: receipt.proposalSha256,
+    operations: receipt.operations,
+    beforeCanonicalStruct: receipt.beforeCanonicalStruct,
+    beforeSelectedProjection: receipt.beforeSelectedProjection,
+    beforeUnselectedProjection: receipt.beforeUnselectedProjection,
+    resultingCanonicalStruct: receipt.resultingCanonicalStruct,
+    resultingSelectedProjection: receipt.resultingSelectedProjection,
+    resultingUnselectedProjection: receipt.resultingUnselectedProjection,
+    groundedVerifier: receipt.groundedVerifier,
+    unchangedUnselected: receipt.unchangedUnselected,
+  }
+}
+
+function evidenceCandidateResolutionProjection(
+  receipt: EvidenceCandidateResolutionReceipt,
+) {
+  const {
+    payloadBytes: _payloadBytes,
+    receiptSha256: _receiptSha256,
+    ...projection
+  } = receipt
+  return projection
+}
+
+function evidenceCandidateResolutionBinding(
+  receipt: EvidenceCandidateResolutionReceipt,
+) {
+  const { payloadBytes: _payloadBytes, ...binding } = receipt
+  return binding
+}
+
+function resolveEvidenceCandidatePayloads(
+  contract: ReconstructionCandidateContract,
+  proposal: StructEvidencePatch,
+  authorities: MaterializationVerificationAuthorities,
+) {
+  const expectedIdentitySha256 =
+    contract.authorities.sourceEvidenceVerifier.identitySha256
+  if (
+    !validGroundedVerifierIdentity(authorities.sourceEvidenceVerifier.identity) ||
+    hashTraceValue(authorities.sourceEvidenceVerifier.identity) !==
+      expectedIdentitySha256
+  ) {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  const references = [
+    ...new Set(
+      proposal.operations.map(
+        ({ candidateReferenceSha256 }) => candidateReferenceSha256,
+      ),
+    ),
+  ].sort()
+  return references.map((referenceSha256) => {
+    const bindings = authorities.evidenceCandidates.filter(
+      (candidate) => candidate.referenceSha256 === referenceSha256,
+    )
+    if (bindings.length !== 1) {
+      throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+    }
+    const request: EvidenceCandidateResolutionRequest = {
+      schemaVersion: '1.0.0',
+      sourceEvidenceGraphSha256: contract.sourceEvidenceGraph.sha256,
+      referenceSha256,
+      bindingSha256: bindings[0]!.bindingSha256,
+    }
+    const receipt = evidenceCandidateResolutionReceiptSchema.parse(
+      authorities.sourceEvidenceVerifier.resolveCandidate(
+        structuredClone(request),
+      ),
+    ) as EvidenceCandidateResolutionReceipt
+    if (
+      hashTraceValue(receipt.verifierIdentity) !== expectedIdentitySha256 ||
+      receipt.verifierIdentitySha256 !== expectedIdentitySha256 ||
+      receipt.requestSha256 !== hashTraceValue(request) ||
+      receipt.referenceSha256 !== request.referenceSha256 ||
+      receipt.bindingSha256 !== request.bindingSha256 ||
+      receipt.payload.byteLength !== receipt.payloadBytes.byteLength ||
+      receipt.payload.sha256 !== sha256HexSync(receipt.payloadBytes) ||
+      receipt.receiptSha256 !==
+        hashTraceValue(evidenceCandidateResolutionProjection(receipt))
+    ) {
+      throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+    }
+    return receipt
+  })
+}
+
+function selectedGroundingRequestProjection(
+  request: SelectedGroundingVerificationRequest,
+) {
+  return {
+    schemaVersion: request.schemaVersion,
+    sourceEvidenceGraphSha256: request.sourceEvidenceGraphSha256,
+    proposalSha256: request.proposalSha256,
+    operations: request.operations,
+    beforeCanonicalStruct: request.beforeCanonicalStruct,
+    resultingCanonicalStruct: request.resultingCanonicalStruct,
+    beforeSelectedProjection: request.beforeSelectedProjection,
+    resultingSelectedProjection: request.resultingSelectedProjection,
+    candidatePayloads: request.candidatePayloads.map(
+      evidenceCandidateResolutionBinding,
+    ),
+  }
+}
+
+export function parseMaterializedRepairApplicationReceipt(
+  input: unknown,
+  before: ReconstructionCandidate,
+  proposal: StructEvidencePatch,
+  contract: ReconstructionCandidateContract,
+  authorities: MaterializationVerificationAuthorities,
+) {
+  const receipt = materializedRepairApplicationReceiptSchema.parse(
+    input,
+  ) as MaterializedRepairApplicationReceipt
+  let beforeProjections: ReturnType<typeof deriveStructRepairProjections>
+  let resultingProjections: ReturnType<typeof deriveStructRepairProjections>
+  try {
+    beforeProjections = deriveStructRepairProjections(
+      before.canonicalStructBytes,
+      proposal.operations,
+    )
+    resultingProjections = deriveStructRepairProjections(
+      receipt.resultingCanonicalStructBytes,
+      proposal.operations,
+    )
+  } catch {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  const operationTargetSetSha256 = hashTraceValue(
+    proposal.operations
+      .map(({ targetKind, targetId }) => ({ targetKind, targetId }))
+      .sort((left, right) =>
+        left.targetKind === right.targetKind
+          ? left.targetId.localeCompare(right.targetId)
+          : left.targetKind.localeCompare(right.targetKind),
+      ),
+  )
+  const candidateReferenceSetSha256 = hashTraceValue(
+    proposal.operations
+      .map(({ candidateReferenceSha256 }) => candidateReferenceSha256)
+      .sort(),
+  )
+  const candidatePayloads = resolveEvidenceCandidatePayloads(
+    contract,
+    proposal,
+    authorities,
+  )
+  const candidatePayloadSetSha256 = hashTraceValue(
+    candidatePayloads.map(evidenceCandidateResolutionBinding),
+  )
+  const groundingRequest: SelectedGroundingVerificationRequest = {
+    schemaVersion: '1.0.0',
+    sourceEvidenceGraphSha256: contract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: before.binding.canonicalStruct,
+    beforeCanonicalStructBytes: before.canonicalStructBytes,
+    resultingCanonicalStruct: receipt.resultingCanonicalStruct,
+    resultingCanonicalStructBytes: receipt.resultingCanonicalStructBytes,
+    beforeSelectedProjection: beforeProjections.selected,
+    beforeSelectedProjectionBytes: beforeProjections.selectedBytes,
+    resultingSelectedProjection: resultingProjections.selected,
+    resultingSelectedProjectionBytes: resultingProjections.selectedBytes,
+    candidatePayloads,
+  }
+  const groundedInputSha256 = hashTraceValue(
+    selectedGroundingRequestProjection(groundingRequest),
+  )
+  const groundedOutputSha256 = hashTraceValue({
+    resultingStructSha256: receipt.resultingCanonicalStruct.sha256,
+    resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+    resultingUnselectedProjectionSha256:
+      resultingProjections.unselected.sha256,
+  })
+  const executedGrounding = groundedVerifierReceiptSchema.parse(
+    authorities.groundedVerifier.verifySelected(
+      structuredClone(groundingRequest),
+    ),
+  ) as GroundedVerifierReceipt
+  const { receiptSha256: groundedReceiptSha256, ...groundedProjection } =
+    receipt.groundedVerifier
+  const {
+    receiptSha256: unchangedReceiptSha256,
+    ...unchangedProjection
+  } = receipt.unchangedUnselected
+  if (
+    receipt.proposalSha256 !== proposal.proposalSha256 ||
+    hashTraceValue(receipt.operations) !== hashTraceValue(proposal.operations) ||
+    hashTraceValue(receipt.beforeCanonicalStruct) !==
+      hashTraceValue(before.binding.canonicalStruct) ||
+    !sameBytes(before.canonicalStructBytes, receipt.beforeCanonicalStructBytes) ||
+    receipt.beforeCanonicalStructBytes.byteLength !==
+      receipt.beforeCanonicalStruct.byteLength ||
+    sha256HexSync(receipt.beforeCanonicalStructBytes) !==
+      receipt.beforeCanonicalStruct.sha256 ||
+    receipt.resultingCanonicalStructBytes.byteLength !==
+      receipt.resultingCanonicalStruct.byteLength ||
+    sha256HexSync(receipt.resultingCanonicalStructBytes) !==
+      receipt.resultingCanonicalStruct.sha256 ||
+    receipt.resultingCanonicalStruct.sha256 ===
+      receipt.beforeCanonicalStruct.sha256 ||
+    hashTraceValue(receipt.beforeSelectedProjection) !==
+      hashTraceValue(beforeProjections.selected) ||
+    hashTraceValue(receipt.beforeUnselectedProjection) !==
+      hashTraceValue(beforeProjections.unselected) ||
+    hashTraceValue(receipt.resultingSelectedProjection) !==
+      hashTraceValue(resultingProjections.selected) ||
+    hashTraceValue(receipt.resultingUnselectedProjection) !==
+      hashTraceValue(resultingProjections.unselected) ||
+    receipt.beforeUnselectedProjection.sha256 !==
+      receipt.resultingUnselectedProjection.sha256 ||
+    receipt.beforeUnselectedProjection.byteLength !==
+      receipt.resultingUnselectedProjection.byteLength ||
+    hashTraceValue(receipt.groundedVerifier.verifierIdentity) !==
+      hashTraceValue(contract.authorities.groundedVerifier.identity) ||
+    receipt.groundedVerifier.verifierIdentitySha256 !==
+      contract.authorities.groundedVerifier.identitySha256 ||
+    receipt.groundedVerifier.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    receipt.groundedVerifier.proposalSha256 !== proposal.proposalSha256 ||
+    receipt.groundedVerifier.operationTargetSetSha256 !==
+      operationTargetSetSha256 ||
+    receipt.groundedVerifier.candidateReferenceSetSha256 !==
+      candidateReferenceSetSha256 ||
+    receipt.groundedVerifier.candidatePayloadSetSha256 !==
+      candidatePayloadSetSha256 ||
+    receipt.groundedVerifier.beforeStructSha256 !==
+      before.binding.canonicalStruct.sha256 ||
+    receipt.groundedVerifier.resultingStructSha256 !==
+      receipt.resultingCanonicalStruct.sha256 ||
+    receipt.groundedVerifier.beforeSelectedProjectionSha256 !==
+      beforeProjections.selected.sha256 ||
+    receipt.groundedVerifier.beforeUnselectedProjectionSha256 !==
+      beforeProjections.unselected.sha256 ||
+    receipt.groundedVerifier.resultingSelectedProjectionSha256 !==
+      resultingProjections.selected.sha256 ||
+    receipt.groundedVerifier.resultingUnselectedProjectionSha256 !==
+      resultingProjections.unselected.sha256 ||
+    receipt.groundedVerifier.inputSha256 !== groundedInputSha256 ||
+    receipt.groundedVerifier.outputSha256 !== groundedOutputSha256 ||
+    hashTraceValue(authorities.groundedVerifier.identity) !==
+      contract.authorities.groundedVerifier.identitySha256 ||
+    hashTraceValue(executedGrounding) !==
+      hashTraceValue(receipt.groundedVerifier) ||
+    groundedReceiptSha256 !== hashTraceValue(groundedProjection) ||
+    receipt.unchangedUnselected.beforeSha256 !==
+      beforeProjections.unselected.sha256 ||
+    receipt.unchangedUnselected.afterSha256 !==
+      resultingProjections.unselected.sha256 ||
+    unchangedReceiptSha256 !== hashTraceValue(unchangedProjection) ||
+    receipt.receiptSha256 !== hashTraceValue(applicationReceiptProjection(receipt))
+  ) {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  return receipt
+}
+
+function candidateAfterApplication(
+  before: ReconstructionCandidate,
+  receipt: MaterializedRepairApplicationReceipt,
+  proposal: StructEvidencePatch,
+) {
+  const patchedTargets = new Set(proposal.operations.map(selectionKey))
+  return {
+    binding: createReconstructionCandidateBinding({
+      schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+      sourcePdfSha256: before.binding.sourcePdfSha256,
+      sourceEvidenceGraphSha256: before.binding.sourceEvidenceGraphSha256,
+      canonicalStruct: receipt.resultingCanonicalStruct,
+      selections: [
+        ...before.binding.selections.filter(
+          (selection) => !patchedTargets.has(selectionKey(selection)),
+        ),
+        ...proposal.operations,
+      ],
+    }),
+    canonicalStructBytes: receipt.resultingCanonicalStructBytes,
+  } satisfies ReconstructionCandidate
+}
+
+function validLoopbackTransport(transport: string) {
+  if (transport.startsWith('unix://')) {
+    const path = transport.slice('unix://'.length)
+    return (
+      path.startsWith('/') &&
+      !path.includes('\0') &&
+      !path.split('/').includes('..')
+    )
+  }
+  try {
+    const url = new URL(transport)
+    return (
+      ['http:', 'https:'].includes(url.protocol) &&
+      ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname) &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+function nonPlaceholderIdentity(value: string) {
+  return safeId(value) && !PLACEHOLDER_IDENTITY_PATTERN.test(value)
+}
+
+export function validateOwnerLocalCodexIdentity(
+  value: OwnerLocalCodexIdentity,
+) {
+  return (
+    exactKeys(value, ['server', 'model', 'prompt', 'tool']) &&
+    exactKeys(value.server, [
+      'id',
+      'version',
+      'transport',
+      'executableSha256',
+    ]) &&
+    nonPlaceholderIdentity(value.server.id) &&
+    nonPlaceholderIdentity(value.server.version) &&
+    validLoopbackTransport(value.server.transport) &&
+    sha256(value.server.executableSha256) &&
+    exactKeys(value.model, ['id', 'version', 'sha256']) &&
+    nonPlaceholderIdentity(value.model.id) &&
+    nonPlaceholderIdentity(value.model.version) &&
+    sha256(value.model.sha256) &&
+    exactKeys(value.prompt, ['id', 'version', 'sha256']) &&
+    nonPlaceholderIdentity(value.prompt.id) &&
+    nonPlaceholderIdentity(value.prompt.version) &&
+    sha256(value.prompt.sha256) &&
+    exactKeys(value.tool, ['id', 'version']) &&
+    value.tool.id === 'codex' &&
+    nonPlaceholderIdentity(value.tool.version)
+  )
+}
+
+export function hashOwnerLocalCodexIdentity(value: OwnerLocalCodexIdentity) {
+  return reconstructionRefinementHash(value)
+}
+
+function validGroundedVerifierIdentity(
+  value: GroundedVerifierIdentity,
+) {
+  return (
+    exactKeys(value, [
+      'id',
+      'version',
+      'configurationSha256',
+      'executableSha256',
+    ]) &&
+    nonPlaceholderIdentity(value.id) &&
+    nonPlaceholderIdentity(value.version) &&
+    sha256(value.configurationSha256) &&
+    sha256(value.executableSha256)
+  )
+}
+
+function validGroundedVerifierAuthority(
+  value: ReconstructionCandidateContract['authorities']['groundedVerifier'],
+) {
+  return (
+    exactKeys(value, ['identity', 'identitySha256']) &&
+    validGroundedVerifierIdentity(value.identity) &&
+    value.identitySha256 === reconstructionRefinementHash(value.identity)
+  )
+}
+
+function validArtifactResolverIdentity(
+  value: OwnerLocalArtifactResolverIdentity,
+) {
+  return (
+    exactKeys(value, ['id', 'version', 'configurationSha256']) &&
+    nonPlaceholderIdentity(value.id) &&
+    nonPlaceholderIdentity(value.version) &&
+    sha256(value.configurationSha256)
+  )
+}
+
+function validArtifactResolverAuthority(
+  value: ReconstructionCandidateContract['authorities']['artifactResolver'],
+) {
+  return (
+    exactKeys(value, ['identity', 'identitySha256']) &&
+    validArtifactResolverIdentity(value.identity) &&
+    value.identitySha256 === reconstructionRefinementHash(value.identity)
+  )
+}
+
+function artifactVerificationProjection(
+  receipt: OwnerLocalArtifactVerificationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    resolverIdentity: receipt.resolverIdentity,
+    resolverIdentitySha256: receipt.resolverIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    artifact: receipt.artifact,
+    status: receipt.status,
+  }
+}
+
+function verifyOwnerLocalArtifact(
+  contract: ReconstructionCandidateContract,
+  resolver: OwnerLocalArtifactResolver,
+  request: OwnerLocalArtifactResolutionRequest,
+) {
+  const receipt = ownerLocalArtifactVerificationReceiptSchema.parse(
+    resolver.resolve(structuredClone(request)),
+  ) as OwnerLocalArtifactVerificationReceipt
+  return (
+    hashTraceValue(resolver.identity) ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    hashTraceValue(receipt.resolverIdentity) ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    receipt.resolverIdentitySha256 ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    receipt.requestSha256 === hashTraceValue(request) &&
+    hashTraceValue(receipt.artifact) === hashTraceValue(request.artifact) &&
+    receipt.bytes.byteLength === request.artifact.byteLength &&
+    sha256HexSync(receipt.bytes) === request.artifact.sha256 &&
+    receipt.receiptSha256 ===
+      hashTraceValue(artifactVerificationProjection(receipt))
+  )
+    ? receipt
+    : null
+}
+
+function verifyTraceArtifacts(
+  contract: ReconstructionCandidateContract,
+  resolver: OwnerLocalArtifactResolver,
+  trace: ReconstructionAttemptTrace,
+) {
+  if (
+    !validArtifactResolverIdentity(resolver.identity) ||
+    hashTraceValue(resolver.identity) !==
+      contract.authorities.artifactResolver.identitySha256
+  ) {
+    return false
+  }
+  const requests: OwnerLocalArtifactResolutionRequest[] = [
+    {
+      schemaVersion: '1.0.0',
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'epub-download',
+      logicalId: 'epub-download',
+      artifact: trace.renderedEpub.download.artifact,
+    },
+    ...trace.renderedEpub.domSnapshots.map(({ spineHref, dom }, index) => ({
+      schemaVersion: '1.0.0' as const,
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'dom-snapshot' as const,
+      logicalId: `dom-snapshot:${index}:${spineHref}`,
+      artifact: dom,
+    })),
+    ...trace.renderedEpub.screenshots.map(({ id, image }) => ({
+      schemaVersion: '1.0.0' as const,
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'screenshot' as const,
+      logicalId: `screenshot:${id}`,
+      artifact: image,
+    })),
+  ]
+  const resolved = requests.map((request) => {
+    const receipt = verifyOwnerLocalArtifact(contract, resolver, request)
+    return receipt
+      ? {
+          ...request,
+          bytes: receipt.bytes,
+          verificationReceiptSha256: receipt.receiptSha256,
+        }
+      : null
+  })
+  return resolved.every(
+    (artifact): artifact is ResolvedRenderArtifact => artifact !== null,
+  )
+    ? resolved
+    : null
+}
+
+function observationSetWithoutBytes<
+  TSet extends SourceExpectedObservationSet | RenderedActualObservationSet,
+>({ payloadBytes: _payloadBytes, ...set }: VerifiedObservationSet<TSet>) {
+  return set
+}
+
+function validVerifiedObservationSet(
+  value: VerifiedObservationSet<
+    SourceExpectedObservationSet | RenderedActualObservationSet
+  >,
+) {
+  const payload = parseCanonicalObservationPayloadBytes(value.payloadBytes)
+  return (
+    payload.check === value.check &&
+    payload.items.length === value.itemCount &&
+    value.payload.byteLength === value.payloadBytes.byteLength &&
+    value.payload.sha256 === sha256HexSync(value.payloadBytes) &&
+    value.setSha256 === value.payload.sha256
+  )
+}
+
+function sourceEvidenceVerificationProjection(
+  receipt: SourceEvidenceVerificationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    verifierIdentity: receipt.verifierIdentity,
+    verifierIdentitySha256: receipt.verifierIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    evidenceGraph: receipt.evidenceGraph,
+    expectedObservationSets: receipt.expectedObservationSets.map(
+      observationSetWithoutBytes,
+    ),
+    status: receipt.status,
+  }
+}
+
+function verifySourceEvidenceAuthority(
+  contract: ReconstructionCandidateContract,
+  verifier: SourceEvidenceVerifier,
+  trace: ReconstructionAttemptTrace,
+) {
+  const request: SourceEvidenceVerificationRequest = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+    evidenceGraph: trace.evidenceGraph.artifact,
+    sourceObligationsSha256:
+      trace.sourceEvidence.sourceObligations.obligationsSha256,
+  }
+  const receipt = sourceEvidenceVerificationReceiptSchema.parse(
+    verifier.verifyExpected(structuredClone(request)),
+  ) as SourceEvidenceVerificationReceipt
+  const expectedIdentitySha256 =
+    contract.authorities.sourceEvidenceVerifier.identitySha256
+  return (
+    validGroundedVerifierIdentity(verifier.identity) &&
+    hashTraceValue(verifier.identity) === expectedIdentitySha256 &&
+    hashTraceValue(receipt.verifierIdentity) === expectedIdentitySha256 &&
+    receipt.verifierIdentitySha256 === expectedIdentitySha256 &&
+    receipt.requestSha256 === hashTraceValue(request) &&
+    hashTraceValue(receipt.evidenceGraph) ===
+      hashTraceValue(trace.evidenceGraph.artifact) &&
+    receipt.evidenceGraphBytes.byteLength ===
+      trace.evidenceGraph.artifact.byteLength &&
+    sha256HexSync(receipt.evidenceGraphBytes) ===
+      trace.evidenceGraph.artifact.sha256 &&
+    receipt.expectedObservationSets.every(
+      (set, index) =>
+        set.check === SOURCE_EPUB_OBSERVATION_CHECK_IDS[index] &&
+        validVerifiedObservationSet(set) &&
+        hashTraceValue(observationSetWithoutBytes(set)) ===
+          hashTraceValue(trace.sourceEvidence.expectedObservationSets[index]),
+    ) &&
+    receipt.receiptSha256 ===
+      hashTraceValue(sourceEvidenceVerificationProjection(receipt))
+  )
+}
+
+function renderExtractionRequestProjection(
+  request: RenderObservationExtractionRequest,
+) {
+  return {
+    schemaVersion: request.schemaVersion,
+    runId: request.runId,
+    attemptTraceSha256: request.attemptTraceSha256,
+    renderedEpubReceiptSha256: request.renderedEpubReceiptSha256,
+    artifacts: request.artifacts.map(
+      ({ bytes: _bytes, ...artifact }) => artifact,
+    ),
+  }
+}
+
+function renderObservationExtractionProjection(
+  receipt: RenderObservationExtractionReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    extractorIdentity: receipt.extractorIdentity,
+    extractorIdentitySha256: receipt.extractorIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    anchorInventorySha256: receipt.anchorInventorySha256,
+    actualObservationSets: receipt.actualObservationSets.map(
+      observationSetWithoutBytes,
+    ),
+    status: receipt.status,
+  }
+}
+
+function verifyRenderObservationAuthority(
+  contract: ReconstructionCandidateContract,
+  extractor: RenderObservationExtractor,
+  trace: ReconstructionAttemptTrace,
+  artifacts: ResolvedRenderArtifact[],
+) {
+  const request: RenderObservationExtractionRequest = {
+    schemaVersion: '1.0.0',
+    runId: contract.runId,
+    attemptTraceSha256: trace.traceSha256,
+    renderedEpubReceiptSha256: trace.renderedEpub.receiptSha256,
+    artifacts,
+  }
+  const receipt = renderObservationExtractionReceiptSchema.parse(
+    extractor.extract(structuredClone(request)),
+  ) as RenderObservationExtractionReceipt
+  const expectedIdentitySha256 =
+    contract.authorities.renderObservationExtractor.identitySha256
+  const anchorInventorySha256 = hashTraceValue(
+    trace.renderedEpub.domSnapshots
+      .map(({ spineHref, anchors }) => ({
+        spineHref,
+        anchors: [...anchors].sort(),
+      }))
+      .sort((left, right) => left.spineHref.localeCompare(right.spineHref)),
+  )
+  const renderedAnchorIds = new Set(
+    trace.renderedEpub.domSnapshots.flatMap(({ anchors }) => anchors),
+  )
+  return (
+    validGroundedVerifierIdentity(extractor.identity) &&
+    hashTraceValue(extractor.identity) === expectedIdentitySha256 &&
+    hashTraceValue(receipt.extractorIdentity) === expectedIdentitySha256 &&
+    receipt.extractorIdentitySha256 === expectedIdentitySha256 &&
+    receipt.requestSha256 === hashTraceValue(renderExtractionRequestProjection(request)) &&
+    receipt.anchorInventorySha256 === anchorInventorySha256 &&
+    receipt.actualObservationSets.every(
+      (set, index) =>
+        set.check === SOURCE_EPUB_OBSERVATION_CHECK_IDS[index] &&
+        validVerifiedObservationSet(set) &&
+        parseCanonicalObservationPayloadBytes(set.payloadBytes).items.every(
+          ({ anchorIds }) =>
+            anchorIds.every((anchorId) => renderedAnchorIds.has(anchorId)),
+        ) &&
+        hashTraceValue(observationSetWithoutBytes(set)) ===
+          hashTraceValue(trace.renderedEpub.actualObservationSets[index]),
+    ) &&
+    receipt.receiptSha256 ===
+      hashTraceValue(renderObservationExtractionProjection(receipt))
+  )
+}
+
+function patchProjection(value: Omit<StructEvidencePatch, 'proposalSha256'>) {
+  return value
+}
+
+export function createStructEvidencePatch(
+  input: Omit<StructEvidencePatch, 'proposalSha256'>,
+) {
+  return parseStructEvidencePatch({
+    ...structuredClone(input),
+    proposalSha256: reconstructionRefinementHash(patchProjection(input)),
+  })
+}
+
+export function validateStructEvidencePatch(
+  proposal: StructEvidencePatch,
+  contract: ReconstructionCandidateContract,
+  trace: RefinementTraceBinding,
+  task: RefinementTask,
+) {
+  try {
+    proposal = parseStructEvidencePatch(proposal)
+  } catch {
+    return false
+  }
+  if (
+    proposal.schemaVersion !== STRUCT_EVIDENCE_PATCH_SCHEMA_VERSION ||
+    proposal.documentId !== contract.documentId ||
+    proposal.sourcePdfSha256 !== contract.sourcePdfSha256 ||
+    proposal.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    proposal.baseStructSha256 !== trace.canonicalStructSha256 ||
+    proposal.priorTraceSha256 !== trace.traceSha256 ||
+    proposal.taskIdSha256 !== task.taskIdSha256
+  ) {
+    return false
+  }
+  const traceCandidates = new Set(trace.evidenceCandidateReferences)
+  const operationKeys = new Set<string>()
+  for (const operation of proposal.operations) {
+    if (
+      !structEvidencePatchOperationSchema.safeParse(operation).success ||
+      !traceCandidates.has(operation.candidateReferenceSha256)
+    ) {
+      return false
+    }
+    const scope = contract.repairScope.find(
+      (candidate) =>
+        candidate.targetKind === operation.targetKind &&
+        candidate.targetId === operation.targetId,
+    )
+    if (
+      !scope?.candidateReferenceSha256s.includes(
+        operation.candidateReferenceSha256,
+      )
+    ) {
+      return false
+    }
+    const key = `${operation.targetKind}:${operation.targetId}`
+    if (operationKeys.has(key)) return false
+    operationKeys.add(key)
+  }
+  return true
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested)
+    }
+  }
+  return value
+}
+
+function immutableClone<T>(value: T) {
+  return deepFreeze(structuredClone(value))
+}
+
+function zeroUsage(): RefinementUsage {
+  return { inputTokens: 0, outputTokens: 0, elapsedMs: 0 }
+}
+
+function validUsage(value: RefinementUsage) {
+  return (
+    exactKeys(value, ['inputTokens', 'outputTokens', 'elapsedMs']) &&
+    nonNegativeInteger(value.inputTokens) &&
+    nonNegativeInteger(value.outputTokens) &&
+    Number.isFinite(value.elapsedMs) &&
+    value.elapsedMs >= 0
+  )
+}
+
+function combinedTokens(usage: RefinementUsage) {
+  return usage.inputTokens + usage.outputTokens
+}
+
+function aborted(signal: AbortSignal) {
+  if (!signal.aborted) return
+  const error = new Error('INTERRUPTED')
+  error.name = 'AbortError'
+  throw error
+}
+
+function linkedAbortController(signal: AbortSignal) {
+  const controller = new AbortController()
+  const abort = () => controller.abort()
+  signal.addEventListener('abort', abort, { once: true })
+  if (signal.aborted) controller.abort()
+  return {
+    controller,
+    dispose: () => signal.removeEventListener('abort', abort),
+  }
+}
+
+type ActiveRefinementRun = {
+  runId: string
+  generationSha256: string
+  nextStageIndex: number
+  pendingStages: Set<symbol>
+  finished: boolean
+}
+
+const activeRefinementRuns = new Map<string, ActiveRefinementRun>()
+const refinementRunGenerations = new Map<string, number>()
+
+function releaseRefinementRunWhenSettled(run: ActiveRefinementRun) {
+  if (
+    run.finished &&
+    run.pendingStages.size === 0 &&
+    activeRefinementRuns.get(run.runId) === run
+  ) {
+    activeRefinementRuns.delete(run.runId)
+  }
+}
+
+type GuardedStageResult<T> = {
+  value: T
+  accept: <TResult>(commit: () => TResult) => TResult
+  discard: () => void
+}
+
+async function withTaskDeadline<T>(
+  operation: (
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal,
+  run: ActiveRefinementRun,
+  stage: string,
+): Promise<GuardedStageResult<T>> {
+  aborted(signal)
+  const { controller, dispose } = linkedAbortController(signal)
+  const pendingStage = Symbol(stage)
+  const stageIndex = run.nextStageIndex
+  run.nextStageIndex += 1
+  let active = true
+  let abortAcknowledged = false
+  const current = () =>
+    active &&
+    !controller.signal.aborted &&
+    activeRefinementRuns.get(run.runId) === run
+  const settle = () => {
+    run.pendingStages.delete(pendingStage)
+    releaseRefinementRunWhenSettled(run)
+  }
+  const lease: CoordinatorStageLease = Object.freeze({
+    runId: run.runId,
+    generationSha256: run.generationSha256,
+    stageSha256: hashTraceValue({
+      generationSha256: run.generationSha256,
+      stage,
+      stageIndex,
+    }),
+    tryCommit: () => current(),
+    acknowledgeAbort: () => {
+      if (!controller.signal.aborted || abortAcknowledged) return false
+      abortAcknowledged = true
+      settle()
+      return true
+    },
+  })
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const interrupted = new Promise<never>((_resolve, reject) => {
+    controller.signal.addEventListener(
+      'abort',
+      () => {
+        active = false
+        const error = new Error('INTERRUPTED')
+        error.name = 'AbortError'
+        reject(error)
+      },
+      { once: true },
+    )
+  })
+  try {
+    run.pendingStages.add(pendingStage)
+    const operationPromise = Promise.resolve().then(() =>
+      operation(controller.signal, lease),
+    )
+    void operationPromise.then(settle, settle)
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => {
+          active = false
+          reject(new Error('TASK_TIMEOUT'))
+          controller.abort()
+        },
+        Math.max(1, timeoutMs),
+      )
+    })
+    const value = await Promise.race([
+      operationPromise,
+      timeout,
+      interrupted,
+    ])
+    return {
+      value,
+      accept: (commit) => {
+        if (!current()) throw new Error('STALE_RUN_GENERATION')
+        try {
+          return commit()
+        } finally {
+          active = false
+        }
+      },
+      discard: () => {
+        active = false
+      },
+    }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+    dispose()
+  }
+}
+
+function validateTraceBinding(
+  value: RefinementTraceBinding,
+  contract: ReconstructionCandidateContract,
+  attemptIndex: number,
+  parentTraceSha256: string | null,
+  expectedUsage: RefinementTraceBinding['usage'],
+) {
+  return (
+    exactKeys(value, [
+      'traceSha256',
+      'sourcePdfSha256',
+      'sourceEvidenceGraphSha256',
+      'canonicalStructSha256',
+      'attemptIndex',
+      'parentTraceSha256',
+      'terminalStatus',
+      'firstCause',
+      'evidenceCandidateReferences',
+      'policy',
+      'usage',
+    ]) &&
+    sha256(value.traceSha256) &&
+    value.sourcePdfSha256 === contract.sourcePdfSha256 &&
+    value.sourceEvidenceGraphSha256 === contract.sourceEvidenceGraph.sha256 &&
+    sha256(value.canonicalStructSha256) &&
+    value.attemptIndex === attemptIndex &&
+    value.parentTraceSha256 === parentTraceSha256 &&
+    ['publication-ready', 'failed'].includes(value.terminalStatus) &&
+    (value.firstCause === null ||
+      (exactKeys(value.firstCause, ['failureReferenceSha256', 'code']) &&
+        sha256(value.firstCause.failureReferenceSha256) &&
+        safeId(value.firstCause.code))) &&
+    Array.isArray(value.evidenceCandidateReferences) &&
+    value.evidenceCandidateReferences.length > 0 &&
+    value.evidenceCandidateReferences.every(sha256) &&
+    new Set(value.evidenceCandidateReferences).size ===
+      value.evidenceCandidateReferences.length &&
+    exactKeys(value.policy, [
+      'repairPolicySha256',
+      'maxRefinements',
+      'maxFreshTasks',
+      'maxTokens',
+      'maxDurationMs',
+    ]) &&
+    value.policy.repairPolicySha256 === contract.budget.repairPolicySha256 &&
+    value.policy.maxRefinements === contract.budget.maxRefinements &&
+    value.policy.maxFreshTasks === contract.budget.maxFreshTasks &&
+    value.policy.maxTokens === contract.budget.maxTokens &&
+    value.policy.maxDurationMs === contract.budget.maxDurationMs &&
+    exactKeys(value.usage, [
+      'refinements',
+      'freshTasks',
+      'tokens',
+      'durationMs',
+    ]) &&
+    value.usage.refinements === expectedUsage.refinements &&
+    value.usage.freshTasks === expectedUsage.freshTasks &&
+    value.usage.tokens === expectedUsage.tokens &&
+    value.usage.durationMs === expectedUsage.durationMs
+  )
+}
+
+function validTask(
+  task: RefinementTask,
+  contract: ReconstructionCandidateContract,
+  trace: RefinementTraceBinding,
+  expectedIdentity: OwnerLocalCodexIdentity,
+) {
+  return (
+    refinementTaskSchema.safeParse(task).success &&
+    task.documentId === contract.documentId &&
+    task.runId === contract.runId &&
+    task.fresh === true &&
+    task.parentTaskId === null &&
+    task.contextPolicy === 'immutable-prior-trace-only' &&
+    task.acceptedTraceSha256 === trace.traceSha256 &&
+    reconstructionRefinementHash(task.identity) ===
+      reconstructionRefinementHash(expectedIdentity)
+  )
+}
+
+function traceMatchesCodexAuthority(
+  trace: ReconstructionAttemptTrace,
+  contract: ReconstructionCandidateContract,
+) {
+  const expected = contract.authorities.codex.identitySha256
+  const reconciliation = trace.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-reconciliation',
+  )
+  const repair = trace.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-repair',
+  )
+  return (
+    reconciliation?.identitySha256 === expected &&
+    (!repair || repair.identitySha256 === expected)
+  )
+}
+
+function receiptProjection(
+  value: Omit<RefinementRunReceipt, 'receiptSha256'>,
+) {
+  return value
+}
+
+function finalizeReceipt(
+  input: Omit<RefinementRunReceipt, 'receiptSha256'>,
+): RefinementRunReceipt {
+  const projection = structuredClone(input)
+  return {
+    ...projection,
+    receiptSha256: reconstructionRefinementHash(receiptProjection(projection)),
+  }
+}
+
+function validRefinementEvent(value: RefinementEvent) {
+  if (
+    !Number.isSafeInteger(value.sequence) ||
+    value.sequence < 0 ||
+    !Number.isSafeInteger(value.attemptIndex) ||
+    value.attemptIndex < 0
+  ) {
+    return false
+  }
+  const base = ['sequence', 'kind', 'attemptIndex']
+  switch (value.kind) {
+    case 'server-verified':
+      return (
+        exactKeys(value, [...base, 'taskIdentitySha256']) &&
+        sha256(value.taskIdentitySha256)
+      )
+    case 'rendered-and-compared':
+      return (
+        exactKeys(value, [
+          ...base,
+          'traceSha256',
+          ...(value.firstCauseCode === undefined ? [] : ['firstCauseCode']),
+        ]) &&
+        sha256(value.traceSha256) &&
+        (value.firstCauseCode === undefined || safeId(value.firstCauseCode))
+      )
+    case 'fresh-task-created':
+      return (
+        exactKeys(value, [
+          ...base,
+          'traceSha256',
+          'taskIdentitySha256',
+        ]) &&
+        sha256(value.traceSha256) &&
+        sha256(value.taskIdentitySha256)
+      )
+    case 'repair-proposed':
+    case 'repair-verified':
+    case 'repair-applied':
+      return (
+        exactKeys(value, [...base, 'traceSha256', 'proposalSha256']) &&
+        sha256(value.traceSha256) &&
+        sha256(value.proposalSha256)
+      )
+    case 'publication-ready':
+      return (
+        exactKeys(value, [...base, 'traceSha256']) &&
+        sha256(value.traceSha256)
+      )
+    case 'failed':
+      return (
+        exactKeys(value, [...base, 'failureCode']) &&
+        REFINEMENT_FAILURE_CODES.includes(value.failureCode!)
+      )
+  }
+}
+
+function validatePublicRefinementReceipt(input: unknown) {
+  const parsed = refinementRunReceiptEnvelopeSchema.safeParse(input)
+  if (!parsed.success) return false
+  const receipt = parsed.data as unknown as RefinementRunReceipt
+  const { receiptSha256, ...projection } = receipt
+  const freshTaskEvents = receipt.events.filter(
+    (event) => event.kind === 'fresh-task-created',
+  )
+  const verifiedRepairEvents = receipt.events.filter(
+    (event) => event.kind === 'repair-verified',
+  )
+  const appliedRepairEvents = receipt.events.filter(
+    (event) => event.kind === 'repair-applied',
+  )
+  const renderedEvents = receipt.events.filter(
+    (event) => event.kind === 'rendered-and-compared',
+  )
+  const terminalEvents = receipt.events.filter(
+    (event) => event.kind === 'publication-ready' || event.kind === 'failed',
+  )
+  if (
+    !exactKeys(receipt, [
+      'schemaVersion',
+      'authority',
+      'promotionAllowed',
+      'contractSha256',
+      'status',
+      'failureCode',
+      'attempts',
+      'proposalSha256s',
+      'freshTaskCount',
+      'refinementCount',
+      'usage',
+      'events',
+      'receiptSha256',
+    ]) ||
+    receipt.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    receipt.authority !== 'diagnostic-only' ||
+    receipt.promotionAllowed !== false ||
+    !['publication-ready', 'failed'].includes(receipt.status) ||
+    !sha256(receipt.contractSha256) ||
+    !sha256(receiptSha256) ||
+    receiptSha256 !== reconstructionRefinementHash(projection) ||
+    !Array.isArray(receipt.attempts) ||
+    !Array.isArray(receipt.proposalSha256s) ||
+    !Array.isArray(receipt.events) ||
+    !nonNegativeInteger(receipt.freshTaskCount) ||
+    !nonNegativeInteger(receipt.refinementCount) ||
+    !validUsage(receipt.usage) ||
+    receipt.events.some((event) => !validRefinementEvent(event)) ||
+    receipt.events.some((event, index) => event.sequence !== index) ||
+    receipt.events.some(
+      (event, index) =>
+        event.attemptIndex < 0 ||
+        !Number.isSafeInteger(event.attemptIndex) ||
+        (index > 0 &&
+          event.attemptIndex < receipt.events[index - 1]!.attemptIndex),
+    ) ||
+    (receipt.attempts.length > 0 &&
+      !validateReconstructionAttemptRefinementTraceBindingLineage(
+        receipt.attempts,
+      )) ||
+    receipt.proposalSha256s.some((proposalSha256) => !sha256(proposalSha256)) ||
+    renderedEvents.length !== receipt.attempts.length ||
+    renderedEvents.some((event, index) => {
+      const attempt = receipt.attempts[index]
+      return (
+        event.traceSha256 !== attempt?.traceSha256 ||
+        event.attemptIndex !== attempt?.attemptIndex ||
+        event.firstCauseCode !== (attempt?.firstCause?.code ?? undefined)
+      )
+    }) ||
+    receipt.proposalSha256s.length !== verifiedRepairEvents.length ||
+    receipt.proposalSha256s.some(
+      (proposalSha256, index) =>
+        verifiedRepairEvents[index]?.proposalSha256 !== proposalSha256,
+    ) ||
+    receipt.refinementCount !== appliedRepairEvents.length ||
+    appliedRepairEvents.length > verifiedRepairEvents.length ||
+    appliedRepairEvents.some(
+      (event, index) =>
+        event.proposalSha256 !== verifiedRepairEvents[index]?.proposalSha256,
+    ) ||
+    receipt.freshTaskCount !== freshTaskEvents.length ||
+    terminalEvents.length !== 1 ||
+    terminalEvents[0] !== receipt.events.at(-1) ||
+    (receipt.status === 'publication-ready' && receipt.attempts.length === 0) ||
+    (receipt.status === 'publication-ready' &&
+      terminalEvents[0]?.kind !== 'publication-ready') ||
+    (receipt.status === 'failed' && terminalEvents[0]?.kind !== 'failed') ||
+    (receipt.status === 'publication-ready' && receipt.failureCode !== null) ||
+    (receipt.status === 'failed' && receipt.failureCode === null) ||
+    (receipt.status === 'publication-ready' &&
+      appliedRepairEvents.length !== verifiedRepairEvents.length)
+  ) {
+    return false
+  }
+  const finalAttempt = receipt.attempts.at(-1)
+  if (
+    receipt.status === 'publication-ready' &&
+    (finalAttempt?.terminalStatus !== 'publication-ready' ||
+      terminalEvents[0]?.traceSha256 !== finalAttempt.traceSha256)
+  ) {
+    return false
+  }
+  return true
+}
+
+/** Public diagnostics are never sufficient evidence for promotion. */
+export function replayRefinementRun(receipt: unknown) {
+  return (
+    validatePublicRefinementReceipt(receipt) &&
+    (receipt as RefinementRunReceipt).status === 'failed'
+  )
+}
+
+/**
+ * Promotion replay is private and authoritative: it requires the complete
+ * owner-local trace and application chain, never the public projection alone.
+ */
+export function replayPrivateRefinementRun(
+  contract: ReconstructionCandidateContract,
+  result: ReconstructionRefinementRunResult,
+  authorities: PrivateReplayAuthorities,
+) {
+  try {
+    const { publicReceipt, privateEvidence } = result
+    if (
+      !validateReconstructionCandidateContract(contract) ||
+      !validatePublicRefinementReceipt(publicReceipt) ||
+      publicReceipt.status !== 'publication-ready' ||
+      publicReceipt.contractSha256 !== contract.contractSha256 ||
+      !validateReconstructionCandidate(
+        privateEvidence.initialCandidate,
+        contract,
+      )
+    ) {
+      return false
+    }
+
+    const traces = parseReconstructionAttemptTraceLineage(
+      privateEvidence.traces,
+    )
+    if (
+      traces.length !== publicReceipt.attempts.length ||
+      privateEvidence.applications.length !== traces.length - 1 ||
+      publicReceipt.refinementCount !== privateEvidence.applications.length ||
+      traces[0]?.structure.artifact.sha256 !==
+        privateEvidence.initialCandidate.binding.canonicalStruct.sha256
+    ) {
+      return false
+    }
+
+    for (const [index, trace] of traces.entries()) {
+      const resolvedRenderArtifacts = verifyTraceArtifacts(
+        contract,
+        authorities.artifactResolver,
+        trace,
+      )
+      if (
+        !resolvedRenderArtifacts ||
+        !verifySourceEvidenceAuthority(
+          contract,
+          authorities.sourceEvidenceVerifier,
+          trace,
+        ) ||
+        !verifyRenderObservationAuthority(
+          contract,
+          authorities.renderObservationExtractor,
+          trace,
+          resolvedRenderArtifacts,
+        ) ||
+        hashTraceValue(toRefinementTraceBinding(trace)) !==
+          hashTraceValue(publicReceipt.attempts[index]) ||
+        hashTraceValue(
+          compareSourceToRenderedEpub({
+            sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+            sourceEvidence: trace.sourceEvidence,
+            structure: trace.structure,
+            epub: trace.epub,
+            renderedEpub: trace.renderedEpub,
+            sourceRegions: trace.comparisonEvidence.sourceRegions,
+            mappings: trace.mappings,
+            observations: trace.comparisonEvidence.observations,
+          }),
+        ) !== hashTraceValue(trace.comparator)
+      ) {
+        return false
+      }
+    }
+
+    let candidate = structuredClone(privateEvidence.initialCandidate)
+    const replayedProposalSha256s: string[] = []
+    for (const [index, application] of privateEvidence.applications.entries()) {
+      const child = traces[index + 1]
+      const proposal = child?.critiqueRepair?.proposal
+      if (!child || !proposal) return false
+      const verifiedApplication = parseMaterializedRepairApplicationReceipt(
+        application,
+        candidate,
+        proposal,
+        contract,
+        {
+          sourceEvidenceVerifier: authorities.sourceEvidenceVerifier,
+          groundedVerifier: authorities.groundedVerifier,
+          evidenceCandidates: traces[0]!.evidenceCandidates,
+        },
+      )
+      candidate = candidateAfterApplication(
+        candidate,
+        verifiedApplication,
+        proposal,
+      )
+      replayedProposalSha256s.push(proposal.proposalSha256)
+      if (
+        candidate.binding.canonicalStruct.sha256 !==
+          child.structure.artifact.sha256 ||
+        child.lineage.appliedRepair?.applicationReceiptSha256 !==
+          verifiedApplication.receiptSha256 ||
+        child.lineage.appliedRepair?.groundedVerifierReceiptSha256 !==
+          verifiedApplication.groundedVerifier.receiptSha256
+      ) {
+        return false
+      }
+    }
+
+    const finalTrace = traces.at(-1)
+    return (
+      finalTrace?.terminalState === 'publication-ready' &&
+      publicReceipt.proposalSha256s.length ===
+        replayedProposalSha256s.length &&
+      publicReceipt.proposalSha256s.every(
+        (proposalSha256, index) =>
+          proposalSha256 === replayedProposalSha256s[index],
+      ) &&
+      publicReceipt.freshTaskCount === (traces.length > 1 ? 1 : 0) &&
+      publicReceipt.usage.inputTokens + publicReceipt.usage.outputTokens ===
+        finalTrace.budget.usage.tokens &&
+      Math.ceil(publicReceipt.usage.elapsedMs) >=
+        finalTrace.budget.usage.durationMs
+    )
+  } catch {
+    return false
+  }
+}
+
+function invalidContractRunResult(
+  initialCandidate: ReconstructionCandidate,
+): ReconstructionRefinementRunResult {
+  const publicReceipt = finalizeReceipt({
+    schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+    authority: 'diagnostic-only',
+    promotionAllowed: false,
+    contractSha256: reconstructionRefinementHash({
+      kind: 'invalid-runtime-contract',
+    }),
+    status: 'failed',
+    failureCode: 'invalid-candidate-contract',
+    attempts: [],
+    proposalSha256s: [],
+    freshTaskCount: 0,
+    refinementCount: 0,
+    usage: zeroUsage(),
+    events: [
+      {
+        sequence: 0,
+        kind: 'failed',
+        attemptIndex: 0,
+        failureCode: 'invalid-candidate-contract',
+      },
+    ],
+  })
+  return {
+    publicReceipt,
+    privateEvidence: {
+      initialCandidate: structuredClone(initialCandidate),
+      traces: [],
+      applications: [],
+    },
+  }
+}
+
+function concurrentRunResult(
+  contract: ReconstructionCandidateContract,
+  initialCandidate: ReconstructionCandidate,
+): ReconstructionRefinementRunResult {
+  const publicReceipt = finalizeReceipt({
+    schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+    authority: 'diagnostic-only',
+    promotionAllowed: false,
+    contractSha256: contract.contractSha256,
+    status: 'failed',
+    failureCode: 'concurrent-run',
+    attempts: [],
+    proposalSha256s: [],
+    freshTaskCount: 0,
+    refinementCount: 0,
+    usage: zeroUsage(),
+    events: [
+      {
+        sequence: 0,
+        kind: 'failed',
+        attemptIndex: 0,
+        failureCode: 'concurrent-run',
+      },
+    ],
+  })
+  return {
+    publicReceipt,
+    privateEvidence: {
+      initialCandidate: structuredClone(initialCandidate),
+      traces: [],
+      applications: [],
+    },
+  }
+}
+
+type ReconstructionRefinementRunInput = {
+  contract: ReconstructionCandidateContract
+  initialCandidate: ReconstructionCandidate
+  dependencies: ReconstructionRefinementDependencies
+  signal?: AbortSignal
+}
+
+async function runReconstructionRefinementExclusive(
+  {
+    contract,
+    initialCandidate,
+    dependencies,
+    signal = new AbortController().signal,
+  }: ReconstructionRefinementRunInput,
+  runLease: ActiveRefinementRun,
+): Promise<ReconstructionRefinementRunResult> {
+  if (!validateReconstructionCandidateContract(contract)) {
+    return invalidContractRunResult(initialCandidate)
+  }
+  const privateTraces: ReconstructionAttemptTrace[] = []
+  const applications: MaterializedRepairApplicationReceipt[] = []
+  const frozenInitialCandidate = structuredClone(initialCandidate)
+  const attempts: ReconstructionAttemptRefinementTraceBinding[] = []
+  const proposalSha256s: string[] = []
+  const events: RefinementEvent[] = []
+  let usage = zeroUsage()
+  let freshTaskCount = 0
+  let refinementCount = 0
+  let candidate = initialCandidate
+  let task: RefinementTask | undefined
+  let parentTraceSha256: string | null = null
+  const startedAt = Date.now()
+  const deadlineAt = startedAt + contract.budget.maxDurationMs
+  const measuredElapsedMs = () => Math.max(0, Date.now() - startedAt)
+  const remainingTimeMs = () => Math.max(0, deadlineAt - Date.now())
+  const refreshElapsedUsage = () => {
+    usage = { ...usage, elapsedMs: measuredElapsedMs() }
+  }
+
+  const event = (value: Omit<RefinementEvent, 'sequence'>): RefinementEvent => {
+    const recorded = { sequence: events.length, ...value }
+    events.push(recorded)
+    return recorded
+  }
+  const finish = (
+    status: RefinementRunReceipt['status'],
+    failureCode: RefinementFailureCode | null,
+  ) => {
+    refreshElapsedUsage()
+    const publicReceipt = finalizeReceipt({
+      schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      contractSha256: contract.contractSha256,
+      status,
+      failureCode,
+      attempts,
+      proposalSha256s,
+      freshTaskCount,
+      refinementCount,
+      usage,
+      events,
+    })
+    return {
+      publicReceipt,
+      privateEvidence: {
+        initialCandidate: frozenInitialCandidate,
+        traces: structuredClone(privateTraces),
+        applications: structuredClone(applications),
+      },
+    }
+  }
+  const fail = (code: RefinementFailureCode, attemptIndex: number) => {
+    refreshElapsedUsage()
+    event({ kind: 'failed', attemptIndex, failureCode: code })
+    return finish('failed', code)
+  }
+
+  if (
+    !validateReconstructionCandidate(initialCandidate, contract)
+  ) {
+    return fail('invalid-candidate-contract', 0)
+  }
+  const codex = dependencies.codex
+  if (!codex) {
+    return fail('codex-server-unavailable', 0)
+  }
+  if (
+    !validateOwnerLocalCodexIdentity(codex.identity) ||
+    hashOwnerLocalCodexIdentity(codex.identity) !==
+      contract.authorities.codex.identitySha256
+  ) {
+    return fail('codex-identity-mismatch', 0)
+  }
+  try {
+    const remaining = remainingTimeMs()
+    if (remaining < 1) return fail('codex-probe-timeout', 0)
+    const guardedProbe = await withTaskDeadline(
+      (taskSignal, lease) => codex.probe(taskSignal, lease),
+      remaining,
+      signal,
+      runLease,
+      'codex-probe',
+    )
+    if (!guardedProbe.value.available) {
+      guardedProbe.discard()
+      return fail('codex-server-unavailable', 0)
+    }
+    guardedProbe.accept(() =>
+      event({
+        kind: 'server-verified',
+        attemptIndex: 0,
+        taskIdentitySha256: reconstructionRefinementHash(codex.identity),
+      }),
+    )
+  } catch (error) {
+    if (
+      signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return fail('interrupted', 0)
+    }
+    if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+      return fail('codex-probe-timeout', 0)
+    }
+    return fail('codex-server-unavailable', 0)
+  }
+  for (
+    let attemptIndex = 0;
+    attemptIndex <= contract.budget.maxRefinements;
+    attemptIndex += 1
+  ) {
+    let trace: ReconstructionAttemptTrace
+    let binding: RefinementTraceBinding
+    let guardedEvaluation: GuardedStageResult<ReconstructionAttemptTrace> | undefined
+    try {
+      aborted(signal)
+      refreshElapsedUsage()
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('evaluation-timeout', attemptIndex)
+      guardedEvaluation = await withTaskDeadline(
+        (taskSignal, lease) =>
+          dependencies.evaluate(candidate, {
+            attemptIndex,
+            parentTraceSha256,
+            usage: {
+              refinements: refinementCount,
+              freshTasks: freshTaskCount,
+              tokens: combinedTokens(usage),
+              durationMs: Math.ceil(usage.elapsedMs),
+            },
+            signal: taskSignal,
+            lease,
+          }),
+        remaining,
+        signal,
+        runLease,
+        `evaluate:${attemptIndex}`,
+      )
+      trace = parseReconstructionAttemptTrace(guardedEvaluation.value)
+      if (!traceMatchesCodexAuthority(trace, contract)) {
+        guardedEvaluation.discard()
+        return fail('codex-identity-mismatch', attemptIndex)
+      }
+      binding = toRefinementTraceBinding(trace)
+    } catch (error) {
+      guardedEvaluation?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('evaluation-timeout', attemptIndex)
+      }
+      return fail('evaluation-failed', attemptIndex)
+    }
+    if (
+      !validateTraceBinding(
+        binding,
+        contract,
+        attemptIndex,
+        parentTraceSha256,
+        {
+          refinements: refinementCount,
+          freshTasks: freshTaskCount,
+          tokens: combinedTokens(usage),
+          durationMs: Math.ceil(usage.elapsedMs),
+        },
+      ) ||
+      binding.canonicalStructSha256 !==
+        candidate.binding.canonicalStruct.sha256
+    ) {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    if (
+      (binding.terminalStatus === 'publication-ready' &&
+        binding.firstCause !== null) ||
+      (binding.terminalStatus === 'failed' && binding.firstCause === null)
+    ) {
+      guardedEvaluation.discard()
+      return fail('missing-first-cause', attemptIndex)
+    }
+    const priorApplication = applications[attemptIndex - 1]
+    if (
+      attemptIndex > 0 &&
+      (!priorApplication ||
+        trace.lineage.appliedRepair?.applicationReceiptSha256 !==
+          priorApplication.receiptSha256 ||
+        trace.lineage.appliedRepair?.groundedVerifierReceiptSha256 !==
+          priorApplication.groundedVerifier.receiptSha256 ||
+        trace.lineage.appliedRepair?.resultingStructSha256 !==
+          priorApplication.resultingCanonicalStruct.sha256)
+    ) {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    try {
+      parseReconstructionAttemptTraceLineage([...privateTraces, trace])
+    } catch {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    try {
+      guardedEvaluation.accept(() => {
+        privateTraces.push(trace)
+        attempts.push(binding)
+        event({
+          kind: 'rendered-and-compared',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          ...(binding.firstCause
+            ? { firstCauseCode: binding.firstCause.code }
+            : {}),
+        })
+        if (binding.terminalStatus === 'publication-ready') {
+          event({
+            kind: 'publication-ready',
+            attemptIndex,
+            traceSha256: binding.traceSha256,
+          })
+        }
+      })
+    } catch {
+      return fail('interrupted', attemptIndex)
+    }
+    if (binding.terminalStatus === 'publication-ready') {
+      return finish('publication-ready', null)
+    }
+    if (!binding.firstCause) return fail('missing-first-cause', attemptIndex)
+    if (attemptIndex >= contract.budget.maxRefinements) {
+      return fail('refinement-budget-exhausted', attemptIndex)
+    }
+
+    const immutablePriorTrace = immutableClone(trace)
+    if (!task) {
+      if (freshTaskCount >= contract.budget.maxFreshTasks) {
+        return fail('fresh-task-budget-exhausted', attemptIndex)
+      }
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('fresh-task-timeout', attemptIndex)
+      let guardedTask: GuardedStageResult<unknown> | undefined
+      let parsedTask: RefinementTask
+      try {
+        guardedTask = await withTaskDeadline(
+          (taskSignal, lease) =>
+              codex.createFreshTask(
+                {
+                  documentId: contract.documentId,
+                  runId: contract.runId,
+                  immutablePriorTrace,
+                  priorTraceSha256: binding.traceSha256,
+                  firstCause: binding.firstCause!,
+                  budget: { ...contract.budget },
+                },
+                taskSignal,
+                lease,
+              ),
+          remaining,
+          signal,
+          runLease,
+          `create-fresh-task:${attemptIndex}`,
+        )
+        parsedTask = refinementTaskSchema.parse(
+          guardedTask.value,
+        ) as RefinementTask
+      } catch (error) {
+        guardedTask?.discard()
+        if (
+          signal.aborted ||
+          (error instanceof Error && error.name === 'AbortError')
+        ) {
+          return fail('interrupted', attemptIndex)
+        }
+        if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+          return fail('fresh-task-timeout', attemptIndex)
+        }
+        return fail('fresh-task-invalid', attemptIndex)
+      }
+      if (!validTask(parsedTask, contract, binding, codex.identity)) {
+        guardedTask.discard()
+        return fail('fresh-task-invalid', attemptIndex)
+      }
+      try {
+        guardedTask.accept(() => {
+          task = parsedTask
+          freshTaskCount += 1
+          event({
+            kind: 'fresh-task-created',
+            attemptIndex,
+            traceSha256: binding.traceSha256,
+            taskIdentitySha256: reconstructionRefinementHash(task.identity),
+          })
+        })
+      } catch {
+        return fail('interrupted', attemptIndex)
+      }
+    }
+
+    const remainingTokens = contract.budget.maxTokens - combinedTokens(usage)
+    const remaining = remainingTimeMs()
+    if (remainingTokens < 1) {
+      return fail('token-budget-exhausted', attemptIndex)
+    }
+    if (remaining < 1) return fail('repair-proposal-timeout', attemptIndex)
+    let proposed: { proposal: StructEvidencePatch; usage: RefinementUsage }
+    let guardedProposal: GuardedStageResult<unknown> | undefined
+    try {
+      guardedProposal = await withTaskDeadline(
+        (taskSignal, lease) =>
+          codex.proposeRepair(
+            {
+              task: structuredClone(task!),
+              immutablePriorTrace,
+              priorTraceSha256: binding.traceSha256,
+              firstCause: binding.firstCause!,
+              remainingTokens,
+              remainingTimeMs: remaining,
+            },
+            taskSignal,
+            lease,
+          ),
+        remaining,
+        signal,
+        runLease,
+        `propose-repair:${attemptIndex}`,
+      )
+      const parsedResponse = codexProposalResponseSchema.parse(
+        guardedProposal.value,
+      )
+      proposed = {
+        proposal: parseStructEvidencePatch(parsedResponse.proposal),
+        usage: parsedResponse.usage as RefinementUsage,
+      }
+    } catch (error) {
+      guardedProposal?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('repair-proposal-timeout', attemptIndex)
+      }
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    if (!validUsage(proposed.usage)) {
+      guardedProposal.discard()
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    const nextUsage = {
+      inputTokens: usage.inputTokens + proposed.usage.inputTokens,
+      outputTokens: usage.outputTokens + proposed.usage.outputTokens,
+      elapsedMs: measuredElapsedMs(),
+    }
+    if (combinedTokens(nextUsage) > contract.budget.maxTokens) {
+      guardedProposal.discard()
+      return fail('token-budget-exhausted', attemptIndex)
+    }
+    if (nextUsage.elapsedMs > contract.budget.maxDurationMs) {
+      guardedProposal.discard()
+      return fail('repair-proposal-timeout', attemptIndex)
+    }
+    if (
+      !validateStructEvidencePatch(proposed.proposal, contract, binding, task!)
+    ) {
+      guardedProposal.discard()
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    try {
+      guardedProposal.accept(() => {
+        usage = nextUsage
+        proposalSha256s.push(proposed.proposal.proposalSha256)
+        event({
+          kind: 'repair-proposed',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+        event({
+          kind: 'repair-verified',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+      })
+    } catch {
+      return fail('interrupted', attemptIndex)
+    }
+    const before = candidate
+    let guardedApplication: GuardedStageResult<unknown> | undefined
+    try {
+      aborted(signal)
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('repair-application-timeout', attemptIndex)
+      guardedApplication = await withTaskDeadline(
+        (taskSignal, lease) =>
+            dependencies.materializeRepair(
+              before,
+              structuredClone(proposed.proposal),
+              taskSignal,
+              lease,
+            ),
+        remaining,
+        signal,
+        runLease,
+        `materialize-repair:${attemptIndex}`,
+      )
+      const application: MaterializedRepairApplicationReceipt =
+        parseMaterializedRepairApplicationReceipt(
+        guardedApplication.value,
+        before,
+        proposed.proposal,
+        contract,
+        {
+          ...dependencies.materializationVerification!,
+          evidenceCandidates: trace.evidenceCandidates,
+        },
+      )
+      const resultingCandidate = candidateAfterApplication(
+        before,
+        application,
+        proposed.proposal,
+      )
+      guardedApplication.accept(() => {
+        applications.push(application)
+        candidate = resultingCandidate
+        refinementCount += 1
+        event({
+          kind: 'repair-applied',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+        parentTraceSha256 = binding.traceSha256
+      })
+    } catch (error) {
+      guardedApplication?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('repair-application-timeout', attemptIndex)
+      }
+      return fail('repair-application-failed', attemptIndex)
+    }
+  }
+
+  return fail('refinement-budget-exhausted', contract.budget.maxRefinements)
+}
+
+export async function runReconstructionRefinement(
+  input: ReconstructionRefinementRunInput,
+): Promise<ReconstructionRefinementRunResult> {
+  if (!validateReconstructionCandidateContract(input.contract)) {
+    return invalidContractRunResult(input.initialCandidate)
+  }
+  const runId = input.contract.runId
+  if (activeRefinementRuns.has(runId)) {
+    return concurrentRunResult(input.contract, input.initialCandidate)
+  }
+  const generation = (refinementRunGenerations.get(runId) ?? 0) + 1
+  refinementRunGenerations.set(runId, generation)
+  const runLease: ActiveRefinementRun = {
+    runId,
+    generationSha256: hashTraceValue({
+      runId,
+      contractSha256: input.contract.contractSha256,
+      generation,
+    }),
+    nextStageIndex: 0,
+    pendingStages: new Set(),
+    finished: false,
+  }
+  activeRefinementRuns.set(runId, runLease)
+  try {
+    return await runReconstructionRefinementExclusive(input, runLease)
+  } finally {
+    runLease.finished = true
+    releaseRefinementRunWhenSettled(runLease)
+  }
+}

--- a/src/research/source-epub-comparator.test.ts
+++ b/src/research/source-epub-comparator.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  DETERMINISTIC_CHECK_IDS,
+  encodeCanonicalObservationPayload,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  type RenderedEpubEvidence,
+  type SourceLocation,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+  type SourceEpubComparisonInput,
+} from './source-epub-comparator'
+
+const digest = (value: string) => hashTraceValue(value)
+const spineHref = 'EPUB/content.xhtml'
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const source: SourceLocation = {
+  page: 2,
+  boxes: [{ page: 2, x: 10, y: 20, width: 300, height: 400, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-figure-1'],
+    })),
+  })
+  return { sha256: sha256HexSync(bytes), byteLength: bytes.byteLength }
+}
+
+function renderedReceipt({
+  sourcePdfSha256,
+  epubSha256,
+  sourceRegions,
+  actualObservationSets,
+}: {
+  sourcePdfSha256: string
+  epubSha256: string
+  sourceRegions: SourceEpubComparisonInput['sourceRegions']
+  actualObservationSets: RenderedEpubEvidence['actualObservationSets']
+}): RenderedEpubEvidence {
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const withoutReceipt: Omit<RenderedEpubEvidence, 'receiptSha256'> = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: 500 },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1',
+      configurationSha256: digest('render-config'),
+    },
+    domSnapshots: [
+      {
+        spineHref,
+        dom: { sha256: digest('rendered-dom'), byteLength: 200 },
+        anchors: ['struct-figure-1'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screen-1',
+        spineHref,
+        domSha256: digest('rendered-dom'),
+        image: { sha256: digest('screen'), byteLength: 800 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+  }
+  const candidate = {
+    ...withoutReceipt,
+    receiptSha256: digest('placeholder'),
+  }
+  candidate.receiptSha256 = hashRenderedEpubEvidence(candidate)
+  return candidate
+}
+
+function comparisonInput(): SourceEpubComparisonInput {
+  const sourcePdfSha256 = digest('source-pdf')
+  const structSha256 = digest('struct')
+  const epubSha256 = digest('epub')
+  const sourceRegions = [{ id: 'region-1', source }]
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const payload = observationPayload(check, [`source-${check}`])
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const payload = observationPayload(check, [`source-${check}`])
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  )
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256,
+    evidenceGraphSha256: digest('evidence-graph'),
+    candidateSetSha256: digest('candidate-set'),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashTraceValue(sourceEvidenceWithoutReceipt),
+  }
+  const renderedEpub = renderedReceipt({
+    sourcePdfSha256,
+    epubSha256,
+    sourceRegions,
+    actualObservationSets,
+  })
+  const mappings: SourceEpubComparisonInput['mappings'] = [
+    {
+      id: 'mapping-1',
+      obligationId: 'obligation-1',
+      source,
+      output: [
+        {
+          spineHref,
+          anchorId: 'struct-figure-1',
+          rendered: {
+            screenshotId: 'screen-1',
+            viewport,
+            rect: { x: 10, y: 20, width: 300, height: 400 },
+          },
+        },
+      ],
+      status: 'mapped',
+    },
+  ]
+  return {
+    sourcePdfSha256,
+    sourceEvidence,
+    structure: {
+      schemaVersion: '0.2.0',
+      documentId: 'document-1',
+      sourcePdfSha256,
+      artifact: { sha256: structSha256, byteLength: 300 },
+      generatedSha256: digest('generated-struct'),
+      assets: [],
+    },
+    epub: {
+      bytes: { sha256: epubSha256, byteLength: 500 },
+      mediaType: 'application/epub+zip',
+      structSha256,
+      epubCheck: {
+        toolId: 'epubcheck',
+        toolVersion: '5.3.0',
+        reportSha256: digest('epubcheck-report'),
+        status: 'passed',
+        errorCount: 0,
+        warningCount: 0,
+      },
+    },
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations: SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+      createDeterministicObservationReceipt({
+        idSha256: digest(`observation-${check}`),
+        check,
+        mappingIds: ['mapping-1'],
+        expectedSetReceiptSha256: expectedObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+        actualSetReceiptSha256: actualObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+      }),
+    ),
+  }
+}
+
+function mismatch(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+) {
+  const input = comparisonInput()
+  const index = input.observations.findIndex(
+    (candidate) => candidate.check === check,
+  )
+  const observation = input.observations[index]!
+  const { receiptSha256: _receiptSha256, ...observationCore } = observation
+  const actual = input.renderedEpub.actualObservationSets.find(
+    (candidate) => candidate.check === check,
+  )!
+  actual.payload = observationPayload(check, [])
+  actual.setSha256 = actual.payload.sha256
+  actual.itemCount = 0
+  actual.receiptSha256 = hashRenderedActualObservationSet(actual)
+  input.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+    input.renderedEpub,
+  )
+  input.observations[index] = createDeterministicObservationReceipt({
+    ...observationCore,
+    source,
+    actualSetReceiptSha256: actual.receiptSha256,
+  })
+  return compareSourceToRenderedEpub(input)
+}
+
+describe('source to rendered EPUB comparator', () => {
+  it('passes only a complete hash-bound renderer and source receipt set', () => {
+    const result = compareSourceToRenderedEpub(comparisonInput())
+
+    expect(result.status).toBe('publication-ready')
+    expect(new Set(result.checkResults.map(({ check }) => check))).toEqual(
+      new Set(DETERMINISTIC_CHECK_IDS),
+    )
+    expect(result.denominator).toBe(result.passed)
+    expect(result.renderObservationReceiptSha256).toMatch(/^[a-f0-9]{64}$/u)
+  })
+
+  it('rejects zero-observation self-attestation for source-bearing evidence', () => {
+    const raw = comparisonInput() as unknown as {
+      observations: Array<Record<string, unknown>>
+    }
+    raw.observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) => ({
+      idSha256: digest(`raw-${check}`),
+      check,
+      mappingIds: ['mapping-1'],
+      expected: [],
+      actual: [],
+    }))
+    expect(() => compareSourceToRenderedEpub(raw)).toThrow(
+      /required/iu,
+    )
+
+    const unproved = comparisonInput()
+    const expected = unproved.sourceEvidence.expectedObservationSets[0]!
+    expected.payload = observationPayload(expected.check, [])
+    expected.setSha256 = expected.payload.sha256
+    expected.itemCount = 0
+    expected.receiptSha256 = hashSourceExpectedObservationSet(expected)
+    unproved.sourceEvidence.receiptSha256 = hashSourceEvidenceReceipt(
+      unproved.sourceEvidence,
+    )
+    const observation = unproved.observations.find(
+      ({ check }) => check === expected.check,
+    )!
+    const { receiptSha256: _receiptSha256, ...observationCore } = observation
+    Object.assign(
+      observation,
+      createDeterministicObservationReceipt({
+        ...observationCore,
+        expectedSetReceiptSha256: expected.receiptSha256,
+      }),
+    )
+    expect(() => compareSourceToRenderedEpub(unproved)).toThrow(/self-attests zero/iu)
+  })
+
+  it.each([
+    'figures',
+    'captions',
+    'reading-order',
+    'code-preformatted',
+  ] as const)('fails and locates a proven %s mismatch', (check) => {
+    const result = mismatch(check)
+    const firstCause = result.failures.find(
+      ({ id }) => id === result.firstCauseFailureId,
+    )
+    expect(result.status).toBe('failed')
+    expect(firstCause).toMatchObject({ check, mappingIds: ['mapping-1'] })
+  })
+
+  it('rejects nonexistent anchors and empty or out-of-bounds locators', () => {
+    const missingAnchor = comparisonInput()
+    missingAnchor.mappings[0]!.output[0]!.anchorId = 'missing-anchor'
+    expect(() => compareSourceToRenderedEpub(missingAnchor)).toThrow(
+      /nonexistent anchor/iu,
+    )
+
+    const zeroArea = comparisonInput()
+    zeroArea.mappings[0]!.output[0]!.rendered!.rect.width = 0
+    expect(() => compareSourceToRenderedEpub(zeroArea)).toThrow(/empty/iu)
+
+    const outOfBounds = comparisonInput()
+    outOfBounds.mappings[0]!.output[0]!.rendered!.rect.x = 700
+    outOfBounds.mappings[0]!.output[0]!.rendered!.rect.width = 200
+    expect(() => compareSourceToRenderedEpub(outOfBounds)).toThrow(
+      /out-of-bounds/iu,
+    )
+  })
+
+  it('rejects stale render/source receipts and fails EPUBCheck warnings', () => {
+    const staleRender = comparisonInput()
+    staleRender.renderedEpub.download.artifact.sha256 = digest('other-epub')
+    expect(() => compareSourceToRenderedEpub(staleRender)).toThrow(
+      /downloaded EPUB/iu,
+    )
+
+    const staleSource = comparisonInput()
+    staleSource.renderedEpub.sourceObligations.obligationCount = 2
+    staleSource.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+      staleSource.renderedEpub,
+    )
+    expect(() => compareSourceToRenderedEpub(staleSource)).toThrow(
+      /source-obligation/iu,
+    )
+
+    const warning = comparisonInput()
+    warning.epub.epubCheck.warningCount = 1
+    expect(compareSourceToRenderedEpub(warning).failures[0]).toMatchObject({
+      check: 'epub-package',
+    })
+  })
+})

--- a/src/research/source-epub-comparator.ts
+++ b/src/research/source-epub-comparator.ts
@@ -1,0 +1,539 @@
+import { z } from 'zod'
+import {
+  SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareComparisonFailures,
+  epubBindingSchema,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  observationReceiptCoreSchema,
+  observationReceiptSchema,
+  renderedEpubSchema,
+  sourceEvidenceReceiptSchema,
+  sourceRegionObligationSchema,
+  sourceOutputMappingSchema,
+  structBindingSchema,
+  type ComparisonFailure,
+  type DeterministicCheckId,
+  type DeterministicComparisonObservation,
+  type EpubArtifactBinding,
+  type RenderedEpubEvidence,
+  type SourceEpubComparatorResult,
+  type SourceLocation,
+  type SourceOutputMapping,
+  type SourceRegionObligation,
+  type SourceEvidenceReceiptBinding,
+  type StructArtifactBinding,
+} from './reconstruction-attempt-trace'
+
+export type {
+  DeterministicComparisonObservation,
+  SourceRegionObligation,
+} from './reconstruction-attempt-trace'
+export { SOURCE_EPUB_OBSERVATION_CHECK_IDS } from './reconstruction-attempt-trace'
+
+const sha256ValueSchema = z.string().regex(/^[a-f0-9]{64}$/u)
+
+const comparisonInputSchema = z
+  .object({
+    sourcePdfSha256: sha256ValueSchema,
+    sourceEvidence: sourceEvidenceReceiptSchema,
+    structure: structBindingSchema,
+    epub: epubBindingSchema,
+    renderedEpub: renderedEpubSchema,
+    sourceRegions: z.array(sourceRegionObligationSchema).min(1),
+    mappings: z.array(sourceOutputMappingSchema).min(1),
+    observations: z
+      .array(
+        observationReceiptSchema.refine(
+          ({ check }) =>
+            SOURCE_EPUB_OBSERVATION_CHECK_IDS.includes(
+              check as (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+            ),
+          'Unsupported source/EPUB observation check.',
+        ),
+      )
+      .min(1),
+  })
+  .strict()
+export type SourceEpubComparisonInput = {
+  sourcePdfSha256: string
+  sourceEvidence: SourceEvidenceReceiptBinding
+  structure: StructArtifactBinding
+  epub: EpubArtifactBinding
+  renderedEpub: RenderedEpubEvidence
+  sourceRegions: SourceRegionObligation[]
+  mappings: SourceOutputMapping[]
+  observations: DeterministicComparisonObservation[]
+}
+
+function compareCodeUnits(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function inputError(message: string): never {
+  throw new TypeError(`Invalid source/EPUB comparison input: ${message}`)
+}
+
+function assertUnique(values: readonly string[], label: string) {
+  if (new Set(values).size !== values.length) {
+    inputError(`${label} must contain unique ids`)
+  }
+}
+
+function observationCore(
+  input: Omit<DeterministicComparisonObservation, 'receiptSha256'>,
+) {
+  return input
+}
+
+export function createDeterministicObservationReceipt(
+  input: Omit<DeterministicComparisonObservation, 'receiptSha256'>,
+) {
+  const core = observationReceiptCoreSchema.parse(input)
+  return observationReceiptSchema.parse({
+    ...core,
+    receiptSha256: hashTraceValue(core),
+  })
+}
+
+function sortedSourceObligations(input: SourceRegionObligation[]) {
+  return [...input].sort((left, right) => compareCodeUnits(left.id, right.id))
+}
+
+function assertInput(input: SourceEpubComparisonInput) {
+  if (
+    input.sourceEvidence.sourcePdfSha256 !== input.sourcePdfSha256 ||
+    input.sourceEvidence.receiptSha256 !==
+      hashSourceEvidenceReceipt(input.sourceEvidence)
+  ) {
+    inputError('source-evidence receipt is stale or unrelated')
+  }
+  if (input.structure.sourcePdfSha256 !== input.sourcePdfSha256) {
+    inputError('STRUCT is not bound to the source PDF')
+  }
+  if (input.epub.structSha256 !== input.structure.artifact.sha256) {
+    inputError('EPUB is not bound to the exact STRUCT artifact')
+  }
+  if (
+    input.renderedEpub.epubSha256 !== input.epub.bytes.sha256 ||
+    hashTraceValue(input.renderedEpub.download.artifact) !==
+      hashTraceValue(input.epub.bytes) ||
+    input.renderedEpub.receiptSha256 !==
+      hashRenderedEpubEvidence(input.renderedEpub)
+  ) {
+    inputError('renderer receipt is not bound to the downloaded EPUB bytes')
+  }
+  const obligationProjection = {
+    sourcePdfSha256: input.sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sortedSourceObligations(input.sourceRegions)),
+    obligationCount: input.sourceRegions.length,
+  }
+  if (
+    input.sourceEvidence.sourceObligations.obligationsSha256 !==
+      obligationProjection.obligationsSha256 ||
+    input.sourceEvidence.sourceObligations.obligationCount !==
+      obligationProjection.obligationCount ||
+    input.sourceEvidence.sourceObligations.receiptSha256 !==
+      hashTraceValue(obligationProjection) ||
+    input.renderedEpub.sourceObligations.sourcePdfSha256 !==
+      obligationProjection.sourcePdfSha256 ||
+    input.renderedEpub.sourceObligations.obligationsSha256 !==
+      obligationProjection.obligationsSha256 ||
+    input.renderedEpub.sourceObligations.obligationCount !==
+      obligationProjection.obligationCount ||
+    input.renderedEpub.sourceObligations.receiptSha256 !==
+      hashTraceValue(obligationProjection)
+  ) {
+    inputError('source-obligation receipt is stale or unrelated')
+  }
+
+  assertUnique(
+    input.sourceRegions.map(({ id }) => id),
+    'sourceRegions',
+  )
+  assertUnique(
+    input.mappings.map(({ id }) => id),
+    'mappings',
+  )
+  assertUnique(
+    input.observations.map(({ idSha256 }) => idSha256),
+    'observations',
+  )
+  assertUnique(
+    input.observations.map(({ check }) => check),
+    'observation categories',
+  )
+  assertUnique(
+    input.sourceEvidence.expectedObservationSets.map(({ check }) => check),
+    'expected observation categories',
+  )
+  assertUnique(
+    input.renderedEpub.actualObservationSets.map(({ check }) => check),
+    'actual observation categories',
+  )
+
+  const expectedSets = new Map(
+    input.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    input.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  if (
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) =>
+        !expectedSets.has(check) ||
+        !actualSets.has(check) ||
+        !input.observations.some((observation) => observation.check === check),
+    )
+  ) {
+    inputError('every observation category requires one expected, actual, and selection receipt')
+  }
+  const sourceRegionIds = new Set(input.sourceRegions.map(({ id }) => id))
+  for (const expected of input.sourceEvidence.expectedObservationSets) {
+    if (
+      expected.receiptSha256 !== hashSourceExpectedObservationSet(expected) ||
+      expected.setSha256 !== expected.payload.sha256 ||
+      new Set(expected.sourceRegionIds).size !== expected.sourceRegionIds.length ||
+      expected.sourceRegionIds.some((id) => !sourceRegionIds.has(id)) ||
+      (expected.sourceRegionIds.length > 0 && expected.itemCount === 0)
+    ) {
+      inputError(
+        `expected ${expected.check} set is stale, ungrounded, or self-attests zero source-bearing items`,
+      )
+    }
+  }
+  for (const actual of input.renderedEpub.actualObservationSets) {
+    if (
+      actual.receiptSha256 !== hashRenderedActualObservationSet(actual) ||
+      actual.setSha256 !== actual.payload.sha256
+    ) {
+      inputError(`actual ${actual.check} set receipt is stale`)
+    }
+  }
+
+  for (const [index, region] of input.sourceRegions.entries()) {
+    if (
+      region.source.sourceRegionIds.length !== 1 ||
+      region.source.sourceRegionIds[0] !== region.id ||
+      !input.mappings.some(({ source }) =>
+        source.sourceRegionIds.includes(region.id),
+      )
+    ) {
+      inputError(`sourceRegions.${index} is not singly and explicitly mapped`)
+    }
+  }
+  for (const [index, observation] of input.observations.entries()) {
+    const { receiptSha256, ...core } = observation
+    const expected = expectedSets.get(observation.check)
+    const actual = actualSets.get(observation.check)
+    if (
+      receiptSha256 !== hashTraceValue(observationCore(core)) ||
+      observation.expectedSetReceiptSha256 !== expected?.receiptSha256 ||
+      observation.actualSetReceiptSha256 !== actual?.receiptSha256
+    ) {
+      inputError(
+        `observations.${index} lacks source-derived or renderer-derived proof`,
+      )
+    }
+  }
+  const doms = new Map(
+    input.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot,
+    ]),
+  )
+  const screenshots = new Map(
+    input.renderedEpub.screenshots.map((screenshot) => [
+      screenshot.id,
+      screenshot,
+    ]),
+  )
+  for (const [index, mapping] of input.mappings.entries()) {
+    const cardinalityValid =
+      (mapping.status === 'mapped' && mapping.output.length === 1) ||
+      (mapping.status === 'missing' && mapping.output.length === 0) ||
+      (mapping.status === 'duplicate' && mapping.output.length >= 2)
+    if (!cardinalityValid) {
+      inputError(`mappings.${index} has invalid status/output cardinality`)
+    }
+    if (mapping.output.some((output) => !output.rendered)) {
+      inputError(`mappings.${index} is missing screenshot locator evidence`)
+    }
+    for (const [outputIndex, output] of mapping.output.entries()) {
+      const dom = doms.get(output.spineHref)
+      const rendered = output.rendered!
+      const screenshot = screenshots.get(rendered.screenshotId)
+      const { rect } = rendered
+      if (!dom?.anchors.includes(output.anchorId)) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} names a nonexistent anchor`,
+        )
+      }
+      if (
+        !screenshot ||
+        screenshot.spineHref !== output.spineHref ||
+        screenshot.domSha256 !== dom.dom.sha256 ||
+        hashTraceValue(rendered.viewport) !== hashTraceValue(screenshot.viewport)
+      ) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} is not bound to its screenshot`,
+        )
+      }
+      if (
+        rect.x < 0 ||
+        rect.y < 0 ||
+        rect.width <= 0 ||
+        rect.height <= 0 ||
+        rect.x + rect.width > rendered.viewport.width ||
+        rect.y + rect.height > rendered.viewport.height
+      ) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} has an empty or out-of-bounds locator`,
+        )
+      }
+    }
+  }
+}
+
+type PendingCheck = {
+  id: string
+  check: DeterministicCheckId
+  passed: boolean
+  expectedSha256: string
+  actualSha256: string
+  mappingIds: string[]
+  source?: SourceLocation
+  output: SourceOutputMapping['output']
+  message: string
+}
+
+function outputForMappings(
+  mappingIds: readonly string[],
+  mappingsById: ReadonlyMap<string, SourceOutputMapping>,
+) {
+  return mappingIds.flatMap((id) => mappingsById.get(id)?.output ?? [])
+}
+
+function receiptCheck({
+  id,
+  check,
+  expected,
+  actual,
+  mappingIds,
+  source,
+  output,
+  message,
+  evidenceValid = true,
+}: Omit<PendingCheck, 'passed' | 'expectedSha256' | 'actualSha256'> & {
+  expected: unknown
+  actual: unknown
+  evidenceValid?: boolean
+}): PendingCheck {
+  const expectedSha256 = hashTraceValue(expected)
+  const actualSha256 = hashTraceValue(actual)
+  return {
+    id,
+    check,
+    passed: evidenceValid && expectedSha256 === actualSha256,
+    expectedSha256,
+    actualSha256,
+    mappingIds,
+    ...(source ? { source } : {}),
+    output,
+    message,
+  }
+}
+
+function renderBindingCheck(input: SourceEpubComparisonInput): PendingCheck {
+  const navigation = input.mappings[0]!
+  return receiptCheck({
+    id: 'render-binding',
+    check: 'render-binding',
+    expected: {
+      epub: input.epub.bytes,
+      sourcePdfSha256: input.sourcePdfSha256,
+      sourceObligationCount: input.sourceRegions.length,
+      invalidLocatorCount: 0,
+    },
+    actual: {
+      epub: input.renderedEpub.download.artifact,
+      sourcePdfSha256:
+        input.renderedEpub.sourceObligations.sourcePdfSha256,
+      sourceObligationCount:
+        input.renderedEpub.sourceObligations.obligationCount,
+      invalidLocatorCount: 0,
+    },
+    mappingIds: [navigation.id],
+    source: navigation.source as SourceLocation,
+    output: navigation.output,
+    message:
+      'Actual-render receipt must bind downloaded EPUB bytes, DOM anchors, screenshots, and source obligations.',
+  })
+}
+
+function epubPackageCheck(input: SourceEpubComparisonInput): PendingCheck {
+  const navigation = input.mappings[0]!
+  return receiptCheck({
+    id: 'epub-package',
+    check: 'epub-package',
+    expected: { status: 'passed', errorCount: 0, warningCount: 0 },
+    actual: {
+      status: input.epub.epubCheck.status,
+      errorCount: input.epub.epubCheck.errorCount,
+      warningCount: input.epub.epubCheck.warningCount,
+    },
+    mappingIds: [navigation.id],
+    source: navigation.source as SourceLocation,
+    output: navigation.output,
+    message: 'EPUBCheck must pass with no errors or warnings.',
+  })
+}
+
+function sourceRegionChecks(input: SourceEpubComparisonInput): PendingCheck[] {
+  const claims = new Map<string, SourceOutputMapping[]>()
+  for (const mapping of input.mappings) {
+    for (const regionId of new Set(mapping.source.sourceRegionIds)) {
+      claims.set(regionId, [...(claims.get(regionId) ?? []), mapping])
+    }
+  }
+  return sortedSourceObligations(input.sourceRegions).map((region) => {
+    const regionClaims = claims.get(region.id) ?? []
+    const successful = regionClaims.filter(
+      ({ status, output }) => status === 'mapped' && output.length === 1,
+    )
+    return receiptCheck({
+      id: `source-region-${region.id}`,
+      check: 'source-region-conservation',
+      expected: { claimCount: 1, successfulClaimCount: 1 },
+      actual: {
+        claimCount: regionClaims.length,
+        successfulClaimCount: successful.length,
+      },
+      mappingIds: regionClaims.map(({ id }) => id).sort(compareCodeUnits),
+      source: region.source as SourceLocation,
+      output: regionClaims.flatMap(({ output }) => output),
+      message: `Source region ${region.id} must map to one output anchor.`,
+    })
+  })
+}
+
+function observationChecks(input: SourceEpubComparisonInput): PendingCheck[] {
+  const mappings = new Map(input.mappings.map((mapping) => [mapping.id, mapping]))
+  const expectedSets = new Map(
+    input.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    input.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  return input.observations.map((observation): PendingCheck => {
+    const cited = observation.mappingIds.map((id) => mappings.get(id))
+    const expected = expectedSets.get(observation.check)!
+    const actual = actualSets.get(observation.check)!
+    const evidenceValid = cited.every(
+      (mapping) =>
+        mapping?.status === 'mapped' && mapping.output.length === 1,
+    )
+    return {
+      id: observation.idSha256,
+      check: observation.check,
+      passed:
+        evidenceValid &&
+        expected.setSha256 === actual.setSha256 &&
+        expected.itemCount === actual.itemCount,
+      expectedSha256: hashTraceValue(expected),
+      actualSha256: hashTraceValue(actual),
+      mappingIds: [...observation.mappingIds].sort(compareCodeUnits),
+      source: (observation.source ?? cited.find(Boolean)?.source) as
+        | SourceLocation
+        | undefined,
+      output: outputForMappings(observation.mappingIds, mappings),
+      message: evidenceValid
+        ? `${observation.check} source-derived and renderer-derived receipts must match.`
+        : `${observation.check} cites missing or duplicate mapping evidence.`,
+    }
+  })
+}
+
+function failureFor(check: PendingCheck): ComparisonFailure {
+  return {
+    id: `failure-${hashTraceValue({
+      check: check.check,
+      id: check.id,
+      source: check.source ?? null,
+    }).slice(0, 24)}`,
+    check: check.check,
+    origin: 'deterministic',
+    message: check.message,
+    mappingIds: check.mappingIds,
+    ...(check.source ? { source: check.source } : {}),
+    output: check.output,
+  }
+}
+
+/**
+ * Compare #198 source-derived receipts with observations from a strict actual-
+ * render adapter. Raw caller expected/actual values are not accepted.
+ */
+export function compareSourceToRenderedEpub(
+  unknownInput: unknown,
+): SourceEpubComparatorResult {
+  const parsed = comparisonInputSchema.safeParse(unknownInput)
+  if (!parsed.success) inputError(parsed.error.issues[0]?.message ?? 'invalid schema')
+  const input = parsed.data as SourceEpubComparisonInput
+  assertInput(input)
+
+  const pending = [
+    renderBindingCheck(input),
+    epubPackageCheck(input),
+    ...sourceRegionChecks(input),
+    ...observationChecks(input),
+  ].sort((left, right) =>
+    compareComparisonFailures(failureFor(left), failureFor(right)),
+  )
+  const failures = pending
+    .filter(({ passed }) => !passed)
+    .map(failureFor)
+    .sort(compareComparisonFailures)
+  const failuresById = new Map(
+    pending.filter(({ passed }) => !passed).map((check) => [check.id, failureFor(check)]),
+  )
+  const checkResults = pending.map((check) => {
+    const failure = failuresById.get(check.id)
+    return {
+      id: check.id,
+      check: check.check,
+      origin: 'deterministic' as const,
+      status: check.passed ? ('passed' as const) : ('failed' as const),
+      expectedSha256: check.expectedSha256,
+      actualSha256: check.actualSha256,
+      mappingIds: check.mappingIds,
+      ...(check.source ? { source: check.source } : {}),
+      message: check.message,
+      ...(failure ? { failureId: failure.id } : {}),
+    }
+  })
+  return {
+    schemaVersion: SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION,
+    sourcePdfSha256: input.sourcePdfSha256,
+    structSha256: input.structure.artifact.sha256,
+    epubSha256: input.epub.bytes.sha256,
+    renderObservationReceiptSha256: input.renderedEpub.receiptSha256,
+    observationSetSha256: hashTraceValue(
+      [...input.observations].sort((left, right) =>
+        compareCodeUnits(left.idSha256, right.idSha256),
+      ),
+    ),
+    status: failures.length === 0 ? 'publication-ready' : 'failed',
+    denominator: checkResults.length,
+    passed: checkResults.length - failures.length,
+    failed: failures.length,
+    checkResults,
+    judgeResults: [],
+    failures,
+    firstCauseFailureId: failures[0]?.id ?? null,
+  }
+}


### PR DESCRIPTION
## What changed

- Adds strict, canonical, hash-bound reconstruction attempt trace contracts.
- Adds source-to-EPUB comparison contracts that bind source obligations to reopened renderer observations.
- Adds the bounded local-Codex refinement coordinator contract, including candidate/materialization verification boundaries, authoritative private replay, coordinator deadlines, and generation/stage leases that reject late commits after timeout or abort.
- Adds focused negative, tamper, privacy, replay, deadline, and same-run fencing regressions.

## Scope

This is the reviewed **contract slice only** for #199. It does not claim the full source-to-EPUB refinement product is complete.

Still intentionally out of scope:

- #198 SourceEvidenceGraph, MinerU/provider adapters, candidate payload production, and grounded-verifier implementation
- #200 materialization implementation
- calibrated judge work
- side-by-side review UX
- representative pilot and frozen 20-document evaluation

Refs #199.

## Validation

- Focused contract suites: 32/32 passed.
- Existing structured-extraction/model-fallback/PDF/EPUB integration slice: 508 passed, 1 intentionally skipped.
- npx tsc --noEmit: passed.
- npm run build:staging: passed; Astro reported 0 errors and 28 existing hints, with 132 pages built.
- Exact immutable diff/whitespace check: passed.
- CI-equivalent immutable-commit secret scan: passed.
- scripts/agent-evidence: all 4 required lanes passed on exact commit 4ba1b010234a399891e131d9ddf10b4620980782; manifest .agent/evidence/20260817T173305075Z/manifest.json.
- The 20-document corpus was deliberately not run for this contract-only slice.

No merge or deployment is requested by this draft.
