### PR TITLE
Add owner-local grounded PDF evidence contracts

### DIFF
--- a/skills/struct-typeset/SKILL.md
+++ b/skills/struct-typeset/SKILL.md
@@ -22,6 +22,187 @@ Build outputs from a canonical, source-backed document graph. Prefer verified se
 
 Use deterministic extraction and validation first. When a bounded layout decision remains ambiguous, open a separate Codex task with `gpt-5.6-luna` and `max` reasoning. Supply only the deterministic candidates and their STRUCT provenance. Reject any response that invents text, bytes, bounds, or destinations. Persist the proposal separately from the autonomous VM implementation receipt, then convert every accepted decision class into a fixture and deterministic rule.
 
+### Grounded PDF production binding
+
+For ordinary incoming PDFs, freeze all enabled arms before extraction and build
+one versioned `SourceEvidenceGraph`; do not promote any arm's Markdown or
+resolved document tree directly to STRUCT.
+
+- The deterministic arm is mandatory. Preserve PDF.js text/glyph runs and
+  boxes, fonts, page rotation and geometry, raster/vector objects and their
+  identities, annotations, destinations and links, full-page renders, and
+  configured local OCR for scanned or hybrid regions on every page.
+- The MinerU arm is mandatory and owner-local. Bind `mineru[vlm]==3.4.4`
+  (wheel SHA-256
+  `d4d678539782a7683d998e2914a52d96b5720676ce65658b29666b1f4d9dfd13`)
+  with formulas/tables/image analysis enabled and model
+  `opendatalab/MinerU2.5-Pro-2605-1.2B` at revision
+  `bff20d4ae2bf202df9f45284b4d43681555a97ed`. The Apache-2.0 model's
+  `model.safetensors` is 2,312,126,640 bytes with SHA-256
+  `abf8681ca63b8dec7b67de257af47b821f179442f72998d0696ae2ed9232a5f0`.
+  Record the Qwen2VL architecture and verify every identity before use. Prefer
+  the owner-laptop MLX binding (`mlx-vlm==0.3.12`, `mlx==0.31.1`); use the
+  trusted ARM64 VM only after an official CPU-only wheel, version, and digest
+  have passed the same bounded preflight. No VM CPU binding is currently
+  accepted merely because its package metadata names Torch. These are distinct
+  execution identities over the same evidence schema. Never install the
+  `pipeline`, `core`, or `all` extras for this binding.
+- Preflight architecture, memory, free disk, package/model license, exact
+  download sizes and digests, and a bounded cache outside the repository.
+  Stop instead of downloading when the runtime, model, or generated-output
+  bound would consume the reserved headroom. Do not substitute another model,
+  revision, license, or remote provider.
+- Retain MinerU Markdown, content-list v1/v2, middle/layout/model JSON, OCR,
+  tables, formulas, figures/images, reading order, and page geometry as
+  separate hashed candidates. Markdown is inspectable evidence, never the
+  canonical representation. Preserve cross-arm and intra-arm disagreements.
+
+Run the authenticated owner-local producer from a Node 22+ checkout only after
+the pinned environment and model already exist:
+
+```bash
+PRIVATE_RUN_ROOT="$(mktemp -d /private/tmp/erniesg-mineru-runs.XXXXXX)"
+chmod 700 "$PRIVATE_RUN_ROOT"
+node --experimental-strip-types src/research/mineru-owner-local-runner.ts \
+  --pdf /absolute/input.pdf \
+  --run-root "$PRIVATE_RUN_ROOT" \
+  --mineru /absolute/pinned-venv/bin/mineru \
+  --python /absolute/pinned-venv/bin/python3.12 \
+  --config /absolute/mineru.json \
+  --model-root /absolute/pinned-model \
+  --max-output-bytes 1073741824
+```
+
+The command creates a new 0700 run directory, forces offline resolution, opens
+and hashes the source, installed package RECORD contents, runtime, backend,
+model/config/cache, and normalized artifacts, and prints only hash receipts.
+It is eligible as an authenticated producer only when it also completes the
+sealed-execution gate: the measured runtime, model, source, and config are
+copied/reflinked into that private run, sandboxed read-only, executed only from
+the sealed paths, and remeasured afterward. The receipt retains the preflight
+MinerU-config digest and complete runtime-tree inventory. The sealed runtime
+must match that inventory, and an exact read-only copy of the preflight config
+is retained alongside the separately hash-bound path-rebased execution config.
+Private HOME, TMPDIR, raw output, and the actual allocated bytes of the sealed
+runtime, model, source, and configs count against the owner-local 8 GiB ceiling,
+including when reflink support falls back to an ordinary copy. A discovery
+manifest from an older unsealed run is not this receipt. Model sealing keeps
+its exact logical source-size cap separate from filesystem allocation: the
+ordinary-copy allocation limit is the remaining global capacity after the
+original cache, sealed runtime/source/configs, and reserved raw-output and
+private HOME/TMP envelopes.
+Keep the manifest and artifacts owner-local; pass the manifest to the
+production assembler, which independently requires the deterministic arm and
+authenticates the MinerU arm before building the graph. A caller-authored
+manifest or declared provider identity is not sufficient.
+
+This command runs only the MinerU provider arm. Scanned and hybrid inputs still
+require configured owner-local OCR in the deterministic reconstruction
+(`page.ocr`); `assembleProductionSourceEvidence` fails closed when that arm is
+missing. This skill does not claim an OCR engine is installed or configured.
+
+Reconciliation uses the local Codex app-server over an absolute owner-only Unix
+socket (preferred) or a numeric/`localhost` loopback WebSocket only. The
+executable Unix transport is `createOwnerLocalUnixSocketTransport` in
+`src/research/local-codex-reconciliation.ts`; it requires a stable socket owned
+by the current user with no group/other permissions, performs and authenticates
+the app-server WebSocket upgrade over that Unix socket, and has no TCP fallback.
+Start the measured local binary in a separate owner-local process:
+
+```bash
+PRIVATE_CODEX_SOCKET_DIR="$(mktemp -d /private/tmp/erniesg-codex.XXXXXX)"
+chmod 700 "$PRIVATE_CODEX_SOCKET_DIR"
+/absolute/measured/codex app-server \
+  --listen "unix://$PRIVATE_CODEX_SOCKET_DIR/app-server.sock" \
+  -c analytics.enabled=false
+```
+
+After the socket appears, set it to mode 0600 and bind its inode/device,
+executable hash, initialized server identity, exact model ID/version and
+reasoning effort in the reconciliation receipt. Use the existing ChatGPT login,
+never an API key or hosted file-upload API. Isolate each document and attempt in
+a fresh ephemeral thread; bind the request and response to the source, graph,
+candidate-set, server, model, prompt, and tool hashes; enforce timeout,
+interrupt, and idempotent replay; and keep logs limited to redacted identities,
+hashes, counts, and terminal status. The model may select or relate frozen graph
+candidates for reading order, semantic type, joins, captions/assets, tables,
+formulas, notes/citations/links, and boilerplate. It may not supply new text,
+asset bytes, bounds, destinations, labels, or scientific claims.
+Send only opaque document/attempt hashes and a size-bounded trace for the
+current candidate set: source-backed snippets, normalized boxes, relationship
+and disagreement context, artifact hashes, a failed prior comparator receipt,
+and matched source-PDF/rendered-EPUB crops with exact provenance. Both crop
+classes are required. Never send the whole graph, a PDF, raw filesystem paths,
+an unbounded page raster, or unrelated provider output. Exact resolver payload
+bytes remain behind the owner-local boundary. The response may contain
+candidate IDs or abstentions only.
+
+Only the source-grounded verifier may materialize a reconciled candidate for
+STRUCT. It must rebuild every accepted token and field from at least one frozen
+source signal, check assets and bounds against source pixels/objects, and close
+every source obligation exactly once. A source-backed figure may remain a
+complete visual asset. A table/formula image preserves loss but leaves its
+semantic obligation blocking. A full-page raster never counts as reconstructed
+semantic text. It may close only an explicit source-preserved-page obligation
+when the verifier matches the exact complete-page deterministic render and
+bounded fallback asset. An ungrounded disagreement is a failed candidate, not
+a successful review artifact.
+
+The graph binds an exact normalized deterministic-context receipt covering the
+PDF source identity, page geometry, source text/payloads and bounds, artifacts,
+and candidates. IDs alone are never ownership evidence. When deterministic and
+MinerU sources converge on one STRUCT owner, compare canonical unique owner
+sets while retaining separate per-provider crosswalk hashes. Image-only links
+must carry exact deterministic asset and native source-object IDs; rectangle
+overlap is only a supporting check and cannot select between equal-overlap
+assets.
+
+### Closed evaluator loop
+
+After each verified candidate, hand the immutable evidence-graph hash and typed
+reader API to the evidence evaluator. Do not define or mutate its attempt trace,
+comparator result, judge schema, refinement state machine, or browser evidence
+inside this skill's parser-core lane. Continue from the evaluator's exact
+hash-bound result: append a new reconciliation receipt and graph continuation;
+never delete, rewrite, or launder earlier provider, candidate, decision, or
+failure provenance.
+
+The handoff must commit canonical expected-observation payload bytes, hashes,
+and counts for all 19 evaluator categories, plus the source-obligation receipt.
+The evaluator must reopen those bytes through the frozen source-evidence
+verifier; naked counts or hashes are not evidence.
+
+Forward tests use fresh Codex threads with no inherited conversation for each
+new document/attempt. The existing born-digital, scanned-page, three-column,
+and link fixture MinerU manifests are provider-discovery receipts only. They
+must not be reported as a product pilot. A durable four-document development
+evaluation requires retained source bytes or a legal owner-local reopen
+reference, graph bytes, all 19 expected-observation payloads, the local Codex
+receipt, grounded materialization receipt, actual EPUB bytes plus EPUBCheck,
+renderer observations, and the final comparator/trace receipt for every item.
+Exercise born-digital two-column, scanned/hybrid, figure-heavy, and
+table/formula-heavy inputs plus malformed negative handling.
+Require deterministic/MinerU/Codex identities, all-arm graph hashes, exact
+obligation closure, and the evaluator handoff on every non-negative case; no
+manifest, basename, title, hash, fixed-page, or seed may change production
+behavior.
+
+Do not call that packet verified merely because its files parse. The v2 packet
+is valid only when it replays authentic #203 prior/final traces and invokes the
+frozen owner-local Codex, #200 grounded-materialization, render-observation,
+and EPUBCheck verifier authorities. Their exact identity/config/executable
+digests must be pinned in the packet policy before evaluation; every authority
+must return its exact identity- and request-bound receipt. Until #200 supplies
+and passes that
+authority, report parser/provider progress only.
+
+For every pilot, retain the source hash, producer receipt hash, graph hash,
+provider host/backend identity, all 19 expected-observation payload receipts,
+and the conservation result. Born-digital or scan inference success is only a
+provider receipt; it is not reconstruction success until every source run,
+required asset, typed link/destination, relationship, and selected obligation
+is materialized exactly once or remains an explicit bounded source fallback.
+
 ## Autonomous development loop
 
 - Resume the newest clean checkpoint for the issue before creating a branch or
@@ -58,7 +239,12 @@ Use deterministic extraction and validation first. When a bounded layout decisio
 Run the narrowest relevant fixtures first, then the repository gates:
 
 ```bash
+npx vitest run src/research/mineru-owner-local-runner.test.ts src/research/source-evidence-assembler.test.ts
+npx vitest run src/research/source-evidence-contract.test.ts src/research/local-codex-reconciliation.test.ts
+npx vitest run src/research/structured-extraction.test.ts src/research/source-grounded-struct.test.ts
+npx vitest run src/research/reconstruction-development-evaluation.test.ts
 npx vitest run src/struct/struct.test.ts src/research/epub-source-fallback.test.ts
+npx tsc --noEmit
 npm run test
 npm run build
 scripts/agent-evidence

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -872,6 +872,21 @@ describe('extraction architecture bake-off', () => {
         .filter(({ layout }) => layout === 'one-column')
         .map(({ stratum }) => stratum),
     ).toEqual(['tables'])
+    expect(
+      report.arms['llm-authored'].documents.every(
+        ({ status }) => status === 'failed',
+      ),
+    ).toBe(true)
+    const authoredCases = report.arms['llm-authored'].documents[0]!.caseScores
+    expect(
+      authoredCases.find(({ stratum }) => stratum === 'tables')?.verification
+        .status,
+    ).toBe('failed')
+    expect(
+      authoredCases
+        .filter(({ stratum }) => stratum !== 'tables')
+        .every(({ verification }) => verification.status === 'passed'),
+    ).toBe(true)
   })
 
   it('does not certify score-once when the same identity is rerun', async () => {

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -7,6 +7,7 @@ import {
   type StructuredExtractionSplit,
   structuredExtractionHash,
   structuredExtractionStableJson,
+  parseStructuredExtractionProposal,
   verifyStructuredExtraction,
   modelInputForStructuredExtraction,
   type VerifiedStructuredExtraction,
@@ -432,7 +433,7 @@ function ratio(numerator: number, denominator: number) {
 }
 
 function verifiedNodeSourceRunIds(
-  node: VerifiedStructuredExtraction['nodes'][number],
+  node: StructuredExtractionProposal['nodes'][number],
 ) {
   return [
     ...node.sourceRunIds,
@@ -440,6 +441,170 @@ function verifiedNodeSourceRunIds(
       cells.flatMap(({ sourceRunIds }) => sourceRunIds),
     ) ?? []),
   ]
+}
+
+function caseEvidenceProjection(
+  context: StructuredExtractionContext,
+  caseInput: ExtractionBakeoffCase,
+) {
+  const sourceRunIds = new Set([
+    ...(caseInput.expectedSourceRunIds ?? []),
+    ...(caseInput.expectedExcludedBoilerplateRunIds ?? []),
+  ])
+  const assetIds = new Set(caseInput.expectedAssetIds ?? [])
+  const sourceRuns = context.sourceRuns.filter(({ id }) =>
+    sourceRunIds.has(id),
+  )
+  const sourceLines = (context.sourceLines ?? [])
+    .map((line) => ({
+      ...line,
+      sourceRunIds: line.sourceRunIds.filter((id) => sourceRunIds.has(id)),
+    }))
+    .filter(({ sourceRunIds: ids }) => ids.length > 0)
+  const sourceAssets = context.sourceAssets.filter(({ id }) =>
+    assetIds.has(id),
+  )
+  const sourceLinks = (context.sourceLinks ?? []).filter(
+    ({ sourceRunIds: runIds, sourceAssetIds: linkAssetIds }) =>
+      runIds.every((id) => sourceRunIds.has(id)) &&
+      (linkAssetIds ?? []).every((id) => assetIds.has(id)) &&
+      (runIds.length > 0 || (linkAssetIds?.length ?? 0) > 0),
+  )
+  const selectedRegionIds = new Set(
+    sourceRuns.flatMap(({ regionId }) => (regionId ? [regionId] : [])),
+  )
+  const regionTopology = context.regionTopology
+    ? {
+        regions: context.regionTopology.regions.filter(({ id }) =>
+          selectedRegionIds.has(id),
+        ),
+        edges: context.regionTopology.edges.filter(
+          ({ fromRegionId, toRegionId }) =>
+            selectedRegionIds.has(fromRegionId) &&
+            selectedRegionIds.has(toRegionId),
+        ),
+      }
+    : undefined
+  const provenArtifacts = (context.provenArtifacts ?? []).filter((artifact) =>
+    [
+      ...artifact.sourceRunIds,
+      ...(artifact.targetSourceRunIds ?? []),
+      ...(artifact.targetSourceRunIdGroups ?? []).flat(),
+    ].every((id) => sourceRunIds.has(id)),
+  )
+  const projectedContext: StructuredExtractionContext = {
+    documentId: context.documentId,
+    sourceSha256: context.sourceSha256,
+    split: context.split,
+    layout: context.layout,
+    ...(regionTopology ? { regionTopology } : {}),
+    sourceRuns,
+    ...(sourceLines.length > 0 ? { sourceLines } : {}),
+    sourceAssets,
+    ...(sourceLinks.length > 0 ? { sourceLinks } : {}),
+    ...(context.pageRenditions
+      ? { pageRenditions: context.pageRenditions }
+      : {}),
+    ...(provenArtifacts.length > 0 ? { provenArtifacts } : {}),
+    ...(caseInput.expectedExcludedBoilerplateRunIds
+      ? {
+          boilerplateRunIds: [
+            ...caseInput.expectedExcludedBoilerplateRunIds,
+          ],
+        }
+      : {}),
+  }
+  return { projectedContext, sourceRunIds, assetIds, sourceLinks }
+}
+
+function projectProposalForCase(
+  proposal: StructuredExtractionProposal,
+  caseInput: ExtractionBakeoffCase,
+  sourceRunIds: ReadonlySet<string>,
+  assetIds: ReadonlySet<string>,
+  sourceLinkIds: ReadonlySet<string>,
+): StructuredExtractionProposal {
+  const nodes = proposal.nodes.filter((node) => {
+    if (verifiedNodeSourceRunIds(node).some((id) => sourceRunIds.has(id))) {
+      return true
+    }
+    if (node.assetId && assetIds.has(node.assetId)) return true
+    return (
+      sourceRunIds.size === 0 &&
+      assetIds.size === 0 &&
+      caseInput.expectedNodeTypes.includes(node.type)
+    )
+  })
+  const nodeIds = new Set(nodes.map(({ id }) => id))
+  return {
+    ...proposal,
+    nodes,
+    assetIds: (proposal.assetIds ?? []).filter((id) => assetIds.has(id)),
+    links: (proposal.links ?? []).filter(
+      ({ sourceLinkId, sourceNodeId }) =>
+        sourceLinkIds.has(sourceLinkId) && nodeIds.has(sourceNodeId),
+    ),
+    excludedBoilerplateRunIds: (
+      proposal.excludedBoilerplateRunIds ?? []
+    ).filter((id) => sourceRunIds.has(id)),
+  }
+}
+
+function scoreCaseAttempts(
+  context: StructuredExtractionContext,
+  caseInput: ExtractionBakeoffCase,
+  firstProposalInput: unknown,
+  secondProposalInput: unknown,
+  documentVerification: ExtractionBakeoffVerification,
+) {
+  let firstProposal: StructuredExtractionProposal
+  let secondProposal: StructuredExtractionProposal
+  try {
+    firstProposal = parseStructuredExtractionProposal(firstProposalInput)
+    secondProposal = parseStructuredExtractionProposal(secondProposalInput)
+  } catch {
+    return scoreCase(caseInput, null, documentVerification)
+  }
+  const { projectedContext, sourceRunIds, assetIds, sourceLinks } =
+    caseEvidenceProjection(context, caseInput)
+  const sourceLinkIds = new Set(sourceLinks.map(({ id }) => id))
+  const firstVerification = verifyStructuredExtraction(
+    projectedContext,
+    projectProposalForCase(
+      firstProposal,
+      caseInput,
+      sourceRunIds,
+      assetIds,
+      sourceLinkIds,
+    ),
+  )
+  const secondVerification = verifyStructuredExtraction(
+    projectedContext,
+    projectProposalForCase(
+      secondProposal,
+      caseInput,
+      sourceRunIds,
+      assetIds,
+      sourceLinkIds,
+    ),
+  )
+  const byteStable =
+    firstVerification.status === 'passed' &&
+    secondVerification.status === 'passed' &&
+    structuredExtractionStableJson(firstVerification.output) ===
+      structuredExtractionStableJson(secondVerification.output)
+  const verification = combinedVerification(
+    firstVerification,
+    secondVerification,
+    byteStable,
+  )
+  const output =
+    firstVerification.status === 'passed' &&
+    secondVerification.status === 'passed' &&
+    byteStable
+      ? firstVerification.output
+      : null
+  return scoreCase(caseInput, output, verification)
 }
 
 function scoreCase(
@@ -748,7 +913,7 @@ function comparisons(
             ].join('\u0000'),
           )
           .sort()
-        return [result.status, result.byteStable, ...rowScores].join('\u0001')
+        return rowScores.length > 0 ? rowScores.join('\u0001') : 'missing'
       })
       return new Set(states).size > 1
     })
@@ -966,7 +1131,13 @@ export async function runExtractionBakeoff({
           ? firstVerification.output
           : null
       const caseScores = document.cases.map((caseInput) =>
-        scoreCase(caseInput, output, verification),
+        scoreCaseAttempts(
+          document.context,
+          caseInput,
+          first.proposal,
+          second.proposal,
+          verification,
+        ),
       )
       const status: ExtractionBakeoffDocumentResult['status'] =
         firstVerification.status === 'passed' &&
@@ -1018,7 +1189,11 @@ export async function runExtractionBakeoff({
         arms: states
           .filter(({ rowScores }) => rowScores.length > 0)
           .map(({ arm }) => arm),
-        reason: states.some(({ result }) => result?.status !== 'passed')
+        reason: states.some(({ rowScores }) =>
+          rowScores.some(
+            ({ verification }) => verification.status !== 'passed',
+          ),
+        )
           ? ('verification' as const)
           : new Set(structures).size > 1
             ? ('structure' as const)

--- a/src/research/local-codex-reconciliation.test.ts
+++ b/src/research/local-codex-reconciliation.test.ts
@@ -1,0 +1,1490 @@
+import { createHash } from 'node:crypto'
+import { chmod, mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  createLocalCodexReconciliationClient,
+  createOwnerLocalUnixSocketTransport,
+  validateLocalCodexEndpoint,
+  type LocalCodexJsonRpcNotification,
+  type LocalCodexJsonRpcRequest,
+  type LocalCodexJsonRpcTransport,
+  type LocalCodexReconciliationClientConfig,
+  type LocalCodexReconciliationRequest,
+} from './local-codex-reconciliation'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  createReconstructionAttemptTrace,
+  hashEpubBytes,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashTraceValue,
+} from './reconstruction-attempt-trace'
+import {
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+import { createSourceEvidenceContract } from './source-evidence-contract'
+import {
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  readSourceEvidenceGraph,
+  type SourceEvidenceGraph,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+
+const SHA_A = 'a'.repeat(64)
+const SHA_B = 'b'.repeat(64)
+const SOURCE_TEXT = 'private source text must never enter the receipt'
+const RAW_REASONING = 'private raw reasoning must be discarded'
+const SOURCE_RENDER_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAFklEQVQYlWP4z8DwnxjMMKrwP12DBwCSw8c5bHZncwAAAABJRU5ErkJggg==',
+  'base64',
+)
+const SOURCE_CROP_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADklEQVQImWP4z8DwH4QBEfcD/RSF9bkAAAAASUVORK5CYII=',
+  'base64',
+)
+const EPUB_RENDER_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAFklEQVQYlWNgYPj/nzjMMKrwPx2DBwDLfMc5JCCjZgAAAABJRU5ErkJggg==',
+  'base64',
+)
+const EPUB_CROP_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAEElEQVQImWNgYPj/H4KhDAA/0gf5WPNCXwAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+function sha256(value: Uint8Array | string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function graphFixture(documentId = 'document-private-id'): SourceEvidenceGraph {
+  const source = {
+    documentId,
+    sha256: SHA_A,
+    byteLength: 128,
+    pageCount: 1,
+  }
+  const provider = {
+    id: 'provider-1',
+    kind: 'pdfjs' as const,
+    name: 'pdfjs-dist',
+    version: '5.4.624',
+    implementationSha256: SHA_B,
+  }
+  const box = {
+    page: 1,
+    x: 0.1,
+    y: 0.1,
+    width: 0.2,
+    height: 0.05,
+    rotation: 0,
+    method: 'pdf-text' as const,
+  }
+  const graphInput: Omit<
+    SourceEvidenceGraphInput,
+    'deterministicContext'
+  > = {
+    schemaVersion: '1.0.0',
+    source,
+    arms: [
+      {
+        id: 'deterministic',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: provider.id,
+      },
+      {
+        id: 'mineru',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: 'mineru-provider',
+      },
+    ],
+    bundles: [
+      {
+        schemaVersion: '1.0.0',
+        id: 'bundle-1',
+        armId: 'deterministic',
+        source,
+        provider,
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'artifact-1',
+            providerId: provider.id,
+            kind: 'source-run-evidence',
+            mediaType: 'application/json',
+            sha256: SHA_B,
+            byteLength: 32,
+            page: 1,
+            box,
+            sourceIds: ['source-1'],
+          },
+        ],
+        sources: [
+          {
+            id: 'source-1',
+            providerId: provider.id,
+            kind: 'text-run',
+            page: 1,
+            box,
+            artifactIds: ['artifact-1'],
+            parentSourceIds: [],
+            payload: { text: SOURCE_TEXT, localPath: '/private/paper.pdf' },
+          },
+        ],
+        candidates: [
+          {
+            id: 'candidate-1',
+            providerId: provider.id,
+            kind: 'text',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['source-1'],
+            artifactIds: ['artifact-1'],
+            payload: { interpretation: 'first' },
+          },
+          {
+            id: 'candidate-2',
+            providerId: provider.id,
+            kind: 'text',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['source-1'],
+            artifactIds: ['artifact-1'],
+            payload: { interpretation: 'second' },
+          },
+        ],
+      },
+      {
+        schemaVersion: '1.0.0',
+        id: 'mineru-bundle',
+        armId: 'mineru',
+        source,
+        provider: {
+          id: 'mineru-provider',
+          kind: 'mineru',
+          name: 'MinerU',
+          version: '3.4.4',
+        },
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'mineru-artifact',
+            providerId: 'mineru-provider',
+            kind: 'content-list-v2',
+            mediaType: 'application/json',
+            sha256: 'c'.repeat(64),
+            byteLength: 32,
+            page: 1,
+            box,
+            sourceIds: ['mineru-source'],
+          },
+        ],
+        sources: [
+          {
+            id: 'mineru-source',
+            providerId: 'mineru-provider',
+            kind: 'provider-record',
+            page: 1,
+            box,
+            artifactIds: ['mineru-artifact'],
+          },
+        ],
+        candidates: [
+          {
+            id: 'mineru-candidate',
+            providerId: 'mineru-provider',
+            kind: 'provider-record',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['mineru-source'],
+            artifactIds: ['mineru-artifact'],
+            payload: { grounded: false },
+          },
+        ],
+      },
+    ],
+    obligations: [
+      {
+        id: 'decision-obligation',
+        kind: 'source-text',
+        page: 1,
+        sourceIds: ['source-1'],
+        artifactIds: ['artifact-1'],
+        candidateIds: ['candidate-1', 'candidate-2'],
+        observationCategories: ['text-exactness'],
+        required: true,
+        semantic: true,
+      },
+      {
+        id: 'mineru-discovery-obligation',
+        kind: 'provider-source-fact',
+        page: 1,
+        sourceIds: ['mineru-source'],
+        artifactIds: ['mineru-artifact'],
+        candidateIds: ['mineru-candidate'],
+        observationCategories: ['object-counts', 'asset-bytes'],
+        required: false,
+        semantic: false,
+      },
+    ],
+    disagreements: [],
+  }
+  return buildSourceEvidenceGraph({
+    ...graphInput,
+    deterministicContext: deterministicContextReceiptForBundle(
+      graphInput.bundles[0]!,
+    ),
+  })
+}
+
+function failedTraceFixture(graph: SourceEvidenceGraph) {
+  const contract = createSourceEvidenceContract(graph, {
+    id: 'fixture-source-evidence-verifier',
+    version: '1.0.0',
+    configurationSha256: sha256('source-evidence-config'),
+    executableSha256: sha256('source-evidence-executable'),
+  })
+  const epubBytes = Buffer.from('PK\u0003\u0004 exact EPUB fixture')
+  const epubSha256 = hashEpubBytes(epubBytes)
+  const structSha256 = sha256('STRUCT fixture')
+  const domSha256 = sha256('fixture DOM')
+  const viewport = { width: 10, height: 10, deviceScaleFactor: 1 }
+  const actualObservationSets = contract.expectedObservationSets.map(
+    ({ check, setSha256, itemCount, payload }) => {
+      const mismatched = check === 'reading-order'
+      const mismatchedPayload = {
+        sha256: sha256('wrong reading order payload'),
+        byteLength: 1,
+      }
+      const projection = {
+        check,
+        setSha256: mismatched ? mismatchedPayload.sha256 : setSha256,
+        itemCount,
+        payload: mismatched ? mismatchedPayload : payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: '0'.repeat(64),
+        }),
+      }
+    },
+  )
+  const renderedEpub = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+      verificationReceiptSha256: sha256('download receipt'),
+    },
+    sourceObligations: {
+      sourcePdfSha256: graph.source.sha256,
+      ...contract.sourceEvidenceReceipt.sourceObligations,
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'fixture-renderer',
+      version: '1.0.0',
+      executableSha256: sha256('fixture renderer executable'),
+      configurationSha256: sha256('fixture renderer config'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: domSha256, byteLength: 11 },
+        anchors: ['candidate-output-1'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'fixture-screenshot',
+        spineHref: 'EPUB/content.xhtml',
+        domSha256,
+        image: {
+          sha256: sha256(EPUB_RENDER_BYTES),
+          byteLength: EPUB_RENDER_BYTES.byteLength,
+        },
+        mediaType: 'image/png' as const,
+        width: 10,
+        height: 10,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: '0'.repeat(64),
+  }
+  renderedEpub.receiptSha256 = hashRenderedEpubEvidence(renderedEpub)
+  const mappings = contract.sourceRegions.map((region, index) => ({
+    id: `mapping-${index + 1}`,
+    obligationId: region.id,
+    source: region.source,
+    output: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        anchorId: 'candidate-output-1',
+        rendered: {
+          screenshotId: 'fixture-screenshot',
+          viewport,
+          rect: { x: 1, y: 1, width: 2, height: 2 },
+        },
+      },
+    ],
+    status: 'mapped' as const,
+  }))
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: sha256(`observation-${check}`),
+      check,
+      source: contract.sourceRegions[0]!.source,
+      mappingIds: [mappings[0]!.id],
+      expectedSetReceiptSha256: contract.expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: graph.source.documentId,
+    sourcePdfSha256: graph.source.sha256,
+    artifact: { sha256: structSha256, byteLength: 128 },
+    generatedSha256: sha256('generated STRUCT'),
+    assets: [],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+    mediaType: 'application/epub+zip' as const,
+    structSha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: sha256('EPUBCheck report'),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256: graph.source.sha256,
+    sourceEvidence: contract.sourceEvidenceReceipt,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions: contract.sourceRegions,
+    mappings,
+    observations,
+  })
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256: graph.source.sha256,
+    evidenceGraphSha256: graph.graphSha256,
+    candidateSetSha256: contract.sourceEvidenceReceipt.candidateSetSha256,
+    structSha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  const codexIdentity = {
+    server: {
+      id: 'owner-local-codex-server',
+      version: '1.0.0',
+      transport: 'http://127.0.0.1:4500/v1',
+      executableSha256: sha256('codex server'),
+    },
+    model: {
+      id: 'gpt-local-test',
+      version: 'fixture-1',
+      sha256: SHA_B,
+    },
+    prompt: {
+      id: 'source-grounded-reconciliation',
+      version: '1.0.0',
+      sha256: sha256('prompt'),
+    },
+    tool: { id: 'codex-cli', version: '0.146.0' },
+  }
+  return createReconstructionAttemptTrace({
+    schemaVersion: '1.0.0',
+    attemptId: 'prior-attempt',
+    lineage: {
+      attemptIndex: 0,
+      parentTraceSha256: null,
+      immutablePriorTraceSha256: null,
+      appliedRepair: null,
+    },
+    sourcePdf: {
+      artifact: {
+        sha256: graph.source.sha256,
+        byteLength: graph.source.byteLength,
+      },
+      pageCount: 1,
+      pageRenders: [
+        {
+          page: 1,
+          sourcePdfSha256: graph.source.sha256,
+          image: {
+            sha256: sha256(SOURCE_RENDER_BYTES),
+            byteLength: SOURCE_RENDER_BYTES.byteLength,
+          },
+          mediaType: 'image/png',
+          width: 10,
+          height: 10,
+        },
+      ],
+    },
+    evidenceGraph: {
+      schemaVersion: contract.schemaVersion,
+      artifact: contract.graphArtifact,
+      sourcePdfSha256: graph.source.sha256,
+    },
+    sourceEvidence: contract.sourceEvidenceReceipt,
+    evidenceCandidates: contract.evidenceCandidates,
+    structure,
+    epub,
+    renderedEpub,
+    mappings,
+    comparisonEvidence: {
+      sourceRegions: contract.sourceRegions,
+      observations,
+    },
+    providerReceipts: [
+      {
+        id: 'source-evidence',
+        role: 'source-evidence',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'source-evidence-contract',
+        receiptSha256: sha256('source receipt'),
+        inputSha256: graph.source.sha256,
+        outputSha256: contract.sourceEvidenceReceipt.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'actual-render',
+        role: 'actual-render',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'fixture-renderer',
+        receiptSha256: sha256('render receipt'),
+        inputSha256: epubSha256,
+        outputSha256: renderedEpub.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'codex-reconciliation',
+        role: 'owner-local-codex-reconciliation',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-codex-server',
+        identitySha256: hashTraceValue(codexIdentity),
+        receiptSha256: sha256('codex receipt'),
+        inputSha256: reconciliationInputSha256,
+        outputSha256: hashTraceValue(comparator),
+        ...codexIdentity,
+        status: 'succeeded',
+      },
+    ],
+    comparator,
+    critiqueRepair: null,
+    budget: {
+      policy: {
+        maxRefinements: 3,
+        maxFreshTasks: 1,
+        maxTokens: 24_000,
+        maxDurationMs: 1_800_000,
+        repairPolicySha256: sha256('repair policy'),
+      },
+      usage: { refinements: 0, freshTasks: 0, tokens: 0, durationMs: 0 },
+    },
+    terminalState: 'failed',
+  })
+}
+
+function reconciliationRequest(
+  graph = graphFixture(),
+): LocalCodexReconciliationRequest {
+  const candidateIds = ['candidate-1', 'candidate-2']
+  const reader = readSourceEvidenceGraph(graph)
+  const priorTrace = failedTraceFixture(graph)
+  const failure = priorTrace.comparator.failures.find(
+    ({ check }) => check === 'reading-order',
+  )!
+  return {
+    documentId: graph.source.documentId,
+    attemptId: 'attempt-1',
+    evidenceGraph: graph,
+    graphSha256: graph.graphSha256,
+    candidateSetSha256: reader.candidateSetSha256(candidateIds),
+    decisions: [{ decisionId: 'reading-order', candidateIds }],
+    comparisonEvidence: priorTrace,
+    renders: [
+      {
+        id: 'source-crop-1',
+        mimeType: 'image/png',
+        dataBase64: SOURCE_CROP_BYTES.toString('base64'),
+        sha256: sha256(SOURCE_CROP_BYTES),
+        page: 1,
+        box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 },
+        candidateIds,
+        provenance: {
+          kind: 'source-pdf',
+          sourcePdfSha256: graph.source.sha256,
+          sourcePageRenderSha256: sha256(SOURCE_RENDER_BYTES),
+          failureId: failure.id,
+        },
+      },
+      {
+        id: 'epub-crop-1',
+        mimeType: 'image/png',
+        dataBase64: EPUB_CROP_BYTES.toString('base64'),
+        sha256: sha256(EPUB_CROP_BYTES),
+        page: 1,
+        box: { x: 0.1, y: 0.1, width: 0.2, height: 0.2 },
+        candidateIds,
+        provenance: {
+          kind: 'rendered-epub',
+          epubSha256: priorTrace.epub.bytes.sha256,
+          renderReceiptSha256: priorTrace.renderedEpub.receiptSha256,
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'candidate-output-1',
+          domSha256: priorTrace.renderedEpub.domSnapshots[0]!.dom.sha256,
+          screenshotSha256: sha256(EPUB_RENDER_BYTES),
+          screenshotId: 'fixture-screenshot',
+          failureId: failure.id,
+        },
+      },
+    ],
+  }
+}
+
+function validOutput(request: LocalCodexReconciliationRequest) {
+  return JSON.stringify({
+    schemaVersion: '1.0.0',
+    graphSha256: request.graphSha256,
+    candidateSetSha256: request.candidateSetSha256,
+    decisions: [
+      {
+        decisionId: request.decisions[0]!.decisionId,
+        candidateId: 'candidate-1',
+      },
+    ],
+  })
+}
+
+type FakeTransportOptions = {
+  endpoint?: string
+  finalEndpoint?: string
+  redirected?: boolean
+  output: string
+  threadId?: string
+  turnId?: string
+  stall?: boolean
+  modelId?: string
+  providerId?: string
+}
+
+class FakeTransport implements LocalCodexJsonRpcTransport {
+  readonly endpoint: string
+  readonly finalEndpoint?: string
+  readonly redirected?: boolean
+  readonly requests: LocalCodexJsonRpcRequest[] = []
+  readonly notifications: LocalCodexJsonRpcNotification[] = []
+  readonly events: unknown[] = []
+  readonly output: string
+  readonly threadId: string
+  readonly turnId: string
+  readonly stall: boolean
+  readonly modelId: string
+  readonly providerId: string
+  interrupted = 0
+  closed = 0
+
+  constructor(options: FakeTransportOptions) {
+    this.endpoint = options.endpoint ?? 'ws://127.0.0.1:4500'
+    this.finalEndpoint = options.finalEndpoint
+    this.redirected = options.redirected
+    this.output = options.output
+    this.threadId = options.threadId ?? 'thread-1'
+    this.turnId = options.turnId ?? 'turn-1'
+    this.stall = options.stall ?? false
+    this.modelId = options.modelId ?? 'gpt-local-test'
+    this.providerId = options.providerId ?? 'codex-subscription'
+  }
+
+  async request(message: LocalCodexJsonRpcRequest) {
+    this.requests.push(structuredClone(message))
+    if (message.method === 'initialize') {
+      return {
+        userAgent: 'codex-cli/0.146.0',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+      }
+    }
+    if (message.method === 'thread/start') {
+      return {
+        thread: {
+          id: this.threadId,
+          sessionId: this.threadId,
+          ephemeral: true,
+        },
+        model: this.modelId,
+        modelProvider: this.providerId,
+      }
+    }
+    if (message.method === 'turn/start') {
+      this.events.push(
+        {
+          method: 'item/completed',
+          params: {
+            threadId: this.threadId,
+            turnId: this.turnId,
+            item: {
+              type: 'reasoning',
+              summary: [],
+              content: [RAW_REASONING],
+            },
+          },
+        },
+        {
+          method: 'item/completed',
+          params: {
+            threadId: this.threadId,
+            turnId: this.turnId,
+            item: {
+              type: 'agentMessage',
+              phase: 'final_answer',
+              text: this.output,
+            },
+          },
+        },
+        {
+          method: 'turn/completed',
+          params: {
+            threadId: this.threadId,
+            turn: {
+              id: this.turnId,
+              status: 'completed',
+              items: [],
+              error: null,
+            },
+          },
+        },
+      )
+      return {
+        turn: {
+          id: this.turnId,
+          status: 'inProgress',
+          items: [],
+          error: null,
+        },
+      }
+    }
+    if (message.method === 'turn/interrupt') {
+      this.interrupted += 1
+      return {}
+    }
+    throw new Error(`Unexpected method ${message.method}`)
+  }
+
+  notify(message: LocalCodexJsonRpcNotification) {
+    this.notifications.push(structuredClone(message))
+  }
+
+  nextMessage({ signal }: { signal: AbortSignal }): Promise<unknown> {
+    if (!this.stall && this.events.length > 0) {
+      return Promise.resolve(this.events.shift())
+    }
+    return new Promise((_, reject) => {
+      const abort = () => reject(new Error('aborted'))
+      if (signal.aborted) abort()
+      else signal.addEventListener('abort', abort, { once: true })
+    })
+  }
+
+  close() {
+    this.closed += 1
+  }
+}
+
+function config(
+  transportFactory: LocalCodexReconciliationClientConfig['transportFactory'],
+  overrides: Partial<LocalCodexReconciliationClientConfig> = {},
+): LocalCodexReconciliationClientConfig {
+  return {
+    endpoint: 'ws://127.0.0.1:4500',
+    transportFactory,
+    timeoutMs: 1_000,
+    interruptTimeoutMs: 50,
+    toolIdentity: {
+      id: 'codex-cli',
+      version: '0.146.0',
+      executableSha256: SHA_A,
+    },
+    modelIdentity: {
+      providerId: 'codex-subscription',
+      modelId: 'gpt-local-test',
+      modelVersion: 'fixture-1',
+      modelDigest: SHA_B,
+      reasoningEffort: 'high',
+    },
+    promptIdentity: {
+      id: 'source-grounded-reconciliation',
+      version: '1.0.0',
+      instructions: 'Choose only a source-grounded candidate reference.',
+    },
+    renderArtifactResolver: {
+      identity: {
+        id: 'fixture-owner-local-render-resolver',
+        version: '1.0.0',
+        configurationSha256: sha256('fixture render resolver config'),
+      },
+      resolve: ({ artifact }) => {
+        if (artifact.sha256 === sha256(SOURCE_RENDER_BYTES)) {
+          return new Uint8Array(SOURCE_RENDER_BYTES)
+        }
+        if (artifact.sha256 === sha256(EPUB_RENDER_BYTES)) {
+          return new Uint8Array(EPUB_RENDER_BYTES)
+        }
+        throw new Error('unexpected fixture artifact')
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('local Codex endpoint boundary', () => {
+  it.each([
+    ['ws://127.0.0.1:4500', 'loopback-websocket'],
+    ['ws://127.20.30.40:4500', 'loopback-websocket'],
+    ['ws://[::1]:4500', 'loopback-websocket'],
+    ['ws://localhost:4500', 'loopback-websocket'],
+    ['unix:///tmp/codex-app-server.sock', 'unix-socket'],
+  ] as const)('accepts only a local endpoint: %s', (endpoint, kind) => {
+    expect(validateLocalCodexEndpoint(endpoint)).toMatchObject({ kind })
+  })
+
+  it.each([
+    'http://127.0.0.1:4500',
+    'https://127.0.0.1:4500',
+    'wss://127.0.0.1:4500',
+    'ws://example.test:4500',
+    'ws://10.0.0.1:4500',
+    'ws://user@127.0.0.1:4500',
+    'ws://127.0.0.1:4500/path',
+    'ws://127.0.0.1:4500?token=value',
+    'ws://127.0.0.1:4500#fragment',
+    'unix://relative/socket',
+    'unix:///tmp/../private/socket',
+    'unix:///tmp/socket?redirect=1',
+    'unix:///tmp/%73ocket',
+  ])(
+    'rejects remote, DNS, credential, and ambiguous endpoint %s',
+    (endpoint) => {
+      expect(() => validateLocalCodexEndpoint(endpoint)).toThrow(
+        'LOCAL_CODEX_ENDPOINT_FORBIDDEN',
+      )
+    },
+  )
+
+  it('rejects redirecting transports before initialization', async () => {
+    const request = reconciliationRequest()
+    for (const transport of [
+      new FakeTransport({ output: validOutput(request), redirected: true }),
+      new FakeTransport({
+        output: validOutput(request),
+        finalEndpoint: 'ws://127.0.0.2:4500',
+      }),
+    ]) {
+      const client = createLocalCodexReconciliationClient(
+        config(() => transport),
+      )
+      await expect(client.reconcile(request)).rejects.toThrow(
+        'LOCAL_CODEX_REDIRECT_FORBIDDEN',
+      )
+      expect(transport.requests).toEqual([])
+    }
+  })
+
+  it('rejects API-key and redirect-shaped configuration', () => {
+    const transport = new FakeTransport({ output: '{}' })
+    for (const unsafe of [
+      { apiKey: 'sk-proj-abcdefghijk' },
+      { authorization: 'Bearer credential-value' },
+      { followRedirects: true },
+      { nested: { accessToken: 'not-even-needed' } },
+    ]) {
+      expect(() =>
+        createLocalCodexReconciliationClient({
+          ...config(() => transport),
+          ...unsafe,
+        } as LocalCodexReconciliationClientConfig),
+      ).toThrow(/LOCAL_CODEX_(?:API_KEY|REDIRECT)_FORBIDDEN/u)
+    }
+  })
+})
+
+describe('local Codex reconciliation contract', () => {
+  it('runs JSON-RPC over a real owner-only Unix WebSocket', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'erniesg-codex-socket-'))
+    const socketPath = join(root, 'app-server.sock')
+    const request = reconciliationRequest()
+    const server = createServer((socket) => {
+      let buffered = Buffer.alloc(0)
+      let upgraded = false
+      const send = (value: unknown) => {
+        const payload = Buffer.from(JSON.stringify(value), 'utf8')
+        const header =
+          payload.byteLength < 126
+            ? Buffer.from([0x81, payload.byteLength])
+            : Buffer.from([
+                0x81,
+                126,
+                (payload.byteLength >> 8) & 0xff,
+                payload.byteLength & 0xff,
+              ])
+        socket.write(Buffer.concat([header, payload]))
+      }
+      socket.on('data', (chunk) => {
+        buffered = Buffer.concat([buffered, chunk])
+        if (!upgraded) {
+          const boundary = buffered.indexOf('\r\n\r\n')
+          if (boundary < 0) return
+          const requestHeaders = buffered
+            .subarray(0, boundary)
+            .toString('ascii')
+          const key = requestHeaders.match(/^Sec-WebSocket-Key: (.+)$/imu)?.[1]
+          if (!key) throw new Error('missing WebSocket key')
+          const accept = createHash('sha1')
+            .update(`${key.trim()}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+            .digest('base64')
+          socket.write(
+            [
+              'HTTP/1.1 101 Switching Protocols',
+              'Upgrade: websocket',
+              'Connection: Upgrade',
+              `Sec-WebSocket-Accept: ${accept}`,
+              '',
+              '',
+            ].join('\r\n'),
+          )
+          buffered = buffered.subarray(boundary + 4)
+          upgraded = true
+        }
+        for (;;) {
+          if (buffered.byteLength < 6) break
+          const encodedLength = buffered[1]! & 0x7f
+          const extendedLength = encodedLength === 126 ? 2 : 0
+          if (encodedLength === 127)
+            throw new Error('fixture frame unexpectedly large')
+          const payloadLength =
+            extendedLength === 0 ? encodedLength : buffered.readUInt16BE(2)
+          const headerLength = 2 + extendedLength + 4
+          if (buffered.byteLength < headerLength + payloadLength) break
+          const mask = buffered.subarray(
+            2 + extendedLength,
+            headerLength,
+          )
+          const payload = Buffer.alloc(payloadLength)
+          for (let index = 0; index < payloadLength; index += 1) {
+            payload[index] =
+              buffered[headerLength + index]! ^ mask[index % 4]!
+          }
+          buffered = buffered.subarray(headerLength + payloadLength)
+          const message = JSON.parse(
+            payload.toString('utf8'),
+          ) as LocalCodexJsonRpcRequest
+          if (message.method === 'initialize') {
+            send({
+              id: message.id,
+              result: {
+                userAgent: 'codex-cli/0.146.0',
+                platformFamily: 'unix',
+                platformOs: 'darwin',
+              },
+            })
+          } else if (message.method === 'thread/start') {
+            send({
+              id: message.id,
+              result: {
+                thread: {
+                  id: 'unix-thread-1',
+                  sessionId: 'unix-thread-1',
+                  ephemeral: true,
+                },
+                model: 'gpt-local-test',
+                modelProvider: 'codex-subscription',
+              },
+            })
+          } else if (message.method === 'turn/start') {
+            send({
+              id: message.id,
+              result: { turn: { id: 'unix-turn-1', status: 'inProgress' } },
+            })
+            send({
+              method: 'item/completed',
+              params: {
+                threadId: 'unix-thread-1',
+                turnId: 'unix-turn-1',
+                item: {
+                  type: 'agentMessage',
+                  phase: 'final_answer',
+                  text: validOutput(request),
+                },
+              },
+            })
+            send({
+              method: 'turn/completed',
+              params: {
+                threadId: 'unix-thread-1',
+                turn: {
+                  id: 'unix-turn-1',
+                  status: 'completed',
+                  items: [],
+                  error: null,
+                },
+              },
+            })
+          }
+        }
+      })
+    })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(socketPath, resolve)
+      })
+      await chmod(socketPath, 0o600)
+      const client = createLocalCodexReconciliationClient(
+        config(createOwnerLocalUnixSocketTransport, {
+          endpoint: `unix://${socketPath}`,
+        }),
+      )
+      await expect(client.reconcile(request)).resolves.toMatchObject({
+        selections: [
+          { decisionId: 'reading-order', candidateId: 'candidate-1' },
+        ],
+        receipt: {
+          status: 'accepted',
+          threadSha256: sha256('unix-thread-1'),
+          turnSha256: sha256('unix-turn-1'),
+        },
+      })
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the exact app-server handshake, isolated ephemeral thread, and read-only turn fields', async () => {
+    const request = reconciliationRequest()
+    const transport = new FakeTransport({ output: validOutput(request) })
+    const client = createLocalCodexReconciliationClient(config(() => transport))
+
+    await expect(client.reconcile(request)).resolves.toMatchObject({
+      selections: [{ decisionId: 'reading-order', candidateId: 'candidate-1' }],
+    })
+
+    expect(transport.requests.map(({ method }) => method)).toEqual([
+      'initialize',
+      'thread/start',
+      'turn/start',
+    ])
+    expect(transport.notifications).toEqual([
+      { method: 'initialized', params: {} },
+    ])
+    expect(transport.requests[0]!.params).toMatchObject({
+      clientInfo: {
+        name: 'erniesg_struct_reconciliation',
+        title: 'Ernie SG STRUCT Reconciliation',
+        version: '1.0.0',
+      },
+      capabilities: {
+        experimentalApi: false,
+        requestAttestation: false,
+        optOutNotificationMethods: expect.arrayContaining([
+          'item/reasoning/textDelta',
+          'item/agentMessage/delta',
+        ]),
+      },
+    })
+    expect(transport.requests[1]!.params).toEqual({
+      model: 'gpt-local-test',
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      ephemeral: true,
+      serviceName: 'erniesg_struct_reconciliation',
+    })
+    const turn = transport.requests[2]!.params!
+    expect(turn).toMatchObject({
+      threadId: 'thread-1',
+      model: 'gpt-local-test',
+      effort: 'high',
+      approvalPolicy: 'never',
+      sandboxPolicy: { type: 'readOnly', networkAccess: false },
+    })
+    expect(turn.sandboxPolicy).toEqual({
+      type: 'readOnly',
+      networkAccess: false,
+    })
+    expect((turn.input as unknown[])[0]).toMatchObject({
+      type: 'text',
+      text_elements: [],
+    })
+    expect((turn.input as unknown[])[1]).toMatchObject({
+      type: 'image',
+      url: expect.stringMatching(/^data:image\/png;base64,/u),
+    })
+    expect(turn.outputSchema).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        graphSha256: { type: 'string', const: request.graphSha256 },
+        candidateSetSha256: {
+          type: 'string',
+          const: request.candidateSetSha256,
+        },
+      },
+    })
+    expect(transport.closed).toBe(1)
+  })
+
+  it('binds the validated source graph and exact candidate set', async () => {
+    const valid = reconciliationRequest()
+    const make = (request: LocalCodexReconciliationRequest) =>
+      createLocalCodexReconciliationClient(
+        config(() => new FakeTransport({ output: validOutput(request) })),
+      )
+
+    await expect(
+      make({ ...valid, graphSha256: SHA_B }).reconcile({
+        ...valid,
+        graphSha256: SHA_B,
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_GRAPH_HASH_MISMATCH')
+    await expect(
+      make({ ...valid, candidateSetSha256: SHA_B }).reconcile({
+        ...valid,
+        candidateSetSha256: SHA_B,
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_CANDIDATE_SET_HASH_MISMATCH')
+    await expect(
+      make(valid).reconcile({
+        ...valid,
+        decisions: [
+          { decisionId: 'reading-order', candidateIds: ['not-in-graph'] },
+        ],
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+  })
+
+  it('rejects independently observed model or provider identity drift', async () => {
+    const request = reconciliationRequest()
+    for (const transport of [
+      new FakeTransport({
+        output: validOutput(request),
+        modelId: 'rerouted-model',
+      }),
+      new FakeTransport({
+        output: validOutput(request),
+        providerId: 'hosted-provider',
+      }),
+    ]) {
+      const client = createLocalCodexReconciliationClient(
+        config(() => transport),
+      )
+      await expect(client.reconcile(request)).rejects.toThrow(
+        'LOCAL_CODEX_MODEL_IDENTITY_MISMATCH',
+      )
+    }
+  })
+
+  it('requires a failed prior comparator receipt and matched source/EPUB crop provenance', async () => {
+    const request = reconciliationRequest()
+    const make = () =>
+      createLocalCodexReconciliationClient(
+        config(() => new FakeTransport({ output: validOutput(request) })),
+      )
+    const { comparisonEvidence: _comparisonEvidence, ...withoutComparison } =
+      request
+    await expect(
+      make().reconcile(withoutComparison as LocalCodexReconciliationRequest),
+    ).rejects.toThrow('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+    await expect(
+      make().reconcile({
+        ...request,
+        comparisonEvidence: {
+          ...request.comparisonEvidence,
+          traceSha256: '0'.repeat(64),
+        },
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+    await expect(
+      make().reconcile({
+        ...request,
+        renders: request.renders.filter(
+          ({ provenance }) => provenance.kind === 'source-pdf',
+        ),
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_SOURCE_EPUB_CROPS_REQUIRED')
+  })
+
+  it('rejects mismatched source/EPUB crop bytes, boxes, and artifact provenance', async () => {
+    const request = reconciliationRequest()
+    const attempts = [
+      {
+        ...request,
+        renders: request.renders.map((render, index) =>
+          index === 0
+            ? {
+                ...render,
+                dataBase64: Buffer.from('invented-crop').toString('base64'),
+                sha256: sha256(Buffer.from('invented-crop')),
+              }
+            : render,
+        ),
+      },
+      {
+        ...request,
+        attemptId: 'attempt-altered-crop-box',
+        renders: request.renders.map((render, index) =>
+          index === 0
+            ? { ...render, box: { ...render.box, width: 0.3 } }
+            : render,
+        ),
+      },
+      {
+        ...request,
+        attemptId: 'attempt-altered-render-provenance',
+        renders: request.renders.map((render, index) =>
+          index === 1 && render.provenance.kind === 'rendered-epub'
+            ? {
+                ...render,
+                provenance: {
+                  ...render.provenance,
+                  screenshotSha256: SHA_B,
+                },
+              }
+            : render,
+        ),
+      },
+    ]
+    for (const attempt of attempts) {
+      const client = createLocalCodexReconciliationClient(
+        config(
+          () =>
+            new FakeTransport({
+              output: validOutput(attempt),
+            }),
+        ),
+      )
+      await expect(
+        client.reconcile(attempt as LocalCodexReconciliationRequest),
+      ).rejects.toThrow(/LOCAL_CODEX_(?:RENDER_CROP_MISMATCH|INVALID_RENDER_EVIDENCE)/u)
+    }
+  })
+
+  it('replays an identical attempt without another transport call and rejects drift', async () => {
+    const request = reconciliationRequest()
+    const transports: FakeTransport[] = []
+    const client = createLocalCodexReconciliationClient(
+      config(() => {
+        const transport = new FakeTransport({ output: validOutput(request) })
+        transports.push(transport)
+        return transport
+      }),
+    )
+    const first = client.reconcile(request)
+    const replay = client.reconcile(request)
+    expect(replay).toBe(first)
+    await expect(first).resolves.toEqual(await replay)
+    expect(transports).toHaveLength(1)
+
+    await expect(
+      client.reconcile({
+        ...request,
+        decisions: [
+          {
+            decisionId: 'caption-association',
+            candidateIds: ['candidate-1', 'candidate-2'],
+          },
+        ],
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_IDEMPOTENCY_CONFLICT')
+    expect(transports).toHaveLength(1)
+  })
+
+  it('creates a distinct transport and thread for every document-attempt session', async () => {
+    const request = reconciliationRequest()
+    const transports: FakeTransport[] = []
+    const client = createLocalCodexReconciliationClient(
+      config((_endpoint, sessionSha256) => {
+        const transport = new FakeTransport({
+          output: validOutput(request),
+          threadId: `thread-${sessionSha256.slice(0, 12)}`,
+          turnId: `turn-${transports.length + 1}`,
+        })
+        transports.push(transport)
+        return transport
+      }),
+    )
+    await client.reconcile(request)
+    const second = { ...request, attemptId: 'attempt-2' }
+    await client.reconcile(second)
+    expect(transports).toHaveLength(2)
+    expect(new Set(transports.map(({ threadId }) => threadId)).size).toBe(
+      transports.length,
+    )
+  })
+
+  it('rejects reuse of one transport across separate attempts', async () => {
+    const request = reconciliationRequest()
+    const transport = new FakeTransport({ output: validOutput(request) })
+    const client = createLocalCodexReconciliationClient(config(() => transport))
+    await client.reconcile(request)
+    await expect(
+      client.reconcile({ ...request, attemptId: 'attempt-2' }),
+    ).rejects.toThrow('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+  })
+
+  it('interrupts an in-flight turn on timeout and closes the transport', async () => {
+    const request = reconciliationRequest()
+    const transport = new FakeTransport({
+      output: validOutput(request),
+      stall: true,
+    })
+    const client = createLocalCodexReconciliationClient(
+      config(() => transport, { timeoutMs: 15 }),
+    )
+
+    await expect(client.reconcile(request)).rejects.toThrow(
+      'LOCAL_CODEX_TIMEOUT',
+    )
+    expect(transport.interrupted).toBe(1)
+    expect(transport.requests.at(-1)).toMatchObject({
+      method: 'turn/interrupt',
+      params: { threadId: 'thread-1', turnId: 'turn-1' },
+    })
+    expect(transport.closed).toBe(1)
+  })
+
+  it.each([
+    {
+      name: 'unlisted candidate',
+      mutate: (value: Record<string, unknown>) => {
+        ;(value.decisions as Record<string, unknown>[])[0]!.candidateId =
+          'invented-candidate'
+      },
+    },
+    {
+      name: 'invented explanation',
+      mutate: (value: Record<string, unknown>) => {
+        value.explanation = 'invented source claim'
+      },
+    },
+    {
+      name: 'stale graph hash',
+      mutate: (value: Record<string, unknown>) => {
+        value.graphSha256 = SHA_B
+      },
+    },
+    {
+      name: 'duplicate decision',
+      mutate: (value: Record<string, unknown>) => {
+        value.decisions = [
+          ...(value.decisions as unknown[]),
+          ...(value.decisions as unknown[]),
+        ]
+      },
+    },
+  ])(
+    'rejects candidate-reference response violation: $name',
+    async ({ mutate }) => {
+      const request = reconciliationRequest()
+      const response = JSON.parse(validOutput(request)) as Record<
+        string,
+        unknown
+      >
+      mutate(response)
+      const client = createLocalCodexReconciliationClient(
+        config(() => new FakeTransport({ output: JSON.stringify(response) })),
+      )
+      await expect(client.reconcile(request)).rejects.toThrow(
+        'LOCAL_CODEX_INVALID_RESPONSE',
+      )
+    },
+  )
+
+  it('returns a redacted deterministic receipt with only identity hashes', async () => {
+    const graph = graphFixture('private-document-name.pdf')
+    const base = reconciliationRequest(graph)
+    const request: LocalCodexReconciliationRequest = {
+      ...base,
+      attemptId: 'private-attempt-name',
+      renders: [
+        {
+          id: 'page-render-1',
+          mimeType: 'image/png',
+          dataBase64: SOURCE_CROP_BYTES.toString('base64'),
+          sha256: sha256(SOURCE_CROP_BYTES),
+          page: 1,
+          box: { x: 0.1, y: 0.1, width: 0.2, height: 0.05 },
+          candidateIds: ['candidate-1', 'candidate-2'],
+          provenance: {
+            kind: 'source-pdf',
+            sourcePdfSha256: graph.source.sha256,
+            sourcePageRenderSha256: sha256(SOURCE_RENDER_BYTES),
+            failureId: base.comparisonEvidence.comparator.failures[0]!.id,
+          },
+        },
+        base.renders.find(
+          ({ provenance }) => provenance.kind === 'rendered-epub',
+        )!,
+      ],
+    }
+    const transport = new FakeTransport({
+      output: validOutput(request),
+      threadId: 'private-thread-id',
+      turnId: 'private-turn-id',
+    })
+    const client = createLocalCodexReconciliationClient(config(() => transport))
+    const result = await client.reconcile(request)
+    const receipt = JSON.stringify(result.receipt)
+    const turnPayload = JSON.stringify(
+      transport.requests.find(({ method }) => method === 'turn/start')?.params,
+    )
+
+    expect(result.receipt.identities).toEqual({
+      endpointSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      serverSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      toolSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      modelSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      promptSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      renderArtifactResolverSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      observedModelSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    })
+    expect(result.receipt).toMatchObject({
+      comparisonEvidenceSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      cropEvidenceSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      counts: {
+        decisionCount: 1,
+        candidateCount: 2,
+        renderCount: 2,
+        sourceCropCount: 1,
+        epubCropCount: 1,
+      },
+    })
+    for (const forbidden of [
+      SOURCE_TEXT,
+      RAW_REASONING,
+      '/private/paper.pdf',
+      request.documentId,
+      request.attemptId,
+      request.renders![0]!.dataBase64,
+      'ws://127.0.0.1:4500',
+      'gpt-local-test',
+      'private-thread-id',
+      'private-turn-id',
+      'Choose only a source-grounded candidate reference.',
+      'credential',
+      'apiKey',
+    ]) {
+      expect(receipt).not.toContain(forbidden)
+    }
+    for (const forbidden of [
+      '/private/paper.pdf',
+      request.documentId,
+      request.attemptId,
+    ]) {
+      expect(turnPayload).not.toContain(forbidden)
+    }
+    expect(turnPayload).toContain(SOURCE_TEXT)
+    expect(turnPayload).toContain(request.renders![0]!.dataBase64)
+    expect(turnPayload).toContain('candidate-1')
+    expect(turnPayload).toContain(request.renders![0]!.sha256)
+    expect(receipt).not.toMatch(
+      /(?:sourceText|rawText|reasoning|image|path|credential|apiKey|token)/iu,
+    )
+    expect(Object.isFrozen(result)).toBe(true)
+    expect(Object.isFrozen(result.receipt)).toBe(true)
+  })
+
+  it('permits a schema-bound abstention without accepting invented content', async () => {
+    const request = reconciliationRequest()
+    const output = JSON.stringify({
+      schemaVersion: '1.0.0',
+      graphSha256: request.graphSha256,
+      candidateSetSha256: request.candidateSetSha256,
+      decisions: [{ decisionId: 'reading-order', abstain: true }],
+    })
+    const client = createLocalCodexReconciliationClient(
+      config(() => new FakeTransport({ output })),
+    )
+    await expect(client.reconcile(request)).resolves.toMatchObject({
+      selections: [{ decisionId: 'reading-order', abstain: true }],
+    })
+  })
+
+  it('rejects oversized or whole-page evidence instead of widening the local trace', async () => {
+    const graph = graphFixture()
+    const request = reconciliationRequest(graph)
+    const large = Buffer.alloc(512 * 1024 + 1, 1)
+    const client = createLocalCodexReconciliationClient(
+      config(() => new FakeTransport({ output: validOutput(request) })),
+    )
+    await expect(
+      client.reconcile({
+        ...request,
+        renders: [
+          {
+            id: 'oversized-crop',
+            mimeType: 'image/png',
+            dataBase64: large.toString('base64'),
+            sha256: sha256(large),
+            page: 1,
+            box: { x: 0, y: 0, width: 0.2, height: 0.2 },
+            candidateIds: ['candidate-1'],
+            provenance: {
+              kind: 'source-pdf',
+              sourcePdfSha256: graph.source.sha256,
+              sourcePageRenderSha256: sha256(SOURCE_RENDER_BYTES),
+              failureId:
+                request.comparisonEvidence.comparator.failures[0]!.id,
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+
+    const small = Buffer.from('crop')
+    await expect(
+      client.reconcile({
+        ...request,
+        attemptId: 'attempt-whole-page',
+        renders: [
+          {
+            id: 'whole-page',
+            mimeType: 'image/png',
+            dataBase64: small.toString('base64'),
+            sha256: sha256(small),
+            page: 1,
+            box: { x: 0, y: 0, width: 1, height: 1 },
+            candidateIds: ['candidate-1'],
+            provenance: {
+              kind: 'source-pdf',
+              sourcePdfSha256: graph.source.sha256,
+              sourcePageRenderSha256: sha256(SOURCE_RENDER_BYTES),
+              failureId:
+                request.comparisonEvidence.comparator.failures[0]!.id,
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  })
+})

--- a/src/research/local-codex-reconciliation.ts
+++ b/src/research/local-codex-reconciliation.ts
@@ -1,0 +1,2407 @@
+import { createHash, randomBytes } from 'node:crypto'
+import { lstat } from 'node:fs/promises'
+import { createConnection, type Socket } from 'node:net'
+import { posix } from 'node:path'
+import sharp from 'sharp'
+import {
+  hashTraceValue,
+  parseReconstructionAttemptTrace,
+  type ReconstructionAttemptTrace,
+} from './reconstruction-attempt-trace'
+import {
+  PDF_EVIDENCE_OBSERVATION_CATEGORIES,
+  readSourceEvidenceGraph,
+  sourceEvidenceGraphSha256,
+  type SourceEvidenceGraph,
+} from './source-evidence-graph'
+
+const RECEIPT_SCHEMA_VERSION = '1.0.0'
+const RESPONSE_SCHEMA_VERSION = '1.0.0'
+const SHA256 = /^[a-f0-9]{64}$/u
+const API_KEY_FIELD =
+  /(?:api.?key|access.?token|refresh.?token|authorization|bearer|credential|password|secret|cookie)/iu
+const REDIRECT_FIELD = /redirect/iu
+const API_KEY_VALUE = /(?:\bBearer\s+\S+|\bsk-(?:proj-)?[A-Za-z0-9_-]{8,})/u
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/u
+const MAX_ID_LENGTH = 512
+const DEFAULT_TIMEOUT_MS = 120_000
+const DEFAULT_INTERRUPT_TIMEOUT_MS = 1_000
+const DEFAULT_MAX_REQUEST_BYTES = 2 * 1024 * 1024
+const MAX_AGENT_RESPONSE_BYTES = 1024 * 1024
+const MAX_TRACE_DECISIONS = 32
+const MAX_TRACE_CANDIDATES = 128
+const MAX_TRACE_SNIPPET_BYTES = 8 * 1024
+const MAX_CROP_COUNT = 8
+const MAX_CROP_BYTES = 512 * 1024
+const MAX_CROP_AREA = 0.25
+const MAX_SOCKET_MESSAGE_BYTES = 2 * 1024 * 1024
+const PRIVATE_PAYLOAD_FIELD =
+  /(?:path|file(?:name)?|directory|folder|uri|base64|bytes|credential|secret|token|password|cookie)/iu
+
+const REDACTED_NOTIFICATION_METHODS = Object.freeze([
+  'item/agentMessage/delta',
+  'item/reasoning/summaryTextDelta',
+  'item/reasoning/summaryPartAdded',
+  'item/reasoning/textDelta',
+  'item/commandExecution/outputDelta',
+  'turn/diff/updated',
+  'turn/plan/updated',
+  'thread/tokenUsage/updated',
+])
+
+type JsonPrimitive = string | number | boolean | null
+export type LocalCodexJsonValue =
+  | JsonPrimitive
+  | readonly LocalCodexJsonValue[]
+  | { readonly [key: string]: LocalCodexJsonValue }
+
+export type LocalCodexEndpoint = Readonly<{
+  kind: 'loopback-websocket' | 'unix-socket'
+  canonical: string
+}>
+
+export type LocalCodexJsonRpcRequest = Readonly<{
+  id: number
+  method: string
+  params?: Readonly<Record<string, unknown>>
+}>
+
+export type LocalCodexJsonRpcNotification = Readonly<{
+  method: string
+  params: Readonly<Record<string, unknown>>
+}>
+
+export interface LocalCodexJsonRpcTransport {
+  /** The endpoint actually used for the connection. */
+  readonly endpoint: string
+  /** A transport must never follow an HTTP/WebSocket redirect. */
+  readonly redirected?: boolean
+  readonly finalEndpoint?: string
+  request(
+    message: LocalCodexJsonRpcRequest,
+    options: Readonly<{ signal: AbortSignal }>,
+  ): Promise<unknown>
+  notify(
+    message: LocalCodexJsonRpcNotification,
+    options: Readonly<{ signal: AbortSignal }>,
+  ): Promise<void> | void
+  nextMessage(options: Readonly<{ signal: AbortSignal }>): Promise<unknown>
+  close?(): Promise<void> | void
+}
+
+export type LocalCodexTransportFactory = (
+  endpoint: LocalCodexEndpoint,
+  isolatedSessionSha256: string,
+) => LocalCodexJsonRpcTransport | Promise<LocalCodexJsonRpcTransport>
+
+export type LocalCodexToolIdentity = Readonly<{
+  id: string
+  version: string
+  executableSha256?: string
+}>
+
+export type LocalCodexModelIdentity = Readonly<{
+  providerId: string
+  modelId: string
+  modelVersion: string
+  modelDigest?: string
+  reasoningEffort?: string
+}>
+
+export type LocalCodexPromptIdentity = Readonly<{
+  id: string
+  version: string
+  instructions: string
+}>
+
+export type LocalCodexReconciliationClientConfig = Readonly<{
+  endpoint: string
+  transportFactory: LocalCodexTransportFactory
+  timeoutMs?: number
+  interruptTimeoutMs?: number
+  maxRequestBytes?: number
+  expectedServerIdentitySha256?: string
+  clientIdentity?: Readonly<{
+    name: string
+    title: string
+    version: string
+  }>
+  toolIdentity: LocalCodexToolIdentity
+  modelIdentity: LocalCodexModelIdentity
+  promptIdentity: LocalCodexPromptIdentity
+  renderArtifactResolver: LocalCodexRenderArtifactResolver
+}>
+
+export type LocalCodexRenderArtifactResolver = Readonly<{
+  identity: Readonly<{
+    id: string
+    version: string
+    configurationSha256: string
+  }>
+  resolve: (
+    request: Readonly<{
+      traceSha256: string
+      kind: 'source-page-render' | 'epub-screenshot'
+      logicalId: string
+      artifact: Readonly<{ sha256: string; byteLength: number }>
+    }>,
+  ) => unknown | Promise<unknown>
+}>
+
+export type LocalCodexDecisionPoint = Readonly<{
+  decisionId: string
+  candidateIds: readonly string[]
+}>
+
+export type LocalCodexPriorComparisonEvidence = Readonly<{
+  schemaVersion: '1.0.0'
+  status: 'failed'
+  sourcePdfSha256: string
+  structSha256: string
+  epubSha256: string
+  renderReceiptSha256: string
+  comparatorReceiptSha256: string
+  failures: readonly Readonly<{
+    idSha256: string
+    check: import('./source-evidence-graph').PdfEvidenceObservationCategory
+    sourceRegionIds: readonly string[]
+    expectedSha256: string
+    actualSha256: string
+  }>[]
+}>
+
+export type LocalCodexRenderProvenance =
+  | Readonly<{
+      kind: 'source-pdf'
+      sourcePdfSha256: string
+      sourcePageRenderSha256: string
+      failureId: string
+    }>
+  | Readonly<{
+      kind: 'rendered-epub'
+      epubSha256: string
+      renderReceiptSha256: string
+      spineHref: string
+      anchorId: string
+      domSha256: string
+      screenshotSha256: string
+      screenshotId: string
+      failureId: string
+    }>
+
+export type LocalCodexRenderEvidence = Readonly<{
+  id: string
+  mimeType: 'image/png' | 'image/jpeg' | 'image/webp'
+  dataBase64: string
+  sha256: string
+  page: number
+  box: Readonly<{ x: number; y: number; width: number; height: number }>
+  candidateIds: readonly string[]
+  provenance: LocalCodexRenderProvenance
+}>
+
+export type LocalCodexReconciliationRequest = Readonly<{
+  documentId: string
+  attemptId: string
+  evidenceGraph: SourceEvidenceGraph
+  graphSha256: string
+  candidateSetSha256: string
+  decisions: readonly LocalCodexDecisionPoint[]
+  comparisonEvidence: ReconstructionAttemptTrace
+  renders: readonly LocalCodexRenderEvidence[]
+}>
+
+export type LocalCodexReconciliationSelection =
+  | Readonly<{ decisionId: string; candidateId: string }>
+  | Readonly<{ decisionId: string; abstain: true }>
+
+export type LocalCodexReconciliationReceipt = Readonly<{
+  schemaVersion: typeof RECEIPT_SCHEMA_VERSION
+  status: 'accepted'
+  documentIdSha256: string
+  attemptIdSha256: string
+  isolatedSessionSha256: string
+  graphSha256: string
+  candidateSetSha256: string
+  requestSha256: string
+  responseSha256: string
+  selectionSetSha256: string
+  comparisonEvidenceSha256: string
+  cropEvidenceSha256: string
+  threadSha256: string
+  turnSha256: string
+  identities: Readonly<{
+    endpointSha256: string
+    serverSha256: string
+    toolSha256: string
+    modelSha256: string
+    promptSha256: string
+    renderArtifactResolverSha256: string
+    observedModelSha256: string
+  }>
+  counts: Readonly<{
+    decisionCount: number
+    candidateCount: number
+    renderCount: number
+    sourceCropCount: number
+    epubCropCount: number
+  }>
+}>
+
+export type LocalCodexReconciliationResult = Readonly<{
+  selections: readonly LocalCodexReconciliationSelection[]
+  receipt: LocalCodexReconciliationReceipt
+}>
+
+type PreparedRequest = Readonly<{
+  request: LocalCodexReconciliationRequest
+  decisions: readonly LocalCodexDecisionPoint[]
+  candidateIds: readonly string[]
+  renders: readonly LocalCodexRenderEvidence[]
+  comparisonEvidence: LocalCodexPriorComparisonEvidence
+  priorTrace: ReconstructionAttemptTrace
+  traceBundle: LocalCodexJsonValue
+  isolatedSessionSha256: string
+  requestSha256: string
+  fingerprint: string
+}>
+
+type AttemptEntry = Readonly<{
+  fingerprint: string
+  promise: Promise<LocalCodexReconciliationResult>
+}>
+
+type Deadline = Readonly<{
+  signal: AbortSignal
+  reason: () => 'timeout' | 'aborted' | null
+  dispose: () => void
+}>
+
+export class LocalCodexReconciliationError extends Error {
+  readonly code: string
+
+  constructor(code: string) {
+    super(code)
+    this.name = 'LocalCodexReconciliationError'
+    this.code = code
+  }
+}
+
+function invalid(code: string): never {
+  throw new LocalCodexReconciliationError(code)
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+) {
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return (
+    actual.length === wanted.length &&
+    actual.every((key, index) => key === wanted[index])
+  )
+}
+
+function boundedId(value: unknown, code: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_ID_LENGTH ||
+    CONTROL_CHARACTER.test(value)
+  ) {
+    invalid(code)
+  }
+  return value
+}
+
+function digest(value: string | Uint8Array) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function canonicalJson(value: unknown, seen = new WeakSet<object>()): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) invalid('LOCAL_CODEX_NON_CANONICAL_VALUE')
+    return JSON.stringify(Object.is(value, -0) ? 0 : value)
+  }
+  if (typeof value !== 'object') invalid('LOCAL_CODEX_NON_CANONICAL_VALUE')
+  if (seen.has(value)) invalid('LOCAL_CODEX_NON_CANONICAL_VALUE')
+  seen.add(value)
+  try {
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => canonicalJson(item, seen)).join(',')}]`
+    }
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) {
+      invalid('LOCAL_CODEX_NON_CANONICAL_VALUE')
+    }
+    const typed = value as Record<string, unknown>
+    return `{${Object.keys(typed)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(typed[key], seen)}`)
+      .join(',')}}`
+  } finally {
+    seen.delete(value)
+  }
+}
+
+function canonicalSha256(value: unknown) {
+  return digest(canonicalJson(value))
+}
+
+function sha256(value: unknown, code: string) {
+  if (typeof value !== 'string' || !SHA256.test(value)) invalid(code)
+  return value
+}
+
+function finiteInteger(
+  value: unknown,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  code: string,
+) {
+  const resolved = value === undefined ? fallback : value
+  if (
+    typeof resolved !== 'number' ||
+    !Number.isSafeInteger(resolved) ||
+    resolved < minimum ||
+    resolved > maximum
+  ) {
+    invalid(code)
+  }
+  return resolved
+}
+
+function assertSafeConfiguration(value: unknown, path = 'config') {
+  if (value === null || value === undefined) return
+  if (typeof value === 'string') {
+    if (API_KEY_VALUE.test(value)) invalid('LOCAL_CODEX_API_KEY_FORBIDDEN')
+    return
+  }
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'function'
+  ) {
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertSafeConfiguration(item, `${path}[${index}]`),
+    )
+    return
+  }
+  if (!record(value)) invalid('LOCAL_CODEX_INVALID_CONFIGURATION')
+  for (const [key, item] of Object.entries(value)) {
+    if (API_KEY_FIELD.test(key)) invalid('LOCAL_CODEX_API_KEY_FORBIDDEN')
+    if (REDIRECT_FIELD.test(key)) invalid('LOCAL_CODEX_REDIRECT_FORBIDDEN')
+    assertSafeConfiguration(item, `${path}.${key}`)
+  }
+}
+
+function unixEndpoint(endpoint: string): LocalCodexEndpoint {
+  if (!endpoint.startsWith('unix:///'))
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  const path = endpoint.slice('unix://'.length)
+  if (
+    path.length <= 1 ||
+    path.startsWith('//') ||
+    path.includes('?') ||
+    path.includes('#') ||
+    path.includes('%') ||
+    path.includes('\\') ||
+    CONTROL_CHARACTER.test(path) ||
+    !posix.isAbsolute(path) ||
+    posix.normalize(path) !== path
+  ) {
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  }
+  return Object.freeze({ kind: 'unix-socket', canonical: `unix://${path}` })
+}
+
+export function validateLocalCodexEndpoint(
+  endpoint: unknown,
+): LocalCodexEndpoint {
+  if (
+    typeof endpoint !== 'string' ||
+    endpoint.length === 0 ||
+    endpoint.length > 4096 ||
+    CONTROL_CHARACTER.test(endpoint) ||
+    endpoint.includes('\\')
+  ) {
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  }
+  if (endpoint.startsWith('unix:')) return unixEndpoint(endpoint)
+
+  let parsed: URL
+  try {
+    parsed = new URL(endpoint)
+  } catch {
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  }
+  if (
+    parsed.protocol !== 'ws:' ||
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    parsed.search !== '' ||
+    parsed.hash !== '' ||
+    (parsed.pathname !== '' && parsed.pathname !== '/')
+  ) {
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  }
+  const hostname = parsed.hostname.toLowerCase()
+  const ipv4 = hostname.match(
+    /^127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$/u,
+  )
+  const loopbackIpv4 =
+    ipv4 !== null &&
+    ipv4.slice(1).every((octet) => Number.parseInt(octet, 10) <= 255)
+  if (
+    !loopbackIpv4 &&
+    hostname !== '[::1]' &&
+    hostname !== '::1' &&
+    hostname !== 'localhost'
+  ) {
+    invalid('LOCAL_CODEX_ENDPOINT_FORBIDDEN')
+  }
+  return Object.freeze({
+    kind: 'loopback-websocket',
+    canonical: parsed.href,
+  })
+}
+
+export const parseLocalCodexEndpoint = validateLocalCodexEndpoint
+
+type PendingSocketRequest = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  signal: AbortSignal
+  abort: () => void
+}
+
+type PendingSocketMessage = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  signal: AbortSignal
+  abort: () => void
+}
+
+class OwnerLocalUnixSocketTransport implements LocalCodexJsonRpcTransport {
+  readonly endpoint: string
+  private readonly socket: Socket
+  private readonly pendingRequests = new Map<number, PendingSocketRequest>()
+  private readonly messages: unknown[] = []
+  private readonly messageWaiters: PendingSocketMessage[] = []
+  private buffered = Buffer.alloc(0)
+  private fragmented = Buffer.alloc(0)
+  private fragmentedOpcode: number | null = null
+  private stopped: Error | null = null
+
+  constructor(endpoint: string, socket: Socket, initialData: Buffer) {
+    this.endpoint = endpoint
+    this.socket = socket
+    socket.on('data', (chunk: Buffer) => this.receive(chunk))
+    socket.once('error', (error) => this.stop(error))
+    socket.once('close', () =>
+      this.stop(new Error('LOCAL_CODEX_UNIX_SOCKET_CLOSED')),
+    )
+    if (initialData.byteLength > 0) this.receive(initialData)
+  }
+
+  private stop(error: Error) {
+    if (this.stopped) return
+    this.stopped = error
+    for (const pending of this.pendingRequests.values()) {
+      pending.signal.removeEventListener('abort', pending.abort)
+      pending.reject(error)
+    }
+    this.pendingRequests.clear()
+    for (const waiter of this.messageWaiters.splice(0)) {
+      waiter.signal.removeEventListener('abort', waiter.abort)
+      waiter.reject(error)
+    }
+  }
+
+  private invalidFrame(message: string) {
+    this.socket.destroy(new Error(message))
+  }
+
+  private receive(chunk: Buffer) {
+    if (this.stopped) return
+    this.buffered = Buffer.concat([this.buffered, chunk])
+    if (this.buffered.byteLength > MAX_SOCKET_MESSAGE_BYTES * 2 + 16) {
+      this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_MESSAGE_TOO_LARGE')
+      return
+    }
+    for (;;) {
+      if (this.buffered.byteLength < 2) return
+      const first = this.buffered[0]!
+      const second = this.buffered[1]!
+      const final = (first & 0x80) !== 0
+      const opcode = first & 0x0f
+      if ((first & 0x70) !== 0 || (second & 0x80) !== 0) {
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+        return
+      }
+      let headerLength = 2
+      let payloadLength = second & 0x7f
+      if (payloadLength === 126) {
+        if (this.buffered.byteLength < 4) return
+        payloadLength = this.buffered.readUInt16BE(2)
+        headerLength = 4
+      } else if (payloadLength === 127) {
+        if (this.buffered.byteLength < 10) return
+        const wideLength = this.buffered.readBigUInt64BE(2)
+        if (wideLength > BigInt(MAX_SOCKET_MESSAGE_BYTES)) {
+          this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_MESSAGE_TOO_LARGE')
+          return
+        }
+        payloadLength = Number(wideLength)
+        headerLength = 10
+      }
+      if (payloadLength > MAX_SOCKET_MESSAGE_BYTES) {
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_MESSAGE_TOO_LARGE')
+        return
+      }
+      if (this.buffered.byteLength < headerLength + payloadLength) return
+      const payload = this.buffered.subarray(
+        headerLength,
+        headerLength + payloadLength,
+      )
+      this.buffered = this.buffered.subarray(headerLength + payloadLength)
+      if (opcode >= 0x8) {
+        if (!final || payloadLength > 125) {
+          this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+          return
+        }
+        if (opcode === 0x8) {
+          this.socket.destroy()
+          return
+        }
+        if (opcode === 0x9) {
+          this.socket.write(webSocketFrame(payload, 0x0a))
+          continue
+        }
+        if (opcode === 0x0a) continue
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+        return
+      }
+      if (opcode === 0x0) {
+        if (this.fragmentedOpcode === null) {
+          this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+          return
+        }
+        this.fragmented = Buffer.concat([this.fragmented, payload])
+      } else if (opcode === 0x1) {
+        if (this.fragmentedOpcode !== null) {
+          this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+          return
+        }
+        this.fragmentedOpcode = opcode
+        this.fragmented = Buffer.from(payload)
+      } else {
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_WEBSOCKET_FRAME')
+        return
+      }
+      if (this.fragmented.byteLength > MAX_SOCKET_MESSAGE_BYTES) {
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_MESSAGE_TOO_LARGE')
+        return
+      }
+      if (!final) continue
+      const encoded = this.fragmented
+      this.fragmented = Buffer.alloc(0)
+      this.fragmentedOpcode = null
+      let message: unknown
+      try {
+        message = JSON.parse(encoded.toString('utf8'))
+      } catch {
+        this.invalidFrame('LOCAL_CODEX_UNIX_SOCKET_INVALID_JSON')
+        return
+      }
+      if (
+        record(message) &&
+        typeof message.id === 'number' &&
+        Number.isSafeInteger(message.id) &&
+        !Object.hasOwn(message, 'method')
+      ) {
+        const pending = this.pendingRequests.get(message.id)
+        if (pending) {
+          this.pendingRequests.delete(message.id)
+          pending.signal.removeEventListener('abort', pending.abort)
+          pending.resolve(message)
+          continue
+        }
+      }
+      const waiter = this.messageWaiters.shift()
+      if (waiter) {
+        waiter.signal.removeEventListener('abort', waiter.abort)
+        waiter.resolve(message)
+      } else {
+        this.messages.push(message)
+      }
+    }
+  }
+
+  private send(message: unknown, signal: AbortSignal) {
+    if (this.stopped) return Promise.reject(this.stopped)
+    if (signal.aborted)
+      return Promise.reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+    const encoded = Buffer.from(canonicalJson(message), 'utf8')
+    if (encoded.byteLength > MAX_SOCKET_MESSAGE_BYTES) {
+      return Promise.reject(
+        new Error('LOCAL_CODEX_UNIX_SOCKET_MESSAGE_TOO_LARGE'),
+      )
+    }
+    return new Promise<void>((resolve, reject) => {
+      const abort = () => reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+      signal.addEventListener('abort', abort, { once: true })
+      this.socket.write(webSocketFrame(encoded), (error) => {
+        signal.removeEventListener('abort', abort)
+        if (error) reject(error)
+        else resolve()
+      })
+    })
+  }
+
+  async request(
+    message: LocalCodexJsonRpcRequest,
+    { signal }: Readonly<{ signal: AbortSignal }>,
+  ) {
+    if (this.pendingRequests.has(message.id)) {
+      throw new Error('LOCAL_CODEX_UNIX_SOCKET_DUPLICATE_REQUEST_ID')
+    }
+    const response = new Promise<unknown>((resolve, reject) => {
+      const abort = () => {
+        this.pendingRequests.delete(message.id)
+        reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+      }
+      const pending = { resolve, reject, signal, abort }
+      this.pendingRequests.set(message.id, pending)
+      if (signal.aborted) abort()
+      else signal.addEventListener('abort', abort, { once: true })
+    })
+    try {
+      await this.send(message, signal)
+    } catch (error) {
+      const pending = this.pendingRequests.get(message.id)
+      if (pending) {
+        this.pendingRequests.delete(message.id)
+        pending.signal.removeEventListener('abort', pending.abort)
+        pending.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        )
+      }
+    }
+    return response
+  }
+
+  notify(
+    message: LocalCodexJsonRpcNotification,
+    { signal }: Readonly<{ signal: AbortSignal }>,
+  ) {
+    return this.send(message, signal)
+  }
+
+  nextMessage({ signal }: Readonly<{ signal: AbortSignal }>) {
+    if (this.messages.length > 0) {
+      return Promise.resolve(this.messages.shift())
+    }
+    if (this.stopped) return Promise.reject(this.stopped)
+    return new Promise<unknown>((resolve, reject) => {
+      const abort = () => {
+        const index = this.messageWaiters.indexOf(waiter)
+        if (index >= 0) this.messageWaiters.splice(index, 1)
+        reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+      }
+      const waiter = { resolve, reject, signal, abort }
+      this.messageWaiters.push(waiter)
+      if (signal.aborted) abort()
+      else signal.addEventListener('abort', abort, { once: true })
+    })
+  }
+
+  close() {
+    this.socket.destroy()
+  }
+}
+
+function webSocketFrame(payload: Buffer, opcode = 0x01) {
+  const mask = randomBytes(4)
+  const extendedLength =
+    payload.byteLength < 126 ? 0 : payload.byteLength <= 0xffff ? 2 : 8
+  const header = Buffer.alloc(2 + extendedLength + mask.byteLength)
+  header[0] = 0x80 | opcode
+  if (extendedLength === 0) header[1] = 0x80 | payload.byteLength
+  else if (extendedLength === 2) {
+    header[1] = 0x80 | 126
+    header.writeUInt16BE(payload.byteLength, 2)
+  } else {
+    header[1] = 0x80 | 127
+    header.writeBigUInt64BE(BigInt(payload.byteLength), 2)
+  }
+  mask.copy(header, 2 + extendedLength)
+  const masked = Buffer.alloc(payload.byteLength)
+  for (let index = 0; index < payload.byteLength; index += 1) {
+    masked[index] = payload[index]! ^ mask[index % 4]!
+  }
+  return Buffer.concat([header, masked])
+}
+
+async function upgradeOwnerLocalWebSocket(socket: Socket) {
+  const key = randomBytes(16).toString('base64')
+  const expectedAccept = createHash('sha1')
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64')
+  const request = [
+    'GET / HTTP/1.1',
+    'Host: localhost',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Key: ${key}`,
+    'Sec-WebSocket-Version: 13',
+    '',
+    '',
+  ].join('\r\n')
+  return new Promise<Buffer>((resolve, reject) => {
+    let buffered = Buffer.alloc(0)
+    const timer = setTimeout(
+      () => fail(new Error('LOCAL_CODEX_UNIX_SOCKET_UPGRADE_TIMEOUT')),
+      5_000,
+    )
+    const cleanup = () => {
+      clearTimeout(timer)
+      socket.off('data', onData)
+      socket.off('error', fail)
+      socket.off('close', closed)
+    }
+    const fail = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    const closed = () =>
+      fail(new Error('LOCAL_CODEX_UNIX_SOCKET_UPGRADE_CLOSED'))
+    const onData = (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk])
+      if (buffered.byteLength > 16 * 1024) {
+        fail(new Error('LOCAL_CODEX_UNIX_SOCKET_INVALID_UPGRADE'))
+        return
+      }
+      const boundary = buffered.indexOf('\r\n\r\n')
+      if (boundary < 0) return
+      const header = buffered.subarray(0, boundary).toString('ascii')
+      const lines = header.split('\r\n')
+      const responseHeaders = new Map<string, string>()
+      for (const line of lines.slice(1)) {
+        const separator = line.indexOf(':')
+        if (separator <= 0) {
+          fail(new Error('LOCAL_CODEX_UNIX_SOCKET_INVALID_UPGRADE'))
+          return
+        }
+        responseHeaders.set(
+          line.slice(0, separator).trim().toLowerCase(),
+          line.slice(separator + 1).trim(),
+        )
+      }
+      if (
+        lines[0] !== 'HTTP/1.1 101 Switching Protocols' ||
+        responseHeaders.get('upgrade')?.toLowerCase() !== 'websocket' ||
+        !responseHeaders
+          .get('connection')
+          ?.toLowerCase()
+          .split(',')
+          .map((value) => value.trim())
+          .includes('upgrade') ||
+        responseHeaders.get('sec-websocket-accept') !== expectedAccept ||
+        responseHeaders.has('location') ||
+        responseHeaders.has('sec-websocket-extensions') ||
+        responseHeaders.has('sec-websocket-protocol')
+      ) {
+        fail(new Error('LOCAL_CODEX_UNIX_SOCKET_INVALID_UPGRADE'))
+        return
+      }
+      cleanup()
+      resolve(buffered.subarray(boundary + 4))
+    }
+    socket.on('data', onData)
+    socket.once('error', fail)
+    socket.once('close', closed)
+    socket.write(request, 'ascii', (error) => {
+      if (error) fail(error)
+    })
+  })
+}
+
+function sameSocketIdentity(
+  left: Awaited<ReturnType<typeof lstat>>,
+  right: Awaited<ReturnType<typeof lstat>>,
+) {
+  return (
+    Number(left.dev) === Number(right.dev) &&
+    Number(left.ino) === Number(right.ino) &&
+    left.isSocket() &&
+    right.isSocket()
+  )
+}
+
+/** Connects only to a stable, owner-only Unix socket; no network fallback. */
+export const createOwnerLocalUnixSocketTransport: LocalCodexTransportFactory =
+  async (endpoint) => {
+    if (endpoint.kind !== 'unix-socket') {
+      invalid('LOCAL_CODEX_UNIX_SOCKET_REQUIRED')
+    }
+    const path = endpoint.canonical.slice('unix://'.length)
+    const before = await lstat(path)
+    const ownerId = process.getuid?.()
+    if (
+      !before.isSocket() ||
+      ownerId === undefined ||
+      Number(before.uid) !== ownerId ||
+      (Number(before.mode) & 0o077) !== 0
+    ) {
+      invalid('LOCAL_CODEX_UNIX_SOCKET_NOT_OWNER_ONLY')
+    }
+    const socket = createConnection({ path })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        socket.once('connect', resolve)
+        socket.once('error', reject)
+      })
+      const after = await lstat(path)
+      if (!sameSocketIdentity(before, after)) {
+        socket.destroy()
+        invalid('LOCAL_CODEX_UNIX_SOCKET_IDENTITY_CHANGED')
+      }
+      const initialData = await upgradeOwnerLocalWebSocket(socket)
+      return new OwnerLocalUnixSocketTransport(
+        endpoint.canonical,
+        socket,
+        initialData,
+      )
+    } catch (error) {
+      socket.destroy()
+      throw error
+    }
+  }
+
+function normalizeIdentity(config: LocalCodexReconciliationClientConfig) {
+  const tool = {
+    id: boundedId(config.toolIdentity?.id, 'LOCAL_CODEX_INVALID_TOOL_IDENTITY'),
+    version: boundedId(
+      config.toolIdentity?.version,
+      'LOCAL_CODEX_INVALID_TOOL_IDENTITY',
+    ),
+    ...(config.toolIdentity?.executableSha256 === undefined
+      ? {}
+      : {
+          executableSha256: sha256(
+            config.toolIdentity.executableSha256,
+            'LOCAL_CODEX_INVALID_TOOL_IDENTITY',
+          ),
+        }),
+  }
+  const model = {
+    providerId: boundedId(
+      config.modelIdentity?.providerId,
+      'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+    ),
+    modelId: boundedId(
+      config.modelIdentity?.modelId,
+      'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+    ),
+    modelVersion: boundedId(
+      config.modelIdentity?.modelVersion,
+      'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+    ),
+    ...(config.modelIdentity?.modelDigest === undefined
+      ? {}
+      : {
+          modelDigest: sha256(
+            config.modelIdentity.modelDigest,
+            'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+          ),
+        }),
+    ...(config.modelIdentity?.reasoningEffort === undefined
+      ? {}
+      : {
+          reasoningEffort: boundedId(
+            config.modelIdentity.reasoningEffort,
+            'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+          ),
+        }),
+  }
+  const prompt = {
+    id: boundedId(
+      config.promptIdentity?.id,
+      'LOCAL_CODEX_INVALID_PROMPT_IDENTITY',
+    ),
+    version: boundedId(
+      config.promptIdentity?.version,
+      'LOCAL_CODEX_INVALID_PROMPT_IDENTITY',
+    ),
+    instructions: config.promptIdentity?.instructions,
+  }
+  if (
+    typeof prompt.instructions !== 'string' ||
+    prompt.instructions.length === 0 ||
+    prompt.instructions.length > 64 * 1024 ||
+    CONTROL_CHARACTER.test(prompt.instructions.replace(/[\n\r\t]/gu, ''))
+  ) {
+    invalid('LOCAL_CODEX_INVALID_PROMPT_IDENTITY')
+  }
+  return Object.freeze({ tool, model, prompt })
+}
+
+function normalizeClientIdentity(
+  value: LocalCodexReconciliationClientConfig['clientIdentity'],
+) {
+  const identity = value ?? {
+    name: 'erniesg_struct_reconciliation',
+    title: 'Ernie SG STRUCT Reconciliation',
+    version: RECEIPT_SCHEMA_VERSION,
+  }
+  return Object.freeze({
+    name: boundedId(identity.name, 'LOCAL_CODEX_INVALID_CLIENT_IDENTITY'),
+    title: boundedId(identity.title, 'LOCAL_CODEX_INVALID_CLIENT_IDENTITY'),
+    version: boundedId(identity.version, 'LOCAL_CODEX_INVALID_CLIENT_IDENTITY'),
+  })
+}
+
+const DROP_PRIVATE_VALUE = Symbol('drop-private-value')
+
+function boundedEvidencePayload(
+  value: unknown,
+  key = '',
+  depth = 0,
+): LocalCodexJsonValue | typeof DROP_PRIVATE_VALUE {
+  if (PRIVATE_PAYLOAD_FIELD.test(key)) return DROP_PRIVATE_VALUE
+  if (value === null || typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) invalid('LOCAL_CODEX_INVALID_TRACE_EVIDENCE')
+    return Object.is(value, -0) ? 0 : value
+  }
+  if (typeof value === 'string') {
+    if (
+      value.length > MAX_TRACE_SNIPPET_BYTES ||
+      API_KEY_VALUE.test(value) ||
+      /^(?:file:\/\/|\/|[A-Za-z]:[\\/])/u.test(value)
+    ) {
+      return DROP_PRIVATE_VALUE
+    }
+    return value
+  }
+  if (depth >= 8 || typeof value !== 'object' || value === undefined) {
+    invalid('LOCAL_CODEX_INVALID_TRACE_EVIDENCE')
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 64) invalid('LOCAL_CODEX_INVALID_TRACE_EVIDENCE')
+    return value
+      .map((item) => boundedEvidencePayload(item, key, depth + 1))
+      .filter(
+        (item): item is LocalCodexJsonValue => item !== DROP_PRIVATE_VALUE,
+      )
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    invalid('LOCAL_CODEX_INVALID_TRACE_EVIDENCE')
+  }
+  const result: Record<string, LocalCodexJsonValue> = {}
+  for (const ownKey of Object.keys(value as Record<string, unknown>).sort()) {
+    if (PRIVATE_PAYLOAD_FIELD.test(ownKey)) continue
+    const item = boundedEvidencePayload(
+      (value as Record<string, unknown>)[ownKey],
+      ownKey,
+      depth + 1,
+    )
+    if (item !== DROP_PRIVATE_VALUE) result[ownKey] = item
+  }
+  return result
+}
+
+function evidencePayload(value: unknown): LocalCodexJsonValue {
+  const projected = boundedEvidencePayload(value)
+  return projected === DROP_PRIVATE_VALUE ? null : projected
+}
+
+function normalizedCropBox(value: unknown) {
+  if (!record(value) || !exactKeys(value, ['x', 'y', 'width', 'height'])) {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  const numbers = ['x', 'y', 'width', 'height'].map((key) => value[key])
+  if (
+    numbers.some((item) => typeof item !== 'number' || !Number.isFinite(item))
+  ) {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  const [x, y, width, height] = numbers as number[]
+  if (
+    x < 0 ||
+    y < 0 ||
+    width <= 0 ||
+    height <= 0 ||
+    x + width > 1 ||
+    y + height > 1 ||
+    width * height > MAX_CROP_AREA
+  ) {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  return Object.freeze({ x, y, width, height })
+}
+
+function normalizeComparisonEvidence(
+  value: unknown,
+): ReconstructionAttemptTrace {
+  let trace: ReconstructionAttemptTrace
+  try {
+    trace = parseReconstructionAttemptTrace(value)
+  } catch {
+    invalid('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+  }
+  if (
+    trace.terminalState !== 'failed' ||
+    trace.comparator.status !== 'failed' ||
+    trace.comparator.failures.length === 0 ||
+    trace.comparator.failures.length > 32
+  ) {
+    invalid('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+  }
+  return trace
+}
+
+function comparisonProjection(
+  trace: ReconstructionAttemptTrace,
+): LocalCodexPriorComparisonEvidence {
+  const categories = new Set<string>(PDF_EVIDENCE_OBSERVATION_CATEGORIES)
+  const failures = trace.comparator.failures.map((failure) => {
+    const checkResult = trace.comparator.checkResults.find(
+      (result) => result.failureId === failure.id,
+    )
+    if (
+      !categories.has(failure.check) ||
+      !failure.source ||
+      failure.source.sourceRegionIds.length === 0 ||
+      !checkResult ||
+      checkResult.status !== 'failed'
+    ) {
+      invalid('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+    }
+    return Object.freeze({
+      idSha256: digest(failure.id),
+      check:
+        failure.check as LocalCodexPriorComparisonEvidence['failures'][number]['check'],
+      sourceRegionIds: Object.freeze([...failure.source.sourceRegionIds]),
+      expectedSha256: checkResult.expectedSha256,
+      actualSha256: checkResult.actualSha256,
+    })
+  })
+  return Object.freeze({
+    schemaVersion: '1.0.0',
+    status: 'failed',
+    sourcePdfSha256: trace.evidenceGraph.sourcePdfSha256,
+    structSha256: trace.structure.artifact.sha256,
+    epubSha256: trace.epub.bytes.sha256,
+    renderReceiptSha256: trace.renderedEpub.receiptSha256,
+    comparatorReceiptSha256: hashTraceValue(trace.comparator),
+    failures: Object.freeze(failures),
+  })
+}
+
+function normalizeRenderProvenance(
+  value: unknown,
+): LocalCodexRenderProvenance {
+  if (!record(value) || typeof value.kind !== 'string') {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  if (
+    value.kind === 'source-pdf' &&
+    exactKeys(value, [
+      'kind',
+      'sourcePdfSha256',
+      'sourcePageRenderSha256',
+      'failureId',
+    ])
+  ) {
+    return Object.freeze({
+      kind: 'source-pdf',
+      sourcePdfSha256: sha256(
+        value.sourcePdfSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      sourcePageRenderSha256: sha256(
+        value.sourcePageRenderSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      failureId: boundedId(
+        value.failureId,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+    })
+  }
+  if (
+    value.kind === 'rendered-epub' &&
+    exactKeys(value, [
+      'kind',
+      'epubSha256',
+      'renderReceiptSha256',
+      'spineHref',
+      'anchorId',
+      'domSha256',
+      'screenshotSha256',
+      'screenshotId',
+      'failureId',
+    ])
+  ) {
+    return Object.freeze({
+      kind: 'rendered-epub',
+      epubSha256: sha256(
+        value.epubSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      renderReceiptSha256: sha256(
+        value.renderReceiptSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      spineHref: boundedId(
+        value.spineHref,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      anchorId: boundedId(
+        value.anchorId,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      domSha256: sha256(
+        value.domSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      screenshotSha256: sha256(
+        value.screenshotSha256,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      screenshotId: boundedId(
+        value.screenshotId,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+      failureId: boundedId(
+        value.failureId,
+        'LOCAL_CODEX_INVALID_RENDER_EVIDENCE',
+      ),
+    })
+  }
+  invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+}
+
+function normalizeRenders(value: unknown): readonly LocalCodexRenderEvidence[] {
+  if (!Array.isArray(value) || value.length > MAX_CROP_COUNT) {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  const ids = new Set<string>()
+  const renders = value.map((item) => {
+    if (
+      !record(item) ||
+      !exactKeys(item, [
+        'id',
+        'mimeType',
+        'dataBase64',
+        'sha256',
+        'page',
+        'box',
+        'candidateIds',
+        'provenance',
+      ])
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    const id = boundedId(item.id, 'LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    if (ids.has(id)) invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    ids.add(id)
+    if (
+      !['image/png', 'image/jpeg', 'image/webp'].includes(String(item.mimeType))
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    if (
+      typeof item.dataBase64 !== 'string' ||
+      item.dataBase64.length === 0 ||
+      !/^[A-Za-z0-9+/]+={0,2}$/u.test(item.dataBase64)
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    const bytes = Buffer.from(item.dataBase64, 'base64')
+    if (
+      bytes.length === 0 ||
+      bytes.length > MAX_CROP_BYTES ||
+      bytes.toString('base64') !== item.dataBase64 ||
+      digest(bytes) !== item.sha256
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    if (!Number.isSafeInteger(item.page) || (item.page as number) < 1) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    if (!Array.isArray(item.candidateIds) || item.candidateIds.length === 0) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    const candidateIds = item.candidateIds.map((candidateId) =>
+      boundedId(candidateId, 'LOCAL_CODEX_INVALID_RENDER_EVIDENCE'),
+    )
+    if (new Set(candidateIds).size !== candidateIds.length) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    return Object.freeze({
+      id,
+      mimeType: item.mimeType as LocalCodexRenderEvidence['mimeType'],
+      dataBase64: item.dataBase64,
+      sha256: item.sha256,
+      page: item.page as number,
+      box: normalizedCropBox(item.box),
+      candidateIds: Object.freeze(candidateIds),
+      provenance: normalizeRenderProvenance(item.provenance),
+    })
+  })
+  return Object.freeze(renders)
+}
+
+function normalizedResolver(
+  value: LocalCodexRenderArtifactResolver | undefined,
+) {
+  if (
+    !record(value) ||
+    !record(value.identity) ||
+    !exactKeys(value.identity, ['id', 'version', 'configurationSha256']) ||
+    typeof value.resolve !== 'function'
+  ) {
+    invalid('LOCAL_CODEX_RENDER_ARTIFACT_RESOLVER_REQUIRED')
+  }
+  return Object.freeze({
+    authority: value,
+    identity: Object.freeze({
+      id: boundedId(
+        value.identity.id,
+        'LOCAL_CODEX_RENDER_ARTIFACT_RESOLVER_REQUIRED',
+      ),
+      version: boundedId(
+        value.identity.version,
+        'LOCAL_CODEX_RENDER_ARTIFACT_RESOLVER_REQUIRED',
+      ),
+      configurationSha256: sha256(
+        value.identity.configurationSha256,
+        'LOCAL_CODEX_RENDER_ARTIFACT_RESOLVER_REQUIRED',
+      ),
+    }),
+  })
+}
+
+function sameCropBox(
+  left: LocalCodexRenderEvidence['box'],
+  right: { x: number; y: number; width: number; height: number },
+) {
+  return (['x', 'y', 'width', 'height'] as const).every(
+    (key) => Math.abs(left[key] - right[key]) <= 1e-9,
+  )
+}
+
+async function encodedCrop(
+  bytes: Uint8Array,
+  dimensions: { width: number; height: number },
+  box: LocalCodexRenderEvidence['box'],
+  mimeType: LocalCodexRenderEvidence['mimeType'],
+) {
+  const left = Math.floor(box.x * dimensions.width + 1e-9)
+  const top = Math.floor(box.y * dimensions.height + 1e-9)
+  const right = Math.ceil((box.x + box.width) * dimensions.width - 1e-9)
+  const bottom = Math.ceil((box.y + box.height) * dimensions.height - 1e-9)
+  if (
+    left < 0 ||
+    top < 0 ||
+    right > dimensions.width ||
+    bottom > dimensions.height ||
+    right <= left ||
+    bottom <= top
+  ) {
+    invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+  }
+  let pipeline = sharp(bytes, { failOn: 'error' }).extract({
+    left,
+    top,
+    width: right - left,
+    height: bottom - top,
+  })
+  pipeline =
+    mimeType === 'image/png'
+      ? pipeline.png()
+      : mimeType === 'image/jpeg'
+        ? pipeline.jpeg()
+        : pipeline.webp()
+  return new Uint8Array(await pipeline.toBuffer())
+}
+
+async function verifyBoundRenderCrops(
+  prepared: PreparedRequest,
+  resolver: ReturnType<typeof normalizedResolver>,
+) {
+  const trace = prepared.priorTrace
+  for (const render of prepared.renders) {
+    const provenance = render.provenance
+    const failure = trace.comparator.failures.find(
+      ({ id }) => id === provenance.failureId,
+    )
+    if (!failure || !failure.source) {
+      invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+    }
+    let artifact: { sha256: string; byteLength: number }
+    let logicalId: string
+    let kind: 'source-page-render' | 'epub-screenshot'
+    let dimensions: { width: number; height: number }
+    if (provenance.kind === 'source-pdf') {
+      const page = trace.sourcePdf.pageRenders.find(
+        (candidate) => candidate.page === render.page,
+      )
+      if (
+        !page ||
+        page.sourcePdfSha256 !== trace.evidenceGraph.sourcePdfSha256 ||
+        page.image.sha256 !== provenance.sourcePageRenderSha256 ||
+        !failure.source.boxes.some(
+          (box) => box.page === render.page && sameCropBox(render.box, box),
+        )
+      ) {
+        invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+      }
+      artifact = page.image
+      logicalId = `source-page-${page.page}`
+      kind = 'source-page-render'
+      dimensions = { width: page.width, height: page.height }
+    } else {
+      const screenshot = trace.renderedEpub.screenshots.find(
+        ({ id }) => id === provenance.screenshotId,
+      )
+      const output = failure.output.find(
+        (candidate) =>
+          candidate.spineHref === provenance.spineHref &&
+          candidate.anchorId === provenance.anchorId &&
+          candidate.rendered?.screenshotId === provenance.screenshotId,
+      )
+      const dom = trace.renderedEpub.domSnapshots.find(
+        ({ spineHref }) => spineHref === provenance.spineHref,
+      )
+      const locator = output?.rendered
+      const normalized = locator
+        ? {
+            x: locator.rect.x / locator.viewport.width,
+            y: locator.rect.y / locator.viewport.height,
+            width: locator.rect.width / locator.viewport.width,
+            height: locator.rect.height / locator.viewport.height,
+          }
+        : null
+      if (
+        !screenshot ||
+        !output ||
+        !dom ||
+        !locator ||
+        !normalized ||
+        !sameCropBox(render.box, normalized) ||
+        screenshot.image.sha256 !== provenance.screenshotSha256 ||
+        screenshot.domSha256 !== provenance.domSha256 ||
+        dom.dom.sha256 !== provenance.domSha256 ||
+        !dom.anchors.includes(provenance.anchorId)
+      ) {
+        invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+      }
+      artifact = screenshot.image
+      logicalId = screenshot.id
+      kind = 'epub-screenshot'
+      dimensions = { width: screenshot.width, height: screenshot.height }
+    }
+    const request = {
+      traceSha256: trace.traceSha256,
+      kind,
+      logicalId,
+      artifact,
+    } as const
+    const resolved = await Promise.resolve(resolver.authority.resolve(request))
+    if (
+      !(resolved instanceof Uint8Array) ||
+      resolved.byteLength !== artifact.byteLength ||
+      digest(resolved) !== artifact.sha256
+    ) {
+      invalid('LOCAL_CODEX_RENDER_ARTIFACT_RESOLUTION_FAILED')
+    }
+    const expectedCrop = await encodedCrop(
+      resolved,
+      dimensions,
+      render.box,
+      render.mimeType,
+    )
+    if (
+      expectedCrop.byteLength === 0 ||
+      digest(expectedCrop) !== render.sha256 ||
+      Buffer.from(expectedCrop).toString('base64') !== render.dataBase64
+    ) {
+      invalid('LOCAL_CODEX_RENDER_CROP_MISMATCH')
+    }
+  }
+}
+
+function evidenceTraceBundle(
+  reader: ReturnType<typeof readSourceEvidenceGraph>,
+  decisions: readonly LocalCodexDecisionPoint[],
+): LocalCodexJsonValue {
+  const graph = reader.graph
+  const traceDecisions = decisions.map((decision) => ({
+    decisionId: decision.decisionId,
+    candidates: decision.candidateIds.map((candidateId) => {
+      const candidate = reader.candidate(candidateId)!
+      const sources = candidate.sourceIds.map((sourceId) => {
+        const source = reader.sourceItem(sourceId)!
+        return {
+          idSha256: digest(source.id),
+          kind: source.kind,
+          ...(source.page === undefined ? {} : { page: source.page }),
+          ...(source.box === undefined ? {} : { box: source.box }),
+          ...(source.payload === undefined
+            ? {}
+            : { payload: evidencePayload(source.payload) }),
+        }
+      })
+      const obligations = graph.obligations
+        .filter(({ candidateIds }) => candidateIds.includes(candidateId))
+        .map(({ id, kind, page, required, semantic }) => ({
+          idSha256: digest(id),
+          kind,
+          ...(page === undefined ? {} : { page }),
+          required,
+          semantic,
+        }))
+      const disagreements = graph.disagreements
+        .filter(({ candidateIds }) => candidateIds.includes(candidateId))
+        .map(({ id, kind, reason }) => ({
+          idSha256: digest(id),
+          kind,
+          reason,
+        }))
+      const artifacts = (candidate.artifactIds ?? []).map((artifactId) => {
+        const artifact = reader.artifact(artifactId)!
+        return {
+          idSha256: digest(artifact.id),
+          kind: artifact.kind,
+          mediaType: artifact.mediaType,
+          sha256: artifact.sha256,
+          ...(artifact.page === undefined ? {} : { page: artifact.page }),
+          ...(artifact.box === undefined ? {} : { box: artifact.box }),
+        }
+      })
+      const candidateTrace = {
+        candidateId,
+        kind: candidate.kind,
+        providerIdSha256: digest(candidate.providerId),
+        ...(candidate.page === undefined ? {} : { page: candidate.page }),
+        boxes: candidate.boxes ?? [],
+        ...(candidate.payload === undefined
+          ? {}
+          : { payload: evidencePayload(candidate.payload) }),
+        sources,
+        artifacts,
+        obligations,
+        disagreements,
+      }
+      if (
+        Buffer.byteLength(canonicalJson(candidateTrace)) >
+        MAX_TRACE_SNIPPET_BYTES
+      ) {
+        invalid('LOCAL_CODEX_TRACE_EVIDENCE_TOO_LARGE')
+      }
+      return candidateTrace
+    }),
+  }))
+  return {
+    schemaVersion: RESPONSE_SCHEMA_VERSION,
+    sourceSha256: reader.source.sha256,
+    pageCount: reader.source.pageCount,
+    decisions: traceDecisions,
+  }
+}
+
+function createDeadline(timeoutMs: number, external?: AbortSignal): Deadline {
+  const controller = new AbortController()
+  let stoppedBecause: 'timeout' | 'aborted' | null = null
+  const abortFromCaller = () => {
+    if (stoppedBecause === null) stoppedBecause = 'aborted'
+    controller.abort()
+  }
+  if (external?.aborted) abortFromCaller()
+  else external?.addEventListener('abort', abortFromCaller, { once: true })
+  const timer = setTimeout(() => {
+    if (stoppedBecause === null) stoppedBecause = 'timeout'
+    controller.abort()
+  }, timeoutMs)
+  return Object.freeze({
+    signal: controller.signal,
+    reason: () => stoppedBecause,
+    dispose: () => {
+      clearTimeout(timer)
+      external?.removeEventListener('abort', abortFromCaller)
+    },
+  })
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted)
+    return Promise.reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(new Error('LOCAL_CODEX_ABORT_SIGNAL'))
+    signal.addEventListener('abort', abort, { once: true })
+    promise
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener('abort', abort))
+  })
+}
+
+function unwrapResult(value: unknown) {
+  if (!record(value)) return value
+  if (Object.hasOwn(value, 'error')) invalid('LOCAL_CODEX_JSON_RPC_ERROR')
+  return Object.hasOwn(value, 'result') ? value.result : value
+}
+
+function responseSchema(decisions: readonly LocalCodexDecisionPoint[]) {
+  return {
+    type: 'object',
+    properties: {
+      schemaVersion: { type: 'string', const: RESPONSE_SCHEMA_VERSION },
+      graphSha256: { type: 'string', const: null },
+      candidateSetSha256: { type: 'string', const: null },
+      decisions: {
+        type: 'array',
+        minItems: decisions.length,
+        maxItems: decisions.length,
+        items: {
+          anyOf: decisions.map((decision) => ({
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  decisionId: {
+                    type: 'string',
+                    const: decision.decisionId,
+                  },
+                  candidateId: {
+                    type: 'string',
+                    enum: [...decision.candidateIds],
+                  },
+                },
+                required: ['decisionId', 'candidateId'],
+                additionalProperties: false,
+              },
+              {
+                type: 'object',
+                properties: {
+                  decisionId: {
+                    type: 'string',
+                    const: decision.decisionId,
+                  },
+                  abstain: { type: 'boolean', const: true },
+                },
+                required: ['decisionId', 'abstain'],
+                additionalProperties: false,
+              },
+            ],
+          })),
+        },
+      },
+    },
+    required: [
+      'schemaVersion',
+      'graphSha256',
+      'candidateSetSha256',
+      'decisions',
+    ],
+    additionalProperties: false,
+  }
+}
+
+function strictSelections(
+  value: unknown,
+  prepared: PreparedRequest,
+): readonly LocalCodexReconciliationSelection[] {
+  let parsed: unknown
+  try {
+    parsed = typeof value === 'string' ? JSON.parse(value) : value
+  } catch {
+    invalid('LOCAL_CODEX_INVALID_RESPONSE')
+  }
+  if (
+    !record(parsed) ||
+    !exactKeys(parsed, [
+      'schemaVersion',
+      'graphSha256',
+      'candidateSetSha256',
+      'decisions',
+    ]) ||
+    parsed.schemaVersion !== RESPONSE_SCHEMA_VERSION ||
+    parsed.graphSha256 !== prepared.request.graphSha256 ||
+    parsed.candidateSetSha256 !== prepared.request.candidateSetSha256 ||
+    !Array.isArray(parsed.decisions) ||
+    parsed.decisions.length !== prepared.decisions.length
+  ) {
+    invalid('LOCAL_CODEX_INVALID_RESPONSE')
+  }
+  const allowed = new Map(
+    prepared.decisions.map((decision) => [
+      decision.decisionId,
+      new Set(decision.candidateIds),
+    ]),
+  )
+  const selected = new Set<string>()
+  const selections = parsed.decisions.map((item) => {
+    if (
+      !record(item) ||
+      (!exactKeys(item, ['decisionId', 'candidateId']) &&
+        !exactKeys(item, ['decisionId', 'abstain']))
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    }
+    const decisionId = boundedId(
+      item.decisionId,
+      'LOCAL_CODEX_INVALID_RESPONSE',
+    )
+    if (selected.has(decisionId) || !allowed.has(decisionId)) {
+      invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    }
+    selected.add(decisionId)
+    if (Object.hasOwn(item, 'abstain')) {
+      if (item.abstain !== true) invalid('LOCAL_CODEX_INVALID_RESPONSE')
+      return Object.freeze({ decisionId, abstain: true as const })
+    }
+    const candidateId = boundedId(
+      item.candidateId,
+      'LOCAL_CODEX_INVALID_RESPONSE',
+    )
+    if (!allowed.get(decisionId)?.has(candidateId)) {
+      invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    }
+    return Object.freeze({ decisionId, candidateId })
+  })
+  if (selected.size !== allowed.size) invalid('LOCAL_CODEX_INVALID_RESPONSE')
+  return Object.freeze(selections)
+}
+
+function threadIdentity(value: unknown) {
+  const result = unwrapResult(value)
+  if (!record(result) || !record(result.thread)) {
+    invalid('LOCAL_CODEX_INVALID_THREAD_RESPONSE')
+  }
+  const id = boundedId(result.thread.id, 'LOCAL_CODEX_INVALID_THREAD_RESPONSE')
+  if (result.thread.sessionId !== undefined && result.thread.sessionId !== id) {
+    invalid('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+  }
+  if (
+    result.thread.forkedFromId !== undefined &&
+    result.thread.forkedFromId !== null
+  ) {
+    invalid('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+  }
+  return {
+    id,
+    modelId: boundedId(
+      result.model,
+      'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+    ),
+    providerId: boundedId(
+      result.modelProvider,
+      'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+    ),
+  }
+}
+
+function turnIdentity(value: unknown) {
+  const result = unwrapResult(value)
+  if (!record(result) || !record(result.turn)) {
+    invalid('LOCAL_CODEX_INVALID_TURN_RESPONSE')
+  }
+  return boundedId(result.turn.id, 'LOCAL_CODEX_INVALID_TURN_RESPONSE')
+}
+
+function messageIdsMatch(
+  params: Record<string, unknown>,
+  threadId: string,
+  turnId: string,
+) {
+  if (params.threadId !== undefined && params.threadId !== threadId)
+    return false
+  if (params.turnId !== undefined && params.turnId !== turnId) return false
+  if (
+    record(params.turn) &&
+    params.turn.id !== undefined &&
+    params.turn.id !== turnId
+  ) {
+    return false
+  }
+  return true
+}
+
+function agentTextFromItems(value: unknown): string | null {
+  if (!Array.isArray(value)) return null
+  let finalText: string | null = null
+  for (const item of value) {
+    if (!record(item) || item.type !== 'agentMessage') continue
+    if (item.phase !== undefined && item.phase !== 'final_answer') continue
+    if (
+      typeof item.text !== 'string' ||
+      item.text.length > MAX_AGENT_RESPONSE_BYTES
+    ) {
+      invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    }
+    if (finalText !== null) invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    finalText = item.text
+  }
+  return finalText
+}
+
+async function waitForFinalResponse(
+  transport: LocalCodexJsonRpcTransport,
+  signal: AbortSignal,
+  threadId: string,
+  turnId: string,
+  initialModelId: string,
+) {
+  let finalText: string | null = null
+  let observedModelId = initialModelId
+  for (;;) {
+    const message = await abortable(
+      Promise.resolve(transport.nextMessage({ signal })),
+      signal,
+    )
+    if (!record(message) || typeof message.method !== 'string') {
+      invalid('LOCAL_CODEX_INVALID_NOTIFICATION')
+    }
+    if (Object.hasOwn(message, 'id')) {
+      invalid('LOCAL_CODEX_UNEXPECTED_SERVER_REQUEST')
+    }
+    if (!record(message.params)) invalid('LOCAL_CODEX_INVALID_NOTIFICATION')
+    if (!messageIdsMatch(message.params, threadId, turnId)) {
+      invalid('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+    }
+    if (message.method === 'item/completed') {
+      const item = message.params.item
+      if (record(item) && item.type === 'agentMessage') {
+        if (item.phase !== undefined && item.phase !== 'final_answer') continue
+        if (
+          typeof item.text !== 'string' ||
+          item.text.length > MAX_AGENT_RESPONSE_BYTES ||
+          finalText !== null
+        ) {
+          invalid('LOCAL_CODEX_INVALID_RESPONSE')
+        }
+        finalText = item.text
+      }
+      // Reasoning, command, tool, file, and log items are deliberately dropped.
+      continue
+    }
+    if (message.method === 'model/rerouted') {
+      observedModelId = boundedId(
+        message.params.toModel,
+        'LOCAL_CODEX_INVALID_MODEL_IDENTITY',
+      )
+      continue
+    }
+    if (message.method !== 'turn/completed') continue
+    const turn = message.params.turn
+    if (!record(turn) || turn.id !== turnId) {
+      invalid('LOCAL_CODEX_INVALID_TURN_RESPONSE')
+    }
+    if (turn.status !== 'completed') invalid('LOCAL_CODEX_TURN_NOT_COMPLETED')
+    const fromTurn = agentTextFromItems(turn.items)
+    if (fromTurn !== null) {
+      if (finalText !== null && fromTurn !== finalText) {
+        invalid('LOCAL_CODEX_INVALID_RESPONSE')
+      }
+      finalText = fromTurn
+    }
+    if (finalText === null) invalid('LOCAL_CODEX_INVALID_RESPONSE')
+    return { text: finalText, observedModelId }
+  }
+}
+
+async function boundedBestEffort(
+  operation: Promise<unknown>,
+  timeoutMs: number,
+) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  await Promise.race([
+    operation.catch(() => undefined),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs)
+    }),
+  ])
+  if (timer !== undefined) clearTimeout(timer)
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const nested of Object.values(value)) deepFreeze(nested)
+  }
+  return value
+}
+
+export class LocalCodexReconciliationClient {
+  private readonly endpoint: LocalCodexEndpoint
+  private readonly timeoutMs: number
+  private readonly interruptTimeoutMs: number
+  private readonly maxRequestBytes: number
+  private readonly expectedServerIdentitySha256?: string
+  private readonly clientIdentity: ReturnType<typeof normalizeClientIdentity>
+  private readonly identities: ReturnType<typeof normalizeIdentity>
+  private readonly renderArtifactResolver: ReturnType<typeof normalizedResolver>
+  private readonly identitySha256s: Readonly<{
+    endpointSha256: string
+    toolSha256: string
+    modelSha256: string
+    promptSha256: string
+    renderArtifactResolverSha256: string
+  }>
+  private readonly transportFactory: LocalCodexTransportFactory
+  private readonly attempts = new Map<string, AttemptEntry>()
+  private readonly usedTransports = new WeakSet<object>()
+  private readonly threadOwners = new Map<string, string>()
+  private nextRequestId = 1
+
+  constructor(config: LocalCodexReconciliationClientConfig) {
+    assertSafeConfiguration(config)
+    if (typeof config.transportFactory !== 'function') {
+      invalid('LOCAL_CODEX_INVALID_CONFIGURATION')
+    }
+    this.endpoint = validateLocalCodexEndpoint(config.endpoint)
+    this.timeoutMs = finiteInteger(
+      config.timeoutMs,
+      DEFAULT_TIMEOUT_MS,
+      1,
+      10 * 60_000,
+      'LOCAL_CODEX_INVALID_TIMEOUT',
+    )
+    this.interruptTimeoutMs = finiteInteger(
+      config.interruptTimeoutMs,
+      DEFAULT_INTERRUPT_TIMEOUT_MS,
+      1,
+      30_000,
+      'LOCAL_CODEX_INVALID_TIMEOUT',
+    )
+    this.maxRequestBytes = finiteInteger(
+      config.maxRequestBytes,
+      DEFAULT_MAX_REQUEST_BYTES,
+      1024,
+      8 * 1024 * 1024,
+      'LOCAL_CODEX_INVALID_REQUEST_LIMIT',
+    )
+    this.expectedServerIdentitySha256 =
+      config.expectedServerIdentitySha256 === undefined
+        ? undefined
+        : sha256(
+            config.expectedServerIdentitySha256,
+            'LOCAL_CODEX_INVALID_SERVER_IDENTITY',
+          )
+    this.clientIdentity = normalizeClientIdentity(config.clientIdentity)
+    this.identities = normalizeIdentity(config)
+    this.renderArtifactResolver = normalizedResolver(
+      config.renderArtifactResolver,
+    )
+    this.transportFactory = config.transportFactory
+    this.identitySha256s = Object.freeze({
+      endpointSha256: canonicalSha256(this.endpoint),
+      toolSha256: canonicalSha256(this.identities.tool),
+      modelSha256: canonicalSha256(this.identities.model),
+      promptSha256: canonicalSha256(this.identities.prompt),
+      renderArtifactResolverSha256: canonicalSha256(
+        this.renderArtifactResolver.identity,
+      ),
+    })
+  }
+
+  reconcile(
+    request: LocalCodexReconciliationRequest,
+    options: Readonly<{ signal?: AbortSignal }> = {},
+  ): Promise<LocalCodexReconciliationResult> {
+    let prepared: PreparedRequest
+    try {
+      prepared = this.prepare(request)
+    } catch (error) {
+      return Promise.reject(error)
+    }
+    const sessionKey = `${request.documentId}\0${request.attemptId}`
+    const existing = this.attempts.get(sessionKey)
+    if (existing) {
+      if (existing.fingerprint !== prepared.fingerprint) {
+        return Promise.reject(
+          new LocalCodexReconciliationError('LOCAL_CODEX_IDEMPOTENCY_CONFLICT'),
+        )
+      }
+      return existing.promise
+    }
+    const promise = this.run(prepared, options.signal)
+    this.attempts.set(
+      sessionKey,
+      Object.freeze({ fingerprint: prepared.fingerprint, promise }),
+    )
+    return promise
+  }
+
+  private prepare(request: LocalCodexReconciliationRequest): PreparedRequest {
+    if (!record(request)) invalid('LOCAL_CODEX_INVALID_REQUEST')
+    const documentId = boundedId(
+      request.documentId,
+      'LOCAL_CODEX_INVALID_REQUEST',
+    )
+    const attemptId = boundedId(
+      request.attemptId,
+      'LOCAL_CODEX_INVALID_REQUEST',
+    )
+    const graphSha256 = sha256(
+      request.graphSha256,
+      'LOCAL_CODEX_GRAPH_HASH_MISMATCH',
+    )
+    const candidateSetSha256 = sha256(
+      request.candidateSetSha256,
+      'LOCAL_CODEX_CANDIDATE_SET_HASH_MISMATCH',
+    )
+    let reader: ReturnType<typeof readSourceEvidenceGraph>
+    try {
+      reader = readSourceEvidenceGraph(request.evidenceGraph)
+    } catch {
+      invalid('LOCAL_CODEX_INVALID_EVIDENCE_GRAPH')
+    }
+    if (
+      reader.source.documentId !== documentId ||
+      reader.graphSha256 !== graphSha256 ||
+      sourceEvidenceGraphSha256(request.evidenceGraph) !== graphSha256
+    ) {
+      invalid('LOCAL_CODEX_GRAPH_HASH_MISMATCH')
+    }
+    if (
+      !Array.isArray(request.decisions) ||
+      request.decisions.length === 0 ||
+      request.decisions.length > MAX_TRACE_DECISIONS
+    ) {
+      invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+    }
+    const decisionIds = new Set<string>()
+    const allCandidateIds = new Set<string>()
+    const decisions = request.decisions.map((decision) => {
+      if (
+        !record(decision) ||
+        !exactKeys(decision, ['decisionId', 'candidateIds'])
+      ) {
+        invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+      }
+      const decisionId = boundedId(
+        decision.decisionId,
+        'LOCAL_CODEX_INVALID_CANDIDATE_SET',
+      )
+      if (
+        decisionIds.has(decisionId) ||
+        !Array.isArray(decision.candidateIds) ||
+        decision.candidateIds.length === 0
+      ) {
+        invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+      }
+      decisionIds.add(decisionId)
+      const local = new Set<string>()
+      const candidateIds = decision.candidateIds.map((candidate) => {
+        const id = boundedId(candidate, 'LOCAL_CODEX_INVALID_CANDIDATE_SET')
+        if (local.has(id)) {
+          invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+        }
+        local.add(id)
+        allCandidateIds.add(id)
+        try {
+          if (!reader.candidate(id))
+            invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+        } catch {
+          invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+        }
+        return id
+      })
+      return Object.freeze({
+        decisionId,
+        candidateIds: Object.freeze(candidateIds),
+      })
+    })
+    const candidateIds = Object.freeze([...allCandidateIds])
+    if (candidateIds.length > MAX_TRACE_CANDIDATES) {
+      invalid('LOCAL_CODEX_INVALID_CANDIDATE_SET')
+    }
+    if (reader.candidateSetSha256(candidateIds) !== candidateSetSha256) {
+      invalid('LOCAL_CODEX_CANDIDATE_SET_HASH_MISMATCH')
+    }
+    const priorTrace = normalizeComparisonEvidence(
+      request.comparisonEvidence,
+    )
+    const comparisonEvidence = comparisonProjection(priorTrace)
+    if (comparisonEvidence.sourcePdfSha256 !== reader.source.sha256) {
+      invalid('LOCAL_CODEX_INVALID_COMPARISON_EVIDENCE')
+    }
+    const renders = normalizeRenders(request.renders)
+    for (const render of renders) {
+      const provenance = render.provenance
+      if (
+        render.page > reader.source.pageCount ||
+        render.candidateIds.some((candidateId) => {
+          if (!allCandidateIds.has(candidateId)) return true
+          const candidate = reader.candidate(candidateId)
+          return candidate?.page !== undefined && candidate.page !== render.page
+        })
+      ) {
+        invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+      }
+      if (
+        (provenance.kind === 'source-pdf' &&
+          (provenance.sourcePdfSha256 !== reader.source.sha256 ||
+            !priorTrace.sourcePdf.pageRenders.some(
+              ({ page, image }) =>
+                page === render.page &&
+                image.sha256 === provenance.sourcePageRenderSha256,
+            ))) ||
+        (provenance.kind === 'rendered-epub' &&
+          (provenance.epubSha256 !== comparisonEvidence.epubSha256 ||
+            provenance.renderReceiptSha256 !==
+              comparisonEvidence.renderReceiptSha256 ||
+            !priorTrace.renderedEpub.screenshots.some(
+              ({ id, image }) =>
+                id === provenance.screenshotId &&
+                image.sha256 === provenance.screenshotSha256,
+            )))
+      ) {
+        invalid('LOCAL_CODEX_INVALID_RENDER_EVIDENCE')
+      }
+    }
+    if (
+      !renders.some(({ provenance }) => provenance.kind === 'source-pdf') ||
+      !renders.some(({ provenance }) => provenance.kind === 'rendered-epub')
+    ) {
+      invalid('LOCAL_CODEX_SOURCE_EPUB_CROPS_REQUIRED')
+    }
+    const traceBundle = evidenceTraceBundle(reader, decisions)
+    const isolatedSessionSha256 = canonicalSha256({ documentId, attemptId })
+    const requestBinding = {
+      schemaVersion: RESPONSE_SCHEMA_VERSION,
+      documentIdSha256: digest(documentId),
+      attemptIdSha256: digest(attemptId),
+      graphSha256,
+      candidateSetSha256,
+      decisions,
+      comparisonEvidence,
+      priorTraceSha256: priorTrace.traceSha256,
+      renderIdentities: renders.map(
+        ({
+          id,
+          mimeType,
+          sha256: renderSha256,
+          page,
+          box,
+          candidateIds: renderCandidateIds,
+          provenance,
+        }) => ({
+          id,
+          mimeType,
+          sha256: renderSha256,
+          page,
+          box,
+          candidateIds: renderCandidateIds,
+          provenance,
+        }),
+      ),
+      traceBundleSha256: canonicalSha256(traceBundle),
+      identities: this.identitySha256s,
+    }
+    const requestSha256 = canonicalSha256(requestBinding)
+    // Whole graphs, PDFs, paths, and provider outputs stay in the owner-local
+    // resolver. The app-server receives only this bounded evidence trace and
+    // explicitly scoped source crops.
+    const requestBytes = Buffer.byteLength(
+      canonicalJson({ requestBinding, traceBundle, renders }),
+    )
+    if (requestBytes > this.maxRequestBytes)
+      invalid('LOCAL_CODEX_REQUEST_TOO_LARGE')
+    return Object.freeze({
+      request,
+      decisions: Object.freeze(decisions),
+      candidateIds,
+      renders,
+      comparisonEvidence,
+      priorTrace,
+      traceBundle,
+      isolatedSessionSha256,
+      requestSha256,
+      fingerprint: canonicalSha256({ requestSha256, isolatedSessionSha256 }),
+    })
+  }
+
+  private requestId() {
+    const id = this.nextRequestId
+    this.nextRequestId += 1
+    return id
+  }
+
+  private async rpc(
+    transport: LocalCodexJsonRpcTransport,
+    signal: AbortSignal,
+    method: string,
+    params: Readonly<Record<string, unknown>>,
+  ) {
+    return abortable(
+      Promise.resolve(
+        transport.request({ id: this.requestId(), method, params }, { signal }),
+      ),
+      signal,
+    )
+  }
+
+  private async run(
+    prepared: PreparedRequest,
+    externalSignal?: AbortSignal,
+  ): Promise<LocalCodexReconciliationResult> {
+    const deadline = createDeadline(this.timeoutMs, externalSignal)
+    let transport: LocalCodexJsonRpcTransport | undefined
+    let threadId: string | undefined
+    let turnId: string | undefined
+    let completed = false
+    try {
+      await abortable(
+        verifyBoundRenderCrops(prepared, this.renderArtifactResolver),
+        deadline.signal,
+      )
+      transport = await abortable(
+        Promise.resolve(
+          this.transportFactory(this.endpoint, prepared.isolatedSessionSha256),
+        ),
+        deadline.signal,
+      )
+      if (!record(transport) || this.usedTransports.has(transport)) {
+        invalid('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+      }
+      this.usedTransports.add(transport)
+      const actualEndpoint = validateLocalCodexEndpoint(transport.endpoint)
+      const finalEndpoint = validateLocalCodexEndpoint(
+        transport.finalEndpoint ?? transport.endpoint,
+      )
+      if (
+        transport.redirected === true ||
+        actualEndpoint.canonical !== this.endpoint.canonical ||
+        finalEndpoint.canonical !== this.endpoint.canonical
+      ) {
+        invalid('LOCAL_CODEX_REDIRECT_FORBIDDEN')
+      }
+
+      const initialize = unwrapResult(
+        await this.rpc(transport, deadline.signal, 'initialize', {
+          clientInfo: this.clientIdentity,
+          capabilities: {
+            experimentalApi: false,
+            requestAttestation: false,
+            optOutNotificationMethods: REDACTED_NOTIFICATION_METHODS,
+          },
+        }),
+      )
+      const serverSha256 = canonicalSha256(initialize)
+      if (
+        this.expectedServerIdentitySha256 !== undefined &&
+        this.expectedServerIdentitySha256 !== serverSha256
+      ) {
+        invalid('LOCAL_CODEX_SERVER_IDENTITY_MISMATCH')
+      }
+      await abortable(
+        Promise.resolve(
+          transport.notify(
+            { method: 'initialized', params: {} },
+            { signal: deadline.signal },
+          ),
+        ),
+        deadline.signal,
+      )
+
+      const startedThread = threadIdentity(
+        await this.rpc(transport, deadline.signal, 'thread/start', {
+          model: this.identities.model.modelId,
+          approvalPolicy: 'never',
+          sandbox: 'read-only',
+          ephemeral: true,
+          serviceName: 'erniesg_struct_reconciliation',
+        }),
+      )
+      threadId = startedThread.id
+      if (
+        startedThread.modelId !== this.identities.model.modelId ||
+        startedThread.providerId !== this.identities.model.providerId
+      ) {
+        invalid('LOCAL_CODEX_MODEL_IDENTITY_MISMATCH')
+      }
+      const existingOwner = this.threadOwners.get(threadId)
+      if (
+        existingOwner !== undefined &&
+        existingOwner !== prepared.isolatedSessionSha256
+      ) {
+        invalid('LOCAL_CODEX_SESSION_NOT_ISOLATED')
+      }
+      this.threadOwners.set(threadId, prepared.isolatedSessionSha256)
+
+      const schema = responseSchema(prepared.decisions)
+      ;(schema.properties.graphSha256 as { const: string | null }).const =
+        prepared.request.graphSha256
+      ;(
+        schema.properties.candidateSetSha256 as { const: string | null }
+      ).const = prepared.request.candidateSetSha256
+      const promptPayload = {
+        schemaVersion: RESPONSE_SCHEMA_VERSION,
+        documentIdSha256: digest(prepared.request.documentId),
+        attemptIdSha256: digest(prepared.request.attemptId),
+        graphSha256: prepared.request.graphSha256,
+        candidateSetSha256: prepared.request.candidateSetSha256,
+        comparisonEvidence: prepared.comparisonEvidence,
+        trace: prepared.traceBundle,
+        cropOrder: prepared.renders.map(
+          ({
+            id,
+            sha256: renderSha256,
+            page,
+            box,
+            candidateIds,
+            provenance,
+          }) => ({
+            id,
+            sha256: renderSha256,
+            page,
+            box,
+            candidateIds,
+            provenance,
+          }),
+        ),
+      }
+      const text = [
+        this.identities.prompt.instructions,
+        'Select exactly one supplied candidate or abstain for every decision.',
+        'Use only the bounded source trace and crops in this owner-local task. Return schema-bound candidate IDs or abstentions only. Do not emit reasoning, new text, labels, bounds, destinations, assets, or claims. Do not use tools.',
+        JSON.stringify(promptPayload),
+      ].join('\n\n')
+      const input: Array<Record<string, unknown>> = [
+        { type: 'text', text, text_elements: [] },
+        ...prepared.renders.map(({ mimeType, dataBase64 }) => ({
+          type: 'image',
+          url: `data:${mimeType};base64,${dataBase64}`,
+        })),
+      ]
+      turnId = turnIdentity(
+        await this.rpc(transport, deadline.signal, 'turn/start', {
+          threadId,
+          input,
+          model: this.identities.model.modelId,
+          ...(this.identities.model.reasoningEffort === undefined
+            ? {}
+            : { effort: this.identities.model.reasoningEffort }),
+          approvalPolicy: 'never',
+          sandboxPolicy: {
+            type: 'readOnly',
+            networkAccess: false,
+          },
+          outputSchema: schema,
+        }),
+      )
+
+      const observed = await waitForFinalResponse(
+        transport,
+        deadline.signal,
+        threadId,
+        turnId,
+        startedThread.modelId,
+      )
+      if (observed.observedModelId !== this.identities.model.modelId) {
+        invalid('LOCAL_CODEX_MODEL_IDENTITY_MISMATCH')
+      }
+      const selections = strictSelections(observed.text, prepared)
+      completed = true
+      const responseBinding = {
+        schemaVersion: RESPONSE_SCHEMA_VERSION,
+        graphSha256: prepared.request.graphSha256,
+        candidateSetSha256: prepared.request.candidateSetSha256,
+        decisions: selections,
+      }
+      const receipt: LocalCodexReconciliationReceipt = {
+        schemaVersion: RECEIPT_SCHEMA_VERSION,
+        status: 'accepted',
+        documentIdSha256: digest(prepared.request.documentId),
+        attemptIdSha256: digest(prepared.request.attemptId),
+        isolatedSessionSha256: prepared.isolatedSessionSha256,
+        graphSha256: prepared.request.graphSha256,
+        candidateSetSha256: prepared.request.candidateSetSha256,
+        requestSha256: prepared.requestSha256,
+        responseSha256: canonicalSha256(responseBinding),
+        selectionSetSha256: canonicalSha256(selections),
+        comparisonEvidenceSha256: prepared.priorTrace.traceSha256,
+        cropEvidenceSha256: canonicalSha256(
+          prepared.renders.map(
+            ({ dataBase64: _dataBase64, ...identity }) => identity,
+          ),
+        ),
+        threadSha256: digest(threadId),
+        turnSha256: digest(turnId),
+        identities: {
+          ...this.identitySha256s,
+          serverSha256,
+          observedModelSha256: canonicalSha256({
+            providerId: startedThread.providerId,
+            modelId: observed.observedModelId,
+          }),
+        },
+        counts: {
+          decisionCount: prepared.decisions.length,
+          candidateCount: prepared.candidateIds.length,
+          renderCount: prepared.renders.length,
+          sourceCropCount: prepared.renders.filter(
+            ({ provenance }) => provenance.kind === 'source-pdf',
+          ).length,
+          epubCropCount: prepared.renders.filter(
+            ({ provenance }) => provenance.kind === 'rendered-epub',
+          ).length,
+        },
+      }
+      return deepFreeze({ selections, receipt })
+    } catch (error) {
+      if (transport && threadId && turnId && !completed) {
+        await boundedBestEffort(
+          Promise.resolve(
+            transport.request(
+              {
+                id: this.requestId(),
+                method: 'turn/interrupt',
+                params: { threadId, turnId },
+              },
+              { signal: new AbortController().signal },
+            ),
+          ),
+          this.interruptTimeoutMs,
+        )
+      }
+      if (deadline.reason() === 'timeout') invalid('LOCAL_CODEX_TIMEOUT')
+      if (deadline.reason() === 'aborted') invalid('LOCAL_CODEX_ABORTED')
+      throw error
+    } finally {
+      deadline.dispose()
+      if (transport?.close) {
+        await boundedBestEffort(
+          Promise.resolve(transport.close()),
+          this.interruptTimeoutMs,
+        )
+      }
+    }
+  }
+}
+
+export function createLocalCodexReconciliationClient(
+  config: LocalCodexReconciliationClientConfig,
+) {
+  return new LocalCodexReconciliationClient(config)
+}

--- a/src/research/mineru-owner-local-runner.test.ts
+++ b/src/research/mineru-owner-local-runner.test.ts
@@ -505,6 +505,32 @@ describe('owner-local MinerU runner', () => {
     await chmod(ordinarySnapshot.sealedRoot, 0o700)
   })
 
+  it('uses one code-unit inventory order for preflight and sealed runtime trees', async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-runtime-order-test-')),
+    )
+    roots.push(root)
+    const source = join(root, 'runtime')
+    await mkdir(join(source, 'bin'), { recursive: true, mode: 0o700 })
+    await writeFile(join(source, 'bin', 'python'), 'runtime', {
+      mode: 0o755,
+    })
+    await writeFile(join(source, 'CACHEDIR.TAG'), 'cache-tag')
+
+    const preflight = await measureOwnerLocalExecutionTree(source)
+    const sealed = await sealOwnerLocalExecutionTree({
+      sourceRoot: source,
+      sealedRoot: join(root, 'sealed-runtime'),
+      maximumLogicalBytes: 32 * 1024,
+      maximumAllocatedBytes: 32 * 1024,
+    })
+    await chmod(join(sealed.sealedRoot, 'bin'), 0o700)
+    await chmod(sealed.sealedRoot, 0o700)
+
+    expect(sealed.inventorySha256).toBe(preflight.sha256)
+    expect(sealed.byteLength).toBe(preflight.byteLength)
+  })
+
   it('admits unaligned logical model bytes by remaining global allocation and rejects true overflow', async () => {
     const root = await realpath(
       await mkdtemp(join(tmpdir(), 'mineru-model-allocation-test-')),

--- a/src/research/mineru-owner-local-runner.test.ts
+++ b/src/research/mineru-owner-local-runner.test.ts
@@ -29,6 +29,7 @@ import {
   assertOwnerLocalMineruResourceUsage,
   buildOwnerLocalMineruIsolationCommand,
   measureOwnerLocalExecutionTree,
+  measureOwnerLocalResourceTreeUsage,
   normalizeMineruRunArtifacts,
   ownerLocalPrivateSnapshotAllocatedBytes,
   parseOwnerLocalMineruArguments,
@@ -278,6 +279,21 @@ describe('owner-local MinerU runner', () => {
         identity,
       } as Parameters<typeof normalizeMineruRunArtifacts>[0]),
     ).rejects.toThrow(/OUTPUT_BOUND/u)
+
+    const linked = await fakeMineruOutput()
+    await symlink(
+      join(linked.outputRoot, 'opaque.md'),
+      join(linked.outputRoot, 'linked-output'),
+    )
+    await expect(
+      normalizeMineruRunArtifacts({
+        sourcePdfPath: fixturePdf,
+        runDirectory: linked.root,
+        outputRoot: linked.outputRoot,
+        maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+        identity,
+      }),
+    ).rejects.toThrow(/SYMLINK_REJECTED/u)
 
     const retained = await fakeMineruOutput()
     const manifest = await normalizeMineruRunArtifacts({
@@ -621,6 +637,35 @@ describe('owner-local MinerU runner', () => {
         fileCount: 4,
       }),
     ).not.toThrow()
+  })
+
+  it('accounts transient private symlinks without following their targets', async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-scratch-symlink-test-')),
+    )
+    roots.push(root)
+    const scratch = join(root, 'scratch')
+    const outside = join(root, 'outside')
+    await mkdir(scratch, { mode: 0o700 })
+    await mkdir(outside, { mode: 0o700 })
+    await writeFile(join(outside, 'large-cache-entry'), Buffer.alloc(64 * 1024))
+    await symlink(outside, join(scratch, 'transient-cache-link'))
+
+    const usage = await measureOwnerLocalResourceTreeUsage(scratch)
+    expect(usage.count).toBe(1)
+    expect(usage.byteLength).toBeGreaterThan(0)
+    expect(usage.byteLength).toBeLessThan(64 * 1024)
+    expect(() =>
+      assertOwnerLocalMineruResourceUsage({
+        maximumOutputBytes: 1,
+        maximumCacheBytes: usage.byteLength - 1,
+        cacheByteLength: 0,
+        privateSnapshotByteLength: 0,
+        outputByteLength: 0,
+        privateScratchByteLength: usage.byteLength,
+        fileCount: usage.count,
+      }),
+    ).toThrow(/CACHE_BOUND/u)
   })
 
   it('binds the real offline MLX born-digital and scan smoke receipts to distinct source bytes', async () => {

--- a/src/research/mineru-owner-local-runner.test.ts
+++ b/src/research/mineru-owner-local-runner.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import {
   chmod,
@@ -49,6 +49,27 @@ function fixturePath(name: string) {
 
 const fixturePdf = fixturePath('born-digital.pdf')
 const scanFixturePdf = fixturePath('scanned-page.pdf')
+
+function linuxIsolationPreflightFailure() {
+  if (process.platform !== 'linux') return null
+  const plan = buildOwnerLocalMineruIsolationCommand({
+    isolation: 'linux-user-netns-loopback-only-v1',
+    isolationExecutable: '/usr/bin/unshare',
+    runDirectory: tmpdir(),
+    program: '/bin/true',
+    args: [],
+  })
+  const result = spawnSync(plan.command, plan.args, {
+    stdio: 'ignore',
+    timeout: 5_000,
+  })
+  return result.status === 0 && result.signal === null
+    ? null
+    : `exact user+network namespace preflight unavailable (${result.error ? (result.error as NodeJS.ErrnoException).code : `status ${result.status ?? 'none'}, signal ${result.signal ?? 'none'}`})`
+}
+
+const linuxIsolationSkipReason = linuxIsolationPreflightFailure()
+const liveIsolationIt = linuxIsolationSkipReason === null ? it : it.skip
 
 const realMlxSmokeReceipts = [
   {
@@ -335,7 +356,9 @@ describe('owner-local MinerU runner', () => {
     ).toThrow(/ABSOLUTE_PATH_REQUIRED/u)
   })
 
-  it('executes through a real OS network-isolation boundary', async () => {
+  liveIsolationIt(
+    `executes through a real OS network-isolation boundary${linuxIsolationSkipReason ? ` [${linuxIsolationSkipReason}]` : ''}`,
+    async () => {
     const runDirectory = await realpath(
       await mkdtemp(join(tmpdir(), 'mineru-network-probe-')),
     )
@@ -368,9 +391,12 @@ describe('owner-local MinerU runner', () => {
         )
       })
     })
-  })
+    },
+  )
 
-  it('enforces the measured execution snapshot as read-only inside isolation', async () => {
+  liveIsolationIt(
+    `enforces the measured execution snapshot as read-only inside isolation${linuxIsolationSkipReason ? ` [${linuxIsolationSkipReason}]` : ''}`,
+    async () => {
     const runDirectory = await realpath(
       await mkdtemp(join(tmpdir(), 'mineru-readonly-probe-')),
     )
@@ -410,6 +436,26 @@ describe('owner-local MinerU runner', () => {
       })
     })
     expect(await readFile(measuredFile, 'utf8')).toBe('measured')
+    },
+  )
+
+  it('keeps unsupported Linux isolation fail-closed without a fallback command', () => {
+    const plan = buildOwnerLocalMineruIsolationCommand({
+      isolation: 'linux-user-netns-loopback-only-v1',
+      isolationExecutable: '/usr/bin/unshare',
+      runDirectory: '/private/tmp/mineru-isolation-contract',
+      program: '/bin/true',
+      args: [],
+    })
+    expect(plan.command).toBe('/usr/bin/unshare')
+    expect(plan.args.slice(0, 4)).toEqual([
+      '--user',
+      '--map-root-user',
+      '--net',
+      '--mount',
+    ])
+    expect(plan.args.join(' ')).toContain('/usr/sbin/ip link set lo up')
+    expect(plan.args.at(-1)).toBe('/bin/true')
   })
 
   it('seals execution bytes before use and rejects swap-use-restore aliases', async () => {

--- a/src/research/mineru-owner-local-runner.test.ts
+++ b/src/research/mineru-owner-local-runner.test.ts
@@ -1,0 +1,629 @@
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import { inspectMineruSourceEvidence } from './mineru-source-evidence'
+import {
+  MINERU_PRODUCTION_MODEL_SHA256,
+  MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+  MINERU_MAX_OWNER_CACHE_BYTES,
+  MINERU_PRODUCTION_VERSION,
+} from './mineru-source-evidence'
+import {
+  OWNER_LOCAL_MINERU_HELP,
+  assertOwnerLocalSealedPreflightIdentity,
+  assertOwnerLocalMineruResourceUsage,
+  buildOwnerLocalMineruIsolationCommand,
+  measureOwnerLocalExecutionTree,
+  normalizeMineruRunArtifacts,
+  ownerLocalPrivateSnapshotAllocatedBytes,
+  parseOwnerLocalMineruArguments,
+  remainingOwnerLocalSealedModelAllocatedBytes,
+  sealOwnerLocalExecutionTree,
+} from './mineru-owner-local-runner'
+
+const roots: string[] = []
+function fixturePath(name: string) {
+  return [
+    new URL(`../../tests/fixtures/pdf/${name}`, import.meta.url),
+    new URL(`../../../../tests/fixtures/pdf/${name}`, import.meta.url),
+  ]
+    .map((url) => fileURLToPath(url))
+    .find(existsSync)!
+}
+
+const fixturePdf = fixturePath('born-digital.pdf')
+const scanFixturePdf = fixturePath('scanned-page.pdf')
+
+const realMlxSmokeReceipts = [
+  {
+    fixture: fixturePdf,
+    sourcePdfSha256:
+      '50874645b2cec033726018c86974241db2048ac46291e02fcb25d3cb7fbaa907',
+    producerReceiptSha256:
+      'b4a77ad340d34fbd6683ca099b66011d256808d560df68bf34f16ecfa0bd3d24',
+    artifacts: {
+      markdown:
+        'c07cd881ed06981303d35a7a039c04670f2eb397976b1061ccb56bf45747409a',
+      'content-list-v1':
+        '1f3ad4482ae1a1485175c32530092a102c4a018520fca8e42141da1bcb2ddc88',
+      'content-list-v2':
+        '0a24ef9cece4ed7acc715c90fe4710ffbf1094cadb2253b5fb824b5bbcb89566',
+      'middle-json':
+        'f57e7e7bdcd6d3c4fe21385496dd2e3a033a89b46df91a7dc0cfda20ed1ff31f',
+      'model-json':
+        '7383748a5fb49422e703cb4cff05f8857c01c6c6c32d9202abf30ed68b4b82bd',
+      'layout-pdf':
+        'd1fa744a8beb2e6ddaad50d93378ff45a0a59dd68ff13e6868fe446f505fa1b4',
+    },
+  },
+  {
+    fixture: scanFixturePdf,
+    sourcePdfSha256:
+      '2bb7049bf4c854d31a95eadc0d8462306708b36bc8a11eb7c885549e0c241c01',
+    producerReceiptSha256:
+      '62895b2a12ae418d18c80c2daa24745a1e17fce731e77a4c7d71ebed4e24c609',
+    artifacts: {
+      markdown:
+        '99c6f4a2d300db88d56a4ce0975428371abc7fb610bb477cab341c0dd23535eb',
+      'content-list-v1':
+        '2a769007c5e921f0f1443b24bd1514762a13c94fa21ce64a276804ce9d899bba',
+      'content-list-v2':
+        '9282e7d829dc9e3eb600aef13f73056ffcfc9d25e3b1f4a528d530e23be0e6ae',
+      'middle-json':
+        '8d3edf6356859d4c047f2d751a3157cbf2ade768e285c9bcee85ca70a83ec06e',
+      'model-json':
+        '4e23ef9bb58f7b2a5ba21e8dcdcbebe4cd0230e02569202a4a15a308bf72a71f',
+      'layout-pdf':
+        '4db642914ce20cfab8225e4a8e4f491174fd8fd158a7284079e1d45374f94806',
+    },
+  },
+] as const
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+async function fakeMineruOutput(options: { omitReferencedImage?: boolean } = {}) {
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), 'mineru-runner-test-')),
+  )
+  roots.push(root)
+  await chmod(root, 0o700)
+  const output = join(root, 'raw-output', 'opaque-document', 'vlm')
+  await mkdir(output, { recursive: true, mode: 0o700 })
+  const records = [
+    {
+      type: 'text',
+      page_idx: 0,
+      bbox: [50, 50, 950, 100],
+      text: 'A Reconstructed Research Paper',
+    },
+    {
+      type: 'image',
+      page_idx: 0,
+      bbox: [50, 150, 450, 550],
+      img_path: 'images/figure.png',
+    },
+  ]
+  await writeFile(
+    join(output, 'opaque.md'),
+    '# A Reconstructed Research Paper\n',
+  )
+  await writeFile(
+    join(output, 'opaque_content_list.json'),
+    JSON.stringify(records),
+  )
+  await writeFile(
+    join(output, 'opaque_content_list_v2.json'),
+    JSON.stringify(records),
+  )
+  await writeFile(
+    join(output, 'opaque_middle.json'),
+    JSON.stringify({ pages: [] }),
+  )
+  await writeFile(
+    join(output, 'opaque_model.json'),
+    JSON.stringify({ pages: [] }),
+  )
+  await writeFile(join(output, 'opaque_layout.pdf'), '%PDF-1.7\n%%EOF\n')
+  if (!options.omitReferencedImage) {
+    await mkdir(join(output, 'images'), { recursive: true, mode: 0o700 })
+    await writeFile(
+      join(output, 'images', 'figure.png'),
+      Buffer.from('89504e470d0a1a0a', 'hex'),
+      { mode: 0o600 },
+    )
+  }
+  return { root, outputRoot: join(root, 'raw-output') }
+}
+
+describe('owner-local MinerU runner', () => {
+  it('normalizes a real PDF fixture into a private authenticated manifest', async () => {
+    const { root, outputRoot } = await fakeMineruOutput()
+    const cacheInventorySha256 = sha256('owner-local-cache-inventory')
+    const rootRef = `cache-${cacheInventorySha256.slice(0, 32)}`
+    const manifest = await normalizeMineruRunArtifacts({
+      sourcePdfPath: fixturePdf,
+      runDirectory: root,
+      outputRoot,
+      maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+      identity: {
+        rootRef,
+        mineruExecutableSha256: sha256('mineru-executable'),
+        mineruConfigSha256: sha256('mineru-config'),
+        modelConfigSha256: sha256('model-config'),
+        runtimeInventorySha256: sha256('runtime-inventory'),
+        runtimeTreeByteLength: 4096,
+        cacheInventorySha256,
+        cacheByteLength: MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+        execution: {
+          hostClass: 'owner-laptop',
+          operatingSystem: 'macOS-15.6',
+          architecture: 'arm64',
+          runtime: 'python-3.12',
+          backend: 'mlx-vlm',
+          backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+          runtimeSha256: sha256('python-runtime'),
+          backendSha256: sha256('mlx-backend'),
+          packageSetSha256: sha256('installed-package-records'),
+          cacheNamespaceSha256: sha256(
+            `{"namespace":"mineru-production","rootRef":"${rootRef}"}`,
+          ),
+          networkIsolation: 'macos-sandbox-exec-deny-network-v1',
+          networkIsolationSha256: sha256('sandbox-exec-deny-network'),
+        },
+      },
+    })
+
+    expect((await stat(root)).mode & 0o777).toBe(0o700)
+    expect(manifest.document.sha256).toBe(
+      '50874645b2cec033726018c86974241db2048ac46291e02fcb25d3cb7fbaa907',
+    )
+    expect(manifest.artifacts.map(({ kind }) => kind)).toEqual(
+      expect.arrayContaining([
+        'markdown',
+        'content-list-v1',
+        'content-list-v2',
+        'middle-json',
+        'layout-json',
+        'model-json',
+        'reading-order',
+        'page-geometry',
+        'layout-pdf',
+        'raw-output',
+      ]),
+    )
+    const bundle = await inspectMineruSourceEvidence({
+      artifactRoot: root,
+      manifest,
+    })
+    expect(bundle.source).toMatchObject({
+      sha256: manifest.document.sha256,
+      pageCount: 1,
+    })
+    expect(bundle.candidates.some(({ kind }) => kind === 'text')).toBe(true)
+    expect(bundle.artifacts.some(({ kind }) => kind === 'layout-pdf')).toBe(
+      true,
+    )
+  })
+
+  it('fails closed on a missing referenced image, raw-output tampering, and the configured output bound', async () => {
+    const missing = await fakeMineruOutput({ omitReferencedImage: true })
+    const identity = {
+      rootRef: `cache-${sha256('cache').slice(0, 32)}`,
+      mineruExecutableSha256: sha256('mineru-executable'),
+      mineruConfigSha256: sha256('mineru-config'),
+      modelConfigSha256: sha256('model-config'),
+      runtimeInventorySha256: sha256('runtime-inventory'),
+      runtimeTreeByteLength: 4096,
+      cacheInventorySha256: sha256('cache'),
+      cacheByteLength: MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+      execution: {
+        hostClass: 'owner-laptop' as const,
+        operatingSystem: 'macOS-15.6',
+        architecture: 'arm64' as const,
+        runtime: 'python-3.12' as const,
+        backend: 'mlx-vlm' as const,
+        backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+        runtimeSha256: sha256('python-runtime'),
+        backendSha256: sha256('mlx-backend'),
+        packageSetSha256: sha256('installed-package-records'),
+        cacheNamespaceSha256: sha256('cache-namespace'),
+        networkIsolation: 'macos-sandbox-exec-deny-network-v1' as const,
+        networkIsolationSha256: sha256('sandbox-exec-deny-network'),
+      },
+    }
+    identity.execution.cacheNamespaceSha256 = sha256(
+      `{"namespace":"mineru-production","rootRef":"${identity.rootRef}"}`,
+    )
+    await expect(
+      normalizeMineruRunArtifacts({
+        sourcePdfPath: fixturePdf,
+        runDirectory: missing.root,
+        outputRoot: missing.outputRoot,
+        maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+        identity,
+      }),
+    ).rejects.toThrow(/REFERENCED_IMAGE/u)
+
+    const bounded = await fakeMineruOutput()
+    await expect(
+      normalizeMineruRunArtifacts({
+        sourcePdfPath: fixturePdf,
+        runDirectory: bounded.root,
+        outputRoot: bounded.outputRoot,
+        maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+        maximumOutputBytes: 1,
+        identity,
+      } as Parameters<typeof normalizeMineruRunArtifacts>[0]),
+    ).rejects.toThrow(/OUTPUT_BOUND/u)
+
+    const retained = await fakeMineruOutput()
+    const manifest = await normalizeMineruRunArtifacts({
+      sourcePdfPath: fixturePdf,
+      runDirectory: retained.root,
+      outputRoot: retained.outputRoot,
+      maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+      identity,
+    })
+    const raw = manifest.artifacts.find(({ kind }) => kind === 'raw-output')!
+    expect(raw).toBeDefined()
+    await writeFile(join(retained.root, raw.relativePath), 'tampered')
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: retained.root,
+        manifest,
+      }),
+    ).rejects.toThrow(/ARTIFACT_IDENTITY_MISMATCH/u)
+  })
+
+  it('exposes a strict help/argument contract without accepting relative paths', () => {
+    expect(OWNER_LOCAL_MINERU_HELP).toContain('--model-root')
+    expect(parseOwnerLocalMineruArguments(['--help'])).toEqual({ help: true })
+    expect(() =>
+      parseOwnerLocalMineruArguments([
+        '--pdf',
+        'relative.pdf',
+        '--run-root',
+        '/private/tmp/runs',
+        '--mineru',
+        '/private/tmp/venv/bin/mineru',
+        '--python',
+        '/private/tmp/venv/bin/python3.12',
+        '--config',
+        '/private/tmp/mineru.json',
+        '--model-root',
+        '/private/tmp/model',
+      ]),
+    ).toThrow(/ABSOLUTE_PATH_REQUIRED/u)
+  })
+
+  it('executes through a real OS network-isolation boundary', async () => {
+    const runDirectory = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-network-probe-')),
+    )
+    roots.push(runDirectory)
+    await chmod(runDirectory, 0o700)
+    const isMac = process.platform === 'darwin'
+    const plan = buildOwnerLocalMineruIsolationCommand({
+      isolation: isMac
+        ? 'macos-sandbox-exec-deny-network-v1'
+        : 'linux-user-netns-loopback-only-v1',
+      isolationExecutable: isMac
+        ? '/usr/bin/sandbox-exec'
+        : '/usr/bin/unshare',
+      runDirectory,
+      program: process.execPath,
+      args: [
+        '-e',
+        `const net=require('node:net');const socket=net.connect(53,'1.1.1.1');socket.once('connect',()=>process.exit(9));socket.once('error',(error)=>process.exit(['EPERM','EACCES','ENETUNREACH','EHOSTUNREACH','EADDRNOTAVAIL'].includes(error.code)?0:8));setTimeout(()=>process.exit(7),2000)`,
+      ],
+    })
+    if (isMac) expect(plan.args[0]).toBe('-p')
+    else expect(plan.args).toContain('--net')
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      const child = spawn(plan.command, plan.args, { stdio: 'ignore' })
+      child.once('error', rejectPromise)
+      child.once('exit', (code, signal) => {
+        if (code === 0 && signal === null) resolvePromise()
+        else rejectPromise(
+          new Error(`NETWORK_ISOLATION_PROBE_FAILED:${code}:${signal}`),
+        )
+      })
+    })
+  })
+
+  it('enforces the measured execution snapshot as read-only inside isolation', async () => {
+    const runDirectory = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-readonly-probe-')),
+    )
+    roots.push(runDirectory)
+    await chmod(runDirectory, 0o700)
+    const measuredRoot = join(runDirectory, 'measured')
+    const measuredFile = join(measuredRoot, 'identity.txt')
+    await mkdir(measuredRoot, { mode: 0o700 })
+    await writeFile(measuredFile, 'measured')
+    const isMac = process.platform === 'darwin'
+    const plan = buildOwnerLocalMineruIsolationCommand({
+      isolation: isMac
+        ? 'macos-sandbox-exec-deny-network-v1'
+        : 'linux-user-netns-loopback-only-v1',
+      isolationExecutable: isMac
+        ? '/usr/bin/sandbox-exec'
+        : '/usr/bin/unshare',
+      runDirectory,
+      program: process.execPath,
+      args: [
+        '-e',
+        `const fs=require('node:fs');try{fs.writeFileSync(${JSON.stringify(
+          measuredFile,
+        )},'swapped');process.exit(9)}catch(error){process.exit(['EPERM','EACCES','EROFS'].includes(error.code)?0:8)}`,
+      ],
+      readOnlyPaths: [measuredRoot],
+    })
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      const child = spawn(plan.command, plan.args, { stdio: 'ignore' })
+      child.once('error', rejectPromise)
+      child.once('exit', (code, signal) => {
+        if (code === 0 && signal === null) resolvePromise()
+        else
+          rejectPromise(
+            new Error(`READONLY_ISOLATION_PROBE_FAILED:${code}:${signal}`),
+          )
+      })
+    })
+    expect(await readFile(measuredFile, 'utf8')).toBe('measured')
+  })
+
+  it('seals execution bytes before use and rejects swap-use-restore aliases', async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-sealed-tree-test-')),
+    )
+    roots.push(root)
+    const source = join(root, 'mutable-runtime')
+    const sealed = join(root, 'sealed-runtime')
+    await mkdir(join(source, 'bin'), { recursive: true, mode: 0o700 })
+    await writeFile(join(source, 'bin', 'python'), 'measured-runtime', {
+      mode: 0o755,
+    })
+    await symlink('python', join(source, 'bin', 'python-alias'))
+    const preflightRuntime = await measureOwnerLocalExecutionTree(source)
+    const snapshot = await sealOwnerLocalExecutionTree({
+      sourceRoot: source,
+      sealedRoot: sealed,
+      maximumLogicalBytes: 32 * 1024,
+      maximumAllocatedBytes: 32 * 1024,
+    })
+    await writeFile(join(source, 'bin', 'python'), 'swapped-then-restored', {
+      mode: 0o755,
+    })
+    expect(await readFile(join(sealed, 'bin', 'python'), 'utf8')).toBe(
+      'measured-runtime',
+    )
+    expect(await readFile(join(sealed, 'bin', 'python-alias'), 'utf8')).toBe(
+      'measured-runtime',
+    )
+    expect((await stat(sealed)).mode & 0o222).toBe(0)
+    expect((await stat(join(sealed, 'bin', 'python'))).mode & 0o222).toBe(0)
+    expect(snapshot.fileCount).toBe(2)
+    expect(snapshot.inventorySha256).toBe(preflightRuntime.sha256)
+    expect(snapshot.byteLength).toBe(preflightRuntime.byteLength)
+    expect(snapshot.allocatedByteLength).toBeGreaterThan(0)
+
+    const ordinarySnapshot = await sealOwnerLocalExecutionTree({
+      sourceRoot: source,
+      sealedRoot: join(root, 'sealed-runtime-ordinary-copy'),
+      maximumLogicalBytes: 32 * 1024,
+      maximumAllocatedBytes: 32 * 1024,
+      copyMode: 'ordinary-copy',
+    })
+    expect(ordinarySnapshot.allocatedByteLength).toBeGreaterThanOrEqual(
+      ordinarySnapshot.byteLength,
+    )
+    const privateSnapshotByteLength =
+      ownerLocalPrivateSnapshotAllocatedBytes({
+        runtimeAllocatedByteLength: snapshot.allocatedByteLength,
+        modelAllocatedByteLength: ordinarySnapshot.allocatedByteLength,
+        sourceAllocatedByteLength: 4096,
+        preflightConfigAllocatedByteLength: 4096,
+        effectiveConfigAllocatedByteLength: 4096,
+      })
+    expect(privateSnapshotByteLength).toBe(
+      snapshot.allocatedByteLength +
+        ordinarySnapshot.allocatedByteLength +
+        3 * 4096,
+    )
+    const preflightConfig = join(root, 'preflight-mineru.json')
+    await writeFile(preflightConfig, '{"model-source":"local"}', {
+      mode: 0o600,
+    })
+    await expect(
+      assertOwnerLocalSealedPreflightIdentity({
+        runtimeSnapshot: ordinarySnapshot,
+        expectedRuntimeInventorySha256: snapshot.inventorySha256,
+        expectedRuntimeTreeByteLength: snapshot.byteLength,
+        sealedPreflightConfigPath: preflightConfig,
+        expectedPreflightConfigSha256: sha256('{"model-source":"local"}'),
+      }),
+    ).rejects.toThrow(/SEALED_RUNTIME_IDENTITY_MISMATCH/u)
+    await expect(
+      assertOwnerLocalSealedPreflightIdentity({
+        runtimeSnapshot: ordinarySnapshot,
+        expectedRuntimeInventorySha256: ordinarySnapshot.inventorySha256,
+        expectedRuntimeTreeByteLength: ordinarySnapshot.byteLength,
+        sealedPreflightConfigPath: preflightConfig,
+        expectedPreflightConfigSha256: sha256('different-config'),
+      }),
+    ).rejects.toThrow(/SEALED_CONFIG_IDENTITY_MISMATCH/u)
+    expect(() =>
+      assertOwnerLocalMineruResourceUsage({
+        maximumOutputBytes: 1,
+        maximumCacheBytes: privateSnapshotByteLength,
+        cacheByteLength: 0,
+        privateSnapshotByteLength: privateSnapshotByteLength + 1,
+        outputByteLength: 0,
+        privateScratchByteLength: 0,
+        fileCount: 0,
+      }),
+    ).toThrow(/CACHE_BOUND/u)
+
+    const plan = buildOwnerLocalMineruIsolationCommand({
+      isolation: 'macos-sandbox-exec-deny-network-v1',
+      isolationExecutable: '/usr/bin/sandbox-exec',
+      runDirectory: root,
+      program: join(sealed, 'bin', 'python'),
+      args: [],
+      readOnlyPaths: [sealed],
+    })
+    expect(plan.args[1]).toContain(
+      `(deny file-write* (subpath "${sealed}"))`,
+    )
+    await chmod(join(sealed, 'bin'), 0o700)
+    await chmod(sealed, 0o700)
+    await chmod(join(ordinarySnapshot.sealedRoot, 'bin'), 0o700)
+    await chmod(ordinarySnapshot.sealedRoot, 0o700)
+  })
+
+  it('admits unaligned logical model bytes by remaining global allocation and rejects true overflow', async () => {
+    const root = await realpath(
+      await mkdtemp(join(tmpdir(), 'mineru-model-allocation-test-')),
+    )
+    roots.push(root)
+    const source = join(root, 'model-source')
+    await mkdir(source, { mode: 0o700 })
+    const logicalBytes = 4097
+    await writeFile(
+      join(source, 'model.safetensors'),
+      Buffer.alloc(logicalBytes, 1),
+    )
+
+    const fixedUsage = {
+      originalCacheByteLength: 8 * 1024,
+      runtimeAllocatedByteLength: 16 * 1024,
+      sourceAllocatedByteLength: 4 * 1024,
+      preflightConfigAllocatedByteLength: 4 * 1024,
+      effectiveConfigAllocatedByteLength: 4 * 1024,
+      reservedOutputByteLength: 16 * 1024,
+      reservedPrivateScratchByteLength: 16 * 1024,
+    }
+    const fixedByteLength = Object.values(fixedUsage).reduce(
+      (total, value) => total + value,
+      0,
+    )
+    const allocatedCapacity = 64 * 1024
+    const maximumCacheBytes = fixedByteLength + allocatedCapacity
+    const maximumAllocatedBytes =
+      remainingOwnerLocalSealedModelAllocatedBytes({
+        maximumCacheBytes,
+        ...fixedUsage,
+      })
+    expect(maximumAllocatedBytes).toBe(allocatedCapacity)
+
+    const snapshot = await sealOwnerLocalExecutionTree({
+      sourceRoot: source,
+      sealedRoot: join(root, 'sealed-model'),
+      maximumLogicalBytes: logicalBytes,
+      maximumAllocatedBytes,
+      copyMode: 'ordinary-copy',
+    })
+    expect(snapshot.byteLength).toBe(logicalBytes)
+    expect(snapshot.allocatedByteLength).toBeGreaterThan(logicalBytes)
+    expect(snapshot.allocatedByteLength).toBeLessThanOrEqual(
+      maximumAllocatedBytes,
+    )
+
+    const overflowAllocatedBytes =
+      remainingOwnerLocalSealedModelAllocatedBytes({
+        maximumCacheBytes:
+          fixedByteLength + snapshot.allocatedByteLength - 1,
+        ...fixedUsage,
+      })
+    await expect(
+      sealOwnerLocalExecutionTree({
+        sourceRoot: source,
+        sealedRoot: join(root, 'sealed-model-overflow'),
+        maximumLogicalBytes: logicalBytes,
+        maximumAllocatedBytes: overflowAllocatedBytes,
+        copyMode: 'ordinary-copy',
+      }),
+    ).rejects.toThrow(/SEALED_SNAPSHOT_BOUND_EXCEEDED/u)
+    await chmod(snapshot.sealedRoot, 0o700)
+  })
+
+  it('counts private HOME and TMPDIR in live and final owner-local bounds', () => {
+    expect(() =>
+      assertOwnerLocalMineruResourceUsage({
+        maximumOutputBytes: 100,
+        maximumCacheBytes: 1_000,
+        cacheByteLength: 700,
+        privateSnapshotByteLength: 100,
+        outputByteLength: 50,
+        privateScratchByteLength: 151,
+        fileCount: 4,
+      }),
+    ).toThrow(/CACHE_BOUND/u)
+    expect(() =>
+      assertOwnerLocalMineruResourceUsage({
+        maximumOutputBytes: 100,
+        maximumCacheBytes: 1_000,
+        cacheByteLength: 700,
+        privateSnapshotByteLength: 100,
+        outputByteLength: 50,
+        privateScratchByteLength: 150,
+        fileCount: 4,
+      }),
+    ).not.toThrow()
+  })
+
+  it('binds the real offline MLX born-digital and scan smoke receipts to distinct source bytes', async () => {
+    expect(MINERU_PRODUCTION_VERSION).toBe('3.4.4')
+    expect(MINERU_PRODUCTION_MODEL_SHA256).toBe(
+      'abf8681ca63b8dec7b67de257af47b821f179442f72998d0696ae2ed9232a5f0',
+    )
+    for (const receipt of realMlxSmokeReceipts) {
+      expect(
+        createHash('sha256')
+          .update(await readFile(receipt.fixture))
+          .digest('hex'),
+      ).toBe(receipt.sourcePdfSha256)
+      expect(receipt.producerReceiptSha256).toMatch(/^[a-f0-9]{64}$/u)
+      expect(Object.keys(receipt.artifacts)).toEqual([
+        'markdown',
+        'content-list-v1',
+        'content-list-v2',
+        'middle-json',
+        'model-json',
+        'layout-pdf',
+      ])
+      expect(
+        Object.values(receipt.artifacts).every((value) =>
+          /^[a-f0-9]{64}$/u.test(value),
+        ),
+      ).toBe(true)
+    }
+    expect(realMlxSmokeReceipts[0].artifacts).not.toEqual(
+      realMlxSmokeReceipts[1].artifacts,
+    )
+  })
+})

--- a/src/research/mineru-owner-local-runner.test.ts
+++ b/src/research/mineru-owner-local-runner.test.ts
@@ -515,6 +515,7 @@ describe('owner-local MinerU runner', () => {
     await writeFile(join(source, 'bin', 'python'), 'runtime', {
       mode: 0o755,
     })
+    await writeFile(join(source, 'bin.cache'), 'cache')
     await writeFile(join(source, 'CACHEDIR.TAG'), 'cache-tag')
 
     const preflight = await measureOwnerLocalExecutionTree(source)

--- a/src/research/mineru-owner-local-runner.ts
+++ b/src/research/mineru-owner-local-runner.ts
@@ -370,6 +370,7 @@ export async function sealOwnerLocalExecutionTree(input: {
   let allocatedByteLength = 0
   let fileCount = 0
   const inventory: Array<{
+    relativePath: string
     pathSha256: string
     byteLength: number
     sha256: string
@@ -430,6 +431,7 @@ export async function sealOwnerLocalExecutionTree(input: {
       }
       const relativePath = relative(sealedRoot, sealedPath)
       inventory.push({
+        relativePath,
         pathSha256: createHash('sha256').update(relativePath).digest('hex'),
         byteLength: copyDetails.size,
         sha256: await hashFile(sealedPath),
@@ -438,13 +440,18 @@ export async function sealOwnerLocalExecutionTree(input: {
   }
   await visit(sourceRoot, sealedRoot, new Set())
   await chmod(sealedRoot, 0o555)
+  const canonicalInventory = inventory
+    .sort((left, right) =>
+      compareCanonicalCodeUnits(left.relativePath, right.relativePath),
+    )
+    .map(({ relativePath: _relativePath, ...item }) => item)
   return Object.freeze({
     sourceRoot,
     sealedRoot,
     byteLength,
     allocatedByteLength,
     fileCount,
-    inventorySha256: canonicalHash(inventory),
+    inventorySha256: canonicalHash(canonicalInventory),
   })
 }
 

--- a/src/research/mineru-owner-local-runner.ts
+++ b/src/research/mineru-owner-local-runner.ts
@@ -212,6 +212,11 @@ function sameFileIdentity(
   )
 }
 
+function compareCanonicalCodeUnits(left: string, right: string) {
+  if (left === right) return 0
+  return left < right ? -1 : 1
+}
+
 async function listFiles(root: string): Promise<OutputFile[]> {
   const canonicalRoot = await realpath(root)
   const output: OutputFile[] = []
@@ -240,7 +245,7 @@ async function listFiles(root: string): Promise<OutputFile[]> {
   }
   await visit(canonicalRoot)
   return output.sort((left, right) =>
-    left.relativePath < right.relativePath ? -1 : 1,
+    compareCanonicalCodeUnits(left.relativePath, right.relativePath),
   )
 }
 
@@ -260,7 +265,9 @@ async function listMaterializedExecutionFiles(
     }
     const nextAncestry = new Set(ancestry).add(canonicalDirectory)
     const entries = await readdir(sourceDirectory, { withFileTypes: true })
-    entries.sort((left, right) => left.name.localeCompare(right.name))
+    entries.sort((left, right) =>
+      compareCanonicalCodeUnits(left.name, right.name),
+    )
     for (const entry of entries) {
       const sourcePath = join(sourceDirectory, entry.name)
       const logicalPath = join(logicalDirectory, entry.name)
@@ -284,7 +291,7 @@ async function listMaterializedExecutionFiles(
   }
   await visit(canonicalRoot, canonicalRoot, new Set())
   return output.sort((left, right) =>
-    left.relativePath.localeCompare(right.relativePath),
+    compareCanonicalCodeUnits(left.relativePath, right.relativePath),
   )
 }
 
@@ -379,7 +386,7 @@ export async function sealOwnerLocalExecutionTree(input: {
     const nextAncestry = new Set(ancestry).add(canonicalSourceDirectory)
     const entries = await readdir(sourceDirectory, { withFileTypes: true })
     entries.sort((left, right) =>
-      left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+      compareCanonicalCodeUnits(left.name, right.name),
     )
     for (const entry of entries) {
       const sourcePath = join(sourceDirectory, entry.name)

--- a/src/research/mineru-owner-local-runner.ts
+++ b/src/research/mineru-owner-local-runner.ts
@@ -1,0 +1,2027 @@
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { constants as fsConstants, createReadStream } from 'node:fs'
+import {
+  chmod,
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { arch, platform, release } from 'node:os'
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+  MINERU_MAX_ARTIFACT_COUNT,
+  MINERU_MAX_OWNER_CACHE_BYTES,
+  MINERU_MAX_RAW_OUTPUT_BYTES,
+  MINERU_PRODUCTION_BINDING,
+  MINERU_PRODUCTION_MODEL_ARCHITECTURE,
+  MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+  MINERU_PRODUCTION_MODEL_FILE,
+  MINERU_PRODUCTION_MODEL_SHA256,
+  type MineruArtifactKind,
+  type MineruArtifactManifest,
+  type MineruProducerReceipt,
+} from './mineru-source-evidence.ts'
+
+const MAX_RUNNER_OUTPUT_BYTES = 4 * 1024 * 1024
+const RUNNER_SCHEMA_VERSION = '1.0.0' as const
+
+export const OWNER_LOCAL_MINERU_HELP = `Usage:
+  node --experimental-strip-types src/research/mineru-owner-local-runner.ts \\
+    --pdf /absolute/input.pdf \\
+    --run-root /absolute/private-runs \\
+    --mineru /absolute/venv/bin/mineru \\
+    --python /absolute/venv/bin/python3.12 \\
+    --config /absolute/mineru.json \\
+    --model-root /absolute/pinned-model \\
+    --max-output-bytes 1073741824
+
+The runner creates a new mode-0700 directory, forces MinerU offline, and prints
+only a hash-bound JSON receipt. It never uploads the source or writes raw output
+inside the Git checkout.`
+
+export type OwnerLocalMineruRunnerOptions = {
+  pdfPath: string
+  runRoot: string
+  mineruExecutable: string
+  pythonExecutable: string
+  configPath: string
+  modelRoot: string
+  maxCacheBytes?: number
+  maxOutputBytes?: number
+}
+
+export type OwnerLocalMineruRun = {
+  schemaVersion: typeof RUNNER_SCHEMA_VERSION
+  runDirectory: string
+  manifestPath: string
+  manifest: MineruArtifactManifest
+}
+
+type IdentityMeasurement = {
+  execution: MineruArtifactManifest['execution']
+  mineruExecutableSha256: string
+  mineruConfigSha256: string
+  modelConfigSha256: string
+  runtimeInventorySha256: string
+  runtimeTreeByteLength: number
+  cacheInventorySha256: string
+  cacheByteLength: number
+}
+
+type StableFileIdentity = {
+  dev: number
+  ino: number
+  size: number
+  mtimeMs: number
+  ctimeMs: number
+}
+
+type MeasuredRunnerIdentity = IdentityMeasurement & {
+  rootRef: string
+  mineruExecutablePath: string
+  pythonExecutablePath: string
+  networkIsolationExecutablePath: string
+  networkIsolationExecutableSha256: string
+  mineruExecutableIdentity: StableFileIdentity
+  pythonExecutableIdentity: StableFileIdentity
+  networkIsolationExecutableIdentity: StableFileIdentity
+  networkIsolationAuxiliaryFiles: Array<{
+    path: string
+    sha256: string
+    identity: StableFileIdentity
+  }>
+  modelRootPath: string
+  configPath: string
+}
+
+type SealedOwnerLocalExecution = Readonly<{
+  options: OwnerLocalMineruRunnerOptions
+  sourcePreflight: Awaited<ReturnType<typeof inspectPdf>>
+  identity: MeasuredRunnerIdentity
+  readOnlyRoots: readonly string[]
+  privateSnapshotByteLength: number
+  sealedIsolationSha256: string
+  preflightConfigPath: string
+  preflightConfigSha256: string
+}>
+
+type OutputFile = {
+  absolutePath: string
+  relativePath: string
+  size: number
+}
+
+export type OwnerLocalSealedTreeSnapshot = Readonly<{
+  sourceRoot: string
+  sealedRoot: string
+  byteLength: number
+  allocatedByteLength: number
+  fileCount: number
+  inventorySha256: string
+}>
+
+function fail(code: string): never {
+  throw new Error(code)
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(',')}}`
+  }
+  const encoded = JSON.stringify(value)
+  if (encoded === undefined) fail('MINERU_RUNNER_NON_CANONICAL_VALUE')
+  return encoded
+}
+
+function canonicalHash(value: unknown) {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex')
+}
+
+async function hashFile(path: string) {
+  const digest = createHash('sha256')
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const stream = createReadStream(path)
+    stream.on('data', (chunk) => digest.update(chunk))
+    stream.once('error', rejectPromise)
+    stream.once('end', resolvePromise)
+  })
+  return digest.digest('hex')
+}
+
+async function secureRegularFile(path: string, code: string) {
+  if (!isAbsolute(path)) fail(code)
+  const canonical = await realpath(path)
+  const before = await stat(canonical)
+  if (!before.isFile() || before.size < 1) fail(code)
+  const identity = fileIdentity(before)
+  const sha256 = await hashFile(canonical)
+  const after = await stat(canonical)
+  if (!after.isFile() || !sameFileIdentity(identity, fileIdentity(after))) {
+    fail(`${code}_CHANGED_DURING_MEASUREMENT`)
+  }
+  return { canonical, size: before.size, sha256, identity }
+}
+
+function fileIdentity(
+  details: Awaited<ReturnType<typeof stat>>,
+): StableFileIdentity {
+  return {
+    dev: Number(details.dev),
+    ino: Number(details.ino),
+    size: Number(details.size),
+    mtimeMs: Number(details.mtimeMs),
+    ctimeMs: Number(details.ctimeMs),
+  }
+}
+
+function sameFileIdentity(
+  left: StableFileIdentity,
+  right: StableFileIdentity,
+) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  )
+}
+
+async function listFiles(root: string): Promise<OutputFile[]> {
+  const canonicalRoot = await realpath(root)
+  const output: OutputFile[] = []
+  async function visit(directory: string) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      const relativePath = relative(canonicalRoot, path)
+      if (
+        relativePath === '..' ||
+        relativePath.startsWith(`..${sep}`) ||
+        isAbsolute(relativePath)
+      ) {
+        fail('MINERU_RUNNER_PATH_ESCAPE')
+      }
+      if (entry.isSymbolicLink()) fail('MINERU_RUNNER_SYMLINK_REJECTED')
+      if (entry.isDirectory()) await visit(path)
+      else if (entry.isFile()) {
+        const details = await stat(path)
+        output.push({
+          absolutePath: path,
+          relativePath,
+          size: details.size,
+        })
+      } else fail('MINERU_RUNNER_UNSUPPORTED_FILE')
+    }
+  }
+  await visit(canonicalRoot)
+  return output.sort((left, right) =>
+    left.relativePath < right.relativePath ? -1 : 1,
+  )
+}
+
+async function listMaterializedExecutionFiles(
+  root: string,
+): Promise<OutputFile[]> {
+  const canonicalRoot = await realpath(root)
+  const output: OutputFile[] = []
+  const visit = async (
+    sourceDirectory: string,
+    logicalDirectory: string,
+    ancestry: ReadonlySet<string>,
+  ) => {
+    const canonicalDirectory = await realpath(sourceDirectory)
+    if (ancestry.has(canonicalDirectory)) {
+      fail('MINERU_RUNNER_SEALED_SNAPSHOT_CYCLE')
+    }
+    const nextAncestry = new Set(ancestry).add(canonicalDirectory)
+    const entries = await readdir(sourceDirectory, { withFileTypes: true })
+    entries.sort((left, right) => left.name.localeCompare(right.name))
+    for (const entry of entries) {
+      const sourcePath = join(sourceDirectory, entry.name)
+      const logicalPath = join(logicalDirectory, entry.name)
+      const sourceDetails = await lstat(sourcePath)
+      const copySource = sourceDetails.isSymbolicLink()
+        ? await realpath(sourcePath)
+        : sourcePath
+      const copyDetails = await stat(copySource)
+      if (copyDetails.isDirectory()) {
+        await visit(copySource, logicalPath, nextAncestry)
+      } else if (copyDetails.isFile()) {
+        output.push({
+          absolutePath: copySource,
+          relativePath: relative(canonicalRoot, logicalPath),
+          size: copyDetails.size,
+        })
+      } else {
+        fail('MINERU_RUNNER_UNSUPPORTED_SEALED_SNAPSHOT_ENTRY')
+      }
+    }
+  }
+  await visit(canonicalRoot, canonicalRoot, new Set())
+  return output.sort((left, right) =>
+    left.relativePath.localeCompare(right.relativePath),
+  )
+}
+
+async function treeMeasurement(
+  root: string,
+  precomputed = new Map<string, string>(),
+  options: { materializeSymlinks?: boolean } = {},
+) {
+  const files = options.materializeSymlinks
+    ? await listMaterializedExecutionFiles(root)
+    : await listFiles(root)
+  const inventory = []
+  for (const file of files) {
+    inventory.push({
+      pathSha256: createHash('sha256').update(file.relativePath).digest('hex'),
+      byteLength: file.size,
+      sha256:
+        precomputed.get(await realpath(file.absolutePath)) ??
+        (await hashFile(file.absolutePath)),
+    })
+  }
+  return {
+    sha256: canonicalHash(inventory),
+    byteLength: inventory.reduce((total, item) => total + item.byteLength, 0),
+  }
+}
+
+export async function measureOwnerLocalExecutionTree(sourceRoot: string) {
+  if (!isAbsolute(sourceRoot)) {
+    fail('MINERU_RUNNER_INVALID_SEALED_SNAPSHOT')
+  }
+  return treeMeasurement(sourceRoot, new Map(), {
+    materializeSymlinks: true,
+  })
+}
+
+/**
+ * Clone an execution tree into the private run directory before inference.
+ * Symlinks are materialized as their referenced file bytes, so the child
+ * process never follows a mutable path outside the sealed tree. Reflinks are
+ * requested when the filesystem supports them and copyFile safely falls back
+ * to an ordinary copy otherwise.
+ */
+export async function sealOwnerLocalExecutionTree(input: {
+  sourceRoot: string
+  sealedRoot: string
+  maximumLogicalBytes: number
+  maximumAllocatedBytes: number
+  copyMode?: 'reflink-or-copy' | 'ordinary-copy'
+}): Promise<OwnerLocalSealedTreeSnapshot> {
+  if (
+    !isAbsolute(input.sourceRoot) ||
+    !isAbsolute(input.sealedRoot) ||
+    !Number.isSafeInteger(input.maximumLogicalBytes) ||
+    input.maximumLogicalBytes < 1 ||
+    !Number.isSafeInteger(input.maximumAllocatedBytes) ||
+    input.maximumAllocatedBytes < 1
+  ) {
+    fail('MINERU_RUNNER_INVALID_SEALED_SNAPSHOT')
+  }
+  const sourceRoot = await realpath(input.sourceRoot)
+  const sourceDetails = await stat(sourceRoot)
+  if (!sourceDetails.isDirectory()) {
+    fail('MINERU_RUNNER_INVALID_SEALED_SNAPSHOT')
+  }
+  await mkdir(input.sealedRoot, { recursive: false, mode: 0o700 })
+  const sealedRoot = await realpath(input.sealedRoot)
+  if (
+    sealedRoot === sourceRoot ||
+    sealedRoot.startsWith(`${sourceRoot}${sep}`) ||
+    sourceRoot.startsWith(`${sealedRoot}${sep}`)
+  ) {
+    fail('MINERU_RUNNER_INVALID_SEALED_SNAPSHOT')
+  }
+  let byteLength = 0
+  let allocatedByteLength = 0
+  let fileCount = 0
+  const inventory: Array<{
+    pathSha256: string
+    byteLength: number
+    sha256: string
+  }> = []
+  const visit = async (
+    sourceDirectory: string,
+    sealedDirectory: string,
+    ancestry: ReadonlySet<string>,
+  ) => {
+    const canonicalSourceDirectory = await realpath(sourceDirectory)
+    if (ancestry.has(canonicalSourceDirectory)) {
+      fail('MINERU_RUNNER_SEALED_SNAPSHOT_CYCLE')
+    }
+    const nextAncestry = new Set(ancestry).add(canonicalSourceDirectory)
+    const entries = await readdir(sourceDirectory, { withFileTypes: true })
+    entries.sort((left, right) =>
+      left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+    )
+    for (const entry of entries) {
+      const sourcePath = join(sourceDirectory, entry.name)
+      const sealedPath = join(sealedDirectory, entry.name)
+      const sourcePathDetails = await lstat(sourcePath)
+      let copySource = sourcePath
+      if (sourcePathDetails.isSymbolicLink()) {
+        copySource = await realpath(sourcePath)
+      }
+      const copyDetails = await stat(copySource)
+      if (copyDetails.isDirectory()) {
+        await mkdir(sealedPath, { mode: 0o700 })
+        await visit(copySource, sealedPath, nextAncestry)
+        await chmod(sealedPath, 0o555)
+        continue
+      }
+      if (!copyDetails.isFile()) {
+        fail('MINERU_RUNNER_UNSUPPORTED_SEALED_SNAPSHOT_ENTRY')
+      }
+      byteLength += copyDetails.size
+      fileCount += 1
+      if (byteLength > input.maximumLogicalBytes) {
+        fail('MINERU_RUNNER_SEALED_SNAPSHOT_BOUND_EXCEEDED')
+      }
+      await copyFile(
+        copySource,
+        sealedPath,
+        input.copyMode === 'ordinary-copy'
+          ? 0
+          : fsConstants.COPYFILE_FICLONE,
+      )
+      const executable = (copyDetails.mode & 0o111) !== 0
+      await chmod(sealedPath, executable ? 0o555 : 0o444)
+      const sealedDetails = await stat(sealedPath)
+      allocatedByteLength += Math.max(
+        0,
+        Number(sealedDetails.blocks) * 512,
+      )
+      if (allocatedByteLength > input.maximumAllocatedBytes) {
+        fail('MINERU_RUNNER_SEALED_SNAPSHOT_BOUND_EXCEEDED')
+      }
+      const relativePath = relative(sealedRoot, sealedPath)
+      inventory.push({
+        pathSha256: createHash('sha256').update(relativePath).digest('hex'),
+        byteLength: copyDetails.size,
+        sha256: await hashFile(sealedPath),
+      })
+    }
+  }
+  await visit(sourceRoot, sealedRoot, new Set())
+  await chmod(sealedRoot, 0o555)
+  return Object.freeze({
+    sourceRoot,
+    sealedRoot,
+    byteLength,
+    allocatedByteLength,
+    fileCount,
+    inventorySha256: canonicalHash(inventory),
+  })
+}
+
+export async function assertOwnerLocalSealedPreflightIdentity(input: {
+  runtimeSnapshot: OwnerLocalSealedTreeSnapshot
+  expectedRuntimeInventorySha256: string
+  expectedRuntimeTreeByteLength: number
+  sealedPreflightConfigPath: string
+  expectedPreflightConfigSha256: string
+}) {
+  if (
+    input.runtimeSnapshot.inventorySha256 !==
+      input.expectedRuntimeInventorySha256 ||
+    input.runtimeSnapshot.byteLength !== input.expectedRuntimeTreeByteLength
+  ) {
+    fail('MINERU_RUNNER_SEALED_RUNTIME_IDENTITY_MISMATCH')
+  }
+  const config = await secureRegularFile(
+    input.sealedPreflightConfigPath,
+    'MINERU_RUNNER_SEALED_PREFLIGHT_CONFIG',
+  )
+  if (config.sha256 !== input.expectedPreflightConfigSha256) {
+    fail('MINERU_RUNNER_SEALED_CONFIG_IDENTITY_MISMATCH')
+  }
+}
+
+async function insideGitCheckout(path: string) {
+  let current = await realpath(path)
+  for (;;) {
+    try {
+      await lstat(join(current, '.git'))
+      return true
+    } catch (error) {
+      if (
+        !record(error) ||
+        (error as unknown as NodeJS.ErrnoException).code !== 'ENOENT'
+      ) {
+        throw error
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
+}
+
+function installedPackageRoots(mineruExecutable: string) {
+  const environmentRoot = dirname(dirname(mineruExecutable))
+  const sitePackages = join(
+    environmentRoot,
+    'lib',
+    'python3.12',
+    'site-packages',
+  )
+  return {
+    sitePackages,
+    mineru: join(sitePackages, 'mineru-3.4.4.dist-info'),
+    mineruVl: join(sitePackages, 'mineru_vl_utils-1.2.1.dist-info'),
+    mlx: join(sitePackages, 'mlx-0.31.1.dist-info'),
+    mlxVlm: join(sitePackages, 'mlx_vlm-0.3.12.dist-info'),
+  }
+}
+
+async function assertPackageMetadata(
+  sitePackages: string,
+  path: string,
+  name: string,
+  version: string,
+) {
+  const metadata = await readFile(join(path, 'METADATA'), 'utf8')
+  const normalizeDistributionName = (value: string) =>
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[._-]+/gu, '-')
+  const installedName = metadata
+    .split(/\r?\n/u)
+    .find((line) => line.startsWith('Name: '))
+    ?.slice('Name: '.length)
+  if (
+    installedName === undefined ||
+    normalizeDistributionName(installedName) !==
+      normalizeDistributionName(name) ||
+    !metadata.split(/\r?\n/u).includes(`Version: ${version}`)
+  ) {
+    fail('MINERU_RUNNER_PACKAGE_IDENTITY_MISMATCH')
+  }
+  const recordFile = await secureRegularFile(
+    join(path, 'RECORD'),
+    'MINERU_RUNNER_PACKAGE_RECORD_MISSING',
+  )
+  const recordText = await readFile(recordFile.canonical, 'utf8')
+  const environmentRoot = resolve(sitePackages, '../../..')
+  const verifiedFiles: Array<{
+    pathSha256: string
+    byteLength: number
+    sha256: string
+  }> = []
+  for (const line of recordText.split(/\r?\n/u).filter(Boolean)) {
+    const columns = line.split(',')
+    if (columns.length !== 3) fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+    const [relativePath, digestField, sizeField] = columns
+    if (!relativePath || relativePath.includes('\\')) {
+      fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+    }
+    if (digestField === '' && sizeField === '') {
+      if (resolve(sitePackages, relativePath) !== recordFile.canonical) {
+        fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+      }
+      continue
+    }
+    if (
+      !digestField?.startsWith('sha256=') ||
+      !/^\d+$/u.test(sizeField ?? '')
+    ) {
+      fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+    }
+    const absolutePath = resolve(sitePackages, relativePath)
+    const relativeToRoot = relative(environmentRoot, absolutePath)
+    if (
+      relativeToRoot === '..' ||
+      relativeToRoot.startsWith(`..${sep}`) ||
+      isAbsolute(relativeToRoot)
+    ) {
+      fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+    }
+    const details = await lstat(absolutePath)
+    if (!details.isFile() || details.isSymbolicLink()) {
+      fail('MINERU_RUNNER_PACKAGE_IDENTITY_MISMATCH')
+    }
+    const actualSha256 = await hashFile(absolutePath)
+    const expectedDigest = digestField.slice('sha256='.length)
+    const actualDigest = Buffer.from(actualSha256, 'hex').toString('base64url')
+    if (Number(sizeField) !== details.size || actualDigest !== expectedDigest) {
+      fail('MINERU_RUNNER_PACKAGE_IDENTITY_MISMATCH')
+    }
+    verifiedFiles.push({
+      pathSha256: createHash('sha256').update(relativePath).digest('hex'),
+      byteLength: details.size,
+      sha256: actualSha256,
+    })
+  }
+  if (verifiedFiles.length === 0) fail('MINERU_RUNNER_INVALID_PACKAGE_RECORD')
+  return {
+    name,
+    version,
+    metadataSha256: createHash('sha256').update(metadata).digest('hex'),
+    recordSha256: recordFile.sha256,
+    installedFilesSha256: canonicalHash(verifiedFiles),
+  }
+}
+
+async function inspectPdf(pdfPath: string) {
+  const source = await secureRegularFile(pdfPath, 'MINERU_RUNNER_INVALID_PDF')
+  const sourceBytes = new Uint8Array(await readFile(source.canonical))
+  if (
+    createHash('sha256').update(sourceBytes).digest('hex') !== source.sha256 ||
+    !sameFileIdentity(
+      source.identity,
+      fileIdentity(await stat(source.canonical)),
+    )
+  ) {
+    fail('MINERU_RUNNER_SOURCE_CHANGED_DURING_PREFLIGHT')
+  }
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs')
+  const task = pdfjs.getDocument({
+    data: sourceBytes,
+    disableFontFace: true,
+    useSystemFonts: false,
+    isEvalSupported: false,
+  })
+  const document = await task.promise
+  const pages = []
+  try {
+    for (let page = 1; page <= document.numPages; page += 1) {
+      const sourcePage = await document.getPage(page)
+      const viewport = sourcePage.getViewport({ scale: 1 })
+      pages.push({
+        page,
+        width: viewport.width,
+        height: viewport.height,
+        rotation: ((viewport.rotation % 360) + 360) % 360,
+      })
+      sourcePage.cleanup()
+    }
+  } finally {
+    await document.destroy()
+  }
+  if (pages.length < 1) fail('MINERU_RUNNER_INVALID_PDF')
+  return { source, pages }
+}
+
+function samePdfInspection(
+  left: Awaited<ReturnType<typeof inspectPdf>>,
+  right: Awaited<ReturnType<typeof inspectPdf>>,
+) {
+  return (
+    left.source.canonical === right.source.canonical &&
+    left.source.sha256 === right.source.sha256 &&
+    sameFileIdentity(left.source.identity, right.source.identity) &&
+    canonicalJson(left.pages) === canonicalJson(right.pages)
+  )
+}
+
+const MACOS_DENY_NETWORK_PROFILE =
+  '(version 1)(allow default)(deny network*)(allow network-inbound (local ip "localhost:*"))(allow network-outbound (remote ip "localhost:*"))'
+const LINUX_LOOPBACK_SETUP =
+  'set -eu; readonly_count="$1"; shift; while [ "$readonly_count" -gt 0 ]; do target="$1"; shift; /usr/bin/mount --bind "$target" "$target"; /usr/bin/mount -o remount,bind,ro "$target"; readonly_count=$((readonly_count - 1)); done; /usr/sbin/ip link set lo up; exec "$@"'
+
+function networkIsolationBinding() {
+  if (platform() === 'darwin' && arch() === 'arm64') {
+    return {
+      kind: 'macos-sandbox-exec-deny-network-v1' as const,
+      executable: '/usr/bin/sandbox-exec',
+      policy: MACOS_DENY_NETWORK_PROFILE,
+      auxiliaries: [] as string[],
+    }
+  }
+  if (platform() === 'linux' && arch() === 'arm64') {
+    return {
+      kind: 'linux-user-netns-loopback-only-v1' as const,
+      executable: '/usr/bin/unshare',
+      policy: `unshare --user --map-root-user --net; ${LINUX_LOOPBACK_SETUP}`,
+      auxiliaries: ['/bin/sh', '/usr/bin/mount', '/usr/sbin/ip'],
+    }
+  }
+  fail('MINERU_RUNNER_UNSUPPORTED_HOST')
+}
+
+async function measureIdentity(options: OwnerLocalMineruRunnerOptions) {
+  const mineru = await secureRegularFile(
+    options.mineruExecutable,
+    'MINERU_RUNNER_INVALID_EXECUTABLE',
+  )
+  const runtime = await secureRegularFile(
+    options.pythonExecutable,
+    'MINERU_RUNNER_INVALID_RUNTIME',
+  )
+  const config = await secureRegularFile(
+    options.configPath,
+    'MINERU_RUNNER_INVALID_CONFIG',
+  )
+  const model = await secureRegularFile(
+    join(options.modelRoot, MINERU_PRODUCTION_MODEL_FILE),
+    'MINERU_RUNNER_INVALID_MODEL',
+  )
+  if (
+    model.size !== MINERU_PRODUCTION_MODEL_BYTE_LENGTH ||
+    model.sha256 !== MINERU_PRODUCTION_MODEL_SHA256
+  ) {
+    fail('MINERU_RUNNER_MODEL_IDENTITY_MISMATCH')
+  }
+  const modelConfigFile = await secureRegularFile(
+    join(options.modelRoot, 'config.json'),
+    'MINERU_RUNNER_INVALID_MODEL_CONFIG',
+  )
+  const isolation = networkIsolationBinding()
+  const networkIsolationExecutable = await secureRegularFile(
+    isolation.executable,
+    'MINERU_RUNNER_NETWORK_ISOLATION_UNAVAILABLE',
+  )
+  const networkIsolationAuxiliaryFiles = await Promise.all(
+    isolation.auxiliaries.map(async (path) => {
+      const measured = await secureRegularFile(
+        path,
+        'MINERU_RUNNER_NETWORK_ISOLATION_UNAVAILABLE',
+      )
+      return {
+        path: resolve(path),
+        sha256: measured.sha256,
+        identity: measured.identity,
+      }
+    }),
+  )
+  const isolationPolicySha256 = canonicalHash({
+    executableSha256: networkIsolationExecutable.sha256,
+    auxiliarySha256: networkIsolationAuxiliaryFiles.map(
+      ({ path, sha256 }) => ({ path, sha256 }),
+    ),
+    policy: isolation.policy,
+  })
+  let modelConfig: unknown
+  let mineruConfig: unknown
+  try {
+    modelConfig = JSON.parse(await readFile(modelConfigFile.canonical, 'utf8'))
+    mineruConfig = JSON.parse(await readFile(config.canonical, 'utf8'))
+  } catch {
+    fail('MINERU_RUNNER_INVALID_CONFIG')
+  }
+  if (
+    !record(modelConfig) ||
+    !Array.isArray(modelConfig.architectures) ||
+    !modelConfig.architectures.includes(MINERU_PRODUCTION_MODEL_ARCHITECTURE) ||
+    modelConfig.model_type !== 'qwen2_vl' ||
+    !record(mineruConfig) ||
+    mineruConfig['model-source'] !== 'local' ||
+    !record(mineruConfig['models-dir']) ||
+    typeof mineruConfig['models-dir'].vlm !== 'string' ||
+    (await realpath(mineruConfig['models-dir'].vlm)) !==
+      (await realpath(options.modelRoot))
+  ) {
+    fail('MINERU_RUNNER_CONFIG_BINDING_MISMATCH')
+  }
+  const packages = installedPackageRoots(mineru.canonical)
+  const packageRecords = [
+    await assertPackageMetadata(
+      packages.sitePackages,
+      packages.mineru,
+      'mineru',
+      '3.4.4',
+    ),
+    await assertPackageMetadata(
+      packages.sitePackages,
+      packages.mineruVl,
+      'mineru-vl-utils',
+      '1.2.1',
+    ),
+  ]
+  let execution: MineruArtifactManifest['execution']
+  if (platform() === 'darwin' && arch() === 'arm64') {
+    packageRecords.push(
+      await assertPackageMetadata(
+        packages.sitePackages,
+        packages.mlx,
+        'mlx',
+        '0.31.1',
+      ),
+      await assertPackageMetadata(
+        packages.sitePackages,
+        packages.mlxVlm,
+        'mlx-vlm',
+        '0.3.12',
+      ),
+    )
+    execution = {
+      hostClass: 'owner-laptop',
+      operatingSystem: `macOS-${release()}`,
+      architecture: 'arm64',
+      runtime: 'python-3.12',
+      backend: 'mlx-vlm',
+      backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+      runtimeSha256: runtime.sha256,
+      backendSha256: canonicalHash(packageRecords.slice(2)),
+      packageSetSha256: canonicalHash(packageRecords),
+      cacheNamespaceSha256: '0'.repeat(64),
+      networkIsolation: isolation.kind,
+      networkIsolationSha256: isolationPolicySha256,
+    }
+  } else if (platform() === 'linux' && arch() === 'arm64') {
+    const torch = join(packages.sitePackages, 'torch-2.13.0+cpu.dist-info')
+    packageRecords.push(
+      await assertPackageMetadata(
+        packages.sitePackages,
+        torch,
+        'torch',
+        '2.13.0+cpu',
+      ),
+    )
+    execution = {
+      hostClass: 'trusted-vm',
+      operatingSystem: `Linux-${release()}`,
+      architecture: 'arm64',
+      runtime: 'python-3.12',
+      backend: 'torch-cpu',
+      backendVersion: 'torch-2.13.0+cpu',
+      runtimeSha256: runtime.sha256,
+      backendSha256: canonicalHash(packageRecords.slice(2)),
+      packageSetSha256: canonicalHash(packageRecords),
+      cacheNamespaceSha256: '0'.repeat(64),
+      networkIsolation: isolation.kind,
+      networkIsolationSha256: isolationPolicySha256,
+    }
+  } else fail('MINERU_RUNNER_UNSUPPORTED_HOST')
+  const cache = await treeMeasurement(
+    options.modelRoot,
+    new Map([[model.canonical, model.sha256]]),
+  )
+  const runtimeTree = await measureOwnerLocalExecutionTree(
+    dirname(dirname(options.mineruExecutable)),
+  )
+  const rootRef = `cache-${cache.sha256.slice(0, 32)}`
+  execution.cacheNamespaceSha256 = canonicalHash({
+    rootRef,
+    namespace: 'mineru-production',
+  })
+  return {
+    execution,
+    mineruExecutableSha256: mineru.sha256,
+    mineruConfigSha256: config.sha256,
+    modelConfigSha256: modelConfigFile.sha256,
+    runtimeInventorySha256: runtimeTree.sha256,
+    runtimeTreeByteLength: runtimeTree.byteLength,
+    cacheInventorySha256: cache.sha256,
+    cacheByteLength: cache.byteLength,
+    rootRef,
+    mineruExecutablePath: resolve(options.mineruExecutable),
+    // Preserve the venv invocation path (and therefore pyvenv.cfg discovery)
+    // while measuring and rechecking the exact canonical runtime it targets.
+    pythonExecutablePath: resolve(options.pythonExecutable),
+    networkIsolationExecutablePath: networkIsolationExecutable.canonical,
+    networkIsolationExecutableSha256: networkIsolationExecutable.sha256,
+    mineruExecutableIdentity: mineru.identity,
+    pythonExecutableIdentity: runtime.identity,
+    networkIsolationExecutableIdentity: networkIsolationExecutable.identity,
+    networkIsolationAuxiliaryFiles,
+    modelRootPath: await realpath(options.modelRoot),
+    configPath: config.canonical,
+  }
+}
+
+function measuredIdentityProjection(identity: MeasuredRunnerIdentity) {
+  return {
+    execution: identity.execution,
+    mineruExecutableSha256: identity.mineruExecutableSha256,
+    mineruConfigSha256: identity.mineruConfigSha256,
+    modelConfigSha256: identity.modelConfigSha256,
+    runtimeInventorySha256: identity.runtimeInventorySha256,
+    runtimeTreeByteLength: identity.runtimeTreeByteLength,
+    cacheInventorySha256: identity.cacheInventorySha256,
+    cacheByteLength: identity.cacheByteLength,
+    rootRef: identity.rootRef,
+    mineruExecutablePath: identity.mineruExecutablePath,
+    pythonExecutablePath: identity.pythonExecutablePath,
+    networkIsolationExecutablePath: identity.networkIsolationExecutablePath,
+    networkIsolationExecutableSha256:
+      identity.networkIsolationExecutableSha256,
+    networkIsolationAuxiliaryFiles: identity.networkIsolationAuxiliaryFiles.map(
+      ({ path, sha256 }) => ({ path, sha256 }),
+    ),
+    modelRootPath: identity.modelRootPath,
+    configPath: identity.configPath,
+  }
+}
+
+function portableMeasuredIdentityProjection(identity: MeasuredRunnerIdentity) {
+  return {
+    execution: identity.execution,
+    mineruExecutableSha256: identity.mineruExecutableSha256,
+    modelConfigSha256: identity.modelConfigSha256,
+    runtimeInventorySha256: identity.runtimeInventorySha256,
+    runtimeTreeByteLength: identity.runtimeTreeByteLength,
+    cacheInventorySha256: identity.cacheInventorySha256,
+    cacheByteLength: identity.cacheByteLength,
+    rootRef: identity.rootRef,
+    networkIsolationExecutableSha256:
+      identity.networkIsolationExecutableSha256,
+    networkIsolationAuxiliaryFiles: identity.networkIsolationAuxiliaryFiles.map(
+      ({ sha256 }) => sha256,
+    ),
+  }
+}
+
+async function sealOwnerLocalExecution(input: {
+  options: OwnerLocalMineruRunnerOptions
+  measured: MeasuredRunnerIdentity
+  sourcePreflight: Awaited<ReturnType<typeof inspectPdf>>
+  runDirectory: string
+  maximumCacheBytes: number
+  reservedOutputByteLength: number
+  reservedPrivateScratchByteLength: number
+}): Promise<SealedOwnerLocalExecution> {
+  const snapshotRoot = join(input.runDirectory, 'sealed-execution')
+  await mkdir(snapshotRoot, { mode: 0o700 })
+  const environmentRoot = dirname(dirname(input.options.mineruExecutable))
+  const mineruRelativePath = relative(
+    environmentRoot,
+    input.options.mineruExecutable,
+  )
+  const pythonRelativePath = relative(
+    environmentRoot,
+    input.options.pythonExecutable,
+  )
+  if (
+    [mineruRelativePath, pythonRelativePath].some(
+      (value) =>
+        value === '..' ||
+        value.startsWith(`..${sep}`) ||
+        isAbsolute(value),
+    )
+  ) {
+    fail('MINERU_RUNNER_EXECUTABLE_OUTSIDE_ENVIRONMENT')
+  }
+  const additionalBudget =
+    input.maximumCacheBytes - input.measured.cacheByteLength
+  if (additionalBudget < input.sourcePreflight.source.size + 1) {
+    fail('MINERU_RUNNER_CACHE_BOUND_EXCEEDED')
+  }
+  const environment = await sealOwnerLocalExecutionTree({
+    sourceRoot: environmentRoot,
+    sealedRoot: join(snapshotRoot, 'runtime'),
+    maximumLogicalBytes:
+      additionalBudget - input.sourcePreflight.source.size,
+    maximumAllocatedBytes: additionalBudget,
+  })
+  const sealedPdfPath = join(snapshotRoot, 'source.pdf')
+  await copyFile(
+    input.sourcePreflight.source.canonical,
+    sealedPdfPath,
+    fsConstants.COPYFILE_FICLONE,
+  )
+  await chmod(sealedPdfPath, 0o444)
+  const preflightConfigBytes = await readFile(input.options.configPath)
+  if (
+    createHash('sha256').update(preflightConfigBytes).digest('hex') !==
+    input.measured.mineruConfigSha256
+  ) {
+    fail('MINERU_RUNNER_CONFIG_IDENTITY_DRIFT')
+  }
+  const preflightConfigPath = join(snapshotRoot, 'preflight-mineru.json')
+  await writeFile(preflightConfigPath, preflightConfigBytes, { mode: 0o400 })
+  await assertOwnerLocalSealedPreflightIdentity({
+    runtimeSnapshot: environment,
+    expectedRuntimeInventorySha256: input.measured.runtimeInventorySha256,
+    expectedRuntimeTreeByteLength: input.measured.runtimeTreeByteLength,
+    sealedPreflightConfigPath: preflightConfigPath,
+    expectedPreflightConfigSha256: input.measured.mineruConfigSha256,
+  })
+  const configValue = JSON.parse(
+    preflightConfigBytes.toString('utf8'),
+  ) as Record<string, unknown>
+  if (!record(configValue['models-dir'])) {
+    fail('MINERU_RUNNER_CONFIG_BINDING_MISMATCH')
+  }
+  const sealedModelRoot = join(snapshotRoot, 'model')
+  configValue['models-dir'] = {
+    ...configValue['models-dir'],
+    vlm: sealedModelRoot,
+  }
+  const sealedConfigPath = join(snapshotRoot, 'mineru.json')
+  await writeFile(sealedConfigPath, canonicalJson(configValue), { mode: 0o400 })
+  const sourceAllocatedByteLength = Math.max(
+    0,
+    Number((await stat(sealedPdfPath)).blocks) * 512,
+  )
+  const preflightConfigAllocatedByteLength = Math.max(
+    0,
+    Number((await stat(preflightConfigPath)).blocks) * 512,
+  )
+  const effectiveConfigAllocatedByteLength = Math.max(
+    0,
+    Number((await stat(sealedConfigPath)).blocks) * 512,
+  )
+  const modelAllocatedLimit =
+    remainingOwnerLocalSealedModelAllocatedBytes({
+      maximumCacheBytes: input.maximumCacheBytes,
+      originalCacheByteLength: input.measured.cacheByteLength,
+      runtimeAllocatedByteLength: environment.allocatedByteLength,
+      sourceAllocatedByteLength,
+      preflightConfigAllocatedByteLength,
+      effectiveConfigAllocatedByteLength,
+      reservedOutputByteLength: input.reservedOutputByteLength,
+      reservedPrivateScratchByteLength:
+        input.reservedPrivateScratchByteLength,
+    })
+  const model = await sealOwnerLocalExecutionTree({
+    sourceRoot: input.options.modelRoot,
+    sealedRoot: sealedModelRoot,
+    maximumLogicalBytes: input.measured.cacheByteLength,
+    maximumAllocatedBytes: modelAllocatedLimit,
+  })
+  if (
+    model.byteLength !== input.measured.cacheByteLength ||
+    model.inventorySha256 !== input.measured.cacheInventorySha256
+  ) {
+    fail('MINERU_RUNNER_SEALED_MODEL_IDENTITY_MISMATCH')
+  }
+  const sealedOptions: OwnerLocalMineruRunnerOptions = {
+    ...input.options,
+    pdfPath: sealedPdfPath,
+    mineruExecutable: join(environment.sealedRoot, mineruRelativePath),
+    pythonExecutable: join(environment.sealedRoot, pythonRelativePath),
+    configPath: sealedConfigPath,
+    modelRoot: model.sealedRoot,
+  }
+  const sourcePreflight = await inspectPdf(sealedPdfPath)
+  if (
+    sourcePreflight.source.sha256 !== input.sourcePreflight.source.sha256 ||
+    sourcePreflight.source.size !== input.sourcePreflight.source.size ||
+    canonicalJson(sourcePreflight.pages) !==
+      canonicalJson(input.sourcePreflight.pages)
+  ) {
+    fail('MINERU_RUNNER_SEALED_SOURCE_IDENTITY_MISMATCH')
+  }
+  const identity = await measureIdentity(sealedOptions)
+  if (
+    canonicalJson(portableMeasuredIdentityProjection(input.measured)) !==
+    canonicalJson(portableMeasuredIdentityProjection(identity))
+  ) {
+    fail('MINERU_RUNNER_SEALED_PROCESS_IDENTITY_MISMATCH')
+  }
+  identity.mineruConfigSha256 = input.measured.mineruConfigSha256
+  const sealedIsolationSha256 = canonicalHash({
+    policy: 'sealed-read-only-owner-local-execution-v1',
+    baseNetworkIsolationSha256: identity.execution.networkIsolationSha256,
+    sourcePdfSha256: sourcePreflight.source.sha256,
+    runtimeInventorySha256: environment.inventorySha256,
+    modelInventorySha256: model.inventorySha256,
+    configSha256: await hashFile(sealedConfigPath),
+    preflightConfigSha256: input.measured.mineruConfigSha256,
+  })
+  identity.execution.networkIsolationSha256 = sealedIsolationSha256
+  await chmod(snapshotRoot, 0o555)
+  return Object.freeze({
+    options: sealedOptions,
+    sourcePreflight,
+    identity,
+    readOnlyRoots: Object.freeze([
+      environment.sealedRoot,
+      model.sealedRoot,
+      sealedPdfPath,
+      preflightConfigPath,
+      sealedConfigPath,
+    ]),
+    privateSnapshotByteLength: ownerLocalPrivateSnapshotAllocatedBytes({
+      runtimeAllocatedByteLength: environment.allocatedByteLength,
+      modelAllocatedByteLength: model.allocatedByteLength,
+      sourceAllocatedByteLength,
+      preflightConfigAllocatedByteLength,
+      effectiveConfigAllocatedByteLength,
+    }),
+    sealedIsolationSha256,
+    preflightConfigPath,
+    preflightConfigSha256: input.measured.mineruConfigSha256,
+  })
+}
+
+async function rebindSealedIsolationIdentity(
+  identity: MeasuredRunnerIdentity,
+  sealed: SealedOwnerLocalExecution,
+) {
+  const runtime = await measureOwnerLocalExecutionTree(
+    dirname(dirname(sealed.options.mineruExecutable)),
+  )
+  const model = await treeMeasurement(sealed.options.modelRoot)
+  const source = await secureRegularFile(
+    sealed.options.pdfPath,
+    'MINERU_RUNNER_SEALED_SOURCE',
+  )
+  const config = await secureRegularFile(
+    sealed.options.configPath,
+    'MINERU_RUNNER_SEALED_CONFIG',
+  )
+  const preflightConfig = await secureRegularFile(
+    sealed.preflightConfigPath,
+    'MINERU_RUNNER_SEALED_PREFLIGHT_CONFIG',
+  )
+  if (preflightConfig.sha256 !== sealed.preflightConfigSha256) {
+    fail('MINERU_RUNNER_SEALED_PREFLIGHT_CONFIG_IDENTITY_DRIFT')
+  }
+  identity.execution.networkIsolationSha256 = canonicalHash({
+    policy: 'sealed-read-only-owner-local-execution-v1',
+    baseNetworkIsolationSha256: identity.execution.networkIsolationSha256,
+    sourcePdfSha256: source.sha256,
+    runtimeInventorySha256: runtime.sha256,
+    modelInventorySha256: model.sha256,
+    configSha256: config.sha256,
+    preflightConfigSha256: preflightConfig.sha256,
+  })
+  if (
+    identity.execution.networkIsolationSha256 !== sealed.sealedIsolationSha256
+  ) {
+    fail('MINERU_RUNNER_SEALED_ISOLATION_IDENTITY_DRIFT')
+  }
+  identity.mineruConfigSha256 = preflightConfig.sha256
+  return identity
+}
+
+export function buildOwnerLocalMineruIsolationCommand(input: {
+  isolation: MineruArtifactManifest['execution']['networkIsolation']
+  isolationExecutable: string
+  runDirectory: string
+  program: string
+  args: string[]
+  readOnlyPaths?: readonly string[]
+}) {
+  const readOnlyPaths = [...new Set(input.readOnlyPaths ?? [])]
+  if (readOnlyPaths.some((path) => !isAbsolute(path))) {
+    fail('MINERU_RUNNER_INVALID_READ_ONLY_PATH')
+  }
+  if (input.isolation === 'macos-sandbox-exec-deny-network-v1') {
+    const escapeSandboxLiteral = (value: string) =>
+      value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+    const profile = `${MACOS_DENY_NETWORK_PROFILE}${readOnlyPaths
+      .map(
+        (path) =>
+          `(deny file-write* (subpath "${escapeSandboxLiteral(path)}"))`,
+      )
+      .join('')}`
+    return {
+      command: input.isolationExecutable,
+      args: ['-p', profile, input.program, ...input.args],
+    }
+  }
+  return {
+    command: input.isolationExecutable,
+    args: [
+      '--user',
+      '--map-root-user',
+      '--net',
+      '--mount',
+      '/bin/sh',
+      '-c',
+      LINUX_LOOPBACK_SETUP,
+      'mineru-netns',
+      String(readOnlyPaths.length),
+      ...readOnlyPaths,
+      input.program,
+      ...input.args,
+    ],
+  }
+}
+
+async function assertMeasuredFile(
+  path: string,
+  identity: StableFileIdentity,
+  sha256: string,
+  code: string,
+) {
+  const reopened = await secureRegularFile(path, code)
+  if (
+    reopened.sha256 !== sha256 ||
+    !sameFileIdentity(reopened.identity, identity)
+  ) {
+    fail(`${code}_IDENTITY_DRIFT`)
+  }
+}
+
+async function outputUsage(outputRoot: string) {
+  const files = await listFiles(outputRoot)
+  return {
+    count: files.length,
+    byteLength: files.reduce((total, file) => total + file.size, 0),
+  }
+}
+
+async function outputUsageForRoots(roots: readonly string[]) {
+  const usage = await Promise.all(roots.map((root) => outputUsage(root)))
+  return {
+    count: usage.reduce((total, value) => total + value.count, 0),
+    byteLength: usage.reduce(
+      (total, value) => total + value.byteLength,
+      0,
+    ),
+    outputByteLength: usage[0]?.byteLength ?? 0,
+  }
+}
+
+export function assertOwnerLocalMineruResourceUsage(input: {
+  maximumOutputBytes: number
+  maximumCacheBytes: number
+  cacheByteLength: number
+  privateSnapshotByteLength: number
+  outputByteLength: number
+  privateScratchByteLength: number
+  fileCount: number
+}) {
+  if (
+    !Object.values(input).every(
+      (value) => Number.isSafeInteger(value) && value >= 0,
+    ) ||
+    input.maximumOutputBytes < 1 ||
+    input.maximumCacheBytes < 1
+  ) {
+    fail('MINERU_RUNNER_INVALID_RESOURCE_BOUND')
+  }
+  if (
+    input.fileCount > MINERU_MAX_ARTIFACT_COUNT ||
+    input.outputByteLength > input.maximumOutputBytes
+  ) {
+    fail('MINERU_RUNNER_OUTPUT_BOUND_EXCEEDED')
+  }
+  if (
+    input.cacheByteLength +
+      input.privateSnapshotByteLength +
+      input.outputByteLength +
+      input.privateScratchByteLength >
+    input.maximumCacheBytes
+  ) {
+    fail('MINERU_RUNNER_CACHE_BOUND_EXCEEDED')
+  }
+}
+
+export function ownerLocalPrivateSnapshotAllocatedBytes(input: {
+  runtimeAllocatedByteLength: number
+  modelAllocatedByteLength: number
+  sourceAllocatedByteLength: number
+  preflightConfigAllocatedByteLength: number
+  effectiveConfigAllocatedByteLength: number
+}) {
+  const values = Object.values(input)
+  if (
+    !values.every((value) => Number.isSafeInteger(value) && value >= 0) ||
+    values.reduce((total, value) => total + value, 0) >
+      Number.MAX_SAFE_INTEGER
+  ) {
+    fail('MINERU_RUNNER_INVALID_RESOURCE_BOUND')
+  }
+  return values.reduce((total, value) => total + value, 0)
+}
+
+export function remainingOwnerLocalSealedModelAllocatedBytes(input: {
+  maximumCacheBytes: number
+  originalCacheByteLength: number
+  runtimeAllocatedByteLength: number
+  sourceAllocatedByteLength: number
+  preflightConfigAllocatedByteLength: number
+  effectiveConfigAllocatedByteLength: number
+  reservedOutputByteLength: number
+  reservedPrivateScratchByteLength: number
+}) {
+  const values = Object.values(input)
+  if (
+    !values.every((value) => Number.isSafeInteger(value) && value >= 0) ||
+    input.maximumCacheBytes < 1
+  ) {
+    fail('MINERU_RUNNER_INVALID_RESOURCE_BOUND')
+  }
+  const committedBytes =
+    input.originalCacheByteLength +
+    input.runtimeAllocatedByteLength +
+    input.sourceAllocatedByteLength +
+    input.preflightConfigAllocatedByteLength +
+    input.effectiveConfigAllocatedByteLength +
+    input.reservedOutputByteLength +
+    input.reservedPrivateScratchByteLength
+  if (
+    !Number.isSafeInteger(committedBytes) ||
+    committedBytes >= input.maximumCacheBytes
+  ) {
+    fail('MINERU_RUNNER_CACHE_BOUND_EXCEEDED')
+  }
+  return input.maximumCacheBytes - committedBytes
+}
+
+async function runMineru(
+  options: OwnerLocalMineruRunnerOptions,
+  measured: MeasuredRunnerIdentity,
+  runDirectory: string,
+  outputRoot: string,
+  maximumOutputBytes: number,
+  maximumCacheBytes: number,
+  privateSnapshotByteLength: number,
+  readOnlyRoots: readonly string[],
+) {
+  await assertMeasuredFile(
+    measured.mineruExecutablePath,
+    measured.mineruExecutableIdentity,
+    measured.mineruExecutableSha256,
+    'MINERU_RUNNER_EXECUTABLE',
+  )
+  for (const auxiliary of measured.networkIsolationAuxiliaryFiles) {
+    await assertMeasuredFile(
+      auxiliary.path,
+      auxiliary.identity,
+      auxiliary.sha256,
+      'MINERU_RUNNER_NETWORK_ISOLATION_AUXILIARY',
+    )
+  }
+  await assertMeasuredFile(
+    measured.pythonExecutablePath,
+    measured.pythonExecutableIdentity,
+    measured.execution.runtimeSha256,
+    'MINERU_RUNNER_RUNTIME',
+  )
+  await assertMeasuredFile(
+    measured.networkIsolationExecutablePath,
+    measured.networkIsolationExecutableIdentity,
+    measured.networkIsolationExecutableSha256,
+    'MINERU_RUNNER_NETWORK_ISOLATION',
+  )
+  const privateHome = join(runDirectory, 'home')
+  const privateTmp = join(runDirectory, 'tmp')
+  await mkdir(privateHome, { mode: 0o700 })
+  await mkdir(privateTmp, { mode: 0o700 })
+  const environment = {
+    PATH: process.env.PATH ?? '',
+    LANG: process.env.LANG ?? 'C.UTF-8',
+    LC_ALL: process.env.LC_ALL ?? 'C.UTF-8',
+    HOME: privateHome,
+    TMPDIR: privateTmp,
+    MINERU_MODEL_SOURCE: 'local',
+    MINERU_TOOLS_CONFIG_JSON: measured.configPath,
+    HF_HUB_OFFLINE: '1',
+    TRANSFORMERS_OFFLINE: '1',
+    NO_PROXY: '*',
+    no_proxy: '*',
+  }
+  const mineruArgs = [
+    '-p',
+    options.pdfPath,
+    '-o',
+    outputRoot,
+    '-b',
+    'vlm-engine',
+    '-f',
+    'true',
+    '-t',
+    'true',
+    '--image-analysis',
+    'true',
+  ]
+  const isolated = buildOwnerLocalMineruIsolationCommand({
+    isolation: measured.execution.networkIsolation,
+    isolationExecutable: measured.networkIsolationExecutablePath,
+    runDirectory,
+    program: measured.pythonExecutablePath,
+    args: [measured.mineruExecutablePath, ...mineruArgs],
+    readOnlyPaths: readOnlyRoots,
+  })
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(isolated.command, isolated.args, {
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let outputBytes = 0
+    let boundFailure: Error | undefined
+    let checking = false
+    const interval = setInterval(() => {
+      if (checking || boundFailure) return
+      checking = true
+      void outputUsageForRoots([outputRoot, privateHome, privateTmp])
+        .then((usage) => {
+          assertOwnerLocalMineruResourceUsage({
+            maximumOutputBytes,
+            maximumCacheBytes,
+            cacheByteLength: measured.cacheByteLength,
+            privateSnapshotByteLength,
+            outputByteLength: usage.outputByteLength,
+            privateScratchByteLength:
+              usage.byteLength - usage.outputByteLength,
+            fileCount: usage.count,
+          })
+        })
+        .catch((error) => {
+          boundFailure =
+            error instanceof Error
+              ? error
+              : new Error('MINERU_RUNNER_OUTPUT_MEASUREMENT_FAILED')
+          child.kill('SIGKILL')
+        })
+        .finally(() => {
+          checking = false
+        })
+    }, 100)
+    const consume = (chunk: Buffer) => {
+      outputBytes += chunk.byteLength
+      if (outputBytes > MAX_RUNNER_OUTPUT_BYTES) {
+        boundFailure = new Error('MINERU_RUNNER_LOG_BOUND_EXCEEDED')
+        child.kill('SIGKILL')
+      }
+    }
+    child.stdout.on('data', consume)
+    child.stderr.on('data', consume)
+    child.once('error', rejectPromise)
+    child.once('exit', (code, signal) => {
+      clearInterval(interval)
+      if (boundFailure) rejectPromise(boundFailure)
+      else if (code === 0 && signal === null) resolvePromise()
+      else rejectPromise(new Error('MINERU_RUNNER_EXECUTION_FAILED'))
+    })
+  })
+  const finalUsage = await outputUsageForRoots([
+    outputRoot,
+    privateHome,
+    privateTmp,
+  ])
+  assertOwnerLocalMineruResourceUsage({
+    maximumOutputBytes,
+    maximumCacheBytes,
+    cacheByteLength: measured.cacheByteLength,
+    privateSnapshotByteLength,
+    outputByteLength: finalUsage.outputByteLength,
+    privateScratchByteLength:
+      finalUsage.byteLength - finalUsage.outputByteLength,
+    fileCount: finalUsage.count,
+  })
+  return {
+    privateScratchByteLength:
+      finalUsage.byteLength - finalUsage.outputByteLength,
+  }
+}
+
+function flattenContentList(value: unknown) {
+  if (!Array.isArray(value)) fail('MINERU_RUNNER_INVALID_CONTENT_LIST')
+  const records: Array<Record<string, unknown> & { _page: number }> = []
+  for (const [index, item] of value.entries()) {
+    if (Array.isArray(item)) {
+      for (const nested of item) {
+        if (!record(nested)) fail('MINERU_RUNNER_INVALID_CONTENT_LIST')
+        records.push({ ...nested, _page: index + 1 })
+      }
+    } else {
+      if (!record(item)) fail('MINERU_RUNNER_INVALID_CONTENT_LIST')
+      const pageIndex = item.page_idx
+      records.push({
+        ...item,
+        _page: Number.isSafeInteger(pageIndex) ? Number(pageIndex) + 1 : 1,
+      })
+    }
+  }
+  return records
+}
+
+function recordClass(recordValue: Record<string, unknown>) {
+  return String(recordValue.type ?? '').toLowerCase()
+}
+
+function referencedImagePaths(value: unknown, output: string[] = []) {
+  if (Array.isArray(value)) {
+    value.forEach((nested) => referencedImagePaths(nested, output))
+  } else if (record(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      if (
+        typeof nested === 'string' &&
+        /^(?:img|image)(?:_?path)?$/iu.test(key)
+      ) {
+        output.push(nested)
+      } else referencedImagePaths(nested, output)
+    }
+  }
+  return output
+}
+
+function resolveReferencedImages(files: OutputFile[], values: unknown[]) {
+  const references = [
+    ...new Set(values.flatMap((value) => referencedImagePaths(value))),
+  ]
+  for (const reference of references) {
+    if (
+      reference.length === 0 ||
+      isAbsolute(reference) ||
+      reference.includes('\\') ||
+      reference.split('/').includes('..')
+    ) {
+      fail('MINERU_RUNNER_INVALID_REFERENCED_IMAGE')
+    }
+    const matches = files.filter(
+      ({ relativePath }) =>
+        relativePath === reference || relativePath.endsWith(`/${reference}`),
+    )
+    if (
+      matches.length !== 1 ||
+      !/\.(?:png|jpe?g|webp)$/iu.test(matches[0]!.relativePath)
+    ) {
+      fail('MINERU_RUNNER_MISSING_REFERENCED_IMAGE')
+    }
+  }
+}
+
+async function copyOpaqueArtifact(
+  source: string,
+  destinationRoot: string,
+  index: number,
+  suffix: string,
+) {
+  const relativePath = `artifacts/${String(index).padStart(4, '0')}.${suffix}`
+  const destination = join(destinationRoot, relativePath)
+  await copyFile(source, destination)
+  await chmod(destination, 0o600)
+  return relativePath
+}
+
+async function writeOpaqueJson(
+  value: unknown,
+  destinationRoot: string,
+  index: number,
+) {
+  const relativePath = `artifacts/${String(index).padStart(4, '0')}.json`
+  const destination = join(destinationRoot, relativePath)
+  await writeFile(destination, canonicalJson(value), { mode: 0o600 })
+  return relativePath
+}
+
+async function descriptor(
+  root: string,
+  id: string,
+  kind: MineruArtifactKind,
+  relativePath: string,
+  mediaType: string,
+  pageScope: 'document' | number[],
+) {
+  const path = join(root, relativePath)
+  const details = await stat(path)
+  return {
+    id,
+    kind,
+    relativePath,
+    mediaType,
+    byteLength: details.size,
+    sha256: await hashFile(path),
+    pageScope,
+  }
+}
+
+async function findUnique(files: OutputFile[], suffix: string) {
+  const matches = files.filter(({ relativePath }) =>
+    relativePath.endsWith(suffix),
+  )
+  if (matches.length !== 1) fail('MINERU_RUNNER_OUTPUT_SHAPE_MISMATCH')
+  return matches[0]!
+}
+
+export async function normalizeMineruRunArtifacts(input: {
+  sourcePdfPath: string
+  runDirectory: string
+  outputRoot: string
+  identity: IdentityMeasurement & { rootRef: string }
+  maximumCacheBytes: number
+  maximumOutputBytes?: number
+  sourcePreflight?: Awaited<ReturnType<typeof inspectPdf>>
+  privateScratchByteLength?: number
+  privateSnapshotByteLength?: number
+}): Promise<MineruArtifactManifest> {
+  const runMode = (await lstat(input.runDirectory)).mode & 0o777
+  if (runMode !== 0o700) fail('MINERU_RUNNER_DIRECTORY_MODE_MISMATCH')
+  const pdf = await inspectPdf(input.sourcePdfPath)
+  if (input.sourcePreflight && !samePdfInspection(input.sourcePreflight, pdf)) {
+    fail('MINERU_RUNNER_SOURCE_IDENTITY_DRIFT')
+  }
+  const files = await listFiles(input.outputRoot)
+  const rawOutputByteLength = files.reduce(
+    (total, file) => total + file.size,
+    0,
+  )
+  const maximumOutputBytes =
+    input.maximumOutputBytes ?? MINERU_MAX_RAW_OUTPUT_BYTES
+  if (
+    !Number.isSafeInteger(maximumOutputBytes) ||
+    maximumOutputBytes < 1 ||
+    maximumOutputBytes > MINERU_MAX_RAW_OUTPUT_BYTES ||
+    files.length > MINERU_MAX_ARTIFACT_COUNT ||
+    rawOutputByteLength > maximumOutputBytes
+  ) {
+    fail('MINERU_RUNNER_OUTPUT_BOUND_EXCEEDED')
+  }
+  const markdown = await findUnique(files, '.md')
+  const contentV1 = await findUnique(files, '_content_list.json')
+  const contentV2 = await findUnique(files, '_content_list_v2.json')
+  const middle = await findUnique(files, '_middle.json')
+  const model = await findUnique(files, '_model.json')
+  const layoutPdf = await findUnique(files, '_layout.pdf')
+  const parse = async (file: OutputFile) => {
+    try {
+      return JSON.parse(await readFile(file.absolutePath, 'utf8'))
+    } catch {
+      fail('MINERU_RUNNER_INVALID_JSON_OUTPUT')
+    }
+  }
+  const contentV1Json = await parse(contentV1)
+  const contentV2Json = await parse(contentV2)
+  const middleJson = await parse(middle)
+  const modelJson = await parse(model)
+  resolveReferencedImages(files, [
+    contentV1Json,
+    contentV2Json,
+    middleJson,
+    modelJson,
+  ])
+  const records = flattenContentList(contentV2Json)
+  const byClass = (pattern: RegExp) =>
+    records.filter((item) => pattern.test(recordClass(item)))
+  const readingOrder = {
+    schemaVersion: '1.0.0',
+    pages: pdf.pages.map(({ page }) => ({
+      page,
+      order: records
+        .map((recordValue, index) => ({ recordValue, index }))
+        .filter(({ recordValue }) => recordValue._page === page)
+        .map(({ index }) => index),
+    })),
+  }
+  const normalizedValues: Array<{
+    kind: MineruArtifactKind
+    value: unknown
+  }> = [
+    { kind: 'layout-json', value: modelJson },
+    { kind: 'ocr', value: byClass(/ocr/u) },
+    { kind: 'table', value: byClass(/table/u) },
+    { kind: 'formula', value: byClass(/formula|equation/u) },
+    { kind: 'figure', value: byClass(/figure|image|chart/u) },
+    {
+      kind: 'image',
+      value: files
+        .filter(({ relativePath }) =>
+          /\.(?:png|jpe?g|webp)$/iu.test(relativePath),
+        )
+        .map(async ({ absolutePath, relativePath, size }) => ({
+          pathSha256: createHash('sha256').update(relativePath).digest('hex'),
+          byteLength: size,
+          sha256: await hashFile(absolutePath),
+        })),
+    },
+    { kind: 'reading-order', value: readingOrder },
+    {
+      kind: 'page-geometry',
+      value: { schemaVersion: '1.0.0', pages: pdf.pages },
+    },
+  ]
+  await mkdir(join(input.runDirectory, 'artifacts'), {
+    recursive: true,
+    mode: 0o700,
+  })
+  const artifacts: MineruArtifactManifest['artifacts'] = []
+  let index = 1
+  const addCopied = async (
+    file: OutputFile,
+    kind: MineruArtifactKind,
+    mediaType: string,
+    suffix: string,
+  ) => {
+    const relativePath = await copyOpaqueArtifact(
+      file.absolutePath,
+      input.runDirectory,
+      index,
+      suffix,
+    )
+    artifacts.push(
+      await descriptor(
+        input.runDirectory,
+        `artifact-${String(index).padStart(4, '0')}`,
+        kind,
+        relativePath,
+        mediaType,
+        'document',
+      ),
+    )
+    index += 1
+  }
+  await addCopied(markdown, 'markdown', 'text/markdown', 'md')
+  await addCopied(contentV1, 'content-list-v1', 'application/json', 'json')
+  await addCopied(contentV2, 'content-list-v2', 'application/json', 'json')
+  await addCopied(middle, 'middle-json', 'application/json', 'json')
+  await addCopied(model, 'model-json', 'application/json', 'json')
+  await addCopied(layoutPdf, 'layout-pdf', 'application/pdf', 'pdf')
+  for (const { kind, value } of normalizedValues) {
+    const resolvedValue = Array.isArray(value)
+      ? await Promise.all(value)
+      : value
+    const relativePath = await writeOpaqueJson(
+      resolvedValue,
+      input.runDirectory,
+      index,
+    )
+    artifacts.push(
+      await descriptor(
+        input.runDirectory,
+        `artifact-${String(index).padStart(4, '0')}`,
+        kind,
+        relativePath,
+        'application/json',
+        'document',
+      ),
+    )
+    index += 1
+  }
+  for (const file of files) {
+    await chmod(file.absolutePath, 0o600)
+    const relativePath = relative(input.runDirectory, file.absolutePath)
+    if (
+      relativePath === '..' ||
+      relativePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativePath)
+    ) {
+      fail('MINERU_RUNNER_PATH_ESCAPE')
+    }
+    artifacts.push(
+      await descriptor(
+        input.runDirectory,
+        `artifact-${String(index).padStart(4, '0')}`,
+        'raw-output',
+        relativePath,
+        'application/octet-stream',
+        'document',
+      ),
+    )
+    index += 1
+  }
+  const retainedBytes = artifacts.reduce(
+    (total, artifactValue) => total + artifactValue.byteLength,
+    0,
+  )
+  const maximumBytes = input.maximumCacheBytes
+  const privateScratchByteLength = input.privateScratchByteLength ?? 0
+  const privateSnapshotByteLength = input.privateSnapshotByteLength ?? 0
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    !Number.isSafeInteger(privateScratchByteLength) ||
+    privateScratchByteLength < 0 ||
+    !Number.isSafeInteger(privateSnapshotByteLength) ||
+    privateSnapshotByteLength < 0 ||
+    maximumBytes <
+      retainedBytes +
+        input.identity.cacheByteLength +
+        privateScratchByteLength +
+        privateSnapshotByteLength ||
+    maximumBytes > MINERU_MAX_OWNER_CACHE_BYTES
+  ) {
+    fail('MINERU_RUNNER_CACHE_BOUND_EXCEEDED')
+  }
+  const document = {
+    id: `document-${pdf.source.sha256.slice(0, 32)}`,
+    sha256: pdf.source.sha256,
+    byteLength: pdf.source.size,
+    pageCount: pdf.pages.length,
+  }
+  const rawOutputInventory = artifacts
+    .filter(({ kind }) => kind === 'raw-output')
+    .map(({ relativePath, byteLength, sha256 }) => ({
+      relativePath,
+      byteLength,
+      sha256,
+    }))
+  const producerProjection = {
+    schemaVersion: '1.0.0' as const,
+    sourcePdfSha256: document.sha256,
+    sourceByteLength: document.byteLength,
+    sourcePageCount: document.pageCount,
+    sourcePageGeometrySha256: canonicalHash(pdf.pages),
+    mineruExecutableSha256: input.identity.mineruExecutableSha256,
+    mineruConfigSha256: input.identity.mineruConfigSha256,
+    runtimeSha256: input.identity.execution.runtimeSha256,
+    runtimeInventorySha256: input.identity.runtimeInventorySha256,
+    runtimeTreeByteLength: input.identity.runtimeTreeByteLength,
+    packageSetSha256: input.identity.execution.packageSetSha256,
+    backendSha256: input.identity.execution.backendSha256,
+    modelSha256: MINERU_PRODUCTION_MODEL_SHA256,
+    modelConfigSha256: input.identity.modelConfigSha256,
+    cacheInventorySha256: input.identity.cacheInventorySha256,
+    cacheByteLength: input.identity.cacheByteLength,
+    privateSnapshotAllocatedByteLength: privateSnapshotByteLength,
+    rawOutputInventorySha256: canonicalHash(rawOutputInventory),
+    rawOutputByteLength,
+    networkIsolation: input.identity.execution.networkIsolation,
+    networkIsolationSha256:
+      input.identity.execution.networkIsolationSha256,
+    artifactSetSha256: canonicalHash(artifacts),
+    offline: true as const,
+    runDirectoryMode: '0700' as const,
+  }
+  const producerReceipt: MineruProducerReceipt = {
+    ...producerProjection,
+    receiptSha256: canonicalHash(producerProjection),
+  }
+  return {
+    schemaVersion: MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+    document,
+    binding: structuredClone(MINERU_PRODUCTION_BINDING),
+    execution: structuredClone(input.identity.execution),
+    cache: {
+      scope: 'owner-local',
+      rootRef: input.identity.rootRef,
+      namespace: 'mineru-production',
+      maximumBytes,
+      retainedBytes,
+      artifactCount: artifacts.length,
+    },
+    artifacts,
+    producerReceipt,
+  }
+}
+
+export async function runOwnerLocalMineru(
+  options: OwnerLocalMineruRunnerOptions,
+): Promise<OwnerLocalMineruRun> {
+  for (const path of [
+    options.pdfPath,
+    options.runRoot,
+    options.mineruExecutable,
+    options.pythonExecutable,
+    options.configPath,
+    options.modelRoot,
+  ]) {
+    if (!isAbsolute(path)) fail('MINERU_RUNNER_ABSOLUTE_PATH_REQUIRED')
+  }
+  const sourceRoot = await realpath(options.runRoot)
+  const sourceDetails = await stat(sourceRoot)
+  if (!sourceDetails.isDirectory()) fail('MINERU_RUNNER_INVALID_RUN_ROOT')
+  if (await insideGitCheckout(sourceRoot)) {
+    fail('MINERU_RUNNER_RUN_ROOT_INSIDE_GIT_CHECKOUT')
+  }
+  const sourcePdf = await realpath(options.pdfPath)
+  if (sourcePdf === sourceRoot || sourcePdf.startsWith(`${sourceRoot}${sep}`)) {
+    fail('MINERU_RUNNER_SOURCE_INSIDE_OUTPUT_ROOT')
+  }
+  const sourcePreflight = await inspectPdf(sourcePdf)
+  const maximumCacheBytes =
+    options.maxCacheBytes ?? MINERU_MAX_OWNER_CACHE_BYTES
+  const maximumOutputBytes =
+    options.maxOutputBytes ?? MINERU_MAX_RAW_OUTPUT_BYTES
+  if (
+    !Number.isSafeInteger(maximumCacheBytes) ||
+    maximumCacheBytes < 1 ||
+    maximumCacheBytes > MINERU_MAX_OWNER_CACHE_BYTES ||
+    !Number.isSafeInteger(maximumOutputBytes) ||
+    maximumOutputBytes < 1 ||
+    maximumOutputBytes > MINERU_MAX_RAW_OUTPUT_BYTES
+  ) {
+    fail('MINERU_RUNNER_INVALID_RESOURCE_BOUND')
+  }
+  const runDirectory = await realpath(
+    await mkdtemp(join(sourceRoot, 'mineru-run-')),
+  )
+  await chmod(runDirectory, 0o700)
+  const outputRoot = join(runDirectory, 'raw-output')
+  await mkdir(outputRoot, { mode: 0o700 })
+  const measured = await measureIdentity(options)
+  if (measured.cacheByteLength >= maximumCacheBytes) {
+    fail('MINERU_RUNNER_CACHE_BOUND_EXCEEDED')
+  }
+  const sealed = await sealOwnerLocalExecution({
+    options: { ...options, pdfPath: sourcePdf },
+    measured,
+    sourcePreflight,
+    runDirectory,
+    maximumCacheBytes,
+    reservedOutputByteLength: maximumOutputBytes,
+    reservedPrivateScratchByteLength: maximumOutputBytes,
+  })
+  assertOwnerLocalMineruResourceUsage({
+    maximumOutputBytes,
+    maximumCacheBytes,
+    cacheByteLength: measured.cacheByteLength,
+    privateSnapshotByteLength: sealed.privateSnapshotByteLength,
+    outputByteLength: 0,
+    privateScratchByteLength: 0,
+    fileCount: 0,
+  })
+  const runUsage = await runMineru(
+    sealed.options,
+    sealed.identity,
+    runDirectory,
+    outputRoot,
+    maximumOutputBytes,
+    maximumCacheBytes,
+    sealed.privateSnapshotByteLength,
+    sealed.readOnlyRoots,
+  )
+  const sourceAfterInference = await inspectPdf(sourcePdf)
+  if (!samePdfInspection(sourcePreflight, sourceAfterInference)) {
+    fail('MINERU_RUNNER_SOURCE_IDENTITY_DRIFT')
+  }
+  const identityAfterInference = await measureIdentity(options)
+  if (
+    canonicalJson(measuredIdentityProjection(measured)) !==
+    canonicalJson(measuredIdentityProjection(identityAfterInference))
+  ) {
+    fail('MINERU_RUNNER_PROCESS_OR_CACHE_IDENTITY_DRIFT')
+  }
+  const sealedSourceAfterInference = await inspectPdf(sealed.options.pdfPath)
+  if (
+    !samePdfInspection(sealed.sourcePreflight, sealedSourceAfterInference)
+  ) {
+    fail('MINERU_RUNNER_SEALED_SOURCE_IDENTITY_DRIFT')
+  }
+  const sealedIdentityAfterInference = await rebindSealedIsolationIdentity(
+    await measureIdentity(sealed.options),
+    sealed,
+  )
+  if (
+    canonicalJson(measuredIdentityProjection(sealed.identity)) !==
+    canonicalJson(measuredIdentityProjection(sealedIdentityAfterInference))
+  ) {
+    fail('MINERU_RUNNER_SEALED_PROCESS_IDENTITY_DRIFT')
+  }
+  const manifest = await normalizeMineruRunArtifacts({
+    sourcePdfPath: sealed.options.pdfPath,
+    runDirectory,
+    outputRoot,
+    identity: sealed.identity,
+    maximumCacheBytes,
+    maximumOutputBytes,
+    sourcePreflight: sealed.sourcePreflight,
+    privateScratchByteLength: runUsage.privateScratchByteLength,
+    privateSnapshotByteLength: sealed.privateSnapshotByteLength,
+  })
+  const manifestPath = join(runDirectory, 'manifest.json')
+  await writeFile(manifestPath, canonicalJson(manifest), { mode: 0o600 })
+  return {
+    schemaVersion: RUNNER_SCHEMA_VERSION,
+    runDirectory,
+    manifestPath,
+    manifest,
+  }
+}
+
+export function parseOwnerLocalMineruArguments(argv: readonly string[]) {
+  if (argv.length === 1 && ['--help', '-h'].includes(argv[0]!)) {
+    return { help: true as const }
+  }
+  const values = new Map<string, string>()
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (
+      !key?.startsWith('--') ||
+      value === undefined ||
+      value.startsWith('--')
+    ) {
+      fail('MINERU_RUNNER_INVALID_ARGUMENTS')
+    }
+    if (values.has(key)) fail('MINERU_RUNNER_DUPLICATE_ARGUMENT')
+    values.set(key, value)
+  }
+  const allowed = new Set([
+    '--pdf',
+    '--run-root',
+    '--mineru',
+    '--python',
+    '--config',
+    '--model-root',
+    '--max-cache-bytes',
+    '--max-output-bytes',
+  ])
+  if ([...values.keys()].some((key) => !allowed.has(key))) {
+    fail('MINERU_RUNNER_INVALID_ARGUMENTS')
+  }
+  const required = [
+    '--pdf',
+    '--run-root',
+    '--mineru',
+    '--python',
+    '--config',
+    '--model-root',
+  ]
+  if (required.some((key) => !values.has(key))) {
+    fail('MINERU_RUNNER_INVALID_ARGUMENTS')
+  }
+  if (
+    required.some((key) => !isAbsolute(values.get(key)!)) ||
+    (values.has('--max-cache-bytes') &&
+      !/^\d+$/u.test(values.get('--max-cache-bytes')!)) ||
+    (values.has('--max-output-bytes') &&
+      !/^\d+$/u.test(values.get('--max-output-bytes')!))
+  ) {
+    fail('MINERU_RUNNER_ABSOLUTE_PATH_REQUIRED')
+  }
+  const maximum = values.get('--max-cache-bytes')
+  const maximumOutput = values.get('--max-output-bytes')
+  const options: OwnerLocalMineruRunnerOptions = {
+    pdfPath: resolve(values.get('--pdf')!),
+    runRoot: resolve(values.get('--run-root')!),
+    mineruExecutable: resolve(values.get('--mineru')!),
+    pythonExecutable: resolve(values.get('--python')!),
+    configPath: resolve(values.get('--config')!),
+    modelRoot: resolve(values.get('--model-root')!),
+    ...(maximum === undefined ? {} : { maxCacheBytes: Number(maximum) }),
+    ...(maximumOutput === undefined
+      ? {}
+      : { maxOutputBytes: Number(maximumOutput) }),
+  }
+  return { help: false as const, options }
+}
+
+async function main() {
+  const parsed = parseOwnerLocalMineruArguments(process.argv.slice(2))
+  if (parsed.help) {
+    process.stdout.write(`${OWNER_LOCAL_MINERU_HELP}\n`)
+    return
+  }
+  const result = await runOwnerLocalMineru(parsed.options)
+  process.stdout.write(
+    `${canonicalJson({
+      schemaVersion: result.schemaVersion,
+      sourcePdfSha256: result.manifest.document.sha256,
+      graphInputManifestSha256: createHash('sha256')
+        .update(await readFile(result.manifestPath))
+        .digest('hex'),
+      producerReceiptSha256: result.manifest.producerReceipt.receiptSha256,
+      artifactCount: result.manifest.artifacts.length,
+      runDirectoryRefSha256: createHash('sha256')
+        .update(basename(result.runDirectory))
+        .digest('hex'),
+    })}\n`,
+  )
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : 'MINERU_RUNNER_FAILED'}\n`,
+    )
+    process.exitCode = 1
+  })
+}

--- a/src/research/mineru-owner-local-runner.ts
+++ b/src/research/mineru-owner-local-runner.ts
@@ -217,7 +217,10 @@ function compareCanonicalCodeUnits(left: string, right: string) {
   return left < right ? -1 : 1
 }
 
-async function listFiles(root: string): Promise<OutputFile[]> {
+async function listFiles(
+  root: string,
+  options: { accountSymlinksWithoutFollowing?: boolean } = {},
+): Promise<OutputFile[]> {
   const canonicalRoot = await realpath(root)
   const output: OutputFile[] = []
   async function visit(directory: string) {
@@ -231,10 +234,20 @@ async function listFiles(root: string): Promise<OutputFile[]> {
       ) {
         fail('MINERU_RUNNER_PATH_ESCAPE')
       }
-      if (entry.isSymbolicLink()) fail('MINERU_RUNNER_SYMLINK_REJECTED')
-      if (entry.isDirectory()) await visit(path)
-      else if (entry.isFile()) {
-        const details = await stat(path)
+      const details = await lstat(path)
+      if (details.isSymbolicLink()) {
+        if (!options.accountSymlinksWithoutFollowing) {
+          fail('MINERU_RUNNER_SYMLINK_REJECTED')
+        }
+        output.push({
+          absolutePath: path,
+          relativePath,
+          size: Math.max(1, details.size, Number(details.blocks) * 512),
+        })
+        continue
+      }
+      if (details.isDirectory()) await visit(path)
+      else if (details.isFile()) {
         output.push({
           absolutePath: path,
           relativePath,
@@ -1179,8 +1192,10 @@ async function assertMeasuredFile(
   }
 }
 
-async function outputUsage(outputRoot: string) {
-  const files = await listFiles(outputRoot)
+export async function measureOwnerLocalResourceTreeUsage(outputRoot: string) {
+  const files = await listFiles(outputRoot, {
+    accountSymlinksWithoutFollowing: true,
+  })
   return {
     count: files.length,
     byteLength: files.reduce((total, file) => total + file.size, 0),
@@ -1188,7 +1203,9 @@ async function outputUsage(outputRoot: string) {
 }
 
 async function outputUsageForRoots(roots: readonly string[]) {
-  const usage = await Promise.all(roots.map((root) => outputUsage(root)))
+  const usage = await Promise.all(
+    roots.map((root) => measureOwnerLocalResourceTreeUsage(root)),
+  )
   return {
     count: usage.reduce((total, value) => total + value.count, 0),
     byteLength: usage.reduce(

--- a/src/research/mineru-source-evidence.test.ts
+++ b/src/research/mineru-source-evidence.test.ts
@@ -1,0 +1,696 @@
+import { createHash } from 'node:crypto'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { validatePdfEvidenceBundle } from './source-evidence-graph'
+import {
+  createMineruOfflineRunReceipt,
+  inspectMineruSourceEvidence,
+  MINERU_ARTIFACT_KINDS,
+  MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+  MINERU_MAX_OWNER_CACHE_BYTES,
+  MINERU_MAX_RETAINED_ARTIFACT_BYTES,
+  MINERU_MAX_TEXTUAL_ARTIFACT_BYTES,
+  MINERU_PRODUCTION_BACKEND,
+  MINERU_PRODUCTION_BINDING,
+  MINERU_PRODUCTION_CONFIGURATION,
+  MINERU_PRODUCTION_MODEL_ARCHITECTURE,
+  MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+  MINERU_PRODUCTION_MODEL_FILE,
+  MINERU_PRODUCTION_MODEL_ID,
+  MINERU_PRODUCTION_MODEL_LICENSE,
+  MINERU_PRODUCTION_MODEL_REVISION,
+  MINERU_PRODUCTION_MODEL_SHA256,
+  MINERU_PRODUCTION_MODEL_TYPE,
+  MINERU_PRODUCTION_VERSION,
+  MINERU_PRODUCTION_WHEEL_SHA256,
+  type MineruArtifactKind,
+  type MineruArtifactManifest,
+} from './mineru-source-evidence'
+
+const roots: string[] = []
+const encoder = new TextEncoder()
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+function sha256(bytes: Uint8Array) {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function jsonBytes(value: unknown) {
+  return encoder.encode(JSON.stringify(value))
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function canonicalHash(value: unknown) {
+  return sha256(encoder.encode(canonicalJson(value)))
+}
+
+function refreshProducerReceipt(manifest: MineruArtifactManifest) {
+  const pages = [
+    { page: 1, width: 612, height: 792, rotation: 0 },
+    { page: 2, width: 792, height: 612, rotation: 90 },
+  ]
+  const projection = {
+    schemaVersion: '1.0.0' as const,
+    sourcePdfSha256: manifest.document.sha256,
+    sourceByteLength: manifest.document.byteLength,
+    sourcePageCount: manifest.document.pageCount,
+    sourcePageGeometrySha256: canonicalHash(pages),
+    mineruExecutableSha256: '5'.repeat(64),
+    mineruConfigSha256: '8'.repeat(64),
+    runtimeSha256: manifest.execution.runtimeSha256,
+    runtimeInventorySha256: '9'.repeat(64),
+    runtimeTreeByteLength: 4096,
+    packageSetSha256: manifest.execution.packageSetSha256,
+    backendSha256: manifest.execution.backendSha256,
+    modelSha256: MINERU_PRODUCTION_MODEL_SHA256,
+    modelConfigSha256: '6'.repeat(64),
+    cacheInventorySha256: '7'.repeat(64),
+    cacheByteLength: MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+    privateSnapshotAllocatedByteLength: 0,
+    rawOutputInventorySha256: canonicalHash(
+      manifest.artifacts
+        .filter(({ kind }) => kind === 'raw-output')
+        .map(({ relativePath, byteLength, sha256: digest }) => ({
+          relativePath,
+          byteLength,
+          sha256: digest,
+        })),
+    ),
+    rawOutputByteLength: manifest.artifacts
+      .filter(({ kind }) => kind === 'raw-output')
+      .reduce((total, { byteLength }) => total + byteLength, 0),
+    networkIsolation: manifest.execution.networkIsolation,
+    networkIsolationSha256: manifest.execution.networkIsolationSha256,
+    artifactSetSha256: canonicalHash(manifest.artifacts),
+    offline: true as const,
+    runDirectoryMode: '0700' as const,
+  }
+  manifest.producerReceipt = {
+    ...projection,
+    receiptSha256: canonicalHash(projection),
+  }
+}
+
+function payload(value: unknown) {
+  return value as Record<string, unknown>
+}
+
+function artifact(manifest: MineruArtifactManifest, kind: MineruArtifactKind) {
+  const found = manifest.artifacts.find((item) => item.kind === kind)
+  if (!found) throw new Error(`fixture is missing ${kind}`)
+  return found
+}
+
+async function fixture() {
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), 'mineru-owner-cache-')),
+  )
+  roots.push(root)
+  await chmod(root, 0o700)
+  const relativeDirectory = 'opaque-run-7/files-with-arbitrary-names'
+  await mkdir(join(root, relativeDirectory), { recursive: true, mode: 0o700 })
+
+  const contents: Record<
+    MineruArtifactKind,
+    { bytes: Uint8Array; mediaType: string; pageScope: 'document' | number[] }
+  > = {
+    markdown: {
+      bytes: encoder.encode(
+        '# Inspectable candidate\n\nComplete MinerU Markdown is not canonical.\n',
+      ),
+      mediaType: 'text/markdown',
+      pageScope: 'document',
+    },
+    'content-list-v1': {
+      bytes: jsonBytes([
+        {
+          type: 'text',
+          page_idx: 0,
+          bbox: [100, 100, 900, 210],
+          text: 'Version one reading.',
+        },
+        {
+          type: 'table',
+          page_idx: 1,
+          bbox: [90, 250, 910, 620],
+          table_body: '<table><tr><td>A</td></tr></table>',
+        },
+      ]),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'content-list-v2': {
+      bytes: jsonBytes([
+        {
+          type: 'text',
+          page_idx: 0,
+          bbox: [100, 100, 900, 210],
+          text: 'Version two disagrees.',
+        },
+        {
+          type: 'equation',
+          page_idx: 1,
+          bbox: [90, 250, 910, 620],
+          latex: 'E=mc^2',
+        },
+      ]),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'middle-json': {
+      bytes: jsonBytes({ schemaVersion: '1.0.0', blocks: [{ id: 'b1' }] }),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'layout-json': {
+      bytes: jsonBytes({ schemaVersion: '1.0.0', layouts: [{ page: 1 }] }),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'model-json': {
+      bytes: jsonBytes({ schemaVersion: '1.0.0', predictions: [{ page: 1 }] }),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    ocr: {
+      bytes: jsonBytes({ schemaVersion: '1.0.0', spans: [{ page: 2 }] }),
+      mediaType: 'application/json',
+      pageScope: [2],
+    },
+    table: {
+      bytes: jsonBytes({ tables: [{ page: 2, rows: 1, columns: 1 }] }),
+      mediaType: 'application/json',
+      pageScope: [2],
+    },
+    formula: {
+      bytes: jsonBytes({ formulas: [{ page: 2, latex: 'E=mc^2' }] }),
+      mediaType: 'application/json',
+      pageScope: [2],
+    },
+    figure: {
+      bytes: jsonBytes({ figures: [{ page: 1, caption: 'Figure 1' }] }),
+      mediaType: 'application/json',
+      pageScope: [1],
+    },
+    image: {
+      bytes: Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]),
+      mediaType: 'image/png',
+      pageScope: [1],
+    },
+    'reading-order': {
+      bytes: jsonBytes({
+        schemaVersion: '1.0.0',
+        pages: [
+          { page: 1, order: ['b1'] },
+          { page: 2, order: ['b2'] },
+        ],
+      }),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'page-geometry': {
+      bytes: jsonBytes({
+        schemaVersion: '1.0.0',
+        pages: [
+          { page: 1, width: 612, height: 792, rotation: 0 },
+          { page: 2, width: 792, height: 612, rotation: 90 },
+        ],
+      }),
+      mediaType: 'application/json',
+      pageScope: 'document',
+    },
+    'layout-pdf': {
+      bytes: encoder.encode('%PDF-1.7\n% owner-local derived layout\n'),
+      mediaType: 'application/pdf',
+      pageScope: 'document',
+    },
+    'raw-output': {
+      bytes: encoder.encode('owner-local raw output'),
+      mediaType: 'application/octet-stream',
+      pageScope: 'document',
+    },
+  }
+
+  const artifacts = [] as MineruArtifactManifest['artifacts']
+  for (const [index, kind] of MINERU_ARTIFACT_KINDS.entries()) {
+    const item = contents[kind]
+    const relativePath = `${relativeDirectory}/${index + 17}.opaque-payload`
+    await writeFile(join(root, relativePath), item.bytes, { mode: 0o600 })
+    artifacts.push({
+      id: `retained:${index + 1}`,
+      kind,
+      relativePath,
+      mediaType: item.mediaType,
+      byteLength: item.bytes.byteLength,
+      sha256: sha256(item.bytes),
+      pageScope: item.pageScope,
+    })
+  }
+  const retainedBytes = artifacts.reduce(
+    (total, item) => total + item.byteLength,
+    0,
+  )
+  const manifest: MineruArtifactManifest = {
+    schemaVersion: MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION,
+    document: {
+      id: 'incoming-document-47',
+      sha256: 'd'.repeat(64),
+      byteLength: 45_127,
+      pageCount: 2,
+    },
+    binding: structuredClone(MINERU_PRODUCTION_BINDING),
+    execution: {
+      hostClass: 'owner-laptop',
+      operatingSystem: 'macOS-15.6',
+      architecture: 'arm64',
+      runtime: 'python-3.12',
+      backend: 'mlx-vlm',
+      backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+      runtimeSha256: '1'.repeat(64),
+      backendSha256: '2'.repeat(64),
+      packageSetSha256: '3'.repeat(64),
+      cacheNamespaceSha256: sha256(
+        encoder.encode(
+          '{"namespace":"mineru-production","rootRef":"owner-cache-47"}',
+        ),
+      ),
+      networkIsolation: 'macos-sandbox-exec-deny-network-v1' as const,
+      networkIsolationSha256: '8'.repeat(64),
+    },
+    cache: {
+      scope: 'owner-local',
+      rootRef: 'owner-cache-47',
+      namespace: 'mineru-production',
+      maximumBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+      retainedBytes,
+      artifactCount: artifacts.length,
+    },
+    artifacts,
+    producerReceipt: null as never,
+  }
+  refreshProducerReceipt(manifest)
+  return { root, manifest }
+}
+
+async function replaceJsonArtifact(
+  value: Awaited<ReturnType<typeof fixture>>,
+  kind: MineruArtifactKind,
+  content: unknown,
+) {
+  const descriptor = artifact(value.manifest, kind)
+  const bytes = jsonBytes(content)
+  await writeFile(join(value.root, descriptor.relativePath), bytes)
+  descriptor.byteLength = bytes.byteLength
+  descriptor.sha256 = sha256(bytes)
+  value.manifest.cache.retainedBytes = value.manifest.artifacts.reduce(
+    (total, item) => total + item.byteLength,
+    0,
+  )
+  refreshProducerReceipt(value.manifest)
+}
+
+describe('MinerU source-evidence normalization', () => {
+  it('binds the two real offline MLX smokes and keeps VM CPU identity distinct', () => {
+    const execution = {
+      hostClass: 'owner-laptop' as const,
+      operatingSystem: 'macOS-15.6',
+      architecture: 'arm64' as const,
+      runtime: 'python-3.12' as const,
+      backend: 'mlx-vlm' as const,
+      backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+      runtimeSha256: '1'.repeat(64),
+      backendSha256: '2'.repeat(64),
+      packageSetSha256: '3'.repeat(64),
+      cacheNamespaceSha256: '4'.repeat(64),
+      networkIsolation: 'macos-sandbox-exec-deny-network-v1' as const,
+      networkIsolationSha256: '5'.repeat(64),
+    }
+    const bornDigital = createMineruOfflineRunReceipt({
+      schemaVersion: '1.0.0',
+      sourceSha256:
+        '50874645b2cec033726018c86974241db2048ac46291e02fcb25d3cb7fbaa907',
+      execution,
+      artifacts: [
+        {
+          kind: 'markdown',
+          sha256:
+            'c07cd881ed06981303d35a7a039c04670f2eb397976b1061ccb56bf45747409a',
+        },
+        {
+          kind: 'content-list-v1',
+          sha256:
+            '1f3ad4482ae1a1485175c32530092a102c4a018520fca8e42141da1bcb2ddc88',
+        },
+        {
+          kind: 'content-list-v2',
+          sha256:
+            '0a24ef9cece4ed7acc715c90fe4710ffbf1094cadb2253b5fb824b5bbcb89566',
+        },
+        {
+          kind: 'middle-json',
+          sha256:
+            'f57e7e7bdcd6d3c4fe21385496dd2e3a033a89b46df91a7dc0cfda20ed1ff31f',
+        },
+        {
+          kind: 'model-json',
+          sha256:
+            '7383748a5fb49422e703cb4cff05f8857c01c6c6c32d9202abf30ed68b4b82bd',
+        },
+        {
+          kind: 'layout-pdf',
+          sha256:
+            'd1fa744a8beb2e6ddaad50d93378ff45a0a59dd68ff13e6868fe446f505fa1b4',
+        },
+      ],
+    })
+    const scan = createMineruOfflineRunReceipt({
+      schemaVersion: '1.0.0',
+      sourceSha256:
+        '2bb7049bf4c854d31a95eadc0d8462306708b36bc8a11eb7c885549e0c241c01',
+      execution,
+      artifacts: [
+        {
+          kind: 'markdown',
+          sha256:
+            '99c6f4a2d300db88d56a4ce0975428371abc7fb610bb477cab341c0dd23535eb',
+        },
+        {
+          kind: 'content-list-v1',
+          sha256:
+            '2a769007c5e921f0f1443b24bd1514762a13c94fa21ce64a276804ce9d899bba',
+        },
+        {
+          kind: 'content-list-v2',
+          sha256:
+            '9282e7d829dc9e3eb600aef13f73056ffcfc9d25e3b1f4a528d530e23be0e6ae',
+        },
+        {
+          kind: 'middle-json',
+          sha256:
+            '8d3edf6356859d4c047f2d751a3157cbf2ade768e285c9bcee85ca70a83ec06e',
+        },
+        {
+          kind: 'model-json',
+          sha256:
+            '4e23ef9bb58f7b2a5ba21e8dcdcbebe4cd0230e02569202a4a15a308bf72a71f',
+        },
+        {
+          kind: 'layout-pdf',
+          sha256:
+            '4db642914ce20cfab8225e4a8e4f491174fd8fd158a7284079e1d45374f94806',
+        },
+      ],
+    })
+    const vmCpu = createMineruOfflineRunReceipt({
+      ...bornDigital,
+      execution: {
+        ...execution,
+        hostClass: 'trusted-vm',
+        operatingSystem: 'Ubuntu-24.04',
+        backend: 'torch-cpu',
+        backendVersion: 'torch-2.13.0+cpu',
+        backendSha256:
+          '6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604',
+      },
+      artifacts: bornDigital.artifacts,
+    })
+
+    expect(bornDigital.receiptSha256).toMatch(/^[a-f0-9]{64}$/u)
+    expect(scan.receiptSha256).toMatch(/^[a-f0-9]{64}$/u)
+    expect(bornDigital.bindingSha256).toBe(scan.bindingSha256)
+    expect(vmCpu.bindingSha256).not.toBe(bornDigital.bindingSha256)
+    expect(Object.keys(vmCpu.execution)).toEqual(Object.keys(execution))
+    expect(() =>
+      createMineruOfflineRunReceipt({
+        ...bornDigital,
+        execution: {
+          ...execution,
+          hostClass: 'trusted-vm',
+          operatingSystem: 'Ubuntu-24.04',
+        },
+        artifacts: bornDigital.artifacts,
+      }),
+    ).toThrow(/INVALID_MINERU_OFFLINE_RUN_RECEIPT/u)
+  })
+
+  it('pins the exact approved production runtime, model file, architecture, and bounded caches', () => {
+    expect(MINERU_PRODUCTION_VERSION).toBe('3.4.4')
+    expect(MINERU_PRODUCTION_WHEEL_SHA256).toBe(
+      'd4d678539782a7683d998e2914a52d96b5720676ce65658b29666b1f4d9dfd13',
+    )
+    expect(MINERU_PRODUCTION_MODEL_ID).toBe(
+      'opendatalab/MinerU2.5-Pro-2605-1.2B',
+    )
+    expect(MINERU_PRODUCTION_MODEL_REVISION).toBe(
+      'bff20d4ae2bf202df9f45284b4d43681555a97ed',
+    )
+    expect(MINERU_PRODUCTION_MODEL_LICENSE).toBe('Apache-2.0')
+    expect(MINERU_PRODUCTION_MODEL_ARCHITECTURE).toBe(
+      'Qwen2VLForConditionalGeneration',
+    )
+    expect(MINERU_PRODUCTION_MODEL_TYPE).toBe('qwen2_vl')
+    expect(MINERU_PRODUCTION_MODEL_FILE).toBe('model.safetensors')
+    expect(MINERU_PRODUCTION_MODEL_BYTE_LENGTH).toBe(2_312_126_640)
+    expect(MINERU_PRODUCTION_MODEL_SHA256).toBe(
+      'abf8681ca63b8dec7b67de257af47b821f179442f72998d0696ae2ed9232a5f0',
+    )
+    expect(MINERU_PRODUCTION_BACKEND).toBe('vlm-engine')
+    expect(MINERU_PRODUCTION_CONFIGURATION).toEqual({
+      formula: true,
+      table: true,
+      imageAnalysis: true,
+    })
+    expect(MINERU_MAX_RETAINED_ARTIFACT_BYTES).toBe(1024 * 1024 * 1024)
+    expect(MINERU_MAX_OWNER_CACHE_BYTES).toBe(8 * 1024 * 1024 * 1024)
+  })
+
+  it('retains every class separately, preserves v1/v2 disagreements, and keeps Markdown noncanonical', async () => {
+    const value = await fixture()
+    const bundle = await inspectMineruSourceEvidence({
+      artifactRoot: value.root,
+      manifest: value.manifest,
+    })
+
+    expect(() => validatePdfEvidenceBundle(bundle)).not.toThrow()
+    expect(bundle.provider).toMatchObject({
+      kind: 'mineru',
+      version: '3.4.4',
+      implementationSha256: MINERU_PRODUCTION_WHEEL_SHA256,
+      model: {
+        id: MINERU_PRODUCTION_MODEL_ID,
+        revision: MINERU_PRODUCTION_MODEL_REVISION,
+        digestSha256: MINERU_PRODUCTION_MODEL_SHA256,
+        license: 'Apache-2.0',
+        architecture: 'Qwen2VLForConditionalGeneration',
+      },
+    })
+    expect(bundle.pages).toEqual([
+      { page: 1, width: 612, height: 792, rotation: 0 },
+      { page: 2, width: 792, height: 612, rotation: 90 },
+    ])
+    expect(new Set(bundle.artifacts.map(({ kind }) => kind))).toEqual(
+      new Set(MINERU_ARTIFACT_KINDS),
+    )
+    const artifactCandidates = bundle.candidates.filter((candidate) =>
+      candidate.id.includes(':candidate:artifact:'),
+    )
+    expect(new Set(artifactCandidates.map(({ kind }) => kind))).toEqual(
+      new Set(MINERU_ARTIFACT_KINDS),
+    )
+    expect(
+      artifactCandidates.every(
+        (candidate) => payload(candidate.payload).grounded === false,
+      ),
+    ).toBe(true)
+
+    const markdownSource = bundle.sources.find(
+      (source) => source.kind === 'markdown',
+    )
+    expect(markdownSource?.payload).toMatchObject({
+      representation: 'complete-inspectable-markdown',
+      complete: true,
+      inspectable: true,
+      canonical: false,
+      markdown: expect.stringContaining('Complete MinerU Markdown'),
+    })
+    const competingText = bundle.candidates.filter(
+      (candidate) =>
+        candidate.kind === 'text' &&
+        !candidate.id.includes(':candidate:artifact:'),
+    )
+    expect(competingText).toHaveLength(2)
+    expect(competingText[0]!.boxes).toEqual(competingText[1]!.boxes)
+    expect(
+      new Set(
+        competingText.map(
+          (candidate) => payload(candidate.payload).representation,
+        ),
+      ),
+    ).toEqual(new Set(['content-list-v1', 'content-list-v2']))
+    expect(
+      new Set(
+        competingText.map(
+          (candidate) => payload(candidate.payload).recordSha256,
+        ),
+      ).size,
+    ).toBe(2)
+    expect(
+      competingText.every(
+        (candidate) =>
+          candidate.providerId === bundle.provider.id &&
+          candidate.sourceIds.length === 1 &&
+          candidate.artifactIds?.length === 1,
+      ),
+    ).toBe(true)
+
+    const serialized = JSON.stringify(bundle)
+    expect(serialized).not.toContain(value.root)
+    expect(serialized).not.toContain('files-with-arbitrary-names')
+    expect(serialized).not.toContain('.opaque-payload')
+  })
+
+  it('fails closed on changed bindings, incomplete classes, cache inflation, and oversized textual artifacts', async () => {
+    const bindingMismatch = await fixture()
+    const wrongBinding = structuredClone(
+      bindingMismatch.manifest,
+    ) as unknown as {
+      binding: { backend: string }
+    }
+    wrongBinding.binding.backend = 'pipeline'
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: bindingMismatch.root,
+        manifest: wrongBinding,
+      }),
+    ).rejects.toThrow('MINERU_PRODUCTION_BINDING_MISMATCH')
+
+    const missingClass = await fixture()
+    missingClass.manifest.artifacts = missingClass.manifest.artifacts.filter(
+      ({ kind }) => kind !== 'formula',
+    )
+    missingClass.manifest.cache.artifactCount =
+      missingClass.manifest.artifacts.length
+    missingClass.manifest.cache.retainedBytes =
+      missingClass.manifest.artifacts.reduce(
+        (total, item) => total + item.byteLength,
+        0,
+      )
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: missingClass.root,
+        manifest: missingClass.manifest,
+      }),
+    ).rejects.toThrow('MISSING_MINERU_ARTIFACT_CLASS')
+
+    const cacheInflation = await fixture()
+    cacheInflation.manifest.cache.retainedBytes += 1
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: cacheInflation.root,
+        manifest: cacheInflation.manifest,
+      }),
+    ).rejects.toThrow('MINERU_CACHE_METADATA_MISMATCH')
+
+    const oversized = await fixture()
+    const layout = artifact(oversized.manifest, 'layout-json')
+    oversized.manifest.cache.retainedBytes +=
+      MINERU_MAX_TEXTUAL_ARTIFACT_BYTES + 1 - layout.byteLength
+    oversized.manifest.cache.maximumBytes =
+      MINERU_MAX_TEXTUAL_ARTIFACT_BYTES + 1024 * 1024
+    layout.byteLength = MINERU_MAX_TEXTUAL_ARTIFACT_BYTES + 1
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: oversized.root,
+        manifest: oversized.manifest,
+      }),
+    ).rejects.toThrow('MINERU_TEXTUAL_ARTIFACT_TOO_LARGE')
+  })
+
+  it('rejects tampered bytes and paths instead of trusting filenames or stale hashes', async () => {
+    const tampered = await fixture()
+    const image = artifact(tampered.manifest, 'image')
+    await writeFile(
+      join(tampered.root, image.relativePath),
+      new Uint8Array(image.byteLength).fill(120),
+    )
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: tampered.root,
+        manifest: tampered.manifest,
+      }),
+    ).rejects.toThrow('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+
+    const escaped = await fixture()
+    artifact(escaped.manifest, 'image').relativePath = '../outside.png'
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: escaped.root,
+        manifest: escaped.manifest,
+      }),
+    ).rejects.toThrow('INVALID_MINERU_ARTIFACT_DESCRIPTOR')
+  })
+
+  it('rejects malformed or incomplete page geometry, reading order, and candidate boxes', async () => {
+    const badGeometry = await fixture()
+    await replaceJsonArtifact(badGeometry, 'page-geometry', {
+      schemaVersion: '1.0.0',
+      pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+    })
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: badGeometry.root,
+        manifest: badGeometry.manifest,
+      }),
+    ).rejects.toThrow('INVALID_MINERU_PAGE_GEOMETRY')
+
+    const badOrder = await fixture()
+    await replaceJsonArtifact(badOrder, 'reading-order', {
+      schemaVersion: '1.0.0',
+      pages: [
+        { page: 1, order: ['b1'] },
+        { page: 1, order: ['b2'] },
+      ],
+    })
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: badOrder.root,
+        manifest: badOrder.manifest,
+      }),
+    ).rejects.toThrow('INVALID_MINERU_READING_ORDER')
+
+    const badBox = await fixture()
+    await replaceJsonArtifact(badBox, 'content-list-v2', [
+      { type: 'text', page_idx: 0, bbox: [100, 100, 1001, 200] },
+    ])
+    await expect(
+      inspectMineruSourceEvidence({
+        artifactRoot: badBox.root,
+        manifest: badBox.manifest,
+      }),
+    ).rejects.toThrow('INVALID_MINERU_CONTENT_LIST_GEOMETRY')
+  })
+})

--- a/src/research/mineru-source-evidence.ts
+++ b/src/research/mineru-source-evidence.ts
@@ -1,0 +1,1145 @@
+import { createHash } from 'node:crypto'
+import { constants, createReadStream } from 'node:fs'
+import { access, lstat, readFile, realpath } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  validatePdfEvidenceBundle,
+  type PdfEvidenceBundle,
+  type PdfEvidenceJsonValue,
+} from './source-evidence-graph.ts'
+
+export const MINERU_SOURCE_EVIDENCE_SCHEMA_VERSION =
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION
+export const MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION = '1.0.0' as const
+
+export const MINERU_PRODUCTION_VERSION = '3.4.4' as const
+export const MINERU_PRODUCTION_WHEEL_SHA256 =
+  'd4d678539782a7683d998e2914a52d96b5720676ce65658b29666b1f4d9dfd13' as const
+export const MINERU_PRODUCTION_MODEL_ID =
+  'opendatalab/MinerU2.5-Pro-2605-1.2B' as const
+export const MINERU_PRODUCTION_MODEL_REVISION =
+  'bff20d4ae2bf202df9f45284b4d43681555a97ed' as const
+export const MINERU_PRODUCTION_MODEL_LICENSE = 'Apache-2.0' as const
+export const MINERU_PRODUCTION_MODEL_ARCHITECTURE =
+  'Qwen2VLForConditionalGeneration' as const
+export const MINERU_PRODUCTION_MODEL_TYPE = 'qwen2_vl' as const
+export const MINERU_PRODUCTION_MODEL_FILE = 'model.safetensors' as const
+export const MINERU_PRODUCTION_MODEL_BYTE_LENGTH = 2_312_126_640 as const
+export const MINERU_PRODUCTION_MODEL_SHA256 =
+  'abf8681ca63b8dec7b67de257af47b821f179442f72998d0696ae2ed9232a5f0' as const
+export const MINERU_PRODUCTION_BACKEND = 'vlm-engine' as const
+
+export const MINERU_PRODUCTION_CONFIGURATION = Object.freeze({
+  formula: true,
+  table: true,
+  imageAnalysis: true,
+})
+
+export const MINERU_PRODUCTION_BINDING = Object.freeze({
+  provider: Object.freeze({
+    id: 'mineru',
+    version: MINERU_PRODUCTION_VERSION,
+    wheelSha256: MINERU_PRODUCTION_WHEEL_SHA256,
+  }),
+  model: Object.freeze({
+    id: MINERU_PRODUCTION_MODEL_ID,
+    revision: MINERU_PRODUCTION_MODEL_REVISION,
+    license: MINERU_PRODUCTION_MODEL_LICENSE,
+    architecture: MINERU_PRODUCTION_MODEL_ARCHITECTURE,
+    modelType: MINERU_PRODUCTION_MODEL_TYPE,
+    file: MINERU_PRODUCTION_MODEL_FILE,
+    byteLength: MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+    sha256: MINERU_PRODUCTION_MODEL_SHA256,
+  }),
+  backend: MINERU_PRODUCTION_BACKEND,
+  configuration: MINERU_PRODUCTION_CONFIGURATION,
+})
+
+export const MINERU_MAX_ARTIFACT_COUNT = 100_000
+export const MINERU_MAX_ARTIFACT_BYTES = 512 * 1024 * 1024
+export const MINERU_MAX_TEXTUAL_ARTIFACT_BYTES = 64 * 1024 * 1024
+export const MINERU_MAX_RETAINED_ARTIFACT_BYTES = 1024 * 1024 * 1024
+export const MINERU_MAX_RAW_OUTPUT_BYTES = 1024 * 1024 * 1024
+export const MINERU_MAX_OWNER_CACHE_BYTES = 8 * 1024 * 1024 * 1024
+
+export const MINERU_ARTIFACT_KINDS = Object.freeze([
+  'markdown',
+  'content-list-v1',
+  'content-list-v2',
+  'middle-json',
+  'layout-json',
+  'model-json',
+  'ocr',
+  'table',
+  'formula',
+  'figure',
+  'image',
+  'reading-order',
+  'page-geometry',
+  'layout-pdf',
+  'raw-output',
+] as const)
+
+export type MineruArtifactKind = (typeof MINERU_ARTIFACT_KINDS)[number]
+
+export type MineruArtifactDescriptor = {
+  id: string
+  kind: MineruArtifactKind
+  relativePath: string
+  mediaType: string
+  byteLength: number
+  sha256: string
+  pageScope: 'document' | number[]
+}
+
+export type MineruArtifactManifest = {
+  schemaVersion: typeof MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION
+  document: {
+    id: string
+    sha256: string
+    byteLength: number
+    pageCount: number
+  }
+  binding: typeof MINERU_PRODUCTION_BINDING
+  execution: {
+    hostClass: 'owner-laptop' | 'trusted-vm'
+    operatingSystem: string
+    architecture: 'arm64'
+    runtime: 'python-3.12'
+    backend: 'mlx-vlm' | 'torch-cpu'
+    backendVersion: string
+    runtimeSha256: string
+    backendSha256: string
+    packageSetSha256: string
+    cacheNamespaceSha256: string
+    networkIsolation:
+      | 'macos-sandbox-exec-deny-network-v1'
+      | 'linux-user-netns-loopback-only-v1'
+    networkIsolationSha256: string
+  }
+  cache: {
+    scope: 'owner-local'
+    rootRef: string
+    namespace: string
+    maximumBytes: number
+    retainedBytes: number
+    artifactCount: number
+  }
+  artifacts: MineruArtifactDescriptor[]
+  producerReceipt: MineruProducerReceipt
+}
+
+export type MineruProducerReceipt = {
+  schemaVersion: '1.0.0'
+  sourcePdfSha256: string
+  sourceByteLength: number
+  sourcePageCount: number
+  sourcePageGeometrySha256: string
+  mineruExecutableSha256: string
+  mineruConfigSha256: string
+  runtimeSha256: string
+  runtimeInventorySha256: string
+  runtimeTreeByteLength: number
+  packageSetSha256: string
+  backendSha256: string
+  modelSha256: string
+  modelConfigSha256: string
+  cacheInventorySha256: string
+  cacheByteLength: number
+  privateSnapshotAllocatedByteLength: number
+  rawOutputInventorySha256: string
+  rawOutputByteLength: number
+  networkIsolation: MineruArtifactManifest['execution']['networkIsolation']
+  networkIsolationSha256: string
+  artifactSetSha256: string
+  offline: true
+  runDirectoryMode: '0700'
+  receiptSha256: string
+}
+
+export const MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS = [
+  'markdown',
+  'content-list-v1',
+  'content-list-v2',
+  'middle-json',
+  'model-json',
+  'layout-pdf',
+] as const
+
+export type MineruOfflineRunReceipt = {
+  schemaVersion: '1.0.0'
+  sourceSha256: string
+  execution: MineruArtifactManifest['execution']
+  bindingSha256: string
+  artifacts: Array<{
+    kind: (typeof MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS)[number]
+    sha256: string
+  }>
+  receiptSha256: string
+}
+
+type VerifiedArtifact = MineruArtifactDescriptor & {
+  json: unknown | null
+  text: string | null
+}
+
+type NormalizedBox = {
+  page: number
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation: number
+  method: 'pdf-object'
+}
+
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u
+const SHA256 = /^[a-f0-9]{64}$/u
+const MEDIA_TYPE = /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/iu
+const JSON_ARTIFACT_KINDS = new Set<MineruArtifactKind>([
+  'content-list-v1',
+  'content-list-v2',
+  'middle-json',
+  'layout-json',
+  'model-json',
+  'ocr',
+  'reading-order',
+  'page-geometry',
+])
+const DOCUMENT_COMPLETE_ARTIFACT_KINDS = new Set<MineruArtifactKind>([
+  'content-list-v1',
+  'content-list-v2',
+  'middle-json',
+  'layout-json',
+  'model-json',
+  'reading-order',
+  'page-geometry',
+])
+
+function invalid(code: string): never {
+  throw new Error(code)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(
+  value: unknown,
+  expected: readonly string[],
+): value is Record<string, unknown> {
+  if (!isRecord(value)) return false
+  const actual = Object.keys(value).sort()
+  const wanted = [...expected].sort()
+  return (
+    actual.length === wanted.length &&
+    actual.every((key, index) => key === wanted[index])
+  )
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function validExecutionIdentity(
+  value: unknown,
+): value is MineruArtifactManifest['execution'] {
+  if (
+    !exactKeys(value, [
+      'hostClass',
+      'operatingSystem',
+      'architecture',
+      'runtime',
+      'backend',
+      'backendVersion',
+      'runtimeSha256',
+      'backendSha256',
+      'packageSetSha256',
+      'cacheNamespaceSha256',
+      'networkIsolation',
+      'networkIsolationSha256',
+    ]) ||
+    typeof value.operatingSystem !== 'string' ||
+    value.operatingSystem.length < 1 ||
+    value.architecture !== 'arm64' ||
+    value.runtime !== 'python-3.12' ||
+    !SHA256.test(String(value.runtimeSha256)) ||
+    !SHA256.test(String(value.networkIsolationSha256)) ||
+    ![
+      'macos-sandbox-exec-deny-network-v1',
+      'linux-user-netns-loopback-only-v1',
+    ].includes(String(value.networkIsolation)) ||
+    !SHA256.test(String(value.backendSha256)) ||
+    !SHA256.test(String(value.packageSetSha256)) ||
+    !SHA256.test(String(value.cacheNamespaceSha256))
+  ) {
+    return false
+  }
+  return (
+    (value.hostClass === 'owner-laptop' &&
+      value.backend === 'mlx-vlm' &&
+      value.backendVersion === 'mlx-vlm-0.3.12+mlx-0.31.1') ||
+    (value.hostClass === 'trusted-vm' &&
+      value.backend === 'torch-cpu' &&
+      value.backendVersion === 'torch-2.13.0+cpu')
+  )
+}
+
+function sha256(value: Uint8Array | string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function canonicalHash(value: unknown) {
+  return sha256(canonicalJson(value))
+}
+
+function safePositiveInteger(
+  value: unknown,
+  maximum = Number.MAX_SAFE_INTEGER,
+) {
+  return (
+    Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= maximum
+  )
+}
+
+function validPageScope(value: unknown, pageCount: number) {
+  return (
+    value === 'document' ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      new Set(value).size === value.length &&
+      value.every(
+        (page) => Number.isSafeInteger(page) && page >= 1 && page <= pageCount,
+      ))
+  )
+}
+
+function validRelativeArtifactPath(value: unknown) {
+  if (
+    typeof value !== 'string' ||
+    value.length < 1 ||
+    value.length > 2_048 ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    isAbsolute(value)
+  ) {
+    return false
+  }
+  const segments = value.split('/')
+  return segments.every(
+    (segment) => segment.length > 0 && segment !== '.' && segment !== '..',
+  )
+}
+
+function manifestArtifact(value: unknown, pageCount: number) {
+  if (
+    !exactKeys(value, [
+      'id',
+      'kind',
+      'relativePath',
+      'mediaType',
+      'byteLength',
+      'sha256',
+      'pageScope',
+    ]) ||
+    typeof value.id !== 'string' ||
+    !SAFE_ID.test(value.id) ||
+    typeof value.kind !== 'string' ||
+    !MINERU_ARTIFACT_KINDS.includes(value.kind as MineruArtifactKind) ||
+    !validRelativeArtifactPath(value.relativePath) ||
+    typeof value.mediaType !== 'string' ||
+    !MEDIA_TYPE.test(value.mediaType) ||
+    !safePositiveInteger(value.byteLength, MINERU_MAX_ARTIFACT_BYTES) ||
+    typeof value.sha256 !== 'string' ||
+    !SHA256.test(value.sha256) ||
+    !validPageScope(value.pageScope, pageCount)
+  ) {
+    invalid('INVALID_MINERU_ARTIFACT_DESCRIPTOR')
+  }
+  const artifact = value as MineruArtifactDescriptor
+  if (artifact.kind === 'markdown' && artifact.mediaType !== 'text/markdown') {
+    invalid('INVALID_MINERU_ARTIFACT_MEDIA_TYPE')
+  }
+  if (
+    JSON_ARTIFACT_KINDS.has(artifact.kind) &&
+    artifact.mediaType !== 'application/json'
+  ) {
+    invalid('INVALID_MINERU_ARTIFACT_MEDIA_TYPE')
+  }
+  if (
+    (artifact.mediaType === 'application/json' ||
+      artifact.kind === 'markdown') &&
+    artifact.byteLength > MINERU_MAX_TEXTUAL_ARTIFACT_BYTES
+  ) {
+    invalid('MINERU_TEXTUAL_ARTIFACT_TOO_LARGE')
+  }
+  if (
+    DOCUMENT_COMPLETE_ARTIFACT_KINDS.has(artifact.kind) &&
+    artifact.pageScope !== 'document'
+  ) {
+    invalid('INCOMPLETE_MINERU_ARTIFACT_PAGE_SCOPE')
+  }
+  return artifact
+}
+
+function validateManifest(value: unknown): MineruArtifactManifest {
+  if (
+    !exactKeys(value, [
+      'schemaVersion',
+      'document',
+      'binding',
+      'execution',
+      'cache',
+      'artifacts',
+      'producerReceipt',
+    ]) ||
+    value.schemaVersion !== MINERU_ARTIFACT_MANIFEST_SCHEMA_VERSION ||
+    !exactKeys(value.document, ['id', 'sha256', 'byteLength', 'pageCount']) ||
+    typeof value.document.id !== 'string' ||
+    !SAFE_ID.test(value.document.id) ||
+    typeof value.document.sha256 !== 'string' ||
+    !SHA256.test(value.document.sha256) ||
+    !safePositiveInteger(value.document.byteLength) ||
+    !safePositiveInteger(value.document.pageCount, 1_000_000) ||
+    canonicalJson(value.binding) !== canonicalJson(MINERU_PRODUCTION_BINDING) ||
+    !validExecutionIdentity(value.execution) ||
+    !exactKeys(value.cache, [
+      'scope',
+      'rootRef',
+      'namespace',
+      'maximumBytes',
+      'retainedBytes',
+      'artifactCount',
+    ]) ||
+    value.cache.scope !== 'owner-local' ||
+    typeof value.cache.rootRef !== 'string' ||
+    !SAFE_ID.test(value.cache.rootRef) ||
+    typeof value.cache.namespace !== 'string' ||
+    !SAFE_ID.test(value.cache.namespace) ||
+    !safePositiveInteger(
+      value.cache.maximumBytes,
+      MINERU_MAX_OWNER_CACHE_BYTES,
+    ) ||
+    !Number.isSafeInteger(value.cache.retainedBytes) ||
+    Number(value.cache.retainedBytes) < 1 ||
+    Number(value.cache.retainedBytes) > Number(value.cache.maximumBytes) ||
+    !safePositiveInteger(
+      value.cache.artifactCount,
+      MINERU_MAX_ARTIFACT_COUNT,
+    ) ||
+    !Array.isArray(value.artifacts) ||
+    value.artifacts.length < 1 ||
+    value.artifacts.length > MINERU_MAX_ARTIFACT_COUNT ||
+    !exactKeys(value.producerReceipt, [
+      'schemaVersion',
+      'sourcePdfSha256',
+      'sourceByteLength',
+      'sourcePageCount',
+      'sourcePageGeometrySha256',
+      'mineruExecutableSha256',
+      'mineruConfigSha256',
+      'runtimeSha256',
+      'runtimeInventorySha256',
+      'runtimeTreeByteLength',
+      'packageSetSha256',
+      'backendSha256',
+      'modelSha256',
+      'modelConfigSha256',
+      'cacheInventorySha256',
+      'cacheByteLength',
+      'privateSnapshotAllocatedByteLength',
+      'rawOutputInventorySha256',
+      'rawOutputByteLength',
+      'networkIsolation',
+      'networkIsolationSha256',
+      'artifactSetSha256',
+      'offline',
+      'runDirectoryMode',
+      'receiptSha256',
+    ])
+  ) {
+    if (
+      isRecord(value) &&
+      Object.hasOwn(value, 'binding') &&
+      canonicalJson(value.binding) !== canonicalJson(MINERU_PRODUCTION_BINDING)
+    ) {
+      invalid('MINERU_PRODUCTION_BINDING_MISMATCH')
+    }
+    invalid('INVALID_MINERU_ARTIFACT_MANIFEST')
+  }
+
+  const pageCount = value.document.pageCount as number
+  const artifacts = value.artifacts.map((artifact) =>
+    manifestArtifact(artifact, pageCount),
+  )
+  if (
+    new Set(artifacts.map(({ id }) => id)).size !== artifacts.length ||
+    new Set(artifacts.map(({ relativePath }) => relativePath)).size !==
+      artifacts.length
+  ) {
+    invalid('DUPLICATE_MINERU_ARTIFACT')
+  }
+  const actualKinds = new Set(artifacts.map(({ kind }) => kind))
+  for (const kind of MINERU_ARTIFACT_KINDS) {
+    if (!actualKinds.has(kind)) invalid('MISSING_MINERU_ARTIFACT_CLASS')
+  }
+  const totalBytes = artifacts.reduce(
+    (total, artifact) => total + artifact.byteLength,
+    0,
+  )
+  if (
+    totalBytes > MINERU_MAX_RETAINED_ARTIFACT_BYTES ||
+    value.cache.artifactCount !== artifacts.length ||
+    value.cache.retainedBytes !== totalBytes
+  ) {
+    invalid('MINERU_CACHE_METADATA_MISMATCH')
+  }
+  const producerReceipt = value.producerReceipt as MineruProducerReceipt
+  const { receiptSha256, ...producerProjection } = producerReceipt
+  const rawOutputInventory = artifacts
+    .filter(({ kind }) => kind === 'raw-output')
+    .map(({ relativePath, byteLength, sha256 }) => ({
+      relativePath,
+      byteLength,
+      sha256,
+    }))
+  const rawOutputByteLength = rawOutputInventory.reduce(
+    (total, { byteLength }) => total + byteLength,
+    0,
+  )
+  if (
+    producerReceipt.schemaVersion !== '1.0.0' ||
+    producerReceipt.sourcePdfSha256 !== value.document.sha256 ||
+    producerReceipt.sourceByteLength !== value.document.byteLength ||
+    producerReceipt.sourcePageCount !== value.document.pageCount ||
+    !SHA256.test(producerReceipt.sourcePageGeometrySha256) ||
+    !SHA256.test(producerReceipt.mineruExecutableSha256) ||
+    !SHA256.test(producerReceipt.mineruConfigSha256) ||
+    producerReceipt.runtimeSha256 !== value.execution.runtimeSha256 ||
+    !SHA256.test(producerReceipt.runtimeInventorySha256) ||
+    !Number.isSafeInteger(producerReceipt.runtimeTreeByteLength) ||
+    producerReceipt.runtimeTreeByteLength < 1 ||
+    producerReceipt.packageSetSha256 !== value.execution.packageSetSha256 ||
+    producerReceipt.backendSha256 !== value.execution.backendSha256 ||
+    producerReceipt.modelSha256 !== MINERU_PRODUCTION_MODEL_SHA256 ||
+    !SHA256.test(producerReceipt.modelConfigSha256) ||
+    !SHA256.test(producerReceipt.cacheInventorySha256) ||
+    !Number.isSafeInteger(producerReceipt.cacheByteLength) ||
+    producerReceipt.cacheByteLength < MINERU_PRODUCTION_MODEL_BYTE_LENGTH ||
+    !Number.isSafeInteger(
+      producerReceipt.privateSnapshotAllocatedByteLength,
+    ) ||
+    producerReceipt.privateSnapshotAllocatedByteLength < 0 ||
+    !SHA256.test(producerReceipt.rawOutputInventorySha256) ||
+    !Number.isSafeInteger(producerReceipt.rawOutputByteLength) ||
+    producerReceipt.rawOutputByteLength < 1 ||
+    producerReceipt.rawOutputByteLength > MINERU_MAX_RAW_OUTPUT_BYTES ||
+    producerReceipt.rawOutputByteLength !== rawOutputByteLength ||
+    producerReceipt.rawOutputInventorySha256 !==
+      canonicalHash(rawOutputInventory) ||
+    producerReceipt.networkIsolation !== value.execution.networkIsolation ||
+    producerReceipt.networkIsolationSha256 !==
+      value.execution.networkIsolationSha256 ||
+    producerReceipt.cacheByteLength +
+      producerReceipt.privateSnapshotAllocatedByteLength +
+      value.cache.retainedBytes >
+      Number(value.cache.maximumBytes) ||
+    producerReceipt.artifactSetSha256 !== canonicalHash(artifacts) ||
+    producerReceipt.offline !== true ||
+    producerReceipt.runDirectoryMode !== '0700' ||
+    receiptSha256 !== canonicalHash(producerProjection)
+  ) {
+    invalid('INVALID_MINERU_PRODUCER_RECEIPT')
+  }
+  if (
+    value.execution.cacheNamespaceSha256 !==
+    canonicalHash({
+      rootRef: value.cache.rootRef,
+      namespace: value.cache.namespace,
+    })
+  ) {
+    invalid('MINERU_CACHE_IDENTITY_MISMATCH')
+  }
+  return value as MineruArtifactManifest
+}
+
+function within(parent: string, child: string) {
+  const path = relative(parent, child)
+  return (
+    path === '' ||
+    (!path.startsWith(`..${sep}`) && path !== '..' && !isAbsolute(path))
+  )
+}
+
+function parseJson(bytes: Uint8Array) {
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
+  } catch {
+    invalid('INVALID_MINERU_JSON_ARTIFACT')
+  }
+}
+
+async function streamFileSha256(path: string, expectedBytes: number) {
+  const digest = createHash('sha256')
+  let byteLength = 0
+  for await (const chunk of createReadStream(path)) {
+    const bytes = chunk as Uint8Array
+    byteLength += bytes.byteLength
+    if (byteLength > expectedBytes) {
+      invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+    }
+    digest.update(bytes)
+  }
+  return { byteLength, sha256: digest.digest('hex') }
+}
+
+function fileIdentity(details: Awaited<ReturnType<typeof lstat>>) {
+  return {
+    dev: details.dev,
+    ino: details.ino,
+    size: details.size,
+    mtimeMs: details.mtimeMs,
+    ctimeMs: details.ctimeMs,
+  }
+}
+
+function sameFileIdentity(
+  left: ReturnType<typeof fileIdentity>,
+  right: ReturnType<typeof fileIdentity>,
+) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  )
+}
+
+async function verifyArtifactRoot(path: string) {
+  if (!isAbsolute(path) || resolve(path) !== path) {
+    invalid('INVALID_MINERU_ARTIFACT_ROOT')
+  }
+  try {
+    const supplied = await lstat(path)
+    const canonical = await realpath(path)
+    const canonicalDetails = await lstat(canonical)
+    if (
+      !supplied.isDirectory() ||
+      supplied.isSymbolicLink() ||
+      canonical !== path ||
+      !canonicalDetails.isDirectory() ||
+      canonicalDetails.isSymbolicLink() ||
+      (process.platform !== 'win32' && (canonicalDetails.mode & 0o077) !== 0)
+    ) {
+      invalid('INVALID_MINERU_ARTIFACT_ROOT')
+    }
+    return canonical
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'INVALID_MINERU_ARTIFACT_ROOT'
+    )
+      throw error
+    invalid('INVALID_MINERU_ARTIFACT_ROOT')
+  }
+}
+
+async function verifyArtifact(
+  root: string,
+  descriptor: MineruArtifactDescriptor,
+): Promise<VerifiedArtifact> {
+  const path = resolve(root, ...descriptor.relativePath.split('/'))
+  if (!within(root, path)) invalid('MINERU_ARTIFACT_PATH_ESCAPE')
+  try {
+    const supplied = await lstat(path)
+    const canonical = await realpath(path)
+    const details = await lstat(canonical)
+    await access(canonical, constants.R_OK)
+    if (
+      !supplied.isFile() ||
+      supplied.isSymbolicLink() ||
+      canonical !== path ||
+      !details.isFile() ||
+      details.isSymbolicLink() ||
+      details.size !== descriptor.byteLength
+    ) {
+      invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+    }
+    const before = fileIdentity(details)
+    const streamed = await streamFileSha256(canonical, descriptor.byteLength)
+    if (
+      streamed.byteLength !== descriptor.byteLength ||
+      streamed.sha256 !== descriptor.sha256
+    ) {
+      invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+    }
+
+    const textual =
+      descriptor.mediaType === 'application/json' ||
+      descriptor.kind === 'markdown'
+    if (textual && descriptor.byteLength > MINERU_MAX_TEXTUAL_ARTIFACT_BYTES) {
+      invalid('MINERU_TEXTUAL_ARTIFACT_TOO_LARGE')
+    }
+    const bytes = textual ? new Uint8Array(await readFile(canonical)) : null
+    if (
+      bytes &&
+      (bytes.byteLength !== descriptor.byteLength ||
+        sha256(bytes) !== descriptor.sha256)
+    ) {
+      invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+    }
+    const after = await lstat(canonical)
+    if (
+      !sameFileIdentity(before, fileIdentity(after)) ||
+      (await realpath(path)) !== canonical
+    ) {
+      invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+    }
+    const json =
+      descriptor.mediaType === 'application/json' ? parseJson(bytes!) : null
+    let text: string | null = null
+    if (descriptor.kind === 'markdown' && bytes) {
+      try {
+        text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+      } catch {
+        invalid('INVALID_MINERU_MARKDOWN_ARTIFACT')
+      }
+    }
+    return { ...descriptor, json, text }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /^[A-Z0-9_]*MINERU[A-Z0-9_]*$/u.test(error.message)
+    ) {
+      throw error
+    }
+    invalid('MINERU_ARTIFACT_IDENTITY_MISMATCH')
+  }
+}
+
+function pageGeometry(value: unknown, pageCount: number) {
+  if (
+    !exactKeys(value, ['schemaVersion', 'pages']) ||
+    value.schemaVersion !== '1.0.0' ||
+    !Array.isArray(value.pages) ||
+    value.pages.length !== pageCount
+  ) {
+    invalid('INVALID_MINERU_PAGE_GEOMETRY')
+  }
+  const pages = value.pages.map((page) => {
+    if (
+      !exactKeys(page, ['page', 'width', 'height', 'rotation']) ||
+      !safePositiveInteger(page.page, pageCount) ||
+      typeof page.width !== 'number' ||
+      !Number.isFinite(page.width) ||
+      page.width <= 0 ||
+      typeof page.height !== 'number' ||
+      !Number.isFinite(page.height) ||
+      page.height <= 0 ||
+      ![0, 90, 180, 270].includes(page.rotation as number)
+    ) {
+      invalid('INVALID_MINERU_PAGE_GEOMETRY')
+    }
+    return {
+      page: page.page as number,
+      width: page.width,
+      height: page.height,
+      rotation: page.rotation as number,
+    }
+  })
+  if (
+    new Set(pages.map(({ page }) => page)).size !== pageCount ||
+    pages.some(({ page }, index) => page !== index + 1)
+  ) {
+    invalid('INVALID_MINERU_PAGE_GEOMETRY')
+  }
+  return pages
+}
+
+function validateReadingOrder(value: unknown, pageCount: number) {
+  if (
+    !exactKeys(value, ['schemaVersion', 'pages']) ||
+    value.schemaVersion !== '1.0.0' ||
+    !Array.isArray(value.pages) ||
+    value.pages.length !== pageCount ||
+    value.pages.some(
+      (page, index) =>
+        !exactKeys(page, ['page', 'order']) ||
+        page.page !== index + 1 ||
+        !Array.isArray(page.order) ||
+        page.order.some(
+          (entry: unknown) =>
+            !(
+              typeof entry === 'string' ||
+              (Number.isSafeInteger(entry) && Number(entry) >= 0)
+            ),
+        ),
+    )
+  ) {
+    invalid('INVALID_MINERU_READING_ORDER')
+  }
+}
+
+type ContentListRecord = {
+  record: Record<string, unknown>
+  pointer: string
+  fallbackPage: number | null
+}
+
+function contentListRecords(value: unknown): ContentListRecord[] {
+  if (!Array.isArray(value)) invalid('INVALID_MINERU_CONTENT_LIST')
+  const records: ContentListRecord[] = []
+  for (const [index, item] of value.entries()) {
+    if (Array.isArray(item)) {
+      for (const [nestedIndex, nested] of item.entries()) {
+        if (!isRecord(nested)) invalid('INVALID_MINERU_CONTENT_LIST')
+        records.push({
+          record: nested,
+          pointer: `/${index}/${nestedIndex}`,
+          fallbackPage: index + 1,
+        })
+      }
+      continue
+    }
+    if (!isRecord(item)) invalid('INVALID_MINERU_CONTENT_LIST')
+    records.push({ record: item, pointer: `/${index}`, fallbackPage: null })
+  }
+  return records
+}
+
+function candidateBox(
+  record: Record<string, unknown>,
+  fallbackPage: number | null,
+  pageCount: number,
+): NormalizedBox {
+  const pageIndex = record.page_idx
+  const page = Number.isSafeInteger(pageIndex)
+    ? Number(pageIndex) + 1
+    : fallbackPage
+  const bbox = record.bbox
+  if (
+    page === null ||
+    !Number.isSafeInteger(page) ||
+    page < 1 ||
+    page > pageCount ||
+    !Array.isArray(bbox) ||
+    bbox.length !== 4 ||
+    bbox.some(
+      (coordinate) =>
+        typeof coordinate !== 'number' ||
+        !Number.isFinite(coordinate) ||
+        coordinate < 0 ||
+        coordinate > 1000,
+    ) ||
+    bbox[2] <= bbox[0] ||
+    bbox[3] <= bbox[1]
+  ) {
+    invalid('INVALID_MINERU_CONTENT_LIST_GEOMETRY')
+  }
+  return {
+    page,
+    x: bbox[0] / 1000,
+    y: bbox[1] / 1000,
+    width: (bbox[2] - bbox[0]) / 1000,
+    height: (bbox[3] - bbox[1]) / 1000,
+    rotation: 0,
+    method: 'pdf-object',
+  }
+}
+
+function candidateKind(record: Record<string, unknown>) {
+  const type = record.type
+  return typeof type === 'string' && SAFE_ID.test(type) ? type : 'unknown'
+}
+
+function opaqueReference(id: string) {
+  return `owner-local:mineru-artifact:${id}`
+}
+
+/**
+ * Inspect a runner-authored artifact manifest and normalize the exact retained
+ * MinerU evidence into the provider-neutral graph arm. Paths are used only for
+ * local verification; the returned bundle contains hashes and opaque refs.
+ */
+export async function inspectMineruSourceEvidence({
+  artifactRoot,
+  manifest: manifestInput,
+}: {
+  artifactRoot: string
+  manifest: unknown
+}): Promise<PdfEvidenceBundle> {
+  const manifest = validateManifest(manifestInput)
+  const root = await verifyArtifactRoot(artifactRoot)
+  const verified: VerifiedArtifact[] = []
+  for (const descriptor of manifest.artifacts) {
+    verified.push(await verifyArtifact(root, descriptor))
+  }
+
+  const geometryArtifacts = verified.filter(
+    ({ kind }) => kind === 'page-geometry',
+  )
+  const readingOrderArtifacts = verified.filter(
+    ({ kind }) => kind === 'reading-order',
+  )
+  if (geometryArtifacts.length !== 1 || readingOrderArtifacts.length !== 1) {
+    invalid('AMBIGUOUS_MINERU_DOCUMENT_EVIDENCE')
+  }
+  const pages = pageGeometry(
+    geometryArtifacts[0].json,
+    manifest.document.pageCount,
+  )
+  if (
+    canonicalHash(pages) !== manifest.producerReceipt.sourcePageGeometrySha256
+  ) {
+    invalid('MINERU_SOURCE_GEOMETRY_RECEIPT_MISMATCH')
+  }
+  validateReadingOrder(
+    readingOrderArtifacts[0].json,
+    manifest.document.pageCount,
+  )
+
+  const providerId = `mineru:${MINERU_PRODUCTION_VERSION}:${canonicalHash({
+    binding: MINERU_PRODUCTION_BINDING,
+    execution: manifest.execution,
+  })}`
+  const artifactId = (id: string) => `${providerId}:artifact:${id}`
+  const artifactSourceId = (id: string) => `${providerId}:source:${id}`
+  const scopedPage = (artifact: VerifiedArtifact) =>
+    Array.isArray(artifact.pageScope) && artifact.pageScope.length === 1
+      ? artifact.pageScope[0]
+      : undefined
+  const artifacts: PdfEvidenceBundle['artifacts'] = verified.map(
+    (artifact) => ({
+      id: artifactId(artifact.id),
+      providerId,
+      kind: artifact.kind,
+      mediaType: artifact.mediaType,
+      sha256: artifact.sha256,
+      byteLength: artifact.byteLength,
+      ...(scopedPage(artifact) === undefined
+        ? {}
+        : { page: scopedPage(artifact) }),
+    }),
+  )
+  const sources: PdfEvidenceBundle['sources'] = verified.map((artifact) => ({
+    id: artifactSourceId(artifact.id),
+    providerId,
+    kind: artifact.kind,
+    artifactIds: [artifactId(artifact.id)],
+    ...(scopedPage(artifact) === undefined
+      ? {}
+      : { page: scopedPage(artifact) }),
+    payload: {
+      retention: 'owner-local-opaque-reference',
+      reference: opaqueReference(artifact.id),
+      pageScope: artifact.pageScope,
+      ...(artifact.kind === 'markdown'
+        ? {
+            representation: 'complete-inspectable-markdown',
+            complete: true,
+            inspectable: true,
+            canonical: false,
+            markdown: artifact.text ?? '',
+          }
+        : artifact.json !== null
+          ? {
+              representation: 'complete-provider-native-json',
+              complete: true,
+              inspectable: true,
+              content: artifact.json as PdfEvidenceJsonValue,
+            }
+          : {
+              representation: 'complete-byte-preserved-artifact',
+              complete: true,
+              inspectable: false,
+            }),
+    },
+  }))
+  const candidates: PdfEvidenceBundle['candidates'] = verified.map(
+    (artifact) => ({
+      id: `${providerId}:candidate:artifact:${artifact.id}`,
+      providerId,
+      kind: artifact.kind,
+      sourceIds: [artifactSourceId(artifact.id)],
+      artifactIds: [artifactId(artifact.id)],
+      ...(scopedPage(artifact) === undefined
+        ? {}
+        : { page: scopedPage(artifact) }),
+      payload: {
+        evidenceClass: artifact.kind,
+        representation:
+          artifact.kind === 'markdown'
+            ? 'complete-inspectable-markdown'
+            : 'retained-provider-artifact',
+        complete: true,
+        inspectable: artifact.text !== null || artifact.json !== null,
+        canonical: artifact.kind === 'markdown' ? false : null,
+        grounded: false,
+        semanticObligationEligible: false,
+        sha256: artifact.sha256,
+      },
+    }),
+  )
+  for (const artifact of verified.filter(({ kind }) =>
+    ['content-list-v1', 'content-list-v2'].includes(kind),
+  )) {
+    const representation = artifact.kind
+    const records = contentListRecords(artifact.json)
+    for (const [
+      recordIndex,
+      { record, pointer, fallbackPage },
+    ] of records.entries()) {
+      const box = candidateBox(
+        record,
+        fallbackPage,
+        manifest.document.pageCount,
+      )
+      const recordSha256 = canonicalHash(record)
+      const recordSourceId = `${artifactSourceId(artifact.id)}:record:${recordIndex}`
+      sources.push({
+        id: recordSourceId,
+        providerId,
+        kind: 'mineru-native-record',
+        page: box.page,
+        box,
+        artifactIds: [artifactId(artifact.id)],
+        parentSourceIds: [artifactSourceId(artifact.id)],
+        payload: {
+          representation,
+          jsonPointer: pointer,
+          recordSha256,
+          reference: opaqueReference(artifact.id),
+          record: record as PdfEvidenceJsonValue,
+        },
+      })
+      candidates.push({
+        id: `${providerId}:candidate:${representation}:${artifact.id}:${recordIndex}`,
+        providerId,
+        kind: candidateKind(record),
+        page: box.page,
+        boxes: [box],
+        sourceIds: [recordSourceId],
+        artifactIds: [artifactId(artifact.id)],
+        payload: {
+          representation,
+          jsonPointer: pointer,
+          recordSha256,
+          nativeType: typeof record.type === 'string' ? record.type : 'unknown',
+          grounded: true,
+          mergePolicy: 'preserve-without-overwrite',
+        },
+      })
+    }
+  }
+
+  const bundle = {
+    schemaVersion: MINERU_SOURCE_EVIDENCE_SCHEMA_VERSION,
+    id: `${providerId}:bundle:${manifest.document.id}`,
+    armId: 'mineru',
+    source: {
+      documentId: manifest.document.id,
+      sha256: manifest.document.sha256,
+      byteLength: manifest.document.byteLength,
+      pageCount: manifest.document.pageCount,
+    },
+    provider: {
+      id: providerId,
+      kind: 'mineru',
+      name: 'MinerU',
+      version: MINERU_PRODUCTION_VERSION,
+      implementationSha256: MINERU_PRODUCTION_WHEEL_SHA256,
+      model: {
+        id: MINERU_PRODUCTION_MODEL_ID,
+        revision: MINERU_PRODUCTION_MODEL_REVISION,
+        digestSha256: MINERU_PRODUCTION_MODEL_SHA256,
+        license: MINERU_PRODUCTION_MODEL_LICENSE,
+        architecture: MINERU_PRODUCTION_MODEL_ARCHITECTURE,
+      },
+      execution: { ...manifest.execution },
+    },
+    pages,
+    artifacts,
+    sources: [
+      ...sources,
+      {
+        id: `${providerId}:source:production-binding`,
+        providerId,
+        kind: 'provider-binding',
+        payload: {
+          binding: MINERU_PRODUCTION_BINDING,
+          bindingSha256: canonicalHash({
+            binding: MINERU_PRODUCTION_BINDING,
+            execution: manifest.execution,
+          }),
+          cache: {
+            scope: manifest.cache.scope,
+            rootRef: manifest.cache.rootRef,
+            namespace: manifest.cache.namespace,
+            maximumBytes: manifest.cache.maximumBytes,
+            retainedBytes: manifest.cache.retainedBytes,
+            artifactCount: manifest.cache.artifactCount,
+          },
+          candidateSetPolicy:
+            'content-list-v1-and-v2-remain-independent-and-unmerged',
+          markdownAuthority: 'inspectable-candidate-noncanonical',
+        },
+      },
+    ],
+    candidates,
+  }
+  validatePdfEvidenceBundle(bundle)
+  return bundle as PdfEvidenceBundle
+}
+
+export const mineruPdfEvidenceBundleFromManifest = inspectMineruSourceEvidence
+export const normalizeMineruSourceEvidence = inspectMineruSourceEvidence
+
+export function createMineruOfflineRunReceipt(
+  input: Omit<MineruOfflineRunReceipt, 'bindingSha256' | 'receiptSha256'>,
+): MineruOfflineRunReceipt {
+  if (
+    input.schemaVersion !== '1.0.0' ||
+    !SHA256.test(input.sourceSha256) ||
+    !validExecutionIdentity(input.execution) ||
+    !Array.isArray(input.artifacts) ||
+    input.artifacts.length !== MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS.length ||
+    input.artifacts.some(
+      (artifact) =>
+        !exactKeys(artifact, ['kind', 'sha256']) ||
+        !MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS.includes(artifact.kind) ||
+        !SHA256.test(artifact.sha256),
+    ) ||
+    new Set(input.artifacts.map(({ kind }) => kind)).size !==
+      MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS.length
+  ) {
+    invalid('INVALID_MINERU_OFFLINE_RUN_RECEIPT')
+  }
+  const orderedArtifacts = MINERU_OFFLINE_RECEIPT_ARTIFACT_KINDS.map((kind) =>
+    input.artifacts.find((artifact) => artifact.kind === kind)!,
+  )
+  const base = {
+    schemaVersion: '1.0.0' as const,
+    sourceSha256: input.sourceSha256,
+    execution: structuredClone(input.execution),
+    bindingSha256: canonicalHash({
+      binding: MINERU_PRODUCTION_BINDING,
+      execution: input.execution,
+    }),
+    artifacts: orderedArtifacts,
+  }
+  return Object.freeze({
+    ...base,
+    receiptSha256: canonicalHash(base),
+  })
+}

--- a/src/research/pdf-source-evidence.test.ts
+++ b/src/research/pdf-source-evidence.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import type { PdfReconstruction } from './import-types'
+import { pdfEvidenceBundlesFromReconstruction } from './pdf-source-evidence'
+import { sha256HexSync } from './sha256-sync'
+import { validatePdfEvidenceBundle } from './source-evidence-graph'
+
+const sourceSha256 = '1'.repeat(64)
+const renderBytes = new TextEncoder().encode('rendered page')
+const renderSha256 = sha256HexSync(renderBytes)
+
+function reconstruction(
+  kind: PdfReconstruction['pages'][number]['kind'] = 'born-digital',
+): PdfReconstruction {
+  return {
+    source: {
+      fileName: 'ordinary.pdf',
+      byteLength: 4096,
+      sha256: sourceSha256,
+      pageCount: 1,
+      localOnly: true,
+    },
+    paper: { id: 'ordinary-document' },
+    pages: [
+      {
+        page: 1,
+        kind,
+        width: 612,
+        height: 792,
+        rotation: 0,
+        textCharacters: 11,
+        imageCount: 0,
+        runs: [
+          {
+            page: 1,
+            text: 'Source text',
+            x: 0.1,
+            y: 0.2,
+            width: 0.2,
+            height: 0.02,
+            rotation: 0,
+            method: 'pdf-text',
+            fontName: 'Fixture Serif',
+            fontSize: 10,
+            confidence: 1,
+          },
+        ],
+      },
+    ],
+    regions: [],
+    readingOrder: { edges: [] },
+    noteRelationships: [],
+    citationRelationships: [],
+    crossReferenceRelationships: [],
+    visualRelationships: [],
+    assets: [],
+  } as unknown as PdfReconstruction
+}
+
+function renderEvidence() {
+  return {
+    page: 1,
+    mediaType: 'image/png' as const,
+    sha256: renderSha256,
+    byteLength: renderBytes.byteLength,
+    width: 1224,
+    height: 1584,
+    bytes: renderBytes,
+  }
+}
+
+describe('deterministic PDF source evidence', () => {
+  it('retains text, fonts, normalized page geometry, and every-page renders in a valid graph', () => {
+    const extracted = pdfEvidenceBundlesFromReconstruction(reconstruction(), {
+      pageRenders: [renderEvidence()],
+    })
+    const bundle = extracted.bundles[0]!
+    expect(bundle.sources.map(({ kind }) => kind)).toEqual(
+      expect.arrayContaining(['page-geometry', 'font', 'text-glyph-run']),
+    )
+    expect(bundle.artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'full-page-render',
+          sha256: renderSha256,
+          box: expect.objectContaining({ width: 1, height: 1 }),
+        }),
+      ]),
+    )
+
+    expect(() => validatePdfEvidenceBundle(bundle)).not.toThrow()
+  })
+
+  it('fails closed when an ordinary page render is missing', () => {
+    expect(() =>
+      pdfEvidenceBundlesFromReconstruction(reconstruction(), {
+        pageRenders: [],
+      }),
+    ).toThrow('MISSING_PDF_FULL_PAGE_RENDER_EVIDENCE')
+  })
+
+  it('fails closed when a hybrid page lacks configured local OCR evidence', () => {
+    expect(() =>
+      pdfEvidenceBundlesFromReconstruction(reconstruction('mixed'), {
+        pageRenders: [renderEvidence()],
+      }),
+    ).toThrow('PDF_LOCAL_OCR_EVIDENCE_REQUIRED')
+  })
+
+  it('keeps OCR conflict candidates valid with the deterministic complete-page fallback', () => {
+    const input = reconstruction('mixed')
+    input.pages[0]!.ocr = {
+      engine: 'fixture-ocr',
+      engineVersion: '1.0.0',
+      model: 'fixture-model',
+      modelVersion: '1',
+      languages: ['eng'],
+      languageMode: 'explicit',
+      sourceSha256,
+      rasterSha256: renderSha256,
+      confidence: 0.8,
+      words: [
+        {
+          text: 'S0urce',
+          confidence: 0.6,
+          lineId: 'ocr-line-1',
+          box: {
+            page: 1,
+            x: 0.1,
+            y: 0.2,
+            width: 0.2,
+            height: 0.02,
+            rotation: 0,
+            method: 'ocr',
+          },
+          mergeStatus: 'conflict',
+        },
+      ],
+      lines: [
+        {
+          id: 'ocr-line-1',
+          text: 'S0urce text',
+          confidence: 0.6,
+          box: {
+            page: 1,
+            x: 0.1,
+            y: 0.2,
+            width: 0.2,
+            height: 0.02,
+            rotation: 0,
+            method: 'ocr',
+          },
+        },
+      ],
+    }
+    const extracted = pdfEvidenceBundlesFromReconstruction(input, {
+      pageRenders: [renderEvidence()],
+    })
+    const ocrBundle = extracted.bundles.find(({ armId }) =>
+      armId.startsWith('ocr-'),
+    )!
+    const deterministicBundle = extracted.bundles.find(
+      ({ armId }) => armId === 'deterministic',
+    )!
+    const disagreement = extracted.disagreements.find(
+      ({ kind }) => kind === 'ocr-conflict',
+    )!
+    expect(disagreement.providerIds).toEqual(
+      [deterministicBundle.provider.id, ocrBundle.provider.id].sort(),
+    )
+    expect(
+      disagreement.candidateIds.some((candidateId) =>
+        deterministicBundle.candidates.some(
+          ({ id, kind }) => id === candidateId && kind === 'full-page-render',
+        ),
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/research/pdf-source-evidence.ts
+++ b/src/research/pdf-source-evidence.ts
@@ -1,0 +1,855 @@
+import type {
+  NormalizedSourceBox,
+  PdfEmbeddedLink,
+  PdfReconstruction,
+} from './import-types'
+import { sha256HexSync } from './sha256-sync'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  type PdfEvidenceArtifact,
+  type PdfEvidenceBox,
+  type PdfEvidenceBundle,
+  type PdfEvidenceCandidate,
+  type PdfEvidenceDisagreement,
+  type PdfEvidenceObligation,
+  type PdfEvidenceObservationCategory,
+  type PdfEvidenceProviderIdentity,
+  type PdfEvidenceSource,
+} from './source-evidence-graph'
+
+export const PDFJS_EVIDENCE_PROVIDER: PdfEvidenceProviderIdentity = {
+  id: 'pdfjs-5.4.624',
+  kind: 'pdfjs',
+  name: 'pdfjs-dist',
+  version: '5.4.624',
+}
+
+export type PdfFullPageRenderEvidence = {
+  page: number
+  mediaType: 'image/png' | 'image/jpeg'
+  sha256: string
+  byteLength: number
+  width: number
+  height: number
+  /** Optional owner-local bytes. They are verified but never copied to graph JSON. */
+  bytes?: Uint8Array
+}
+
+export type PdfDeterministicEvidenceOptions = {
+  pageRenders: readonly PdfFullPageRenderEvidence[]
+  provider?: PdfEvidenceProviderIdentity
+  /** Scanned and hybrid pages fail closed unless local OCR evidence is present. */
+  requireLocalOcr?: boolean
+}
+
+export type PdfDeterministicEvidence = {
+  bundles: PdfEvidenceBundle[]
+  obligations: PdfEvidenceObligation[]
+  disagreements: PdfEvidenceDisagreement[]
+}
+
+const SHA256 = /^[a-f0-9]{64}$/u
+
+function invalid(code: string): never {
+  throw new Error(code)
+}
+
+function pad(value: number) {
+  return String(value).padStart(6, '0')
+}
+
+function evidenceBox(box: NormalizedSourceBox): PdfEvidenceBox {
+  return {
+    page: box.page,
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    rotation: box.rotation,
+    method: box.method,
+  }
+}
+
+function clonePayload<T>(value: T): T {
+  return structuredClone(value)
+}
+
+function evidenceJson(
+  value: unknown,
+): import('./source-evidence-graph').PdfEvidenceJsonValue {
+  const encoded = JSON.stringify(value)
+  if (encoded === undefined) invalid('INVALID_PDF_EVIDENCE_JSON')
+  return JSON.parse(
+    encoded,
+  ) as import('./source-evidence-graph').PdfEvidenceJsonValue
+}
+
+function linkBox(link: PdfEmbeddedLink) {
+  return 'box' in link && link.box ? evidenceBox(link.box) : undefined
+}
+
+function requirePageRender(
+  renderByPage: ReadonlyMap<number, PdfFullPageRenderEvidence>,
+  page: number,
+) {
+  const render = renderByPage.get(page)
+  if (
+    !render ||
+    !SHA256.test(render.sha256) ||
+    !Number.isSafeInteger(render.byteLength) ||
+    render.byteLength <= 0 ||
+    !Number.isFinite(render.width) ||
+    render.width <= 0 ||
+    !Number.isFinite(render.height) ||
+    render.height <= 0 ||
+    (render.bytes !== undefined &&
+      (render.bytes.byteLength !== render.byteLength ||
+        sha256HexSync(render.bytes) !== render.sha256))
+  ) {
+    invalid('INVALID_PDF_FULL_PAGE_RENDER_EVIDENCE')
+  }
+  return render
+}
+
+function sourceIdentity(reconstruction: PdfReconstruction) {
+  return {
+    documentId: reconstruction.paper.id,
+    sha256: reconstruction.source.sha256,
+    byteLength: reconstruction.source.byteLength,
+    pageCount: reconstruction.source.pageCount,
+  }
+}
+
+function relationshipPage(value: { sourceBoxes?: NormalizedSourceBox[] }) {
+  return value.sourceBoxes?.[0]?.page
+}
+
+function relationshipObservationCategories(
+  kind: string,
+): PdfEvidenceObservationCategory[] {
+  switch (kind) {
+    case 'table-relationship':
+      return [
+        'object-counts',
+        'table-cells',
+        'table-spans',
+        'table-headers',
+        'captions',
+        'asset-bytes',
+        'clipping',
+        'overflow',
+      ]
+    case 'figure-relationship':
+      return [
+        'object-counts',
+        'figures',
+        'captions',
+        'asset-bytes',
+        'clipping',
+        'overflow',
+      ]
+    case 'equation-relationship':
+      return [
+        'object-counts',
+        'formulas',
+        'captions',
+        'asset-bytes',
+        'clipping',
+        'overflow',
+      ]
+    case 'note-relationship':
+      return ['notes', 'links', 'dangling-targets']
+    case 'citation-relationship':
+      return ['citations', 'links', 'dangling-targets']
+    case 'cross-reference-relationship':
+      return ['links', 'dangling-targets']
+    default:
+      throw new TypeError(`UNCLASSIFIED_RELATIONSHIP_OBSERVATION:${kind}`)
+  }
+}
+
+/**
+ * Preserve the already-extracted PDF.js/native arm without treating its
+ * resolved semantic graph as exclusive truth. Full-page renders are explicit
+ * inputs so callers cannot silently omit born-digital pages.
+ */
+export function pdfEvidenceBundlesFromReconstruction(
+  reconstruction: PdfReconstruction,
+  options: PdfDeterministicEvidenceOptions,
+): PdfDeterministicEvidence {
+  if (
+    !SHA256.test(reconstruction.source.sha256) ||
+    !Number.isSafeInteger(reconstruction.source.pageCount) ||
+    reconstruction.source.pageCount < 1 ||
+    reconstruction.pages.length !== reconstruction.source.pageCount
+  ) {
+    invalid('INVALID_PDF_RECONSTRUCTION_SOURCE_IDENTITY')
+  }
+  const provider = clonePayload(options.provider ?? PDFJS_EVIDENCE_PROVIDER)
+  if (provider.kind !== 'pdfjs') invalid('INVALID_PDFJS_PROVIDER_IDENTITY')
+  const renderByPage = new Map(
+    options.pageRenders.map((render) => [render.page, render]),
+  )
+  if (
+    renderByPage.size !== reconstruction.source.pageCount ||
+    options.pageRenders.length !== reconstruction.source.pageCount
+  ) {
+    invalid('MISSING_PDF_FULL_PAGE_RENDER_EVIDENCE')
+  }
+
+  const artifacts: PdfEvidenceArtifact[] = []
+  const sources: PdfEvidenceSource[] = []
+  const candidates: PdfEvidenceCandidate[] = []
+  const obligations: PdfEvidenceObligation[] = []
+  const disagreements: PdfEvidenceDisagreement[] = []
+  const assetArtifactIds = new Map<string, string>()
+
+  for (const [index, asset] of reconstruction.assets.entries()) {
+    if (
+      asset.bytes.byteLength <= 0 ||
+      !SHA256.test(asset.sha256) ||
+      sha256HexSync(asset.bytes) !== asset.sha256
+    ) {
+      invalid('PDF_ASSET_IDENTITY_MISMATCH')
+    }
+    const artifactId = `pdfjs-artifact-asset-${pad(index + 1)}`
+    assetArtifactIds.set(asset.id, artifactId)
+    artifacts.push({
+      id: artifactId,
+      providerId: provider.id,
+      kind: asset.rendition,
+      mediaType: asset.mediaType,
+      sha256: asset.sha256,
+      byteLength: asset.bytes.byteLength,
+      ...(asset.sourceCropBox
+        ? {
+            page: asset.sourceCropBox.page,
+            box: evidenceBox(asset.sourceCropBox),
+          }
+        : {}),
+    })
+  }
+
+  for (const page of [...reconstruction.pages].sort(
+    (left, right) => left.page - right.page,
+  )) {
+    if (page.page < 1 || page.page > reconstruction.source.pageCount) {
+      invalid('INVALID_PDF_PAGE_EVIDENCE')
+    }
+    const pageKey = `p${pad(page.page)}`
+    const pageSourceId = `pdfjs-source-page-${pageKey}`
+    const pageBox: PdfEvidenceBox = {
+      page: page.page,
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      rotation: page.rotation,
+      method: 'pdf-object',
+    }
+    sources.push({
+      id: pageSourceId,
+      providerId: provider.id,
+      kind: 'page-geometry',
+      page: page.page,
+      box: pageBox,
+      payload: {
+        width: page.width,
+        height: page.height,
+        rotation: page.rotation,
+        pageKind: page.kind,
+      },
+    })
+
+    const render = requirePageRender(renderByPage, page.page)
+    const renderArtifactId = `pdfjs-artifact-page-render-${pageKey}`
+    artifacts.push({
+      id: renderArtifactId,
+      providerId: provider.id,
+      kind: 'full-page-render',
+      mediaType: render.mediaType,
+      sha256: render.sha256,
+      byteLength: render.byteLength,
+      page: page.page,
+      box: pageBox,
+      sourceIds: [pageSourceId],
+    })
+    const renderCandidateId = `pdfjs-candidate-page-render-${pageKey}`
+    candidates.push({
+      id: renderCandidateId,
+      providerId: provider.id,
+      kind: 'full-page-render',
+      page: page.page,
+      boxes: [pageBox],
+      sourceIds: [pageSourceId],
+      artifactIds: [renderArtifactId],
+      payload: { semantic: false, completePageRaster: true },
+    })
+    const fontSourceIds = new Map<string, string>()
+    for (const [runIndex, run] of page.runs.entries()) {
+      const runKey = `${pageKey}-r${pad(runIndex + 1)}`
+      const runSourceId = `pdfjs-source-run-${runKey}`
+      const runCandidateId = `pdfjs-candidate-run-${runKey}`
+      const box = evidenceBox(run)
+      let fontSourceId = fontSourceIds.get(run.fontName)
+      if (!fontSourceId) {
+        fontSourceId = `pdfjs-source-font-${pageKey}-f${pad(fontSourceIds.size + 1)}`
+        fontSourceIds.set(run.fontName, fontSourceId)
+        sources.push({
+          id: fontSourceId,
+          providerId: provider.id,
+          kind: 'font',
+          page: page.page,
+          payload: { name: run.fontName },
+        })
+      }
+      sources.push({
+        id: runSourceId,
+        providerId: provider.id,
+        kind: 'text-glyph-run',
+        page: page.page,
+        box,
+        parentSourceIds: [pageSourceId, fontSourceId],
+        payload: {
+          text: run.text,
+          fontName: run.fontName,
+          fontSize: run.fontSize,
+          confidence: run.confidence,
+          bold: run.bold ?? false,
+          italic: run.italic ?? false,
+          sourceSequenceIndex: run.sourceSequenceIndex ?? null,
+          sourceWhitespaceBefore: run.sourceWhitespaceBefore ?? null,
+          sourceTextPaint: run.sourceTextPaint ?? null,
+          sourceSemanticAdmission: run.sourceSemanticAdmission ?? null,
+        },
+      })
+      candidates.push({
+        id: runCandidateId,
+        providerId: provider.id,
+        kind: 'text-glyph-run',
+        page: page.page,
+        boxes: [box],
+        sourceIds: [runSourceId, fontSourceId],
+        payload: {
+          text: run.text,
+          fontName: run.fontName,
+          fontSize: run.fontSize,
+          confidence: run.confidence,
+          sourceSequenceIndex: run.sourceSequenceIndex ?? runIndex,
+        },
+      })
+      obligations.push({
+        id: `obligation-text-${runKey}`,
+        kind: 'source-text',
+        page: page.page,
+        sourceIds: [runSourceId],
+        artifactIds: [],
+        candidateIds: [runCandidateId],
+        observationCategories: [
+          'text-exactness',
+          'reading-order',
+          'clipping',
+          'overflow',
+        ],
+        required: true,
+        semantic: true,
+      })
+    }
+
+    for (const [objectIndex, object] of (page.objects ?? []).entries()) {
+      const objectKey = `${pageKey}-o${pad(objectIndex + 1)}`
+      const objectSourceId = `pdfjs-source-object-${objectKey}`
+      const objectCandidateId = `pdfjs-candidate-object-${objectKey}`
+      const artifactIds = object.assetId
+        ? [assetArtifactIds.get(object.assetId)].filter(
+            (id): id is string => id !== undefined,
+          )
+        : []
+      sources.push({
+        id: objectSourceId,
+        providerId: provider.id,
+        kind: `${object.kind}-object`,
+        page: page.page,
+        box: evidenceBox(object.box),
+        artifactIds,
+        parentSourceIds: [pageSourceId],
+        payload: {
+          objectId: object.id,
+          confidence: object.confidence,
+          role: object.role ?? null,
+          rolePolicy: object.rolePolicy ?? null,
+        },
+      })
+      candidates.push({
+        id: objectCandidateId,
+        providerId: provider.id,
+        kind: `${object.kind}-object`,
+        page: page.page,
+        boxes: [evidenceBox(object.box)],
+        sourceIds: [objectSourceId],
+        artifactIds,
+        payload: { objectId: object.id, assetId: object.assetId },
+      })
+      obligations.push({
+        id: `obligation-object-${objectKey}`,
+        kind: 'source-object',
+        page: page.page,
+        sourceIds: [objectSourceId],
+        artifactIds,
+        candidateIds: [objectCandidateId],
+        observationCategories: [
+          'object-counts',
+          ...(object.kind === 'image'
+            ? (['figures'] as const)
+            : (['diagrams'] as const)),
+          ...(artifactIds.length > 0 ? (['asset-bytes'] as const) : []),
+          'clipping',
+          'overflow',
+        ],
+        required: object.role !== 'scan-source',
+        semantic: object.role !== 'scan-source',
+      })
+    }
+
+    for (const [linkIndex, link] of (page.links ?? []).entries()) {
+      const linkKey = `${pageKey}-a${pad(linkIndex + 1)}`
+      const linkSourceId = `pdfjs-source-annotation-${linkKey}`
+      const linkCandidateId = `pdfjs-candidate-annotation-${linkKey}`
+      const box = linkBox(link)
+      const payload = evidenceJson(link)
+      sources.push({
+        id: linkSourceId,
+        providerId: provider.id,
+        kind: 'annotation-link-destination',
+        page: page.page,
+        ...(box ? { box } : {}),
+        parentSourceIds: [pageSourceId],
+        payload,
+      })
+      candidates.push({
+        id: linkCandidateId,
+        providerId: provider.id,
+        kind: 'annotation-link-destination',
+        page: page.page,
+        ...(box ? { boxes: [box] } : {}),
+        sourceIds: [linkSourceId],
+        payload,
+      })
+      obligations.push({
+        id: `obligation-annotation-${linkKey}`,
+        kind: 'annotation-destination',
+        page: page.page,
+        sourceIds: [linkSourceId],
+        artifactIds: [],
+        candidateIds: [linkCandidateId],
+        observationCategories: [
+          'links',
+          'clipping',
+          'overflow',
+          'dangling-targets',
+        ],
+        required: true,
+        semantic: true,
+      })
+    }
+
+    const requiresOcr = ['mixed', 'ocr-required', 'ocr-complete'].includes(
+      page.kind,
+    )
+    if (requiresOcr) {
+      obligations.push({
+        id: `obligation-source-preserved-${pageKey}`,
+        kind: 'source-preserved-page',
+        page: page.page,
+        sourceIds: [pageSourceId],
+        artifactIds: [renderArtifactId],
+        candidateIds: [renderCandidateId],
+        observationCategories: [
+          'object-counts',
+          'asset-bytes',
+          'clipping',
+          'overflow',
+        ],
+        required: true,
+        semantic: true,
+      })
+    }
+    if ((options.requireLocalOcr ?? true) && requiresOcr && !page.ocr) {
+      invalid('PDF_LOCAL_OCR_EVIDENCE_REQUIRED')
+    }
+  }
+
+  for (const [regionIndex, region] of reconstruction.regions.entries()) {
+    const regionSourceId = `pdfjs-source-region-${pad(regionIndex + 1)}`
+    const regionCandidateId = `pdfjs-candidate-region-${pad(regionIndex + 1)}`
+    sources.push({
+      id: regionSourceId,
+      providerId: provider.id,
+      kind: 'layout-region',
+      page: region.page,
+      box: evidenceBox(region.box),
+      payload: evidenceJson(region),
+    })
+    candidates.push({
+      id: regionCandidateId,
+      providerId: provider.id,
+      kind: 'layout-region',
+      page: region.page,
+      boxes: [evidenceBox(region.box)],
+      sourceIds: [regionSourceId],
+      payload: {
+        regionId: region.id,
+        type: region.kind,
+        column: region.column,
+        text: region.text,
+        includedInReadingOrder: region.includedInReadingOrder,
+      },
+    })
+    obligations.push({
+      id: `obligation-region-${pad(regionIndex + 1)}`,
+      kind: 'layout-region',
+      page: region.page,
+      sourceIds: [regionSourceId],
+      artifactIds: [],
+      candidateIds: [regionCandidateId],
+      observationCategories: [
+        'reading-order',
+        ...(region.kind === 'figure' ? (['figures'] as const) : []),
+        ...(region.kind === 'caption' ? (['captions'] as const) : []),
+        ...(region.kind === 'equation' ? (['formulas'] as const) : []),
+        ...(region.kind === 'footnote' || region.kind === 'endnote'
+          ? (['notes'] as const)
+          : []),
+        'clipping',
+        'overflow',
+      ],
+      required: !['header', 'footer', 'page-number'].includes(region.kind),
+      semantic: !['header', 'footer', 'page-number'].includes(region.kind),
+    })
+  }
+
+  for (const [edgeIndex, edge] of reconstruction.readingOrder.edges.entries()) {
+    const key = pad(edgeIndex + 1)
+    const sourceId = `pdfjs-source-reading-order-${key}`
+    const candidateId = `pdfjs-candidate-reading-order-${key}`
+    sources.push({
+      id: sourceId,
+      providerId: provider.id,
+      kind: 'reading-order-edge',
+      page: edge.sourceBoxes[0]?.page,
+      box: edge.sourceBoxes[0] ? evidenceBox(edge.sourceBoxes[0]) : undefined,
+      payload: clonePayload(edge),
+    })
+    candidates.push({
+      id: candidateId,
+      providerId: provider.id,
+      kind: 'reading-order-edge',
+      page: edge.sourceBoxes[0]?.page,
+      boxes: edge.sourceBoxes.map(evidenceBox),
+      sourceIds: [sourceId],
+      payload: clonePayload(edge),
+    })
+    obligations.push({
+      id: `obligation-reading-order-${key}`,
+      kind: 'reading-order',
+      page: edge.sourceBoxes[0]?.page,
+      sourceIds: [sourceId],
+      artifactIds: [],
+      candidateIds: [candidateId],
+      observationCategories: ['reading-order', 'clipping', 'overflow'],
+      required: true,
+      semantic: true,
+    })
+  }
+
+  const relationships = [
+    ...reconstruction.noteRelationships.map((value) => ({
+      kind: 'note-relationship',
+      value,
+      alternatives: value.candidates,
+    })),
+    ...reconstruction.citationRelationships.map((value) => ({
+      kind: 'citation-relationship',
+      value,
+      alternatives: value.candidateNodeIds ?? [],
+    })),
+    ...reconstruction.crossReferenceRelationships.map((value) => ({
+      kind: 'cross-reference-relationship',
+      value,
+      alternatives: value.targets.flatMap(
+        (target) => target.candidateNodeIds ?? [],
+      ),
+    })),
+    ...reconstruction.visualRelationships.map((value) => ({
+      kind: `${value.kind}-relationship`,
+      value,
+      alternatives: value.candidates,
+    })),
+  ]
+  for (const [index, relationship] of relationships.entries()) {
+    const key = pad(index + 1)
+    const sourceId = `pdfjs-source-relationship-${key}`
+    const selectedId = `pdfjs-candidate-relationship-${key}-selected`
+    const page = relationshipPage(relationship.value)
+    sources.push({
+      id: sourceId,
+      providerId: provider.id,
+      kind: relationship.kind,
+      page,
+      box: relationship.value.sourceBoxes[0]
+        ? evidenceBox(relationship.value.sourceBoxes[0])
+        : undefined,
+      payload: clonePayload(relationship.value),
+    })
+    const relationshipCandidateIds = [selectedId]
+    candidates.push({
+      id: selectedId,
+      providerId: provider.id,
+      kind: relationship.kind,
+      page,
+      boxes: relationship.value.sourceBoxes.map(evidenceBox),
+      sourceIds: [sourceId],
+      payload: clonePayload(relationship.value),
+    })
+    for (const [
+      alternativeIndex,
+      alternative,
+    ] of relationship.alternatives.entries()) {
+      const candidateId = `pdfjs-candidate-relationship-${key}-alternative-${pad(alternativeIndex + 1)}`
+      relationshipCandidateIds.push(candidateId)
+      candidates.push({
+        id: candidateId,
+        providerId: provider.id,
+        kind: relationship.kind,
+        page,
+        boxes: relationship.value.sourceBoxes.map(evidenceBox),
+        sourceIds: [sourceId],
+        payload: clonePayload(alternative),
+      })
+    }
+    const obligationId = `obligation-relationship-${key}`
+    obligations.push({
+      id: obligationId,
+      kind: relationship.kind,
+      page,
+      sourceIds: [sourceId],
+      artifactIds: [],
+      candidateIds: relationshipCandidateIds,
+      observationCategories: relationshipObservationCategories(
+        relationship.kind,
+      ),
+      required: true,
+      semantic: true,
+    })
+    if (relationshipCandidateIds.length > 1) {
+      disagreements.push({
+        id: `disagreement-relationship-${key}`,
+        kind: relationship.kind,
+        obligationIds: [obligationId],
+        candidateIds: relationshipCandidateIds,
+        providerIds: [provider.id],
+        reason:
+          'deterministic alternatives are retained until grounded reconciliation',
+      })
+    }
+  }
+
+  const deterministicBundle: PdfEvidenceBundle = {
+    schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+    id: 'pdfjs-deterministic-evidence',
+    armId: 'deterministic',
+    source: sourceIdentity(reconstruction),
+    provider,
+    pages: reconstruction.pages.map(({ page, width, height, rotation }) => ({
+      page,
+      width,
+      height,
+      rotation,
+    })),
+    artifacts,
+    sources,
+    candidates,
+  }
+
+  const ocrBundles = ocrEvidenceBundles(reconstruction, deterministicBundle)
+  return {
+    bundles: [deterministicBundle, ...ocrBundles.bundles],
+    obligations: [...obligations, ...ocrBundles.obligations],
+    disagreements: [...disagreements, ...ocrBundles.disagreements],
+  }
+}
+
+function ocrEvidenceBundles(
+  reconstruction: PdfReconstruction,
+  deterministicBundle: PdfEvidenceBundle,
+) {
+  const grouped = new Map<
+    string,
+    {
+      provider: PdfEvidenceProviderIdentity
+      pages: PdfEvidenceBundle['pages']
+      sources: PdfEvidenceSource[]
+      candidates: PdfEvidenceCandidate[]
+      obligations: PdfEvidenceObligation[]
+      disagreements: PdfEvidenceDisagreement[]
+    }
+  >()
+  for (const page of reconstruction.pages) {
+    if (!page.ocr) continue
+    const identityKey = [
+      page.ocr.engine,
+      page.ocr.engineVersion,
+      page.ocr.model,
+      page.ocr.modelVersion,
+      [...page.ocr.languages].sort().join(','),
+    ].join('\0')
+    let group = grouped.get(identityKey)
+    if (!group) {
+      const identityDigest = sha256HexSync(identityKey).slice(0, 16)
+      group = {
+        provider: {
+          id: `ocr-${identityDigest}`,
+          kind: 'ocr',
+          name: page.ocr.engine,
+          version: page.ocr.engineVersion,
+          model: {
+            id: page.ocr.model,
+            revision: page.ocr.modelVersion,
+          },
+        },
+        pages: reconstruction.pages.map(
+          ({ page: sourcePage, width, height, rotation }) => ({
+            page: sourcePage,
+            width,
+            height,
+            rotation,
+          }),
+        ),
+        sources: [],
+        candidates: [],
+        obligations: [],
+        disagreements: [],
+      }
+      grouped.set(identityKey, group)
+    }
+    const pageKey = `p${pad(page.page)}`
+    for (const [wordIndex, word] of page.ocr.words.entries()) {
+      const key = `${pageKey}-w${pad(wordIndex + 1)}`
+      const sourceId = `${group.provider.id}-source-word-${key}`
+      const candidateId = `${group.provider.id}-candidate-word-${key}`
+      group.sources.push({
+        id: sourceId,
+        providerId: group.provider.id,
+        kind: 'ocr-word',
+        page: page.page,
+        box: evidenceBox(word.box),
+        payload: clonePayload(word),
+      })
+      group.candidates.push({
+        id: candidateId,
+        providerId: group.provider.id,
+        kind: 'ocr-word',
+        page: page.page,
+        boxes: [evidenceBox(word.box)],
+        sourceIds: [sourceId],
+        payload: clonePayload(word),
+      })
+      const obligationId = `${group.provider.id}-obligation-word-${key}`
+      group.obligations.push({
+        id: obligationId,
+        kind: 'ocr-text',
+        page: page.page,
+        sourceIds: [sourceId],
+        artifactIds: [],
+        candidateIds: [candidateId],
+        observationCategories: [
+          'text-exactness',
+          'reading-order',
+          'clipping',
+          'overflow',
+        ],
+        required: true,
+        semantic: true,
+      })
+      if (word.mergeStatus === 'conflict') {
+        const sourcePageFallback = deterministicBundle.candidates.find(
+          (candidate) =>
+            candidate.kind === 'full-page-render' &&
+            candidate.page === page.page,
+        )
+        if (!sourcePageFallback) invalid('PDF_SOURCE_PAGE_FALLBACK_REQUIRED')
+        group.disagreements.push({
+          id: `${group.provider.id}-disagreement-word-${key}`,
+          kind: 'ocr-conflict',
+          obligationIds: [obligationId],
+          candidateIds: [candidateId, sourcePageFallback.id],
+          providerIds: [group.provider.id, deterministicBundle.provider.id],
+          reason:
+            'OCR conflicts with embedded deterministic text; retain the complete deterministic source page as the bounded alternative',
+        })
+      }
+    }
+    for (const [lineIndex, line] of page.ocr.lines.entries()) {
+      const key = `${pageKey}-l${pad(lineIndex + 1)}`
+      const sourceId = `${group.provider.id}-source-line-${key}`
+      const candidateId = `${group.provider.id}-candidate-line-${key}`
+      group.sources.push({
+        id: sourceId,
+        providerId: group.provider.id,
+        kind: 'ocr-line',
+        page: page.page,
+        box: evidenceBox(line.box),
+        payload: clonePayload(line),
+      })
+      group.candidates.push({
+        id: candidateId,
+        providerId: group.provider.id,
+        kind: 'ocr-line',
+        page: page.page,
+        boxes: [evidenceBox(line.box)],
+        sourceIds: [sourceId],
+        payload: clonePayload(line),
+      })
+      if (page.ocr.words.length === 0) {
+        group.obligations.push({
+          id: `${group.provider.id}-obligation-line-${key}`,
+          kind: 'ocr-text',
+          page: page.page,
+          sourceIds: [sourceId],
+          artifactIds: [],
+          candidateIds: [candidateId],
+          observationCategories: [
+            'text-exactness',
+            'reading-order',
+            'clipping',
+            'overflow',
+          ],
+          required: true,
+          semantic: true,
+        })
+      }
+    }
+  }
+
+  const result = {
+    bundles: [] as PdfEvidenceBundle[],
+    obligations: [] as PdfEvidenceObligation[],
+    disagreements: [] as PdfEvidenceDisagreement[],
+  }
+  for (const [index, group] of [...grouped.values()].entries()) {
+    result.bundles.push({
+      schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+      id: `ocr-evidence-${pad(index + 1)}`,
+      armId: group.provider.id,
+      source: sourceIdentity(reconstruction),
+      provider: group.provider,
+      pages: group.pages,
+      artifacts: [],
+      sources: group.sources,
+      candidates: group.candidates,
+    })
+    result.obligations.push(...group.obligations)
+    result.disagreements.push(...group.disagreements)
+  }
+  return result
+}

--- a/src/research/reconstruction-attempt-trace.test.ts
+++ b/src/research/reconstruction-attempt-trace.test.ts
@@ -1,0 +1,712 @@
+import { describe, expect, it } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+  canonicalTraceJson,
+  createReconstructionAttemptTrace,
+  encodeCanonicalObservationPayload,
+  hashAppliedRepairBinding,
+  hashEpubBytes,
+  hashReconstructionAttemptTrace,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  serializeReconstructionAttemptTrace,
+  toRefinementTraceBinding,
+  validateReconstructionAttemptTrace,
+  validateReconstructionAttemptTraceLineage,
+  verifyEpubArtifactBytes,
+  type ReconstructionAttemptTraceCore,
+  type RenderedEpubEvidence,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+
+const digest = (value: string | Uint8Array) => sha256HexSync(value)
+const epubBytes = new TextEncoder().encode('exact downloadable epub bytes')
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const source = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 20, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+const source2 = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 140, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-2'],
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-paragraph-1'],
+    })),
+  })
+  return { sha256: digest(bytes), byteLength: bytes.byteLength }
+}
+
+function coreFixture(
+  status: 'publication-ready' | 'failed' = 'publication-ready',
+): ReconstructionAttemptTraceCore {
+  const sourcePdfSha256 = digest('source-pdf')
+  const evidenceGraphSha256 = digest('evidence-graph')
+  const structSha256 = digest('struct-artifact')
+  const epubSha256 = hashEpubBytes(epubBytes)
+  const evidenceCandidates = [
+    {
+      referenceSha256: digest('provider-neutral-candidate'),
+      bindingSha256: digest('provider-neutral-candidate-binding'),
+    },
+  ]
+  const sourceRegions = [
+    { id: 'region-1', source },
+    { id: 'region-2', source: source2 },
+  ]
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures' ? ['source-figure'] : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1', 'region-2'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashSourceExpectedObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-expected-observation-set'),
+        }),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures'
+          ? status === 'failed'
+            ? []
+            : ['source-figure']
+          : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: status === 'failed' && check === 'figures' ? 0 : 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-actual-observation-set'),
+        }),
+      }
+    },
+  )
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '198.1.0',
+    sourcePdfSha256,
+    evidenceGraphSha256,
+    candidateSetSha256: hashTraceValue(evidenceCandidates),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashSourceEvidenceReceipt({
+      ...sourceEvidenceWithoutReceipt,
+      receiptSha256: digest('pending-source-evidence'),
+    }),
+  }
+  const renderedEpub: RenderedEpubEvidence = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1.0.0',
+      executableSha256: digest('chromium'),
+      configurationSha256: digest('render-configuration'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: digest('rendered-dom'), byteLength: 200 },
+        anchors: ['struct-paragraph-1', 'struct-paragraph-2'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screenshot-1',
+        spineHref: 'EPUB/content.xhtml',
+        domSha256: digest('rendered-dom'),
+        image: { sha256: digest('screenshot'), byteLength: 400 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: digest('pending-render-receipt'),
+  }
+  renderedEpub.receiptSha256 = hashRenderedEpubEvidence(renderedEpub)
+  const mappings = [
+    {
+      id: 'mapping-1',
+      obligationId: 'obligation-1',
+      source,
+      output: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'struct-paragraph-1',
+          rendered: {
+            screenshotId: 'screenshot-1',
+            viewport,
+            rect: { x: 10, y: 20, width: 100, height: 80 },
+          },
+        },
+      ],
+      status: 'mapped' as const,
+    },
+    {
+      id: 'mapping-2',
+      obligationId: 'obligation-2',
+      source: source2,
+      output: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'struct-paragraph-2',
+          rendered: {
+            screenshotId: 'screenshot-1',
+            viewport,
+            rect: { x: 10, y: 140, width: 100, height: 80 },
+          },
+        },
+      ],
+      status: 'mapped' as const,
+    },
+  ]
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: digest(`observation-${check}`),
+      check,
+      source,
+      mappingIds: ['mapping-1'],
+      expectedSetReceiptSha256: expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: 'document-1',
+    sourcePdfSha256,
+    artifact: { sha256: structSha256, byteLength: 600 },
+    generatedSha256: digest('generated-struct'),
+    assets: [
+      { id: 'asset-1', sha256: digest('asset-bytes'), byteLength: 100 },
+    ],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+    mediaType: 'application/epub+zip' as const,
+    structSha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: digest('epubcheck-report'),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256,
+    sourceEvidence,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations,
+  })
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256,
+    evidenceGraphSha256,
+    candidateSetSha256: sourceEvidence.candidateSetSha256,
+    structSha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  const codexIdentity = {
+    server: {
+      id: 'owner-local-codex-server',
+      version: '1.0.0',
+      transport: 'http://127.0.0.1:4500/v1',
+      executableSha256: digest('codex-server'),
+    },
+    model: {
+      id: 'gpt-5.6-sol',
+      version: '2026.08.01',
+      sha256: digest('codex-model'),
+    },
+    prompt: {
+      id: 'reconstruction-reconciliation',
+      version: '1.0.0',
+      sha256: digest('codex-prompt'),
+    },
+    tool: { id: 'codex', version: '0.99.0' },
+  }
+  return {
+    schemaVersion: RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+    attemptId: 'attempt-0',
+    lineage: {
+      attemptIndex: 0,
+      parentTraceSha256: null,
+      immutablePriorTraceSha256: null,
+      appliedRepair: null,
+    },
+    sourcePdf: {
+      artifact: { sha256: sourcePdfSha256, byteLength: 1_000 },
+      pageCount: 1,
+      pageRenders: [
+        {
+          page: 1,
+          sourcePdfSha256,
+          image: { sha256: digest('source-page-1'), byteLength: 500 },
+          mediaType: 'image/png',
+          width: 600,
+          height: 800,
+        },
+      ],
+    },
+    evidenceGraph: {
+      schemaVersion: '198.1.0',
+      artifact: { sha256: evidenceGraphSha256, byteLength: 800 },
+      sourcePdfSha256,
+    },
+    sourceEvidence,
+    evidenceCandidates,
+    structure,
+    epub,
+    renderedEpub,
+    mappings,
+    comparisonEvidence: { sourceRegions, observations },
+    providerReceipts: [
+      {
+        id: 'provider-source-evidence',
+        role: 'source-evidence',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'provider-neutral-source-evidence',
+        receiptSha256: digest('provider-source-evidence-receipt'),
+        inputSha256: sourcePdfSha256,
+        outputSha256: sourceEvidence.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-render',
+        role: 'actual-render',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-chromium',
+        receiptSha256: digest('provider-render-receipt'),
+        inputSha256: epubSha256,
+        outputSha256: renderedEpub.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-codex-reconciliation',
+        role: 'owner-local-codex-reconciliation',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-codex-server',
+        identitySha256: hashTraceValue(codexIdentity),
+        receiptSha256: digest('provider-codex-reconciliation-receipt'),
+        inputSha256: reconciliationInputSha256,
+        outputSha256: hashTraceValue(comparator),
+        ...codexIdentity,
+        status: 'succeeded',
+      },
+    ],
+    comparator,
+    critiqueRepair: null,
+    budget: {
+      policy: {
+        maxRefinements: 3,
+        maxFreshTasks: 1,
+        maxTokens: 24_000,
+        maxDurationMs: 1_800_000,
+        repairPolicySha256: digest('repair-policy'),
+      },
+      usage: { refinements: 0, freshTasks: 0, tokens: 0, durationMs: 0 },
+    },
+    terminalState: status,
+  }
+}
+
+function childCoreFixture(
+  parent: ReturnType<typeof createReconstructionAttemptTrace>,
+) {
+  const child = coreFixture('publication-ready')
+  const resultingStructSha256 = digest('struct-artifact-child')
+  child.attemptId = 'attempt-1'
+  child.structure.artifact = {
+    sha256: resultingStructSha256,
+    byteLength: 620,
+  }
+  child.epub.structSha256 = resultingStructSha256
+  child.comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    sourceEvidence: child.sourceEvidence,
+    structure: child.structure,
+    epub: child.epub,
+    renderedEpub: child.renderedEpub,
+    sourceRegions: child.comparisonEvidence.sourceRegions,
+    mappings: child.mappings,
+    observations: child.comparisonEvidence.observations,
+  })
+  const proposalProjection = {
+    schemaVersion: '1.0.0' as const,
+    documentId: child.structure.documentId,
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    sourceEvidenceGraphSha256: child.evidenceGraph.artifact.sha256,
+    baseStructSha256: parent.structure.artifact.sha256,
+    priorTraceSha256: parent.traceSha256,
+    taskIdSha256: digest('fresh-task'),
+    operations: [
+      {
+        op: 'select-evidence-candidate' as const,
+        targetKind: 'relationship' as const,
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256:
+          child.evidenceCandidates[0]!.referenceSha256,
+      },
+    ],
+  }
+  const proposal = {
+    ...proposalProjection,
+    proposalSha256: hashTraceValue(proposalProjection),
+  }
+  const applicationProjection = {
+    proposalSha256: proposal.proposalSha256,
+    baseStructSha256: parent.structure.artifact.sha256,
+    resultingStructSha256,
+    applicationReceiptSha256: digest('materialized-application-receipt'),
+    groundedVerifierReceiptSha256: digest('grounded-verifier-receipt'),
+  }
+  child.lineage = {
+    attemptIndex: 1,
+    parentTraceSha256: parent.traceSha256,
+    immutablePriorTraceSha256: parent.traceSha256,
+    appliedRepair: {
+      ...applicationProjection,
+      applicationSha256: hashAppliedRepairBinding(applicationProjection),
+    },
+  }
+  child.critiqueRepair = {
+    providerReceiptId: 'provider-codex-repair',
+    priorComparatorSha256: hashTraceValue(parent.comparator),
+    priorFirstCauseFailureId: parent.comparator.firstCauseFailureId!,
+    critiqueSha256: digest('critique'),
+    proposal,
+    disposition: 'verified',
+  }
+  const reconciliation = child.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-reconciliation',
+  )!
+  reconciliation.inputSha256 = hashTraceValue({
+    sourcePdfSha256: child.sourcePdf.artifact.sha256,
+    evidenceGraphSha256: child.evidenceGraph.artifact.sha256,
+    candidateSetSha256: child.sourceEvidence.candidateSetSha256,
+    structSha256: child.structure.artifact.sha256,
+    epubSha256: child.epub.bytes.sha256,
+    renderObservationReceiptSha256: child.renderedEpub.receiptSha256,
+  })
+  reconciliation.outputSha256 = hashTraceValue(child.comparator)
+  child.providerReceipts.push({
+    ...reconciliation,
+    id: 'provider-codex-repair',
+    role: 'owner-local-codex-repair',
+    receiptSha256: digest('provider-codex-repair-receipt'),
+    inputSha256: hashTraceValue(parent.comparator),
+    outputSha256: proposal.proposalSha256,
+  })
+  child.budget.usage = {
+    refinements: 1,
+    freshTasks: 1,
+    tokens: 100,
+    durationMs: 10,
+  }
+  return child
+}
+
+describe('reconstruction attempt trace', () => {
+  it('canonically hashes, serializes, and verifies exact EPUB bytes', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture())
+
+    expect(validateReconstructionAttemptTrace(trace)).toEqual([])
+    expect(trace.traceSha256).toBe(hashReconstructionAttemptTrace(trace))
+    expect(JSON.parse(serializeReconstructionAttemptTrace(trace))).toEqual(trace)
+    expect(verifyEpubArtifactBytes(trace.epub.bytes, epubBytes)).toBe(true)
+    expect(
+      verifyEpubArtifactBytes(
+        trace.epub.bytes,
+        new TextEncoder().encode('different epub'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects hidden or noncanonical array properties and unsupported values', () => {
+    const hidden = [1]
+    Object.defineProperty(hidden, 'privateSource', { value: 'secret' })
+    expect(() => canonicalTraceJson(hidden)).toThrow(/noncanonical/iu)
+
+    const enumerable = [1] as number[] & { extra?: number }
+    enumerable.extra = 2
+    expect(() => canonicalTraceJson(enumerable)).toThrow(/noncanonical/iu)
+    expect(() => canonicalTraceJson({ missing: undefined })).toThrow()
+    expect(() => canonicalTraceJson(new Date())).toThrow()
+  })
+
+  it('rejects stale renderer, missing reconciliation, warnings, and bad locators', () => {
+    const stale = coreFixture()
+    stale.renderedEpub.epubSha256 = digest('stale-epub')
+    expect(() => createReconstructionAttemptTrace(stale)).toThrow(
+      /exact EPUB bytes/u,
+    )
+
+    const missing = coreFixture()
+    missing.providerReceipts = missing.providerReceipts.filter(
+      ({ role }) => role !== 'owner-local-codex-reconciliation',
+    )
+    expect(() => createReconstructionAttemptTrace(missing)).toThrow(
+      /owner-local-codex-reconciliation/u,
+    )
+
+    const warning = coreFixture()
+    warning.epub.epubCheck.warningCount = 1
+    expect(() => createReconstructionAttemptTrace(warning)).toThrow(
+      /Publication-ready/u,
+    )
+
+    const missingAnchor = coreFixture()
+    missingAnchor.mappings[0]!.output[0]!.anchorId = 'not-rendered'
+    expect(() => createReconstructionAttemptTrace(missingAnchor)).toThrow(
+      /anchor/u,
+    )
+  })
+
+  it('fails closed on uncalibrated judge input and unavailable reconciliation', () => {
+    const judge = coreFixture()
+    judge.comparator.judgeResults.push({ id: 'untrusted-judge' } as never)
+    expect(() => createReconstructionAttemptTrace(judge)).toThrow()
+
+    const unavailable = coreFixture()
+    unavailable.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-reconciliation',
+    )!.status = 'available'
+    expect(() => createReconstructionAttemptTrace(unavailable)).toThrow(
+      /reconciliation must succeed/iu,
+    )
+  })
+
+  it('exports only opaque allowlisted non-promotion bindings', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture('failed'))
+    const binding = toRefinementTraceBinding(trace)
+
+    expect(Object.keys(binding).sort()).toEqual(
+      [
+        'attemptIndex',
+        'canonicalStructSha256',
+        'evidenceCandidateReferences',
+        'firstCause',
+        'parentTraceSha256',
+        'policy',
+        'sourceEvidenceGraphSha256',
+        'sourcePdfSha256',
+        'terminalStatus',
+        'traceSha256',
+        'usage',
+      ].sort(),
+    )
+    expect(binding.firstCause?.failureReferenceSha256).toBe(
+      hashTraceValue({
+        kind: 'first-cause',
+        failureId: trace.comparator.firstCauseFailureId!,
+      }),
+    )
+    expect(JSON.stringify(binding)).not.toMatch(
+      /failure-missing|providerReceipts|mappings|pageRenders|source-figure/u,
+    )
+  })
+
+  it('validates private lineage and rejects hash tampering', () => {
+    const trace = createReconstructionAttemptTrace(coreFixture())
+
+    expect(validateReconstructionAttemptTraceLineage([trace])).toEqual([])
+    expect(toRefinementTraceBinding(trace)).toMatchObject({
+      traceSha256: trace.traceSha256,
+      terminalStatus: 'publication-ready',
+      firstCause: null,
+      evidenceCandidateReferences: [digest('provider-neutral-candidate')],
+    })
+    expect(() =>
+      toRefinementTraceBinding({ ...trace, attemptId: 'tampered' }),
+    ).toThrow(/Trace hash/u)
+  })
+
+  it('rejects a child that shrinks the frozen source-obligation sets', () => {
+    const parent = createReconstructionAttemptTrace(coreFixture('failed'))
+    const child = createReconstructionAttemptTrace(childCoreFixture(parent))
+
+    expect(validateReconstructionAttemptTraceLineage([parent, child])).toEqual(
+      [],
+    )
+
+    const shrunkCore = childCoreFixture(parent)
+    shrunkCore.comparisonEvidence.sourceRegions =
+      shrunkCore.comparisonEvidence.sourceRegions.slice(0, 1)
+    shrunkCore.mappings = shrunkCore.mappings.slice(0, 1)
+    const obligationProjection = {
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      obligationsSha256: hashTraceValue(
+        shrunkCore.comparisonEvidence.sourceRegions,
+      ),
+      obligationCount: 1,
+    }
+    shrunkCore.sourceEvidence.sourceObligations = {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    }
+    shrunkCore.sourceEvidence.expectedObservationSets =
+      shrunkCore.sourceEvidence.expectedObservationSets.map((set) => {
+        const projection = { ...set, sourceRegionIds: ['region-1'] }
+        return {
+          ...projection,
+          receiptSha256: hashSourceExpectedObservationSet(projection),
+        }
+      })
+    shrunkCore.sourceEvidence.receiptSha256 = hashSourceEvidenceReceipt({
+      ...shrunkCore.sourceEvidence,
+      receiptSha256: digest('pending-shrunk-source-evidence'),
+    })
+    shrunkCore.renderedEpub.sourceObligations = {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    }
+    shrunkCore.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+      shrunkCore.renderedEpub,
+    )
+    shrunkCore.comparisonEvidence.observations =
+      shrunkCore.comparisonEvidence.observations.map((observation) =>
+        createDeterministicObservationReceipt({
+          idSha256: observation.idSha256,
+          check: observation.check,
+          source: observation.source,
+          mappingIds: observation.mappingIds,
+          expectedSetReceiptSha256:
+            shrunkCore.sourceEvidence.expectedObservationSets.find(
+              (set) => set.check === observation.check,
+            )!.receiptSha256,
+          actualSetReceiptSha256: observation.actualSetReceiptSha256,
+        }),
+      )
+    shrunkCore.comparator = compareSourceToRenderedEpub({
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      sourceEvidence: shrunkCore.sourceEvidence,
+      structure: shrunkCore.structure,
+      epub: shrunkCore.epub,
+      renderedEpub: shrunkCore.renderedEpub,
+      sourceRegions: shrunkCore.comparisonEvidence.sourceRegions,
+      mappings: shrunkCore.mappings,
+      observations: shrunkCore.comparisonEvidence.observations,
+    })
+    const sourceReceipt = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'source-evidence',
+    )!
+    sourceReceipt.outputSha256 = shrunkCore.sourceEvidence.receiptSha256
+    const renderReceipt = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'actual-render',
+    )!
+    renderReceipt.outputSha256 = shrunkCore.renderedEpub.receiptSha256
+    const reconciliation = shrunkCore.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-reconciliation',
+    )!
+    reconciliation.inputSha256 = hashTraceValue({
+      sourcePdfSha256: shrunkCore.sourcePdf.artifact.sha256,
+      evidenceGraphSha256: shrunkCore.evidenceGraph.artifact.sha256,
+      candidateSetSha256: shrunkCore.sourceEvidence.candidateSetSha256,
+      structSha256: shrunkCore.structure.artifact.sha256,
+      epubSha256: shrunkCore.epub.bytes.sha256,
+      renderObservationReceiptSha256: shrunkCore.renderedEpub.receiptSha256,
+    })
+    reconciliation.outputSha256 = hashTraceValue(shrunkCore.comparator)
+    const shrunk = createReconstructionAttemptTrace(shrunkCore)
+
+    expect(
+      validateReconstructionAttemptTraceLineage([parent, shrunk]).some(
+        ({ path }) => path.includes('evidenceGraph'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects repair identity drift from the frozen reconciliation identity', () => {
+    const parent = createReconstructionAttemptTrace(coreFixture('failed'))
+    const child = childCoreFixture(parent)
+    const repairReceipt = child.providerReceipts.find(
+      ({ role }) => role === 'owner-local-codex-repair',
+    )!
+    repairReceipt.model = {
+      ...repairReceipt.model!,
+      version: '2026.08.02',
+    }
+    repairReceipt.identitySha256 = hashTraceValue({
+      server: repairReceipt.server,
+      model: repairReceipt.model,
+      prompt: repairReceipt.prompt,
+      tool: repairReceipt.tool,
+    })
+
+    expect(() => createReconstructionAttemptTrace(child)).toThrow(
+      /driver-compatible Codex patch/iu,
+    )
+  })
+})

--- a/src/research/reconstruction-attempt-trace.ts
+++ b/src/research/reconstruction-attempt-trace.ts
@@ -1,0 +1,2238 @@
+import { z } from 'zod'
+import type { StructBox } from '../struct/types'
+import { sha256HexSync } from '../struct/sha256'
+
+/**
+ * Closed, content-addressed evidence for one source-PDF reconstruction attempt.
+ *
+ * The trace deliberately stores hashes and stable identifiers, not document
+ * bytes, DOM text, screenshots, prompts, or provider output. Private artifacts
+ * remain owner-local and can be verified against these bindings.
+ */
+export const RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION = '1.0.0' as const
+export const SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION = '1.0.0' as const
+
+export const DETERMINISTIC_CHECK_IDS = [
+  'render-binding',
+  'epub-package',
+  'source-region-conservation',
+  'text-exactness',
+  'reading-order',
+  'hierarchy',
+  'object-counts',
+  'table-cells',
+  'table-spans',
+  'table-headers',
+  'figures',
+  'diagrams',
+  'captions',
+  'formulas',
+  'code-preformatted',
+  'notes',
+  'citations',
+  'links',
+  'asset-bytes',
+  'clipping',
+  'overflow',
+  'dangling-targets',
+] as const
+
+export type DeterministicCheckId = (typeof DETERMINISTIC_CHECK_IDS)[number]
+
+export const SOURCE_EPUB_OBSERVATION_CHECK_IDS = [
+  'text-exactness',
+  'reading-order',
+  'hierarchy',
+  'object-counts',
+  'table-cells',
+  'table-spans',
+  'table-headers',
+  'figures',
+  'diagrams',
+  'captions',
+  'formulas',
+  'code-preformatted',
+  'notes',
+  'citations',
+  'links',
+  'asset-bytes',
+  'clipping',
+  'overflow',
+  'dangling-targets',
+] as const satisfies readonly DeterministicCheckId[]
+
+export type SourceEpubObservationCheckId =
+  (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number]
+
+export const RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET = {
+  maxRefinements: 3,
+  maxFreshTasks: 1,
+  maxTokens: 24_000,
+  maxDurationMs: 30 * 60 * 1_000,
+} as const
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/u)
+const nonEmptyStringSchema = z.string().trim().min(1).max(512)
+const nonNegativeIntegerSchema = z.number().int().min(0)
+const positiveIntegerSchema = z.number().int().positive()
+const finiteNumberSchema = z.number().finite()
+const rasterMediaTypeSchema = z.enum(['image/png', 'image/webp', 'image/jpeg'])
+
+const hashedArtifactSchema = z
+  .object({
+    sha256: sha256Schema,
+    byteLength: nonNegativeIntegerSchema,
+  })
+  .strict()
+
+const nonEmptyHashedArtifactSchema = hashedArtifactSchema.refine(
+  ({ byteLength }) => byteLength > 0,
+  'Artifact bytes cannot be empty.',
+)
+
+const boxSchema = z
+  .object({
+    page: positiveIntegerSchema,
+    x: finiteNumberSchema,
+    y: finiteNumberSchema,
+    width: finiteNumberSchema.nonnegative(),
+    height: finiteNumberSchema.nonnegative(),
+    rotation: finiteNumberSchema,
+  })
+  .strict()
+
+export const sourceLocationSchema = z
+  .object({
+    page: positiveIntegerSchema,
+    boxes: z.array(boxSchema),
+    sourceRegionIds: z.array(nonEmptyStringSchema).min(1),
+  })
+  .strict()
+
+const viewportSchema = z
+  .object({
+    width: positiveIntegerSchema,
+    height: positiveIntegerSchema,
+    deviceScaleFactor: finiteNumberSchema.positive(),
+  })
+  .strict()
+
+const rectSchema = z
+  .object({
+    x: finiteNumberSchema,
+    y: finiteNumberSchema,
+    width: finiteNumberSchema.nonnegative(),
+    height: finiteNumberSchema.nonnegative(),
+  })
+  .strict()
+
+const renderedLocatorSchema = z
+  .object({
+    screenshotId: nonEmptyStringSchema,
+    viewport: viewportSchema,
+    rect: rectSchema,
+    scrollOffset: z
+      .object({ x: finiteNumberSchema, y: finiteNumberSchema })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const epubLocationSchema = z
+  .object({
+    spineHref: nonEmptyStringSchema,
+    anchorId: nonEmptyStringSchema,
+    /** Advisory only; the stable spine href and anchor id are authoritative. */
+    domPath: nonEmptyStringSchema.optional(),
+    /** Hash-bound visual locator for offline review, never an identity key. */
+    rendered: renderedLocatorSchema.optional(),
+  })
+  .strict()
+
+export const sourceOutputMappingSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    obligationId: nonEmptyStringSchema,
+    source: sourceLocationSchema,
+    output: z.array(epubLocationSchema),
+    status: z.enum(['mapped', 'missing', 'duplicate']),
+  })
+  .strict()
+
+export const sourceRegionObligationSchema = z
+  .object({ id: nonEmptyStringSchema, source: sourceLocationSchema })
+  .strict()
+
+export const canonicalObservationItemSchema = z
+  .object({
+    idSha256: sha256Schema,
+    valueSha256: sha256Schema,
+    anchorIds: z.array(nonEmptyStringSchema),
+  })
+  .strict()
+
+export const canonicalObservationPayloadSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    items: z.array(canonicalObservationItemSchema),
+  })
+  .strict()
+
+export const sourceExpectedObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256Schema,
+    itemCount: nonNegativeIntegerSchema,
+    payload: nonEmptyHashedArtifactSchema,
+    sourceRegionIds: z.array(nonEmptyStringSchema),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const renderedActualObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256Schema,
+    itemCount: nonNegativeIntegerSchema,
+    payload: nonEmptyHashedArtifactSchema,
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const observationReceiptCoreSchema = z
+  .object({
+    idSha256: sha256Schema,
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    source: sourceLocationSchema.optional(),
+    mappingIds: z.array(nonEmptyStringSchema).min(1),
+    expectedSetReceiptSha256: sha256Schema,
+    actualSetReceiptSha256: sha256Schema,
+  })
+  .strict()
+
+export const observationReceiptSchema = observationReceiptCoreSchema
+  .extend({ receiptSha256: sha256Schema })
+  .strict()
+
+const comparisonEvidenceSchema = z
+  .object({
+    sourceRegions: z.array(sourceRegionObligationSchema).min(1),
+    observations: z.array(observationReceiptSchema).min(1),
+  })
+  .strict()
+
+const sourcePdfSchema = z
+  .object({
+    artifact: hashedArtifactSchema,
+    pageCount: positiveIntegerSchema,
+    pageRenders: z
+      .array(
+        z
+          .object({
+            page: positiveIntegerSchema,
+            sourcePdfSha256: sha256Schema,
+            image: hashedArtifactSchema,
+            mediaType: rasterMediaTypeSchema,
+            width: positiveIntegerSchema,
+            height: positiveIntegerSchema,
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict()
+
+const evidenceGraphSchema = z
+  .object({
+    /** #198 owns the graph schema; this module treats it as an opaque blob. */
+    schemaVersion: nonEmptyStringSchema,
+    artifact: hashedArtifactSchema,
+    sourcePdfSha256: sha256Schema,
+  })
+  .strict()
+
+export const sourceEvidenceReceiptSchema = z
+  .object({
+    schemaVersion: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    evidenceGraphSha256: sha256Schema,
+    candidateSetSha256: sha256Schema,
+    sourceObligations: z
+      .object({
+        obligationsSha256: sha256Schema,
+        obligationCount: positiveIntegerSchema,
+        receiptSha256: sha256Schema,
+      })
+      .strict(),
+    expectedObservationSets: z
+      .array(sourceExpectedObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+const evidenceCandidateReferenceSchema = z
+  .object({
+    referenceSha256: sha256Schema,
+    bindingSha256: sha256Schema,
+  })
+  .strict()
+
+export const structBindingSchema = z
+  .object({
+    schemaVersion: nonEmptyStringSchema,
+    documentId: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    artifact: hashedArtifactSchema,
+    generatedSha256: sha256Schema,
+    assets: z.array(
+      z
+        .object({
+          id: nonEmptyStringSchema,
+          sha256: sha256Schema,
+          byteLength: nonNegativeIntegerSchema,
+        })
+        .strict(),
+    ),
+  })
+  .strict()
+
+export const epubBindingSchema = z
+  .object({
+    bytes: nonEmptyHashedArtifactSchema,
+    mediaType: z.literal('application/epub+zip'),
+    structSha256: sha256Schema,
+    epubCheck: z
+      .object({
+        toolId: nonEmptyStringSchema,
+        toolVersion: nonEmptyStringSchema,
+        reportSha256: sha256Schema,
+        status: z.enum(['passed', 'failed', 'not-run']),
+        errorCount: nonNegativeIntegerSchema,
+        warningCount: nonNegativeIntegerSchema,
+      })
+      .strict(),
+  })
+  .strict()
+
+export const renderedEpubSchema = z
+  .object({
+    epubSha256: sha256Schema,
+    download: z
+      .object({
+        artifact: nonEmptyHashedArtifactSchema,
+        verificationReceiptSha256: sha256Schema,
+      })
+      .strict(),
+    sourceObligations: z
+      .object({
+        sourcePdfSha256: sha256Schema,
+        obligationsSha256: sha256Schema,
+        obligationCount: positiveIntegerSchema,
+        receiptSha256: sha256Schema,
+      })
+      .strict(),
+    actualObservationSets: z
+      .array(renderedActualObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    renderer: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        executableSha256: sha256Schema.optional(),
+        configurationSha256: sha256Schema,
+      })
+      .strict(),
+    domSnapshots: z
+      .array(
+        z
+          .object({
+            spineHref: nonEmptyStringSchema,
+            dom: hashedArtifactSchema,
+            anchors: z.array(nonEmptyStringSchema).min(1),
+          })
+          .strict(),
+      )
+      .min(1),
+    screenshots: z
+      .array(
+        z
+          .object({
+            id: nonEmptyStringSchema,
+            spineHref: nonEmptyStringSchema,
+            domSha256: sha256Schema,
+            image: nonEmptyHashedArtifactSchema,
+            mediaType: rasterMediaTypeSchema,
+            width: positiveIntegerSchema,
+            height: positiveIntegerSchema,
+            viewport: viewportSchema,
+            fullPage: z.boolean(),
+          })
+          .strict(),
+      )
+      .min(1),
+    receiptSha256: sha256Schema,
+  })
+  .strict()
+
+const providerReceiptSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    role: z.enum([
+      'source-evidence',
+      'actual-render',
+      'owner-local-codex-reconciliation',
+      'owner-local-codex-repair',
+      'optional',
+    ]),
+    required: z.boolean(),
+    enabledBeforeRun: z.boolean(),
+    providerId: nonEmptyStringSchema,
+    identitySha256: sha256Schema.optional(),
+    receiptSha256: sha256Schema,
+    inputSha256: sha256Schema,
+    outputSha256: sha256Schema,
+    prompt: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        sha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    tool: z
+      .object({ id: nonEmptyStringSchema, version: nonEmptyStringSchema })
+      .strict()
+      .optional(),
+    model: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        sha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    server: z
+      .object({
+        id: nonEmptyStringSchema,
+        version: nonEmptyStringSchema,
+        transport: nonEmptyStringSchema,
+        executableSha256: sha256Schema,
+      })
+      .strict()
+      .optional(),
+    status: z.enum([
+      'available',
+      'succeeded',
+      'failed',
+      'abstained',
+      'disabled',
+    ]),
+  })
+  .strict()
+
+const comparatorCheckResultSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    check: z.enum(DETERMINISTIC_CHECK_IDS),
+    origin: z.enum(['deterministic', 'judge']),
+    judgeResultId: nonEmptyStringSchema.optional(),
+    status: z.enum(['passed', 'failed']),
+    expectedSha256: sha256Schema,
+    actualSha256: sha256Schema,
+    mappingIds: z.array(nonEmptyStringSchema),
+    source: sourceLocationSchema.optional(),
+    message: nonEmptyStringSchema,
+    failureId: nonEmptyStringSchema.optional(),
+  })
+  .strict()
+
+const comparisonFailureSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    check: z.enum(DETERMINISTIC_CHECK_IDS),
+    origin: z.enum(['deterministic', 'judge']),
+    judgeResultId: nonEmptyStringSchema.optional(),
+    message: nonEmptyStringSchema,
+    mappingIds: z.array(nonEmptyStringSchema),
+    source: sourceLocationSchema.optional(),
+    output: z.array(epubLocationSchema),
+  })
+  .strict()
+
+// Interpretive judges are intentionally fail-closed in the core trace. A
+// separately calibrated judge slice may replace this empty contract only after
+// its frozen human labels and held-out thresholds are available.
+const comparatorJudgeResultSchema = z.never()
+
+const comparatorResultSchema = z
+  .object({
+    schemaVersion: z.literal(SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION),
+    sourcePdfSha256: sha256Schema,
+    structSha256: sha256Schema,
+    epubSha256: sha256Schema,
+    renderObservationReceiptSha256: sha256Schema,
+    observationSetSha256: sha256Schema,
+    status: z.enum(['publication-ready', 'failed']),
+    denominator: nonNegativeIntegerSchema,
+    passed: nonNegativeIntegerSchema,
+    failed: nonNegativeIntegerSchema,
+    checkResults: z.array(comparatorCheckResultSchema).min(1),
+    judgeResults: z.array(comparatorJudgeResultSchema).max(0),
+    failures: z.array(comparisonFailureSchema),
+    firstCauseFailureId: nonEmptyStringSchema.nullable(),
+  })
+  .strict()
+
+export const structEvidencePatchOperationSchema = z
+  .object({
+    op: z.literal('select-evidence-candidate'),
+    targetKind: z.enum(['block', 'asset', 'relationship']),
+    targetId: nonEmptyStringSchema,
+    candidateReferenceSha256: sha256Schema,
+  })
+  .strict()
+
+export const structEvidencePatchSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    documentId: nonEmptyStringSchema,
+    sourcePdfSha256: sha256Schema,
+    sourceEvidenceGraphSha256: sha256Schema,
+    baseStructSha256: sha256Schema,
+    priorTraceSha256: sha256Schema,
+    taskIdSha256: sha256Schema,
+    operations: z.array(structEvidencePatchOperationSchema).min(1),
+    proposalSha256: sha256Schema,
+  })
+  .strict()
+
+const critiqueRepairSchema = z
+  .object({
+    providerReceiptId: nonEmptyStringSchema,
+    priorComparatorSha256: sha256Schema,
+    priorFirstCauseFailureId: nonEmptyStringSchema,
+    critiqueSha256: sha256Schema,
+    proposal: structEvidencePatchSchema,
+    disposition: z.enum(['proposed', 'verified', 'rejected']),
+  })
+  .strict()
+
+const budgetSchema = z
+  .object({
+    policy: z
+      .object({
+        maxRefinements: nonNegativeIntegerSchema,
+        maxFreshTasks: positiveIntegerSchema,
+        maxTokens: positiveIntegerSchema,
+        maxDurationMs: positiveIntegerSchema,
+        repairPolicySha256: sha256Schema,
+      })
+      .strict(),
+    usage: z
+      .object({
+        refinements: nonNegativeIntegerSchema,
+        freshTasks: nonNegativeIntegerSchema,
+        tokens: nonNegativeIntegerSchema,
+        durationMs: nonNegativeIntegerSchema,
+      })
+      .strict(),
+  })
+  .strict()
+
+const traceCoreSchema = z
+  .object({
+    schemaVersion: z.literal(RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION),
+    attemptId: nonEmptyStringSchema,
+    lineage: z
+      .object({
+        attemptIndex: nonNegativeIntegerSchema,
+        parentTraceSha256: sha256Schema.nullable(),
+        immutablePriorTraceSha256: sha256Schema.nullable(),
+        appliedRepair: z
+          .object({
+            proposalSha256: sha256Schema,
+            baseStructSha256: sha256Schema,
+            resultingStructSha256: sha256Schema,
+            applicationReceiptSha256: sha256Schema,
+            groundedVerifierReceiptSha256: sha256Schema,
+            applicationSha256: sha256Schema,
+          })
+          .strict()
+          .nullable(),
+      })
+      .strict(),
+    sourcePdf: sourcePdfSchema,
+    evidenceGraph: evidenceGraphSchema,
+    sourceEvidence: sourceEvidenceReceiptSchema,
+    evidenceCandidates: z.array(evidenceCandidateReferenceSchema).min(1),
+    structure: structBindingSchema,
+    epub: epubBindingSchema,
+    renderedEpub: renderedEpubSchema,
+    mappings: z.array(sourceOutputMappingSchema).min(1),
+    comparisonEvidence: comparisonEvidenceSchema,
+    providerReceipts: z.array(providerReceiptSchema),
+    comparator: comparatorResultSchema,
+    critiqueRepair: critiqueRepairSchema.nullable(),
+    budget: budgetSchema,
+    terminalState: z.enum(['publication-ready', 'failed']),
+  })
+  .strict()
+
+const traceSchema = traceCoreSchema
+  .extend({ traceSha256: sha256Schema })
+  .strict()
+
+export type HashedArtifact = z.infer<typeof hashedArtifactSchema>
+export type SourceLocation = Omit<
+  z.infer<typeof sourceLocationSchema>,
+  'boxes'
+> & { boxes: StructBox[] }
+export type EpubLocation = z.infer<typeof epubLocationSchema>
+export type SourceOutputMapping = z.infer<typeof sourceOutputMappingSchema>
+export type SourceRegionObligation = z.infer<
+  typeof sourceRegionObligationSchema
+>
+export type CanonicalObservationPayload = z.infer<
+  typeof canonicalObservationPayloadSchema
+>
+export type SourceExpectedObservationSet = z.infer<
+  typeof sourceExpectedObservationSetSchema
+>
+export type RenderedActualObservationSet = z.infer<
+  typeof renderedActualObservationSetSchema
+>
+export type DeterministicComparisonObservation = z.infer<
+  typeof observationReceiptSchema
+>
+export type SourcePdfBinding = z.infer<typeof sourcePdfSchema>
+export type EvidenceGraphBinding = z.infer<typeof evidenceGraphSchema>
+export type SourceEvidenceReceiptBinding = z.infer<
+  typeof sourceEvidenceReceiptSchema
+>
+export type EvidenceCandidateReference = z.infer<
+  typeof evidenceCandidateReferenceSchema
+>
+export type StructArtifactBinding = z.infer<typeof structBindingSchema>
+export type EpubArtifactBinding = z.infer<typeof epubBindingSchema>
+export type RenderedEpubEvidence = z.infer<typeof renderedEpubSchema>
+export type ProviderReceiptBinding = z.infer<typeof providerReceiptSchema>
+export type ComparatorCheckResult = z.infer<typeof comparatorCheckResultSchema>
+export type ComparisonFailure = z.infer<typeof comparisonFailureSchema>
+export type ComparatorJudgeResult = z.infer<typeof comparatorJudgeResultSchema>
+export type SourceEpubComparatorResult = z.infer<typeof comparatorResultSchema>
+export type StructEvidencePatchOperation = z.infer<
+  typeof structEvidencePatchOperationSchema
+>
+export type StructEvidencePatch = z.infer<typeof structEvidencePatchSchema>
+export type CritiqueRepairBinding = z.infer<typeof critiqueRepairSchema>
+export type ReconstructionAttemptBudget = z.infer<typeof budgetSchema>
+export type ReconstructionAttemptTraceCore = z.infer<typeof traceCoreSchema>
+export type ReconstructionAttemptTrace = z.infer<typeof traceSchema>
+
+export type TraceValidationIssue = {
+  code:
+    | 'invalid-schema'
+    | 'hash-mismatch'
+    | 'binding-mismatch'
+    | 'invalid-lineage'
+    | 'invalid-page-render-set'
+    | 'invalid-mapping'
+    | 'invalid-comparator'
+    | 'invalid-budget'
+    | 'invalid-repair'
+    | 'duplicate-id'
+  path: string
+  message: string
+}
+
+export class ReconstructionAttemptTraceValidationError extends Error {
+  constructor(public readonly issues: TraceValidationIssue[]) {
+    super(issues.map((issue) => `${issue.path}: ${issue.message}`).join('\n'))
+    this.name = 'ReconstructionAttemptTraceValidationError'
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/** Stable, locale-independent JSON used by all trace commitments. */
+export function canonicalTraceJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Only finite numbers hash')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    const expectedOwnKeys = new Set([
+      'length',
+      ...Array.from({ length: value.length }, (_, index) => String(index)),
+    ])
+    if (
+      Reflect.ownKeys(value).some(
+        (key) => typeof key !== 'string' || !expectedOwnKeys.has(key),
+      ) ||
+      Reflect.ownKeys(value).length !== expectedOwnKeys.size ||
+      Array.from({ length: value.length }, (_, index) =>
+        descriptors[String(index)],
+      ).some((descriptor) => !descriptor?.enumerable || !('value' in descriptor))
+    ) {
+      throw new TypeError(
+        'Arrays with holes or noncanonical own properties cannot be committed to a trace',
+      )
+    }
+    return `[${Array.from({ length: value.length }, (_, index) =>
+      canonicalTraceJson(descriptors[String(index)]!.value),
+    ).join(',')}]`
+  }
+  if (isPlainObject(value)) {
+    const ownKeys = Reflect.ownKeys(value)
+    if (ownKeys.some((key) => typeof key !== 'string')) {
+      throw new TypeError('Symbol keys cannot be committed to a trace')
+    }
+    const keys = ownKeys as string[]
+    const descriptors = Object.getOwnPropertyDescriptors(value)
+    if (
+      keys.some((key) => {
+        const descriptor = descriptors[key]
+        return !descriptor?.enumerable || !('value' in descriptor)
+      })
+    ) {
+      throw new TypeError(
+        'Only enumerable data properties can be committed to a trace',
+      )
+    }
+    return `{${keys
+      .sort(compareCodeUnits)
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${canonicalTraceJson(descriptors[key]!.value)}`,
+      )
+      .join(',')}}`
+  }
+  throw new TypeError('Only plain JSON values can be committed to a trace')
+}
+
+export function hashTraceValue(value: unknown) {
+  return sha256HexSync(canonicalTraceJson(value))
+}
+
+export function encodeCanonicalObservationPayload(
+  input: CanonicalObservationPayload,
+) {
+  const payload = canonicalObservationPayloadSchema.parse(input)
+  const bytes = new TextEncoder().encode(canonicalTraceJson(payload))
+  parseCanonicalObservationPayloadBytes(bytes)
+  return bytes
+}
+
+export function parseCanonicalObservationPayloadBytes(bytes: Uint8Array) {
+  let text: string
+  let parsed: unknown
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    parsed = JSON.parse(text)
+  } catch {
+    throw new TypeError('INVALID_CANONICAL_OBSERVATION_PAYLOAD')
+  }
+  const payload = canonicalObservationPayloadSchema.parse(parsed)
+  const sortedItems = [...payload.items].sort((left, right) =>
+    compareCodeUnits(left.idSha256, right.idSha256),
+  )
+  if (
+    text !== canonicalTraceJson(payload) ||
+    new Set(payload.items.map(({ idSha256 }) => idSha256)).size !==
+      payload.items.length ||
+    hashTraceValue(payload.items) !== hashTraceValue(sortedItems) ||
+    payload.items.some(
+      ({ anchorIds }) =>
+        new Set(anchorIds).size !== anchorIds.length ||
+        anchorIds.some(
+          (anchorId, index) =>
+            index > 0 &&
+            compareCodeUnits(anchorIds[index - 1]!, anchorId) >= 0,
+        ),
+    )
+  ) {
+    throw new TypeError('INVALID_CANONICAL_OBSERVATION_PAYLOAD')
+  }
+  return payload
+}
+
+export function hashSourceExpectedObservationSet(
+  value: SourceExpectedObservationSet,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function hashRenderedActualObservationSet(
+  value: RenderedActualObservationSet,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function hashSourceEvidenceReceipt(
+  value: SourceEvidenceReceiptBinding,
+) {
+  const { receiptSha256: _receiptSha256, ...projection } = value
+  return hashTraceValue(projection)
+}
+
+export function codexProviderIdentityProjection(
+  value: ProviderReceiptBinding,
+) {
+  return {
+    server: value.server ?? null,
+    model: value.model ?? null,
+    prompt: value.prompt ?? null,
+    tool: value.tool ?? null,
+  }
+}
+
+export function hashCodexProviderIdentity(value: ProviderReceiptBinding) {
+  return hashTraceValue(codexProviderIdentityProjection(value))
+}
+
+/** Commit the exact downloadable EPUB bytes with the browser-safe hasher. */
+export function hashEpubBytes(bytes: Uint8Array) {
+  return sha256HexSync(bytes)
+}
+
+export function verifyEpubArtifactBytes(
+  artifact: HashedArtifact,
+  bytes: Uint8Array,
+) {
+  return (
+    artifact.byteLength === bytes.byteLength &&
+    artifact.sha256 === hashEpubBytes(bytes)
+  )
+}
+
+/** Hash the complete renderer receipt independently of the EPUB byte hash. */
+export function hashRenderedEpubEvidence(evidence: RenderedEpubEvidence) {
+  const { receiptSha256: _receiptSha256, ...projection } = evidence
+  return hashTraceValue(projection)
+}
+
+export function hashRepairProposal(
+  proposal: Omit<CritiqueRepairBinding['proposal'], 'proposalSha256'>,
+) {
+  return hashTraceValue(proposal)
+}
+
+export function parseStructEvidencePatch(input: unknown): StructEvidencePatch {
+  const proposal = structEvidencePatchSchema.parse(input)
+  const { proposalSha256, ...projection } = proposal
+  if (proposalSha256 !== hashTraceValue(projection)) {
+    throw new TypeError('Repair proposal hash does not match its content.')
+  }
+  return proposal
+}
+
+export function hashAppliedRepairBinding(input: {
+  proposalSha256: string
+  baseStructSha256: string
+  resultingStructSha256: string
+  applicationReceiptSha256: string
+  groundedVerifierReceiptSha256: string
+}) {
+  return hashTraceValue(input)
+}
+
+const DETERMINISTIC_CHECK_PRIORITY: Readonly<
+  Record<DeterministicCheckId, number>
+> = {
+  'render-binding': 0,
+  'epub-package': 1,
+  'source-region-conservation': 2,
+  figures: 3,
+  diagrams: 4,
+  captions: 5,
+  'table-cells': 6,
+  'table-spans': 7,
+  'table-headers': 8,
+  formulas: 9,
+  'code-preformatted': 10,
+  notes: 11,
+  citations: 12,
+  links: 13,
+  'text-exactness': 14,
+  'reading-order': 15,
+  hierarchy: 16,
+  'object-counts': 17,
+  'asset-bytes': 18,
+  clipping: 19,
+  overflow: 20,
+  'dangling-targets': 21,
+}
+
+function compareCodeUnits(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+/** Stable order used to select the single first actionable cause. */
+export function compareComparisonFailures(
+  left: ComparisonFailure,
+  right: ComparisonFailure,
+) {
+  // A judge can add a narrow failure but can never outrank deterministic
+  // evidence, even when its semantic category has an earlier display order.
+  if (left.origin !== right.origin)
+    return left.origin === 'deterministic' ? -1 : 1
+  const checkDifference =
+    DETERMINISTIC_CHECK_PRIORITY[left.check] -
+    DETERMINISTIC_CHECK_PRIORITY[right.check]
+  if (checkDifference !== 0) return checkDifference
+  const pageDifference =
+    (left.source?.page ?? Number.MAX_SAFE_INTEGER) -
+    (right.source?.page ?? Number.MAX_SAFE_INTEGER)
+  if (pageDifference !== 0) return pageDifference
+  const leftBox = left.source?.boxes[0]
+  const rightBox = right.source?.boxes[0]
+  const yDifference =
+    (leftBox?.y ?? Number.MAX_SAFE_INTEGER) -
+    (rightBox?.y ?? Number.MAX_SAFE_INTEGER)
+  if (yDifference !== 0) return yDifference
+  const xDifference =
+    (leftBox?.x ?? Number.MAX_SAFE_INTEGER) -
+    (rightBox?.x ?? Number.MAX_SAFE_INTEGER)
+  if (xDifference !== 0) return xDifference
+  return compareCodeUnits(left.id, right.id)
+}
+
+function uniqueIssues(
+  values: readonly string[],
+  path: string,
+): TraceValidationIssue[] {
+  const seen = new Set<string>()
+  const duplicate = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) duplicate.add(value)
+    seen.add(value)
+  }
+  return [...duplicate].sort().map((value) => ({
+    code: 'duplicate-id' as const,
+    path,
+    message: `Duplicate id ${value}.`,
+  }))
+}
+
+function isOwnerLocalTransport(transport: string) {
+  if (transport.startsWith('unix://')) {
+    const path = transport.slice('unix://'.length)
+    return path.startsWith('/') && !path.includes('\0') && !path.split('/').includes('..')
+  }
+  try {
+    const url = new URL(transport)
+    return (
+      ['http:', 'https:'].includes(url.protocol) &&
+      ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname) &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+function coreInvariantIssues(
+  trace: ReconstructionAttemptTraceCore,
+): TraceValidationIssue[] {
+  const issues: TraceValidationIssue[] = []
+  const sourceSha256 = trace.sourcePdf.artifact.sha256
+
+  const renderedPages = trace.sourcePdf.pageRenders.map((render) => render.page)
+  const expectedPages = Array.from(
+    { length: trace.sourcePdf.pageCount },
+    (_, index) => index + 1,
+  )
+  if (
+    renderedPages.length !== expectedPages.length ||
+    [...renderedPages]
+      .sort((a, b) => a - b)
+      .some((page, index) => page !== expectedPages[index])
+  ) {
+    issues.push({
+      code: 'invalid-page-render-set',
+      path: 'sourcePdf.pageRenders',
+      message: 'Page renders must contain every source page exactly once.',
+    })
+  }
+  for (const [index, render] of trace.sourcePdf.pageRenders.entries()) {
+    if (render.sourcePdfSha256 !== sourceSha256) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `sourcePdf.pageRenders.${index}.sourcePdfSha256`,
+        message: 'Page render is not bound to the source PDF.',
+      })
+    }
+  }
+
+  const sourceBindings: Array<[string, string]> = [
+    ['evidenceGraph.sourcePdfSha256', trace.evidenceGraph.sourcePdfSha256],
+    [
+      'sourceEvidence.sourcePdfSha256',
+      trace.sourceEvidence.sourcePdfSha256,
+    ],
+    ['structure.sourcePdfSha256', trace.structure.sourcePdfSha256],
+  ]
+  for (const [path, actual] of sourceBindings) {
+    if (actual !== sourceSha256) {
+      issues.push({
+        code: 'binding-mismatch',
+        path,
+        message: 'Artifact is not bound to the source PDF.',
+      })
+    }
+  }
+  if (
+    trace.sourceEvidence.evidenceGraphSha256 !==
+    trace.evidenceGraph.artifact.sha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'sourceEvidence.evidenceGraphSha256',
+      message: 'Source-evidence receipt is not bound to the evidence graph.',
+    })
+  }
+  if (
+    trace.sourceEvidence.candidateSetSha256 !==
+    hashTraceValue(trace.evidenceCandidates)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'sourceEvidence.candidateSetSha256',
+      message:
+        'Source-evidence receipt is not bound to the provider-neutral candidate references.',
+    })
+  }
+  if (
+    trace.sourceEvidence.receiptSha256 !==
+    hashSourceEvidenceReceipt(trace.sourceEvidence)
+  ) {
+    issues.push({
+      code: 'hash-mismatch',
+      path: 'sourceEvidence.receiptSha256',
+      message: 'Source-evidence receipt hash does not match its content.',
+    })
+  }
+  const expectedChecks = trace.sourceEvidence.expectedObservationSets.map(
+    ({ check }) => check,
+  )
+  if (
+    new Set(expectedChecks).size !== SOURCE_EPUB_OBSERVATION_CHECK_IDS.length ||
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) => !expectedChecks.includes(check),
+    )
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'sourceEvidence.expectedObservationSets',
+      message:
+        'Source evidence must commit exactly one expected set for every observation category.',
+    })
+  }
+  const sourceRegionIds = new Set(
+    trace.comparisonEvidence.sourceRegions.map(({ id }) => id),
+  )
+  for (const [index, expected] of
+    trace.sourceEvidence.expectedObservationSets.entries()) {
+    if (
+      expected.receiptSha256 !== hashSourceExpectedObservationSet(expected) ||
+      expected.setSha256 !== expected.payload.sha256 ||
+      new Set(expected.sourceRegionIds).size !== expected.sourceRegionIds.length ||
+      expected.sourceRegionIds.some((id) => !sourceRegionIds.has(id)) ||
+      (expected.sourceRegionIds.length > 0 && expected.itemCount === 0)
+    ) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `sourceEvidence.expectedObservationSets.${index}`,
+        message:
+          'Expected category sets must be hash-bound to known source obligations and cannot self-attest zero items for source-bearing evidence.',
+      })
+    }
+  }
+  const actualChecks = trace.renderedEpub.actualObservationSets.map(
+    ({ check }) => check,
+  )
+  if (
+    new Set(actualChecks).size !== SOURCE_EPUB_OBSERVATION_CHECK_IDS.length ||
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) => !actualChecks.includes(check),
+    )
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'renderedEpub.actualObservationSets',
+      message:
+        'Actual renderer evidence must commit exactly one set for every observation category.',
+    })
+  }
+  for (const [index, actual] of
+    trace.renderedEpub.actualObservationSets.entries()) {
+    if (
+      actual.receiptSha256 !== hashRenderedActualObservationSet(actual) ||
+      actual.setSha256 !== actual.payload.sha256
+    ) {
+      issues.push({
+        code: 'hash-mismatch',
+        path: `renderedEpub.actualObservationSets.${index}.receiptSha256`,
+        message: 'Actual renderer category-set receipt is stale.',
+      })
+    }
+  }
+  if (trace.epub.structSha256 !== trace.structure.artifact.sha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'epub.structSha256',
+      message: 'EPUB is not bound to this serialized STRUCT artifact.',
+    })
+  }
+  if (trace.renderedEpub.epubSha256 !== trace.epub.bytes.sha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'renderedEpub.epubSha256',
+      message: 'Rendered evidence is not from the exact EPUB bytes.',
+    })
+  }
+  if (
+    hashTraceValue(trace.renderedEpub.download.artifact) !==
+      hashTraceValue(trace.epub.bytes) ||
+    trace.renderedEpub.receiptSha256 !==
+      hashRenderedEpubEvidence(trace.renderedEpub) ||
+    trace.renderedEpub.sourceObligations.sourcePdfSha256 !== sourceSha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'renderedEpub',
+      message:
+        'Actual-render receipt must bind the downloaded EPUB artifact, source obligations, and complete renderer observation.',
+    })
+  }
+
+  if (trace.lineage.attemptIndex === 0) {
+    if (
+      trace.lineage.parentTraceSha256 !== null ||
+      trace.lineage.immutablePriorTraceSha256 !== null ||
+      trace.lineage.appliedRepair !== null ||
+      trace.critiqueRepair !== null
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: 'lineage',
+        message: 'The first attempt cannot have a parent trace.',
+      })
+    }
+  } else if (
+    trace.lineage.parentTraceSha256 === null ||
+    trace.lineage.immutablePriorTraceSha256 !==
+      trace.lineage.parentTraceSha256 ||
+    trace.lineage.appliedRepair === null ||
+    trace.critiqueRepair === null
+  ) {
+    issues.push({
+      code: 'invalid-lineage',
+      path: 'lineage',
+      message:
+        'A refinement must name the same immutable parent trace in both lineage fields.',
+    })
+  }
+  if (trace.lineage.appliedRepair) {
+    const application = trace.lineage.appliedRepair
+    if (
+      application.resultingStructSha256 !== trace.structure.artifact.sha256 ||
+      application.applicationSha256 !==
+        hashAppliedRepairBinding({
+          proposalSha256: application.proposalSha256,
+          baseStructSha256: application.baseStructSha256,
+          resultingStructSha256: application.resultingStructSha256,
+          applicationReceiptSha256: application.applicationReceiptSha256,
+          groundedVerifierReceiptSha256:
+            application.groundedVerifierReceiptSha256,
+        })
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: 'lineage.appliedRepair',
+        message:
+          'Repair application must commit its parent, proposal, base STRUCT, and exact resulting STRUCT.',
+      })
+    }
+  }
+
+  issues.push(
+    ...uniqueIssues(
+      trace.evidenceCandidates.map((candidate) => candidate.referenceSha256),
+      'evidenceCandidates',
+    ),
+    ...uniqueIssues(
+      trace.structure.assets.map((asset) => asset.id),
+      'structure.assets',
+    ),
+    ...uniqueIssues(
+      trace.renderedEpub.domSnapshots.map((snapshot) => snapshot.spineHref),
+      'renderedEpub.domSnapshots',
+    ),
+    ...uniqueIssues(
+      trace.renderedEpub.screenshots.map((screenshot) => screenshot.id),
+      'renderedEpub.screenshots',
+    ),
+    ...uniqueIssues(
+      trace.mappings.map((mapping) => mapping.id),
+      'mappings',
+    ),
+    ...uniqueIssues(
+      trace.mappings.map((mapping) => mapping.obligationId),
+      'mappings.obligationId',
+    ),
+    ...uniqueIssues(
+      trace.comparisonEvidence.sourceRegions.map((region) => region.id),
+      'comparisonEvidence.sourceRegions',
+    ),
+    ...uniqueIssues(
+      trace.comparisonEvidence.observations.map(
+        (observation) => observation.idSha256,
+      ),
+      'comparisonEvidence.observations',
+    ),
+    ...uniqueIssues(
+      trace.providerReceipts.map((receipt) => receipt.id),
+      'providerReceipts',
+    ),
+    ...uniqueIssues(
+      trace.comparator.checkResults.map((result) => result.id),
+      'comparator.checkResults',
+    ),
+    ...uniqueIssues(
+      trace.comparator.failures.map((failure) => failure.id),
+      'comparator.failures',
+    ),
+  )
+
+  const requiredProviderRoles: ProviderReceiptBinding['role'][] = [
+    'source-evidence',
+    'actual-render',
+    'owner-local-codex-reconciliation',
+    ...(trace.critiqueRepair ? ['owner-local-codex-repair' as const] : []),
+  ]
+  const requiredReceipts = new Map<
+    ProviderReceiptBinding['role'],
+    ProviderReceiptBinding[]
+  >(
+    requiredProviderRoles.map((role) => [
+      role,
+      trace.providerReceipts.filter((receipt) => receipt.role === role),
+    ] as const),
+  )
+  for (const role of requiredProviderRoles) {
+    const receipts = requiredReceipts.get(role) ?? []
+    if (receipts.length !== 1) {
+      issues.push({
+        code: receipts.length === 0 ? 'invalid-schema' : 'duplicate-id',
+        path: 'providerReceipts',
+        message: `Required provider role ${role} must appear exactly once.`,
+      })
+      continue
+    }
+    const receipt = receipts[0]!
+    if (!receipt.required || !receipt.enabledBeforeRun) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `providerReceipts.${receipt.id}`,
+        message: `Required provider role ${role} must be enabled before the run.`,
+      })
+    }
+  }
+  for (const receipt of trace.providerReceipts) {
+    if (receipt.role === 'optional') {
+      if (receipt.required) {
+        issues.push({
+          code: 'binding-mismatch',
+          path: `providerReceipts.${receipt.id}.required`,
+          message: 'An optional provider arm cannot be marked required.',
+        })
+      }
+      if (
+        (!receipt.enabledBeforeRun && receipt.status !== 'disabled') ||
+        (receipt.enabledBeforeRun && receipt.status === 'disabled')
+      ) {
+        issues.push({
+          code: 'binding-mismatch',
+          path: `providerReceipts.${receipt.id}.status`,
+          message:
+            'Optional provider status must preserve whether it was enabled before the run.',
+        })
+      }
+    } else if (!receipt.required) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `providerReceipts.${receipt.id}.required`,
+        message: 'Core provider roles are required.',
+      })
+    }
+  }
+  const deterministicReceipt = requiredReceipts.get('source-evidence')?.[0]
+  if (
+    deterministicReceipt &&
+    (deterministicReceipt.status !== 'succeeded' ||
+      deterministicReceipt.inputSha256 !== sourceSha256 ||
+      deterministicReceipt.outputSha256 !== trace.sourceEvidence.receiptSha256)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${deterministicReceipt.id}`,
+      message:
+        'Source-evidence provider must bind the source PDF to its graph and candidate receipt.',
+    })
+  }
+  const renderReceipt = requiredReceipts.get('actual-render')?.[0]
+  const renderedEvidenceSha256 = hashRenderedEpubEvidence(trace.renderedEpub)
+  if (
+    renderReceipt &&
+    (renderReceipt.status !== 'succeeded' ||
+      renderReceipt.inputSha256 !== trace.epub.bytes.sha256 ||
+      renderReceipt.outputSha256 !== renderedEvidenceSha256 ||
+      trace.renderedEpub.receiptSha256 !== renderedEvidenceSha256)
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${renderReceipt.id}`,
+      message:
+        'Actual EPUB renderer must bind the exact EPUB bytes to its complete evidence receipt.',
+    })
+  }
+  const codexReceipt = requiredReceipts.get(
+    'owner-local-codex-reconciliation',
+  )?.[0]
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256: sourceSha256,
+    evidenceGraphSha256: trace.evidenceGraph.artifact.sha256,
+    candidateSetSha256: trace.sourceEvidence.candidateSetSha256,
+    structSha256: trace.structure.artifact.sha256,
+    epubSha256: trace.epub.bytes.sha256,
+    renderObservationReceiptSha256: trace.renderedEpub.receiptSha256,
+  })
+  if (
+    codexReceipt &&
+    (codexReceipt.status !== 'succeeded' ||
+      codexReceipt.inputSha256 !== reconciliationInputSha256 ||
+      codexReceipt.outputSha256 !== hashTraceValue(trace.comparator))
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${codexReceipt.id}`,
+      message:
+        'Owner-local Codex reconciliation must succeed and bind the exact render input to the comparator result.',
+    })
+  }
+  if (
+    codexReceipt &&
+    (!codexReceipt.server ||
+      !codexReceipt.model ||
+      !codexReceipt.prompt ||
+      !codexReceipt.tool ||
+      codexReceipt.identitySha256 !==
+        hashCodexProviderIdentity(codexReceipt) ||
+      !isOwnerLocalTransport(codexReceipt.server.transport))
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: `providerReceipts.${codexReceipt.id}.server`,
+      message:
+        'Owner-local Codex requires an identified local server transport.',
+    })
+  }
+
+  const doms = new Map(
+    trace.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot,
+    ]),
+  )
+  const screenshots = new Map(
+    trace.renderedEpub.screenshots.map((screenshot) => [
+      screenshot.id,
+      screenshot,
+    ]),
+  )
+  for (const [mappingIndex, mapping] of trace.mappings.entries()) {
+    if (mapping.source.page > trace.sourcePdf.pageCount) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.source.page`,
+        message: 'Mapping page is outside the source PDF.',
+      })
+    }
+    if (
+      new Set(mapping.source.sourceRegionIds).size !==
+      mapping.source.sourceRegionIds.length
+    ) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.source.sourceRegionIds`,
+        message: 'A mapping cannot repeat a source region id.',
+      })
+    }
+    for (const [boxIndex, box] of mapping.source.boxes.entries()) {
+      if (box.page !== mapping.source.page) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.source.boxes.${boxIndex}.page`,
+          message: 'Every source box must be on the mapping source page.',
+        })
+      }
+    }
+    if (mapping.status === 'missing' && mapping.output.length !== 0) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message: 'A missing mapping cannot claim output locations.',
+      })
+    }
+    if (mapping.status === 'mapped' && mapping.output.length !== 1) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message: 'A mapped obligation must have exactly one output location.',
+      })
+    }
+    if (mapping.status === 'duplicate' && mapping.output.length < 2) {
+      issues.push({
+        code: 'invalid-mapping',
+        path: `mappings.${mappingIndex}.output`,
+        message:
+          'A duplicate obligation must have at least two output locations.',
+      })
+    }
+    for (const [outputIndex, output] of mapping.output.entries()) {
+      if (!output.rendered) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.rendered`,
+          message:
+            'Every output locator must include hash-bound screenshot geometry.',
+        })
+      }
+      const dom = doms.get(output.spineHref)
+      if (!dom) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.spineHref`,
+          message: 'Output location does not exist in rendered DOM evidence.',
+        })
+      }
+      if (dom && !dom.anchors.includes(output.anchorId)) {
+        issues.push({
+          code: 'invalid-mapping',
+          path: `mappings.${mappingIndex}.output.${outputIndex}.anchorId`,
+          message: 'Output anchor does not exist in rendered DOM evidence.',
+        })
+      }
+      if (output.rendered) {
+        const screenshot = screenshots.get(output.rendered.screenshotId)
+        if (!screenshot || screenshot.spineHref !== output.spineHref) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.screenshotId`,
+            message:
+              'Rendered locator must reference a screenshot of the same spine item.',
+          })
+        } else if (
+          output.rendered.viewport.width !== screenshot.viewport.width ||
+          output.rendered.viewport.height !== screenshot.viewport.height ||
+          output.rendered.viewport.deviceScaleFactor !==
+            screenshot.viewport.deviceScaleFactor
+        ) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.viewport`,
+            message: 'Rendered locator viewport does not match its screenshot.',
+          })
+        }
+        const { rect, viewport } = output.rendered
+        if (
+          rect.x < 0 ||
+          rect.y < 0 ||
+          rect.width <= 0 ||
+          rect.height <= 0 ||
+          rect.x + rect.width > viewport.width ||
+          rect.y + rect.height > viewport.height
+        ) {
+          issues.push({
+            code: 'invalid-mapping',
+            path: `mappings.${mappingIndex}.output.${outputIndex}.rendered.rect`,
+            message:
+              'Rendered locator must have positive area inside its screenshot viewport.',
+          })
+        }
+      }
+    }
+  }
+
+  const domHashes = new Map(
+    trace.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot.dom.sha256,
+    ]),
+  )
+  for (const [index, screenshot] of trace.renderedEpub.screenshots.entries()) {
+    if (screenshot.domSha256 !== domHashes.get(screenshot.spineHref)) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `renderedEpub.screenshots.${index}.domSha256`,
+        message: 'Screenshot is not bound to its rendered DOM snapshot.',
+      })
+    }
+  }
+
+  const sortedSourceRegions = [...trace.comparisonEvidence.sourceRegions].sort(
+    (left, right) => compareCodeUnits(left.id, right.id),
+  )
+  const sourceObligationProjection = {
+    sourcePdfSha256: sourceSha256,
+    obligationsSha256: hashTraceValue(sortedSourceRegions),
+    obligationCount: sortedSourceRegions.length,
+  }
+  const sourceObligationReceiptSha256 = hashTraceValue(
+    sourceObligationProjection,
+  )
+  if (
+    trace.sourceEvidence.sourceObligations.obligationsSha256 !==
+      sourceObligationProjection.obligationsSha256 ||
+    trace.sourceEvidence.sourceObligations.obligationCount !==
+      sourceObligationProjection.obligationCount ||
+    trace.sourceEvidence.sourceObligations.receiptSha256 !==
+      sourceObligationReceiptSha256 ||
+    trace.renderedEpub.sourceObligations.obligationsSha256 !==
+      sourceObligationProjection.obligationsSha256 ||
+    trace.renderedEpub.sourceObligations.obligationCount !==
+      sourceObligationProjection.obligationCount ||
+    trace.renderedEpub.sourceObligations.receiptSha256 !==
+      sourceObligationReceiptSha256
+  ) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'comparisonEvidence.sourceRegions',
+      message:
+        'Private comparison evidence must match the authoritative source-evidence obligation receipt and renderer copy.',
+    })
+  }
+  const expectedSets = new Map(
+    trace.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    trace.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  for (const [index, observation] of trace.comparisonEvidence.observations.entries()) {
+    const { receiptSha256, ...core } = observation
+    if (
+      receiptSha256 !== hashTraceValue(core) ||
+      observation.expectedSetReceiptSha256 !==
+        expectedSets.get(observation.check)?.receiptSha256 ||
+      observation.actualSetReceiptSha256 !==
+        actualSets.get(observation.check)?.receiptSha256
+    ) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `comparisonEvidence.observations.${index}`,
+        message:
+          'Observation must select the authoritative source-expected and renderer-actual category receipts.',
+      })
+    }
+  }
+
+  const comparator = trace.comparator
+  const comparatorBindings: Array<[string, string, string]> = [
+    ['sourcePdfSha256', comparator.sourcePdfSha256, sourceSha256],
+    ['structSha256', comparator.structSha256, trace.structure.artifact.sha256],
+    ['epubSha256', comparator.epubSha256, trace.epub.bytes.sha256],
+    [
+      'renderObservationReceiptSha256',
+      comparator.renderObservationReceiptSha256,
+      trace.renderedEpub.receiptSha256,
+    ],
+  ]
+  for (const [field, actual, expected] of comparatorBindings) {
+    if (actual !== expected) {
+      issues.push({
+        code: 'binding-mismatch',
+        path: `comparator.${field}`,
+        message: 'Comparator result is stale for this attempt.',
+      })
+    }
+  }
+  const expectedObservationSetSha256 = hashTraceValue(
+    [...trace.comparisonEvidence.observations].sort((left, right) =>
+      compareCodeUnits(left.idSha256, right.idSha256),
+    ),
+  )
+  if (comparator.observationSetSha256 !== expectedObservationSetSha256) {
+    issues.push({
+      code: 'binding-mismatch',
+      path: 'comparator.observationSetSha256',
+      message: 'Comparator is not bound to the private observation receipt set.',
+    })
+  }
+  if (
+    comparator.denominator !== comparator.checkResults.length ||
+    comparator.passed !==
+      comparator.checkResults.filter((result) => result.status === 'passed')
+        .length ||
+    comparator.failed !==
+      comparator.checkResults.filter((result) => result.status === 'failed')
+        .length ||
+    comparator.denominator !== comparator.passed + comparator.failed
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator',
+      message: 'Comparator totals do not match its check results.',
+    })
+  }
+
+  const evaluatedChecks = new Set(
+    comparator.checkResults
+      .filter((result) => result.origin === 'deterministic')
+      .map((result) => result.check),
+  )
+  if (DETERMINISTIC_CHECK_IDS.some((check) => !evaluatedChecks.has(check))) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.checkResults',
+      message: 'Comparator omitted a required deterministic check category.',
+    })
+  }
+
+  const failureById = new Map(
+    comparator.failures.map((failure) => [failure.id, failure]),
+  )
+  for (const result of comparator.checkResults) {
+    if (
+      (result.status === 'passed' && result.failureId !== undefined) ||
+      (result.status === 'failed' &&
+        (!result.failureId || !failureById.has(result.failureId)))
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}`,
+        message: 'Failed checks and failure records must reference each other.',
+      })
+    }
+    if (
+      result.origin === 'deterministic' &&
+      result.status === 'passed' &&
+      result.check !== 'render-binding' &&
+      result.check !== 'epub-package' &&
+      result.check !== 'source-region-conservation' &&
+      (result.mappingIds.length === 0 ||
+        result.mappingIds.some((id) => {
+          const mapping = trace.mappings.find(
+            (candidate) => candidate.id === id,
+          )
+          return (
+            !mapping ||
+            mapping.status !== 'mapped' ||
+            mapping.output.length !== 1
+          )
+        }))
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}.mappingIds`,
+        message:
+          'A passing semantic observation requires known one-to-one mapping evidence.',
+      })
+    }
+  }
+  for (const result of comparator.checkResults) {
+    if (
+      result.origin !== 'deterministic' ||
+      result.judgeResultId !== undefined
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.checkResults.${result.id}.origin`,
+        message:
+          'Interpretive judges cannot enter the core trace until their separately calibrated contract is enabled.',
+      })
+    }
+  }
+  const referencedFailureIds = new Set(
+    comparator.checkResults.flatMap((result) =>
+      result.failureId ? [result.failureId] : [],
+    ),
+  )
+  for (const failure of comparator.failures) {
+    const citedMappings = failure.mappingIds.map((id) =>
+      trace.mappings.find((mapping) => mapping.id === id),
+    )
+    if (
+      failure.mappingIds.length === 0 ||
+      !failure.source ||
+      citedMappings.some((mapping) => !mapping) ||
+      !citedMappings.some(
+        (mapping) =>
+          mapping &&
+          hashTraceValue(mapping.source) === hashTraceValue(failure.source),
+      )
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: `comparator.failures.${failure.id}`,
+        message:
+          'Every failure must cite a known mapping and source location for browser navigation.',
+      })
+    }
+  }
+  if (
+    comparator.failures.some((failure) => !referencedFailureIds.has(failure.id))
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.failures',
+      message: 'Every failure must be referenced by a failed check.',
+    })
+  }
+  if (comparator.failures.length !== comparator.failed) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.failures',
+      message: 'Every failed check must have exactly one failure record.',
+    })
+  }
+  if (comparator.status === 'publication-ready') {
+    if (
+      comparator.failed !== 0 ||
+      comparator.failures.length !== 0 ||
+      comparator.firstCauseFailureId !== null ||
+      trace.epub.epubCheck.status !== 'passed' ||
+      trace.epub.epubCheck.errorCount !== 0 ||
+      trace.epub.epubCheck.warningCount !== 0 ||
+      [...requiredReceipts.values()].some(
+        ([receipt]) =>
+          !receipt || receipt.status !== 'succeeded',
+      )
+    ) {
+      issues.push({
+        code: 'invalid-comparator',
+        path: 'comparator.status',
+        message:
+          'Publication-ready requires every check and EPUBCheck to pass.',
+      })
+    }
+  } else if (
+    comparator.failed === 0 ||
+    comparator.failures.length === 0 ||
+    comparator.firstCauseFailureId === null ||
+    !failureById.has(comparator.firstCauseFailureId)
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.firstCauseFailureId',
+      message: 'A failed comparison requires a valid first cause.',
+    })
+  }
+  if (
+    comparator.firstCauseFailureId !== null &&
+    [...comparator.failures].sort(compareComparisonFailures)[0]?.id !==
+      comparator.firstCauseFailureId
+  ) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'comparator.firstCauseFailureId',
+      message: 'First cause is not the deterministic earliest failure.',
+    })
+  }
+  if (trace.terminalState !== comparator.status) {
+    issues.push({
+      code: 'invalid-comparator',
+      path: 'terminalState',
+      message: 'Only the comparator may declare publication-ready.',
+    })
+  }
+
+  const { policy, usage } = trace.budget
+  if (
+    usage.refinements > policy.maxRefinements ||
+    usage.freshTasks > policy.maxFreshTasks ||
+    usage.tokens > policy.maxTokens ||
+    usage.durationMs > policy.maxDurationMs ||
+    usage.refinements !== trace.lineage.attemptIndex
+  ) {
+    issues.push({
+      code: 'invalid-budget',
+      path: 'budget',
+      message: 'Attempt usage exceeds its frozen policy or lineage index.',
+    })
+  }
+
+  if (trace.critiqueRepair) {
+    const repair = trace.critiqueRepair
+    const receipt = trace.providerReceipts.find(
+      (candidate) => candidate.id === repair.providerReceiptId,
+    )
+    const candidateIds = new Set(
+      trace.evidenceCandidates.map((candidate) => candidate.referenceSha256),
+    )
+    const hasUnknownEvidenceCandidate = repair.proposal.operations.some(
+      (operation) =>
+        !candidateIds.has(operation.candidateReferenceSha256),
+    )
+    const { proposalSha256, ...proposalProjection } = repair.proposal
+    const application = trace.lineage.appliedRepair
+    if (
+      repair.disposition !== 'verified' ||
+      repair.proposal.documentId !== trace.structure.documentId ||
+      repair.proposal.sourcePdfSha256 !== sourceSha256 ||
+      repair.proposal.sourceEvidenceGraphSha256 !==
+        trace.evidenceGraph.artifact.sha256 ||
+      repair.proposal.priorTraceSha256 !== trace.lineage.parentTraceSha256 ||
+      repair.proposal.baseStructSha256 !== application?.baseStructSha256 ||
+      repair.proposal.proposalSha256 !== application?.proposalSha256 ||
+      repair.proposal.proposalSha256 !==
+        hashRepairProposal(proposalProjection) ||
+      !receipt ||
+      receipt.role !== 'owner-local-codex-repair' ||
+      receipt.status !== 'succeeded' ||
+      !receipt.server ||
+      !receipt.model ||
+      !receipt.prompt ||
+      !receipt.tool ||
+      receipt.identitySha256 !== hashCodexProviderIdentity(receipt) ||
+      receipt.identitySha256 !== codexReceipt?.identitySha256 ||
+      receipt.inputSha256 !== repair.priorComparatorSha256 ||
+      receipt.outputSha256 !== repair.proposal.proposalSha256 ||
+      hasUnknownEvidenceCandidate
+    ) {
+      issues.push({
+        code: 'invalid-repair',
+        path: 'critiqueRepair',
+        message:
+          'Child repair must be a verified driver-compatible Codex patch bound to its parent, evidence, and applied STRUCT.',
+      })
+    }
+  }
+
+  return issues
+}
+
+function schemaIssues(error: z.ZodError): TraceValidationIssue[] {
+  return error.issues.map((issue) => ({
+    code: 'invalid-schema',
+    path: issue.path.join('.') || 'trace',
+    message: issue.message,
+  }))
+}
+
+export function validateReconstructionAttemptTrace(
+  input: unknown,
+): TraceValidationIssue[] {
+  const parsed = traceSchema.safeParse(input)
+  if (!parsed.success) return schemaIssues(parsed.error)
+  const issues = coreInvariantIssues(parsed.data)
+  const expectedTraceSha256 = hashReconstructionAttemptTrace(parsed.data)
+  if (parsed.data.traceSha256 !== expectedTraceSha256) {
+    issues.push({
+      code: 'hash-mismatch',
+      path: 'traceSha256',
+      message: 'Trace hash does not match its canonical content.',
+    })
+  }
+  return issues
+}
+
+export function parseReconstructionAttemptTrace(
+  input: unknown,
+): ReconstructionAttemptTrace {
+  const parsed = traceSchema.safeParse(input)
+  if (!parsed.success) {
+    throw new ReconstructionAttemptTraceValidationError(
+      schemaIssues(parsed.error),
+    )
+  }
+  const issues = validateReconstructionAttemptTrace(parsed.data)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return parsed.data
+}
+
+export function hashReconstructionAttemptTrace(
+  input: ReconstructionAttemptTrace | ReconstructionAttemptTraceCore,
+) {
+  const { traceSha256: _traceSha256, ...candidateCore } = input as
+    | ReconstructionAttemptTrace
+    | (ReconstructionAttemptTraceCore & { traceSha256?: string })
+  const core = traceCoreSchema.parse(candidateCore)
+  return hashTraceValue(core)
+}
+
+export function createReconstructionAttemptTrace(
+  input: ReconstructionAttemptTraceCore,
+): ReconstructionAttemptTrace {
+  const core = traceCoreSchema.parse(input)
+  const issues = coreInvariantIssues(core)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return parseReconstructionAttemptTrace({
+    ...core,
+    traceSha256: hashReconstructionAttemptTrace(core),
+  })
+}
+
+export function serializeReconstructionAttemptTrace(
+  trace: ReconstructionAttemptTrace,
+) {
+  return canonicalTraceJson(parseReconstructionAttemptTrace(trace))
+}
+
+function providerIdentityProjection(
+  trace: ReconstructionAttemptTrace,
+  role: ProviderReceiptBinding['role'],
+) {
+  const receipt = trace.providerReceipts.find(
+    (candidate) => candidate.role === role,
+  )
+  if (!receipt) return null
+  return {
+    role: receipt.role,
+    required: receipt.required,
+    enabledBeforeRun: receipt.enabledBeforeRun,
+    providerId: receipt.providerId,
+    identitySha256: receipt.identitySha256 ?? null,
+    prompt: receipt.prompt ?? null,
+    tool: receipt.tool ?? null,
+    model: receipt.model ?? null,
+    server: receipt.server ?? null,
+  }
+}
+
+function executionIdentityProjection(trace: ReconstructionAttemptTrace) {
+  const requiredRoles: ProviderReceiptBinding['role'][] = [
+    'source-evidence',
+    'actual-render',
+    'owner-local-codex-reconciliation',
+  ]
+  return {
+    providers: requiredRoles.map((role) =>
+      providerIdentityProjection(trace, role),
+    ),
+    renderer: trace.renderedEpub.renderer,
+    epubCheck: {
+      toolId: trace.epub.epubCheck.toolId,
+      toolVersion: trace.epub.epubCheck.toolVersion,
+    },
+  }
+}
+
+/**
+ * Validate deterministic resume/replay across the complete ordered history.
+ * A child cannot establish this property by naming an arbitrary parent hash;
+ * callers must retain and validate every immutable prior trace.
+ */
+export function validateReconstructionAttemptTraceLineage(
+  input: readonly unknown[],
+): TraceValidationIssue[] {
+  if (input.length === 0) {
+    return [
+      {
+        code: 'invalid-lineage',
+        path: 'traces',
+        message: 'A replay lineage must contain at least one attempt.',
+      },
+    ]
+  }
+
+  const issues: TraceValidationIssue[] = []
+  const traces: Array<ReconstructionAttemptTrace | undefined> = input.map(
+    (candidate, index) => {
+      const parsed = traceSchema.safeParse(candidate)
+      if (!parsed.success) {
+        issues.push(
+          ...schemaIssues(parsed.error).map((issue) => ({
+            ...issue,
+            path: `traces.${index}.${issue.path}`,
+          })),
+        )
+        return undefined
+      }
+      issues.push(
+        ...validateReconstructionAttemptTrace(parsed.data).map((issue) => ({
+          ...issue,
+          path: `traces.${index}.${issue.path}`,
+        })),
+      )
+      return parsed.data
+    },
+  )
+
+  const first = traces[0]
+  if (!first) return issues
+  const frozenSourceSha256 = hashTraceValue(first.sourcePdf)
+  const frozenEvidenceSha256 = hashTraceValue({
+    evidenceGraph: first.evidenceGraph,
+    sourceEvidence: first.sourceEvidence,
+    evidenceCandidates: first.evidenceCandidates,
+  })
+  const frozenPolicySha256 = hashTraceValue(first.budget.policy)
+  const frozenExecutionIdentitySha256 = hashTraceValue(
+    executionIdentityProjection(first),
+  )
+  const documentId = first.structure.documentId
+  const seenAttemptIds = new Set<string>()
+
+  for (const [index, trace] of traces.entries()) {
+    if (!trace) continue
+    if (seenAttemptIds.has(trace.attemptId)) {
+      issues.push({
+        code: 'duplicate-id',
+        path: `traces.${index}.attemptId`,
+        message: 'Attempt ids must be unique across a replay lineage.',
+      })
+    }
+    seenAttemptIds.add(trace.attemptId)
+
+    if (trace.lineage.attemptIndex !== index) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.lineage.attemptIndex`,
+        message: 'Attempt indexes must be contiguous and ordered from zero.',
+      })
+    }
+    const previous = index > 0 ? traces[index - 1] : undefined
+    const expectedParentSha256 = previous?.traceSha256 ?? null
+    if (
+      trace.lineage.parentTraceSha256 !== expectedParentSha256 ||
+      trace.lineage.immutablePriorTraceSha256 !== expectedParentSha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.lineage`,
+        message:
+          'Parent and immutable-prior hashes must name the immediately preceding trace.',
+      })
+    }
+    if (previous) {
+      const application = trace.lineage.appliedRepair
+      const repair = trace.critiqueRepair
+      if (
+        previous.terminalState !== 'failed' ||
+        !application ||
+        !repair ||
+        repair.priorComparatorSha256 !== hashTraceValue(previous.comparator) ||
+        repair.priorFirstCauseFailureId !==
+          previous.comparator.firstCauseFailureId ||
+        repair.proposal.priorTraceSha256 !== previous.traceSha256 ||
+        repair.proposal.baseStructSha256 !==
+          previous.structure.artifact.sha256 ||
+        application.proposalSha256 !== repair.proposal.proposalSha256 ||
+        application.baseStructSha256 !== previous.structure.artifact.sha256 ||
+        application.resultingStructSha256 !== trace.structure.artifact.sha256 ||
+        application.resultingStructSha256 === application.baseStructSha256
+      ) {
+        issues.push({
+          code: 'invalid-lineage',
+          path: `traces.${index}.lineage.appliedRepair`,
+          message:
+            'A child requires its verified proposal for the exact failed parent comparator to produce a changed STRUCT.',
+        })
+      }
+    }
+    if (
+      hashTraceValue(trace.sourcePdf) !== frozenSourceSha256 ||
+      trace.structure.documentId !== documentId
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.sourcePdf`,
+        message: 'Source identity changed during replay.',
+      })
+    }
+    if (
+      hashTraceValue({
+        evidenceGraph: trace.evidenceGraph,
+        sourceEvidence: trace.sourceEvidence,
+        evidenceCandidates: trace.evidenceCandidates,
+      }) !== frozenEvidenceSha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.evidenceGraph`,
+        message: 'Extraction evidence changed during replay.',
+      })
+    }
+    if (hashTraceValue(trace.budget.policy) !== frozenPolicySha256) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.budget.policy`,
+        message: 'The refinement policy changed during replay.',
+      })
+    }
+    if (
+      hashTraceValue(executionIdentityProjection(trace)) !==
+      frozenExecutionIdentitySha256
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.providerReceipts`,
+        message:
+          'Required provider, tool, renderer, EPUBCheck, model, server, or prompt identity changed during replay.',
+      })
+    }
+    if (
+      previous &&
+      (trace.budget.usage.freshTasks < previous.budget.usage.freshTasks ||
+        trace.budget.usage.tokens < previous.budget.usage.tokens ||
+        trace.budget.usage.durationMs < previous.budget.usage.durationMs)
+    ) {
+      issues.push({
+        code: 'invalid-lineage',
+        path: `traces.${index}.budget.usage`,
+        message: 'Replay usage counters cannot move backwards.',
+      })
+    }
+  }
+  return issues
+}
+
+export function parseReconstructionAttemptTraceLineage(
+  input: readonly unknown[],
+): ReconstructionAttemptTrace[] {
+  const issues = validateReconstructionAttemptTraceLineage(input)
+  if (issues.length > 0) {
+    throw new ReconstructionAttemptTraceValidationError(issues)
+  }
+  return input.map((trace) => parseReconstructionAttemptTrace(trace))
+}
+
+const reconstructionAttemptRefinementTraceBindingSchema = z
+  .object({
+    traceSha256: sha256Schema,
+    sourcePdfSha256: sha256Schema,
+    sourceEvidenceGraphSha256: sha256Schema,
+    canonicalStructSha256: sha256Schema,
+    attemptIndex: nonNegativeIntegerSchema,
+    parentTraceSha256: sha256Schema.nullable(),
+    terminalStatus: z.enum(['publication-ready', 'failed']),
+    firstCause: z
+      .object({
+        failureReferenceSha256: sha256Schema,
+        code: z.enum(DETERMINISTIC_CHECK_IDS),
+      })
+      .strict()
+      .nullable(),
+    evidenceCandidateReferences: z.array(sha256Schema).min(1),
+    policy: budgetSchema.shape.policy,
+    usage: budgetSchema.shape.usage,
+  })
+  .strict()
+
+/** Public, allowlisted receipt projection; it never contains source text or bytes. */
+export type ReconstructionAttemptRefinementTraceBinding = z.infer<
+  typeof reconstructionAttemptRefinementTraceBindingSchema
+>
+
+export function parseReconstructionAttemptRefinementTraceBinding(
+  input: unknown,
+): ReconstructionAttemptRefinementTraceBinding {
+  return reconstructionAttemptRefinementTraceBindingSchema.parse(input)
+}
+
+/** Validate the public projection without requiring private owner-local payloads. */
+export function validateReconstructionAttemptRefinementTraceBindingLineage(
+  input: readonly unknown[],
+) {
+  const parsed = input.map((value) =>
+    reconstructionAttemptRefinementTraceBindingSchema.safeParse(value),
+  )
+  if (parsed.length === 0 || parsed.some((result) => !result.success)) {
+    return false
+  }
+  const bindings = parsed.flatMap((result) =>
+    result.success ? [result.data] : [],
+  )
+  const first = bindings[0]!
+  const policySha256 = hashTraceValue(first.policy)
+  for (const [index, binding] of bindings.entries()) {
+    const previous = bindings[index - 1]
+    if (
+      binding.attemptIndex !== index ||
+      binding.parentTraceSha256 !== (previous?.traceSha256 ?? null) ||
+      binding.sourcePdfSha256 !== first.sourcePdfSha256 ||
+      binding.sourceEvidenceGraphSha256 !==
+        first.sourceEvidenceGraphSha256 ||
+      hashTraceValue(binding.policy) !== policySha256 ||
+      new Set(binding.evidenceCandidateReferences).size !==
+        binding.evidenceCandidateReferences.length ||
+      (binding.terminalStatus === 'publication-ready') !==
+        (binding.firstCause === null) ||
+      binding.usage.refinements > binding.policy.maxRefinements ||
+      binding.usage.refinements !== binding.attemptIndex ||
+      binding.usage.freshTasks > binding.policy.maxFreshTasks ||
+      binding.usage.tokens > binding.policy.maxTokens ||
+      binding.usage.durationMs > binding.policy.maxDurationMs ||
+      (previous !== undefined &&
+        (binding.usage.refinements < previous.usage.refinements ||
+          binding.usage.freshTasks < previous.usage.freshTasks ||
+          binding.usage.tokens < previous.usage.tokens ||
+          binding.usage.durationMs < previous.usage.durationMs))
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Bind the generic bounded-refinement loop to one fully verified trace. */
+export function toRefinementTraceBinding(
+  input: unknown,
+): ReconstructionAttemptRefinementTraceBinding {
+  const trace = parseReconstructionAttemptTrace(input)
+  const firstCause = trace.comparator.firstCauseFailureId
+    ? trace.comparator.failures.find(
+        (failure) => failure.id === trace.comparator.firstCauseFailureId,
+      )
+    : undefined
+  return parseReconstructionAttemptRefinementTraceBinding({
+    traceSha256: trace.traceSha256,
+    sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+    sourceEvidenceGraphSha256: trace.evidenceGraph.artifact.sha256,
+    canonicalStructSha256: trace.structure.artifact.sha256,
+    attemptIndex: trace.lineage.attemptIndex,
+    parentTraceSha256: trace.lineage.parentTraceSha256,
+    terminalStatus: trace.terminalState,
+    firstCause: firstCause
+      ? {
+          failureReferenceSha256: hashTraceValue({
+            kind: 'first-cause',
+            failureId: firstCause.id,
+          }),
+          code: firstCause.check,
+        }
+      : null,
+    evidenceCandidateReferences: trace.evidenceCandidates
+      .map((candidate) => candidate.referenceSha256)
+      .sort(compareCodeUnits),
+    policy: trace.budget.policy,
+    usage: trace.budget.usage,
+  })
+}
+
+export function assertSha256(value: string, label = 'sha256') {
+  if (!sha256Schema.safeParse(value).success) {
+    throw new TypeError(`${label} must be a lowercase SHA-256 digest`)
+  }
+}

--- a/src/research/reconstruction-development-evaluation.test.ts
+++ b/src/research/reconstruction-development-evaluation.test.ts
@@ -1,0 +1,697 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createReconstructionAttemptTrace,
+  hashEpubBytes,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashTraceValue,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+} from './reconstruction-attempt-trace'
+import {
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+import { sha256HexSync } from './sha256-sync'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  serializeSourceEvidenceGraph,
+  type SourceEvidenceGraph,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+import { createSourceEvidenceContract } from './source-evidence-contract'
+import {
+  RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION,
+  createReconstructionDevelopmentEvaluationPolicy,
+  createReconstructionDevelopmentStageVerificationReceipt,
+  verifyReconstructionDevelopmentEvaluationPacket,
+  type OwnerLocalEvaluationArtifact,
+  type ReconstructionDevelopmentEvaluationDocument,
+  type ReconstructionDevelopmentVerificationContext,
+  type ReconstructionDevelopmentVerifierAuthorities,
+} from './reconstruction-development-evaluation'
+
+const encoder = new TextEncoder()
+const jsonBytes = (value: unknown) => encoder.encode(JSON.stringify(value))
+
+function graphFor(sourceBytes: Uint8Array, index: number) {
+  const source = {
+    documentId: `development-document-${index}`,
+    sha256: sha256HexSync(sourceBytes),
+    byteLength: sourceBytes.byteLength,
+    pageCount: 1,
+  }
+  const box = {
+    page: 1,
+    x: 0.1,
+    y: 0.1,
+    width: 0.5,
+    height: 0.05,
+    rotation: 0,
+    method: 'pdf-text' as const,
+  }
+  const providers = [
+    {
+      armId: 'deterministic',
+      id: `pdfjs-provider-${index}`,
+      kind: 'pdfjs' as const,
+      artifactSha256: 'a'.repeat(64),
+    },
+    {
+      armId: 'mineru',
+      id: `mineru-provider-${index}`,
+      kind: 'mineru' as const,
+      artifactSha256: 'b'.repeat(64),
+    },
+  ]
+  const graphInput: Omit<
+    SourceEvidenceGraphInput,
+    'deterministicContext'
+  > = {
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source,
+    arms: providers.map((provider) => ({
+      id: provider.armId,
+      requirement: 'required' as const,
+      status: 'enabled' as const,
+      frozen: true as const,
+      providerId: provider.id,
+    })),
+    bundles: providers.map((provider) => ({
+      schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+      id: `${provider.armId}-bundle-${index}`,
+      armId: provider.armId,
+      source,
+      provider: {
+        id: provider.id,
+        kind: provider.kind,
+        name: provider.kind === 'mineru' ? 'MinerU' : 'pdfjs-dist',
+        version: provider.kind === 'mineru' ? '3.4.4' : '5.4.624',
+      },
+      pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+      artifacts: [
+        {
+          id: `${provider.armId}-artifact-${index}`,
+          providerId: provider.id,
+          kind: 'source-evidence',
+          mediaType: 'application/json',
+          sha256: provider.artifactSha256,
+          byteLength: 32,
+          page: 1,
+          box,
+          sourceIds: [`${provider.armId}-source-${index}`],
+        },
+      ],
+      sources: [
+        {
+          id: `${provider.armId}-source-${index}`,
+          providerId: provider.id,
+          kind: 'text',
+          page: 1,
+          box,
+          artifactIds: [`${provider.armId}-artifact-${index}`],
+          payload: { text: `development source ${index}` },
+        },
+      ],
+      candidates: [
+        {
+          id: `${provider.armId}-candidate-${index}`,
+          providerId: provider.id,
+          kind: 'text',
+          page: 1,
+          boxes: [box],
+          sourceIds: [`${provider.armId}-source-${index}`],
+          artifactIds: [`${provider.armId}-artifact-${index}`],
+          payload: { text: `development source ${index}`, grounded: true },
+        },
+      ],
+    })),
+    obligations: [
+      {
+        id: `source-obligation-${index}`,
+        kind: 'source-text',
+        page: 1,
+        sourceIds: providers.map(
+          ({ armId }) => `${armId}-source-${index}`,
+        ),
+        artifactIds: providers.map(
+          ({ armId }) => `${armId}-artifact-${index}`,
+        ),
+        candidateIds: providers.map(
+          ({ armId }) => `${armId}-candidate-${index}`,
+        ),
+        observationCategories: ['text-exactness'],
+        required: true,
+        semantic: true,
+      },
+    ],
+    disagreements: [],
+  }
+  return buildSourceEvidenceGraph({
+    ...graphInput,
+    deterministicContext: deterministicContextReceiptForBundle(
+      graphInput.bundles[0]!,
+    ),
+  })
+}
+
+function traceFor(input: {
+  graph: SourceEvidenceGraph
+  index: number
+  epubBytes: Uint8Array
+  epubCheckReportBytes: Uint8Array
+  mismatch: boolean
+}) {
+  const { graph, index, epubBytes, epubCheckReportBytes, mismatch } = input
+  const contract = createSourceEvidenceContract(graph, {
+    id: 'source-evidence-verifier',
+    version: '1.0.0',
+    configurationSha256: 'c'.repeat(64),
+    executableSha256: 'd'.repeat(64),
+  })
+  const actualObservationSets = contract.expectedObservationSets.map(
+    ({ check, setSha256, itemCount, payload }) => {
+      const changed = mismatch && check === 'reading-order'
+      const changedPayload = {
+        sha256: sha256HexSync('wrong-reading-order'),
+        byteLength: 1,
+      }
+      const projection = {
+        check,
+        setSha256: changed ? changedPayload.sha256 : setSha256,
+        itemCount,
+        payload: changed ? changedPayload : payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: '0'.repeat(64),
+        }),
+      }
+    },
+  )
+  const epubSha256 = hashEpubBytes(epubBytes)
+  const structSha256 = sha256HexSync(`struct-${index}`)
+  const screenshotSha256 = sha256HexSync(`screenshot-${index}`)
+  const domSha256 = sha256HexSync(`dom-${index}`)
+  const viewport = { width: 100, height: 100, deviceScaleFactor: 1 }
+  const renderedEpub = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+      verificationReceiptSha256: sha256HexSync(`download-${index}`),
+    },
+    sourceObligations: {
+      sourcePdfSha256: graph.source.sha256,
+      ...contract.sourceEvidenceReceipt.sourceObligations,
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'owner-local-renderer',
+      version: '1.0.0',
+      executableSha256: sha256HexSync('renderer-executable'),
+      configurationSha256: sha256HexSync('renderer-configuration'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: domSha256, byteLength: 10 },
+        anchors: [`output-${index}`],
+      },
+    ],
+    screenshots: [
+      {
+        id: `screenshot-${index}`,
+        spineHref: 'EPUB/content.xhtml',
+        domSha256,
+        image: { sha256: screenshotSha256, byteLength: 20 },
+        mediaType: 'image/png' as const,
+        width: 100,
+        height: 100,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: '0'.repeat(64),
+  }
+  renderedEpub.receiptSha256 = hashRenderedEpubEvidence(renderedEpub)
+  const mappings = contract.sourceRegions.map((region, mappingIndex) => ({
+    id: `mapping-${index}-${mappingIndex}`,
+    obligationId: region.id,
+    source: region.source,
+    output: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        anchorId: `output-${index}`,
+        rendered: {
+          screenshotId: `screenshot-${index}`,
+          viewport,
+          rect: { x: 1, y: 1, width: 10, height: 10 },
+        },
+      },
+    ],
+    status: 'mapped' as const,
+  }))
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: sha256HexSync(`observation-${index}-${check}`),
+      check,
+      source: contract.sourceRegions[0]!.source,
+      mappingIds: [mappings[0]!.id],
+      expectedSetReceiptSha256: contract.expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: graph.source.documentId,
+    sourcePdfSha256: graph.source.sha256,
+    artifact: { sha256: structSha256, byteLength: 128 },
+    generatedSha256: sha256HexSync(`generated-${index}`),
+    assets: [],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+    mediaType: 'application/epub+zip' as const,
+    structSha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: sha256HexSync(epubCheckReportBytes),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256: graph.source.sha256,
+    sourceEvidence: contract.sourceEvidenceReceipt,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions: contract.sourceRegions,
+    mappings,
+    observations,
+  })
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256: graph.source.sha256,
+    evidenceGraphSha256: graph.graphSha256,
+    candidateSetSha256: contract.sourceEvidenceReceipt.candidateSetSha256,
+    structSha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  const codexIdentity = {
+    server: {
+      id: 'owner-local-codex-server',
+      version: '1.0.0',
+      transport: 'unix:///private/opaque/codex.sock',
+      executableSha256: sha256HexSync('codex-server'),
+    },
+    model: {
+      id: 'gpt-local-test',
+      version: 'fixture-1',
+      sha256: 'e'.repeat(64),
+    },
+    prompt: {
+      id: 'source-grounded-reconciliation',
+      version: '1.0.0',
+      sha256: sha256HexSync('prompt'),
+    },
+    tool: { id: 'codex-cli', version: '0.146.0' },
+  }
+  return {
+    contract,
+    trace: createReconstructionAttemptTrace({
+      schemaVersion: '1.0.0',
+      attemptId: `attempt-${index}-${mismatch ? 'prior' : 'final'}`,
+      lineage: {
+        attemptIndex: 0,
+        parentTraceSha256: null,
+        immutablePriorTraceSha256: null,
+        appliedRepair: null,
+      },
+      sourcePdf: {
+        artifact: {
+          sha256: graph.source.sha256,
+          byteLength: graph.source.byteLength,
+        },
+        pageCount: 1,
+        pageRenders: [
+          {
+            page: 1,
+            sourcePdfSha256: graph.source.sha256,
+            image: {
+              sha256: sha256HexSync(`source-render-${index}`),
+              byteLength: 20,
+            },
+            mediaType: 'image/png',
+            width: 100,
+            height: 100,
+          },
+        ],
+      },
+      evidenceGraph: {
+        schemaVersion: contract.schemaVersion,
+        artifact: contract.graphArtifact,
+        sourcePdfSha256: graph.source.sha256,
+      },
+      sourceEvidence: contract.sourceEvidenceReceipt,
+      evidenceCandidates: contract.evidenceCandidates,
+      structure,
+      epub,
+      renderedEpub,
+      mappings,
+      comparisonEvidence: {
+        sourceRegions: contract.sourceRegions,
+        observations,
+      },
+      providerReceipts: [
+        {
+          id: 'source-evidence',
+          role: 'source-evidence',
+          required: true,
+          enabledBeforeRun: true,
+          providerId: 'source-evidence-contract',
+          receiptSha256: sha256HexSync('source-receipt'),
+          inputSha256: graph.source.sha256,
+          outputSha256: contract.sourceEvidenceReceipt.receiptSha256,
+          status: 'succeeded',
+        },
+        {
+          id: 'actual-render',
+          role: 'actual-render',
+          required: true,
+          enabledBeforeRun: true,
+          providerId: 'owner-local-renderer',
+          receiptSha256: sha256HexSync('render-receipt'),
+          inputSha256: epubSha256,
+          outputSha256: renderedEpub.receiptSha256,
+          status: 'succeeded',
+        },
+        {
+          id: 'codex-reconciliation',
+          role: 'owner-local-codex-reconciliation',
+          required: true,
+          enabledBeforeRun: true,
+          providerId: 'owner-local-codex-server',
+          identitySha256: hashTraceValue(codexIdentity),
+          receiptSha256: sha256HexSync('codex-receipt'),
+          inputSha256: reconciliationInputSha256,
+          outputSha256: hashTraceValue(comparator),
+          ...codexIdentity,
+          status: 'succeeded',
+        },
+      ],
+      comparator,
+      critiqueRepair: null,
+      budget: {
+        policy: {
+          maxRefinements: 3,
+          maxFreshTasks: 1,
+          maxTokens: 24_000,
+          maxDurationMs: 1_800_000,
+          repairPolicySha256: sha256HexSync('repair-policy'),
+        },
+        usage: { refinements: 0, freshTasks: 0, tokens: 0, durationMs: 0 },
+      },
+      terminalState: mismatch ? 'failed' : 'publication-ready',
+    }),
+  }
+}
+
+function packetFixture() {
+  const store = new Map<string, Uint8Array>()
+  let nextId = 0
+  const retain = (bytes: Uint8Array): OwnerLocalEvaluationArtifact => {
+    const opaqueId = `retained-artifact-${nextId++}`
+    store.set(opaqueId, bytes.slice())
+    return {
+      sha256: sha256HexSync(bytes),
+      byteLength: bytes.byteLength,
+      resolverId: 'owner-local-development-resolver',
+      opaqueId,
+    }
+  }
+  const documents: ReconstructionDevelopmentEvaluationDocument[] = []
+  for (let index = 1; index <= 4; index += 1) {
+    const sourceBytes = encoder.encode(`%PDF-${index}\npublic development input`)
+    const graph = graphFor(sourceBytes, index)
+    const epubBytes = encoder.encode(`PK\u0003\u0004development-epub-${index}`)
+    const epubCheckReportBytes = encoder.encode(
+      `EPUBCheck 5.3.0 PASS document ${index}`,
+    )
+    const prior = traceFor({
+      graph,
+      index,
+      epubBytes,
+      epubCheckReportBytes,
+      mismatch: true,
+    })
+    const final = traceFor({
+      graph,
+      index,
+      epubBytes,
+      epubCheckReportBytes,
+      mismatch: false,
+    })
+    const codexReceipt = {
+      schemaVersion: '1.0.0',
+      status: 'accepted',
+      documentIdSha256: '1'.repeat(64),
+      attemptIdSha256: '2'.repeat(64),
+      isolatedSessionSha256: '3'.repeat(64),
+      graphSha256: graph.graphSha256,
+      candidateSetSha256:
+        prior.contract.sourceEvidenceReceipt.candidateSetSha256,
+      requestSha256: '4'.repeat(64),
+      responseSha256: '5'.repeat(64),
+      selectionSetSha256: '6'.repeat(64),
+      comparisonEvidenceSha256: prior.trace.traceSha256,
+      cropEvidenceSha256: '8'.repeat(64),
+      threadSha256: '9'.repeat(64),
+      turnSha256: 'a'.repeat(64),
+      identities: {
+        endpointSha256: 'b'.repeat(64),
+        serverSha256: 'c'.repeat(64),
+        toolSha256: 'd'.repeat(64),
+        modelSha256: 'e'.repeat(64),
+        promptSha256: 'f'.repeat(64),
+        renderArtifactResolverSha256: '1'.repeat(64),
+        observedModelSha256: '2'.repeat(64),
+      },
+      counts: {
+        decisionCount: 1,
+        candidateCount: 2,
+        renderCount: 2,
+        sourceCropCount: 1,
+        epubCropCount: 1,
+      },
+    }
+    documents.push({
+      idSha256: sha256HexSync(`development-document-${index}`),
+      status: 'passed',
+      sourcePdfSha256: graph.source.sha256,
+      graphSha256: graph.graphSha256,
+      candidateSetSha256:
+        prior.contract.sourceEvidenceReceipt.candidateSetSha256,
+      sourcePdf: retain(sourceBytes),
+      sourceEvidenceGraph: retain(serializeSourceEvidenceGraph(graph)),
+      expectedObservationPayloads: prior.contract.expectedObservationSets.map(
+        ({ check, payloadBytes }) => ({ check, artifact: retain(payloadBytes) }),
+      ),
+      localCodexPriorTrace: retain(jsonBytes(prior.trace)),
+      localCodexReceipt: retain(jsonBytes(codexReceipt)),
+      materializationReceipt: retain(
+        jsonBytes({ verifiedBy: 'exact-external-200-verifier', document: index }),
+      ),
+      epub: retain(epubBytes),
+      epubCheckReport: retain(epubCheckReportBytes),
+      finalAttemptTrace: retain(jsonBytes(final.trace)),
+    })
+  }
+  const calls = {
+    codex: vi.fn(),
+    materialization: vi.fn(),
+    rendered: vi.fn(),
+    epubCheck: vi.fn(),
+  }
+  const authority = (
+    stage:
+      | 'owner-local-codex'
+      | 'grounded-materialization'
+      | 'rendered-epub'
+      | 'epubcheck',
+    spy: (context: ReconstructionDevelopmentVerificationContext) => unknown,
+    predicate: (
+      context: ReconstructionDevelopmentVerificationContext,
+    ) => boolean,
+  ) => {
+    const identity = {
+      id: `${stage}-verifier`,
+      version: '1.0.0',
+      configurationSha256: sha256HexSync(`${stage}-configuration`),
+      executableSha256: sha256HexSync(`${stage}-executable`),
+    }
+    return {
+      identity,
+      verify: async (context: ReconstructionDevelopmentVerificationContext) => {
+        spy(context)
+        return predicate(context)
+          ? createReconstructionDevelopmentStageVerificationReceipt(
+              stage,
+              identity,
+              context,
+            )
+          : { status: 'failed' }
+      },
+    }
+  }
+  const authorities: ReconstructionDevelopmentVerifierAuthorities = {
+    localCodex: authority('owner-local-codex', calls.codex, () => true),
+    groundedMaterialization: authority(
+      'grounded-materialization',
+      calls.materialization,
+      ({ materializationReceiptBytes }) =>
+        new TextDecoder()
+          .decode(materializationReceiptBytes)
+          .includes('exact-external-200-verifier'),
+    ),
+    renderedEpub: authority(
+      'rendered-epub',
+      calls.rendered,
+      ({ finalTrace }) => finalTrace.renderedEpub.screenshots.length > 0,
+    ),
+    epubCheck: authority(
+      'epubcheck',
+      calls.epubCheck,
+      ({ epubCheckReportBytes }) =>
+        new TextDecoder().decode(epubCheckReportBytes).includes('PASS'),
+    ),
+  }
+  return {
+    packet: {
+      schemaVersion: RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION,
+      policy: createReconstructionDevelopmentEvaluationPolicy(authorities),
+      documents,
+    },
+    store,
+    resolver: async (reference: OwnerLocalEvaluationArtifact) =>
+      store.get(reference.opaqueId)?.slice() ?? new Uint8Array(),
+    authorities,
+    calls,
+  }
+}
+
+describe('durable four-document reconstruction development evaluation', () => {
+  it('validates the synthetic verifier-authority contract without claiming tool execution', async () => {
+    const fixture = packetFixture()
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        fixture.packet,
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).resolves.toMatchObject({
+      schemaVersion: '2.0.0',
+      status: 'passed',
+      documentCount: 4,
+    })
+    expect(fixture.calls.codex).toHaveBeenCalledTimes(4)
+    expect(fixture.calls.materialization).toHaveBeenCalledTimes(4)
+    expect(fixture.calls.rendered).toHaveBeenCalledTimes(4)
+    expect(fixture.calls.epubCheck).toHaveBeenCalledTimes(4)
+  })
+
+  it('rejects evaluator authority identity drift from the frozen packet policy', async () => {
+    const fixture = packetFixture()
+    const mutableIdentity = fixture.authorities.renderedEpub.identity as {
+      configurationSha256: string
+    }
+    mutableIdentity.configurationSha256 = sha256HexSync(
+      'drifted-renderer-configuration',
+    )
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        fixture.packet,
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).rejects.toThrow('INVALID_DEVELOPMENT_EVALUATION_VERIFIER_AUTHORITY')
+  })
+
+  it('rejects fabricated #200 materialization despite self-consistent PDF and EPUB shapes', async () => {
+    const fixture = packetFixture()
+    const reference = fixture.packet.documents[0]!.materializationReceipt
+    const fabricated = jsonBytes({
+      schemaVersion: '1.0.0',
+      readyForStruct: true,
+      claim: 'self-hashed but never verified',
+    })
+    reference.sha256 = sha256HexSync(fabricated)
+    reference.byteLength = fabricated.byteLength
+    fixture.store.set(reference.opaqueId, fabricated)
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        fixture.packet,
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).rejects.toThrow('EXTERNAL_VERIFICATION_FAILED')
+  })
+
+  it('rejects a tampered comparator trace even when the retained hash is updated', async () => {
+    const fixture = packetFixture()
+    const reference = fixture.packet.documents[0]!.finalAttemptTrace
+    const trace = JSON.parse(
+      new TextDecoder().decode(fixture.store.get(reference.opaqueId)!),
+    )
+    trace.comparator.status = 'failed'
+    const tampered = jsonBytes(trace)
+    reference.sha256 = sha256HexSync(tampered)
+    reference.byteLength = tampered.byteLength
+    fixture.store.set(reference.opaqueId, tampered)
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        fixture.packet,
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('rejects a provider-only packet and retained source tampering', async () => {
+    const fixture = packetFixture()
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        {
+          schemaVersion: '2.0.0',
+          policy: fixture.packet.policy,
+          documents: fixture.packet.documents.map((document) => ({
+            idSha256: document.idSha256,
+            mineruManifest: document.sourceEvidenceGraph,
+          })),
+        },
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).rejects.toThrow('INVALID_DEVELOPMENT_EVALUATION_DOCUMENT')
+
+    const source = fixture.packet.documents[0]!.sourcePdf
+    fixture.store.set(source.opaqueId, encoder.encode('%PDF-tampered'))
+    await expect(
+      verifyReconstructionDevelopmentEvaluationPacket(
+        fixture.packet,
+        fixture.resolver,
+        fixture.authorities,
+      ),
+    ).rejects.toThrow('ARTIFACT_IDENTITY_MISMATCH')
+  })
+})

--- a/src/research/reconstruction-development-evaluation.ts
+++ b/src/research/reconstruction-development-evaluation.ts
@@ -1,0 +1,700 @@
+import {
+  hashTraceValue,
+  parseCanonicalObservationPayloadBytes,
+  parseReconstructionAttemptTrace,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  type ReconstructionAttemptTrace,
+} from './reconstruction-attempt-trace'
+import { compareSourceToRenderedEpub } from './source-epub-comparator'
+import { sha256HexSync } from './sha256-sync'
+import {
+  buildSourceEvidenceGraph,
+  readSourceEvidenceGraph,
+  type SourceEvidenceGraph,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+
+export const RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION =
+  '2.0.0' as const
+
+const SHA256 = /^[a-f0-9]{64}$/u
+const OPAQUE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/u
+const MAX_ARTIFACT_BYTES = 128 * 1024 * 1024
+const MAX_PACKET_BYTES = 512 * 1024 * 1024
+
+export type OwnerLocalEvaluationArtifact = {
+  sha256: string
+  byteLength: number
+  resolverId: string
+  opaqueId: string
+}
+
+export type ReconstructionDevelopmentEvaluationDocument = {
+  idSha256: string
+  status: 'passed' | 'failed'
+  sourcePdfSha256: string
+  graphSha256: string
+  candidateSetSha256: string
+  sourcePdf: OwnerLocalEvaluationArtifact
+  sourceEvidenceGraph: OwnerLocalEvaluationArtifact
+  expectedObservationPayloads: Array<{
+    check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number]
+    artifact: OwnerLocalEvaluationArtifact
+  }>
+  localCodexPriorTrace: OwnerLocalEvaluationArtifact
+  localCodexReceipt: OwnerLocalEvaluationArtifact
+  materializationReceipt: OwnerLocalEvaluationArtifact
+  epub: OwnerLocalEvaluationArtifact
+  epubCheckReport: OwnerLocalEvaluationArtifact
+  finalAttemptTrace: OwnerLocalEvaluationArtifact
+}
+
+export type ReconstructionDevelopmentEvaluationPacket = {
+  schemaVersion: typeof RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION
+  policy: ReconstructionDevelopmentEvaluationPolicy
+  documents: ReconstructionDevelopmentEvaluationDocument[]
+}
+
+export type OwnerLocalEvaluationArtifactResolver = (
+  artifact: OwnerLocalEvaluationArtifact,
+) => Promise<Uint8Array>
+
+export type ReconstructionDevelopmentVerificationContext = Readonly<{
+  document: ReconstructionDevelopmentEvaluationDocument
+  sourcePdfBytes: Uint8Array
+  graph: SourceEvidenceGraph
+  expectedObservationPayloadBytes: ReadonlyMap<string, Uint8Array>
+  priorTrace: ReconstructionAttemptTrace
+  localCodexReceiptBytes: Uint8Array
+  materializationReceiptBytes: Uint8Array
+  epubBytes: Uint8Array
+  epubCheckReportBytes: Uint8Array
+  finalTrace: ReconstructionAttemptTrace
+}>
+
+export const RECONSTRUCTION_DEVELOPMENT_VERIFICATION_STAGES = [
+  'owner-local-codex',
+  'grounded-materialization',
+  'rendered-epub',
+  'epubcheck',
+] as const
+
+export type ReconstructionDevelopmentVerificationStage =
+  (typeof RECONSTRUCTION_DEVELOPMENT_VERIFICATION_STAGES)[number]
+
+export type ReconstructionDevelopmentVerifierIdentity = Readonly<{
+  id: string
+  version: string
+  configurationSha256: string
+  executableSha256: string
+}>
+
+export type ReconstructionDevelopmentStageVerificationReceipt = Readonly<{
+  schemaVersion: '1.0.0'
+  stage: ReconstructionDevelopmentVerificationStage
+  verifierIdentity: ReconstructionDevelopmentVerifierIdentity
+  verifierIdentitySha256: string
+  requestSha256: string
+  status: 'succeeded'
+  receiptSha256: string
+}>
+
+export type ReconstructionDevelopmentVerifierAuthority = Readonly<{
+  identity: ReconstructionDevelopmentVerifierIdentity
+  verify: (
+    context: ReconstructionDevelopmentVerificationContext,
+  ) => Promise<unknown>
+}>
+
+/** Frozen production trust boundaries; none accepts a self-attested receipt. */
+export type ReconstructionDevelopmentVerifierAuthorities = Readonly<{
+  localCodex: ReconstructionDevelopmentVerifierAuthority
+  groundedMaterialization: ReconstructionDevelopmentVerifierAuthority
+  renderedEpub: ReconstructionDevelopmentVerifierAuthority
+  epubCheck: ReconstructionDevelopmentVerifierAuthority
+}>
+
+export type ReconstructionDevelopmentEvaluationPolicy = Readonly<{
+  schemaVersion: '1.0.0'
+  verifierIdentities: Readonly<{
+    localCodex: ReconstructionDevelopmentVerifierIdentity
+    groundedMaterialization: ReconstructionDevelopmentVerifierIdentity
+    renderedEpub: ReconstructionDevelopmentVerifierIdentity
+    epubCheck: ReconstructionDevelopmentVerifierIdentity
+  }>
+  policySha256: string
+}>
+
+function invalid(code: string): never {
+  throw new Error(code)
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]) {
+  const actual = Object.keys(value).sort()
+  const expected = [...keys].sort()
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  )
+}
+
+function artifact(value: unknown): OwnerLocalEvaluationArtifact {
+  if (
+    !record(value) ||
+    !exactKeys(value, ['sha256', 'byteLength', 'resolverId', 'opaqueId']) ||
+    !SHA256.test(String(value.sha256)) ||
+    !Number.isSafeInteger(value.byteLength) ||
+    (value.byteLength as number) <= 0 ||
+    (value.byteLength as number) > MAX_ARTIFACT_BYTES ||
+    !OPAQUE_ID.test(String(value.resolverId)) ||
+    !OPAQUE_ID.test(String(value.opaqueId))
+  ) {
+    invalid('INVALID_DEVELOPMENT_EVALUATION_ARTIFACT')
+  }
+  return {
+    sha256: value.sha256 as string,
+    byteLength: value.byteLength as number,
+    resolverId: value.resolverId as string,
+    opaqueId: value.opaqueId as string,
+  }
+}
+
+function parseJson(bytes: Uint8Array, code: string) {
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes))
+  } catch {
+    invalid(code)
+  }
+}
+
+async function reopen(
+  reference: OwnerLocalEvaluationArtifact,
+  resolver: OwnerLocalEvaluationArtifactResolver,
+) {
+  const bytes = await resolver(reference)
+  if (
+    !(bytes instanceof Uint8Array) ||
+    bytes.byteLength !== reference.byteLength ||
+    sha256HexSync(bytes) !== reference.sha256
+  ) {
+    invalid('DEVELOPMENT_EVALUATION_ARTIFACT_IDENTITY_MISMATCH')
+  }
+  return bytes
+}
+
+function parseCodexReceipt(
+  value: unknown,
+  context: {
+    graphSha256: string
+    candidateSetSha256: string
+    priorTraceSha256: string
+  },
+) {
+  if (
+    !record(value) ||
+    !exactKeys(value, [
+      'schemaVersion',
+      'status',
+      'documentIdSha256',
+      'attemptIdSha256',
+      'isolatedSessionSha256',
+      'graphSha256',
+      'candidateSetSha256',
+      'requestSha256',
+      'responseSha256',
+      'selectionSetSha256',
+      'comparisonEvidenceSha256',
+      'cropEvidenceSha256',
+      'threadSha256',
+      'turnSha256',
+      'identities',
+      'counts',
+    ]) ||
+    value.schemaVersion !== '1.0.0' ||
+    value.status !== 'accepted' ||
+    value.graphSha256 !== context.graphSha256 ||
+    value.candidateSetSha256 !== context.candidateSetSha256 ||
+    value.comparisonEvidenceSha256 !== context.priorTraceSha256 ||
+    [
+      value.documentIdSha256,
+      value.attemptIdSha256,
+      value.isolatedSessionSha256,
+      value.requestSha256,
+      value.responseSha256,
+      value.selectionSetSha256,
+      value.cropEvidenceSha256,
+      value.threadSha256,
+      value.turnSha256,
+    ].some((digest) => !SHA256.test(String(digest))) ||
+    !record(value.identities) ||
+    !exactKeys(value.identities, [
+      'endpointSha256',
+      'serverSha256',
+      'toolSha256',
+      'modelSha256',
+      'promptSha256',
+      'renderArtifactResolverSha256',
+      'observedModelSha256',
+    ]) ||
+    Object.values(value.identities).some(
+      (digest) => !SHA256.test(String(digest)),
+    ) ||
+    !record(value.counts) ||
+    !exactKeys(value.counts, [
+      'decisionCount',
+      'candidateCount',
+      'renderCount',
+      'sourceCropCount',
+      'epubCropCount',
+    ]) ||
+    Object.values(value.counts).some(
+      (count) => !Number.isSafeInteger(count) || Number(count) < 1,
+    )
+  ) {
+    invalid('DEVELOPMENT_EVALUATION_CODEX_BINDING_MISMATCH')
+  }
+}
+
+function recompare(trace: ReconstructionAttemptTrace) {
+  return compareSourceToRenderedEpub({
+    sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+    sourceEvidence: trace.sourceEvidence,
+    structure: trace.structure,
+    epub: trace.epub,
+    renderedEpub: trace.renderedEpub,
+    sourceRegions: trace.comparisonEvidence.sourceRegions,
+    mappings: trace.mappings,
+    observations: trace.comparisonEvidence.observations,
+  })
+}
+
+function verifierRequestSha256(
+  stage: ReconstructionDevelopmentVerificationStage,
+  context: ReconstructionDevelopmentVerificationContext,
+) {
+  return hashTraceValue({
+    stage,
+    documentIdSha256: context.document.idSha256,
+    sourcePdfSha256: context.document.sourcePdfSha256,
+    graphSha256: context.document.graphSha256,
+    candidateSetSha256: context.document.candidateSetSha256,
+    priorTraceSha256: context.priorTrace.traceSha256,
+    localCodexReceiptSha256: context.document.localCodexReceipt.sha256,
+    materializationReceiptSha256:
+      context.document.materializationReceipt.sha256,
+    epubSha256: context.document.epub.sha256,
+    epubCheckReportSha256: context.document.epubCheckReport.sha256,
+    finalTraceSha256: context.finalTrace.traceSha256,
+  })
+}
+
+export function createReconstructionDevelopmentStageVerificationReceipt(
+  stage: ReconstructionDevelopmentVerificationStage,
+  identity: ReconstructionDevelopmentVerifierIdentity,
+  context: ReconstructionDevelopmentVerificationContext,
+): ReconstructionDevelopmentStageVerificationReceipt {
+  const base = {
+    schemaVersion: '1.0.0' as const,
+    stage,
+    verifierIdentity: structuredClone(identity),
+    verifierIdentitySha256: hashTraceValue(identity),
+    requestSha256: verifierRequestSha256(stage, context),
+    status: 'succeeded' as const,
+  }
+  return Object.freeze({ ...base, receiptSha256: hashTraceValue(base) })
+}
+
+export function createReconstructionDevelopmentEvaluationPolicy(
+  authorities: ReconstructionDevelopmentVerifierAuthorities,
+): ReconstructionDevelopmentEvaluationPolicy {
+  const base = {
+    schemaVersion: '1.0.0' as const,
+    verifierIdentities: {
+      localCodex: structuredClone(authorities.localCodex.identity),
+      groundedMaterialization: structuredClone(
+        authorities.groundedMaterialization.identity,
+      ),
+      renderedEpub: structuredClone(authorities.renderedEpub.identity),
+      epubCheck: structuredClone(authorities.epubCheck.identity),
+    },
+  }
+  return Object.freeze({ ...base, policySha256: hashTraceValue(base) })
+}
+
+function parseEvaluationPolicy(
+  value: unknown,
+): ReconstructionDevelopmentEvaluationPolicy {
+  if (
+    !record(value) ||
+    !exactKeys(value, ['schemaVersion', 'verifierIdentities', 'policySha256']) ||
+    value.schemaVersion !== '1.0.0' ||
+    !record(value.verifierIdentities) ||
+    !exactKeys(value.verifierIdentities, [
+      'localCodex',
+      'groundedMaterialization',
+      'renderedEpub',
+      'epubCheck',
+    ]) ||
+    !SHA256.test(String(value.policySha256))
+  ) {
+    invalid('INVALID_DEVELOPMENT_EVALUATION_POLICY')
+  }
+  for (const identity of Object.values(value.verifierIdentities)) {
+    if (
+      !record(identity) ||
+      !exactKeys(identity, [
+        'id',
+        'version',
+        'configurationSha256',
+        'executableSha256',
+      ]) ||
+      !OPAQUE_ID.test(String(identity.id)) ||
+      !OPAQUE_ID.test(String(identity.version)) ||
+      !SHA256.test(String(identity.configurationSha256)) ||
+      !SHA256.test(String(identity.executableSha256))
+    ) {
+      invalid('INVALID_DEVELOPMENT_EVALUATION_POLICY')
+    }
+  }
+  const { policySha256, ...base } = value
+  if (policySha256 !== hashTraceValue(base)) {
+    invalid('INVALID_DEVELOPMENT_EVALUATION_POLICY')
+  }
+  return structuredClone(value) as ReconstructionDevelopmentEvaluationPolicy
+}
+
+async function invokeAuthority(
+  stage: ReconstructionDevelopmentVerificationStage,
+  authority: ReconstructionDevelopmentVerifierAuthority,
+  pinnedIdentity: ReconstructionDevelopmentVerifierIdentity,
+  context: ReconstructionDevelopmentVerificationContext,
+) {
+  if (
+    !record(authority) ||
+    !exactKeys(authority, ['identity', 'verify']) ||
+    !record(authority.identity) ||
+    !exactKeys(authority.identity, [
+      'id',
+      'version',
+      'configurationSha256',
+      'executableSha256',
+    ]) ||
+    !OPAQUE_ID.test(String(authority.identity.id)) ||
+    !OPAQUE_ID.test(String(authority.identity.version)) ||
+    !SHA256.test(String(authority.identity.configurationSha256)) ||
+    !SHA256.test(String(authority.identity.executableSha256)) ||
+    typeof authority.verify !== 'function' ||
+    hashTraceValue(authority.identity) !== hashTraceValue(pinnedIdentity)
+  ) {
+    invalid('INVALID_DEVELOPMENT_EVALUATION_VERIFIER_AUTHORITY')
+  }
+  const receipt = await authority.verify(context)
+  if (
+    !record(receipt) ||
+    !exactKeys(receipt, [
+      'schemaVersion',
+      'stage',
+      'verifierIdentity',
+      'verifierIdentitySha256',
+      'requestSha256',
+      'status',
+      'receiptSha256',
+    ]) ||
+    receipt.schemaVersion !== '1.0.0' ||
+    receipt.stage !== stage ||
+    receipt.status !== 'succeeded' ||
+    hashTraceValue(receipt.verifierIdentity) !==
+      hashTraceValue(authority.identity) ||
+    receipt.verifierIdentitySha256 !== hashTraceValue(authority.identity) ||
+    receipt.requestSha256 !== verifierRequestSha256(stage, context)
+  ) {
+    invalid('DEVELOPMENT_EVALUATION_EXTERNAL_VERIFICATION_FAILED')
+  }
+  const { receiptSha256, ...base } = receipt
+  if (
+    !SHA256.test(String(receiptSha256)) ||
+    receiptSha256 !== hashTraceValue(base)
+  ) {
+    invalid('DEVELOPMENT_EVALUATION_EXTERNAL_VERIFICATION_FAILED')
+  }
+}
+
+export async function verifyReconstructionDevelopmentEvaluationPacket(
+  input: unknown,
+  resolver: OwnerLocalEvaluationArtifactResolver,
+  authorities: ReconstructionDevelopmentVerifierAuthorities,
+) {
+  if (
+    !record(input) ||
+    !exactKeys(input, ['schemaVersion', 'policy', 'documents']) ||
+    input.schemaVersion !==
+      RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION ||
+    !Array.isArray(input.documents) ||
+    input.documents.length !== 4 ||
+    typeof resolver !== 'function' ||
+    !record(authorities) ||
+    !exactKeys(authorities, [
+      'localCodex',
+      'groundedMaterialization',
+      'renderedEpub',
+      'epubCheck',
+    ])
+  ) {
+    invalid('INVALID_DEVELOPMENT_EVALUATION_PACKET')
+  }
+  const policy = parseEvaluationPolicy(input.policy)
+  const parsed: ReconstructionDevelopmentEvaluationDocument[] =
+    input.documents.map((value) => {
+      if (
+        !record(value) ||
+        !exactKeys(value, [
+          'idSha256',
+          'status',
+          'sourcePdfSha256',
+          'graphSha256',
+          'candidateSetSha256',
+          'sourcePdf',
+          'sourceEvidenceGraph',
+          'expectedObservationPayloads',
+          'localCodexPriorTrace',
+          'localCodexReceipt',
+          'materializationReceipt',
+          'epub',
+          'epubCheckReport',
+          'finalAttemptTrace',
+        ]) ||
+        !SHA256.test(String(value.idSha256)) ||
+        !['passed', 'failed'].includes(String(value.status)) ||
+        !SHA256.test(String(value.sourcePdfSha256)) ||
+        !SHA256.test(String(value.graphSha256)) ||
+        !SHA256.test(String(value.candidateSetSha256)) ||
+        !Array.isArray(value.expectedObservationPayloads) ||
+        value.expectedObservationPayloads.length !==
+          SOURCE_EPUB_OBSERVATION_CHECK_IDS.length
+      ) {
+        invalid('INVALID_DEVELOPMENT_EVALUATION_DOCUMENT')
+      }
+      const expectedObservationPayloads =
+        value.expectedObservationPayloads.map((entry) => {
+          if (
+            !record(entry) ||
+            !exactKeys(entry, ['check', 'artifact']) ||
+            !SOURCE_EPUB_OBSERVATION_CHECK_IDS.includes(
+              entry.check as (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+            )
+          ) {
+            invalid('INVALID_DEVELOPMENT_EVALUATION_EXPECTED_SET')
+          }
+          return {
+            check:
+              entry.check as (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+            artifact: artifact(entry.artifact),
+          }
+        })
+      if (
+        new Set(expectedObservationPayloads.map(({ check }) => check)).size !==
+        SOURCE_EPUB_OBSERVATION_CHECK_IDS.length
+      ) {
+        invalid('INVALID_DEVELOPMENT_EVALUATION_EXPECTED_SET')
+      }
+      return {
+        idSha256: value.idSha256 as string,
+        status: value.status as 'passed' | 'failed',
+        sourcePdfSha256: value.sourcePdfSha256 as string,
+        graphSha256: value.graphSha256 as string,
+        candidateSetSha256: value.candidateSetSha256 as string,
+        sourcePdf: artifact(value.sourcePdf),
+        sourceEvidenceGraph: artifact(value.sourceEvidenceGraph),
+        expectedObservationPayloads,
+        localCodexPriorTrace: artifact(value.localCodexPriorTrace),
+        localCodexReceipt: artifact(value.localCodexReceipt),
+        materializationReceipt: artifact(value.materializationReceipt),
+        epub: artifact(value.epub),
+        epubCheckReport: artifact(value.epubCheckReport),
+        finalAttemptTrace: artifact(value.finalAttemptTrace),
+      }
+    })
+  if (
+    new Set(parsed.map(({ idSha256 }) => idSha256)).size !== 4 ||
+    new Set(parsed.map(({ sourcePdfSha256 }) => sourcePdfSha256)).size !== 4
+  ) {
+    invalid('DEVELOPMENT_EVALUATION_REQUIRES_FOUR_UNIQUE_DOCUMENTS')
+  }
+  const totalBytes = parsed
+    .flatMap((document) => [
+      document.sourcePdf,
+      document.sourceEvidenceGraph,
+      ...document.expectedObservationPayloads.map(({ artifact }) => artifact),
+      document.localCodexPriorTrace,
+      document.localCodexReceipt,
+      document.materializationReceipt,
+      document.epub,
+      document.epubCheckReport,
+      document.finalAttemptTrace,
+    ])
+    .reduce((total, value) => total + value.byteLength, 0)
+  if (totalBytes > MAX_PACKET_BYTES) {
+    invalid('DEVELOPMENT_EVALUATION_PACKET_TOO_LARGE')
+  }
+
+  for (const document of parsed) {
+    const sourcePdfBytes = await reopen(document.sourcePdf, resolver)
+    if (
+      sha256HexSync(sourcePdfBytes) !== document.sourcePdfSha256 ||
+      new TextDecoder().decode(sourcePdfBytes.slice(0, 5)) !== '%PDF-'
+    ) {
+      invalid('DEVELOPMENT_EVALUATION_SOURCE_PDF_MISMATCH')
+    }
+    const graphBytes = await reopen(document.sourceEvidenceGraph, resolver)
+    const graph = buildSourceEvidenceGraph(
+      parseJson(graphBytes, 'INVALID_DEVELOPMENT_EVALUATION_GRAPH') as
+        SourceEvidenceGraphInput,
+    )
+    const reader = readSourceEvidenceGraph(graph)
+    if (
+      reader.graphSha256 !== document.graphSha256 ||
+      reader.source.sha256 !== document.sourcePdfSha256
+    ) {
+      invalid('DEVELOPMENT_EVALUATION_GRAPH_BINDING_MISMATCH')
+    }
+    const expectedObservationPayloadBytes = new Map<string, Uint8Array>()
+    for (const expected of document.expectedObservationPayloads) {
+      const bytes = await reopen(expected.artifact, resolver)
+      const payload = parseCanonicalObservationPayloadBytes(bytes)
+      if (payload.check !== expected.check) {
+        invalid('DEVELOPMENT_EVALUATION_EXPECTED_SET_MISMATCH')
+      }
+      expectedObservationPayloadBytes.set(expected.check, bytes)
+    }
+    const priorTrace = parseReconstructionAttemptTrace(
+      parseJson(
+        await reopen(document.localCodexPriorTrace, resolver),
+        'INVALID_DEVELOPMENT_EVALUATION_PRIOR_TRACE',
+      ),
+    )
+    const finalTrace = parseReconstructionAttemptTrace(
+      parseJson(
+        await reopen(document.finalAttemptTrace, resolver),
+        'INVALID_DEVELOPMENT_EVALUATION_FINAL_TRACE',
+      ),
+    )
+    for (const trace of [priorTrace, finalTrace]) {
+      if (trace.sourcePdf.artifact.sha256 !== document.sourcePdfSha256)
+        invalid('DEVELOPMENT_EVALUATION_TRACE_SOURCE_MISMATCH')
+      if (trace.evidenceGraph.sourcePdfSha256 !== document.sourcePdfSha256)
+        invalid('DEVELOPMENT_EVALUATION_TRACE_GRAPH_SOURCE_MISMATCH')
+      if (trace.sourceEvidence.evidenceGraphSha256 !== document.graphSha256)
+        invalid('DEVELOPMENT_EVALUATION_TRACE_GRAPH_MISMATCH')
+      if (
+        trace.sourceEvidence.candidateSetSha256 !== document.candidateSetSha256
+      )
+        invalid('DEVELOPMENT_EVALUATION_TRACE_CANDIDATE_SET_MISMATCH')
+      if (
+        trace.evidenceGraph.artifact.sha256 !==
+          document.graphSha256 ||
+        trace.evidenceGraph.artifact.byteLength !== graphBytes.byteLength
+      ) {
+        invalid('DEVELOPMENT_EVALUATION_GRAPH_ARTIFACT_MISMATCH')
+      }
+      if (
+        hashTraceValue(recompare(trace)) !== hashTraceValue(trace.comparator)
+      ) {
+        invalid('DEVELOPMENT_EVALUATION_COMPARATOR_REPLAY_MISMATCH')
+      }
+      for (const expected of trace.sourceEvidence.expectedObservationSets) {
+        const payloadBytes = expectedObservationPayloadBytes.get(expected.check)
+        if (
+          !payloadBytes ||
+          expected.payload.sha256 !== sha256HexSync(payloadBytes) ||
+          expected.payload.byteLength !== payloadBytes.byteLength
+        ) {
+          invalid('DEVELOPMENT_EVALUATION_EXPECTED_SET_MISMATCH')
+        }
+      }
+    }
+    if (
+      priorTrace.terminalState !== 'failed' ||
+      priorTrace.comparator.status !== 'failed' ||
+      finalTrace.epub.bytes.sha256 !== document.epub.sha256 ||
+      finalTrace.epub.bytes.byteLength !== document.epub.byteLength ||
+      finalTrace.epub.epubCheck.reportSha256 !==
+        document.epubCheckReport.sha256 ||
+      finalTrace.epub.epubCheck.status !== 'passed' ||
+      (document.status === 'passed') !==
+        (finalTrace.terminalState === 'publication-ready' &&
+          finalTrace.comparator.status === 'publication-ready')
+    ) {
+      invalid('DEVELOPMENT_EVALUATION_FINAL_BINDING_MISMATCH')
+    }
+    const localCodexReceiptBytes = await reopen(
+      document.localCodexReceipt,
+      resolver,
+    )
+    parseCodexReceipt(
+      parseJson(
+        localCodexReceiptBytes,
+        'INVALID_DEVELOPMENT_EVALUATION_CODEX_RECEIPT',
+      ),
+      {
+        graphSha256: document.graphSha256,
+        candidateSetSha256: document.candidateSetSha256,
+        priorTraceSha256: priorTrace.traceSha256,
+      },
+    )
+    const context: ReconstructionDevelopmentVerificationContext =
+      Object.freeze({
+        document,
+        sourcePdfBytes,
+        graph,
+        expectedObservationPayloadBytes,
+        priorTrace,
+        localCodexReceiptBytes,
+        materializationReceiptBytes: await reopen(
+          document.materializationReceipt,
+          resolver,
+        ),
+        epubBytes: await reopen(document.epub, resolver),
+        epubCheckReportBytes: await reopen(document.epubCheckReport, resolver),
+        finalTrace,
+      })
+    await invokeAuthority(
+      'owner-local-codex',
+      authorities.localCodex,
+      policy.verifierIdentities.localCodex,
+      context,
+    )
+    await invokeAuthority(
+      'grounded-materialization',
+      authorities.groundedMaterialization,
+      policy.verifierIdentities.groundedMaterialization,
+      context,
+    )
+    await invokeAuthority(
+      'rendered-epub',
+      authorities.renderedEpub,
+      policy.verifierIdentities.renderedEpub,
+      context,
+    )
+    await invokeAuthority(
+      'epubcheck',
+      authorities.epubCheck,
+      policy.verifierIdentities.epubCheck,
+      context,
+    )
+  }
+  return Object.freeze({
+    schemaVersion: RECONSTRUCTION_DEVELOPMENT_EVALUATION_SCHEMA_VERSION,
+    status: parsed.every(({ status }) => status === 'passed')
+      ? ('passed' as const)
+      : ('failed' as const),
+    documentCount: 4,
+    policySha256: policy.policySha256,
+    sourcePdfSha256s: Object.freeze(
+      parsed.map(({ sourcePdfSha256 }) => sourcePdfSha256),
+    ),
+  })
+}

--- a/src/research/reconstruction-refinement.test.ts
+++ b/src/research/reconstruction-refinement.test.ts
@@ -1,0 +1,1510 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+  createReconstructionAttemptTrace,
+  encodeCanonicalObservationPayload,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  type ReconstructionAttemptTraceCore,
+  type ReconstructionAttemptTrace,
+  type RenderedEpubEvidence,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+import {
+  createReconstructionCandidateBinding,
+  createReconstructionCandidateContract,
+  createStructEvidencePatch,
+  deriveStructRepairProjections,
+  parseMaterializedRepairApplicationReceipt,
+  reconstructionRefinementHash,
+  replayPrivateRefinementRun,
+  replayRefinementRun,
+  runReconstructionRefinement,
+  type MaterializedRepairApplicationReceipt,
+  type MaterializationVerificationAuthorities,
+  type OwnerLocalCodexIdentity,
+  type OwnerLocalArtifactResolutionRequest,
+  type OwnerLocalArtifactResolver,
+  type PrivateReplayAuthorities,
+  type ReconstructionCandidate,
+  type ReconstructionCandidateContract,
+  type RefinementRunReceipt,
+  type StructEvidencePatch,
+} from './reconstruction-refinement'
+
+const digest = (value: string | Uint8Array) => sha256HexSync(value)
+const sourcePdfSha256 = digest('source-pdf')
+const sourceEvidenceGraphSha256 = digest('source-evidence-graph')
+const candidateReferenceSha256 = digest('provider-neutral-candidate-reference')
+const source = {
+  page: 1,
+  boxes: [{ page: 1, x: 10, y: 20, width: 100, height: 80, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+const sourceRegions = [{ id: 'region-1', source }]
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const mappings = [
+  {
+    id: 'mapping-1',
+    obligationId: 'obligation-1',
+    source,
+    output: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        anchorId: 'struct-paragraph-1',
+        rendered: {
+          screenshotId: 'screenshot-1',
+          viewport,
+          rect: { x: 10, y: 20, width: 100, height: 80 },
+        },
+      },
+    ],
+    status: 'mapped' as const,
+  },
+]
+
+function observationPayloadBytes(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  return encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-paragraph-1'],
+    })),
+  })
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = observationPayloadBytes(check, labels)
+  return { sha256: digest(bytes), byteLength: bytes.byteLength }
+}
+
+const identity: OwnerLocalCodexIdentity = {
+  server: {
+    id: 'owner-local-codex-server',
+    version: '2026.08.1',
+    transport: 'http://127.0.0.1:4500/v1',
+    executableSha256: digest('codex-server'),
+  },
+  model: {
+    id: 'gpt-5.6-sol',
+    version: '2026-08-01',
+    sha256: digest('codex-model'),
+  },
+  prompt: {
+    id: 'reconstruction-first-cause-repair',
+    version: '1.0.0',
+    sha256: digest('prompt'),
+  },
+  tool: { id: 'codex', version: '0.99.0' },
+}
+const verifierIdentity = {
+  id: 'owner-local-grounded-verifier',
+  version: '2026.08.1',
+  configurationSha256: digest('verifier-configuration'),
+  executableSha256: digest('verifier-executable'),
+}
+const artifactResolverIdentity = {
+  id: 'owner-local-artifact-resolver',
+  version: '2026.08.1',
+  configurationSha256: digest('artifact-resolver-configuration'),
+}
+const sourceEvidenceVerifierIdentity = {
+  id: 'source-evidence-verifier',
+  version: '198.1.0',
+  configurationSha256: digest('source-evidence-verifier-configuration'),
+  executableSha256: digest('source-evidence-verifier-executable'),
+}
+const renderObservationExtractorIdentity = {
+  id: 'render-observation-extractor',
+  version: '1.0.0',
+  configurationSha256: digest('render-observation-configuration'),
+  executableSha256: digest('render-observation-executable'),
+}
+
+function contract(
+  budget: Partial<ReconstructionCandidateContract['budget']> = {},
+) {
+  return createReconstructionCandidateContract({
+    schemaVersion: '1.0.0',
+    runId: 'run-document-a',
+    documentId: 'document-a',
+    sourcePdfSha256,
+    sourceEvidenceGraph: {
+      schemaVersion: '1.0.0',
+      sha256: sourceEvidenceGraphSha256,
+    },
+    authorities: {
+      codex: {
+        identity,
+        identitySha256: hashTraceValue(identity),
+      },
+      groundedVerifier: {
+        identity: verifierIdentity,
+        identitySha256: hashTraceValue(verifierIdentity),
+      },
+      artifactResolver: {
+        identity: artifactResolverIdentity,
+        identitySha256: hashTraceValue(artifactResolverIdentity),
+      },
+      sourceEvidenceVerifier: {
+        identity: sourceEvidenceVerifierIdentity,
+        identitySha256: hashTraceValue(sourceEvidenceVerifierIdentity),
+      },
+      renderObservationExtractor: {
+        identity: renderObservationExtractorIdentity,
+        identitySha256: hashTraceValue(renderObservationExtractorIdentity),
+      },
+    },
+    budget: {
+      maxRefinements: 1,
+      maxFreshTasks: 1,
+      maxTokens: 1_000,
+      maxDurationMs: 10_000,
+      repairPolicySha256: digest('repair-policy'),
+      ...budget,
+    },
+    repairScope: [
+      {
+        targetKind: 'relationship',
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256s: [candidateReferenceSha256],
+      },
+    ],
+  })
+}
+
+function initialCandidate(): ReconstructionCandidate {
+  const canonicalStructBytes = new TextEncoder().encode(
+    '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"unresolved"}]}',
+  )
+  return {
+    binding: createReconstructionCandidateBinding({
+      schemaVersion: '1.0.0',
+      sourcePdfSha256,
+      sourceEvidenceGraphSha256,
+      canonicalStruct: {
+        sha256: digest(canonicalStructBytes),
+        byteLength: canonicalStructBytes.byteLength,
+      },
+      selections: [],
+    }),
+    canonicalStructBytes,
+  }
+}
+
+function renderer(
+  epubSha256: string,
+  actualObservationSets: RenderedEpubEvidence['actualObservationSets'],
+): RenderedEpubEvidence {
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const evidence: RenderedEpubEvidence = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: 4 },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1.0.0',
+      executableSha256: digest('chromium'),
+      configurationSha256: digest('render-configuration'),
+    },
+    domSnapshots: [
+      {
+        spineHref: 'EPUB/content.xhtml',
+        dom: { sha256: digest('dom'), byteLength: 3 },
+        anchors: ['struct-paragraph-1'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screenshot-1',
+        spineHref: 'EPUB/content.xhtml',
+        domSha256: digest('dom'),
+        image: { sha256: digest('screenshot'), byteLength: 10 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+    receiptSha256: digest('pending-render-receipt'),
+  }
+  evidence.receiptSha256 = hashRenderedEpubEvidence(evidence)
+  return evidence
+}
+
+function attemptTrace(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+  usage: ReconstructionAttemptTraceCore['budget']['usage'],
+  terminalState: 'failed' | 'publication-ready' = 'failed',
+) {
+  const epubSha256 = digest('epub')
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures' ? ['source-figure'] : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashSourceExpectedObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-expected-set'),
+        }),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const labels =
+        check === 'figures'
+          ? terminalState === 'failed'
+            ? []
+            : ['source-figure']
+          : [`value-${check}`]
+      const payload = observationPayload(check, labels)
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount:
+          terminalState === 'failed' && check === 'figures' ? 0 : 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashRenderedActualObservationSet({
+          ...projection,
+          receiptSha256: digest('pending-actual-set'),
+        }),
+      }
+    },
+  )
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256,
+    evidenceGraphSha256: sourceEvidenceGraphSha256,
+    candidateSetSha256: hashTraceValue([
+      {
+        referenceSha256: candidateReferenceSha256,
+        bindingSha256: digest('candidate-binding'),
+      },
+    ]),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashTraceValue(sourceEvidenceWithoutReceipt),
+  }
+  const renderedEpub = renderer(epubSha256, actualObservationSets)
+  const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+    createDeterministicObservationReceipt({
+      idSha256: digest(`observation-${check}`),
+      check,
+      source,
+      mappingIds: ['mapping-1'],
+      expectedSetReceiptSha256: expectedObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+      actualSetReceiptSha256: actualObservationSets.find(
+        (set) => set.check === check,
+      )!.receiptSha256,
+    }),
+  )
+  const structure = {
+    schemaVersion: '0.2.0',
+    documentId: candidateContract.documentId,
+    sourcePdfSha256,
+    artifact: candidate.binding.canonicalStruct,
+    generatedSha256: digest('generated-struct'),
+    assets: [],
+  }
+  const epub = {
+    bytes: { sha256: epubSha256, byteLength: 4 },
+    mediaType: 'application/epub+zip' as const,
+    structSha256: structure.artifact.sha256,
+    epubCheck: {
+      toolId: 'epubcheck',
+      toolVersion: '5.3.0',
+      reportSha256: digest('epubcheck-report'),
+      status: 'passed' as const,
+      errorCount: 0,
+      warningCount: 0,
+    },
+  }
+  const comparator = compareSourceToRenderedEpub({
+    sourcePdfSha256,
+    sourceEvidence,
+    structure,
+    epub,
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations,
+  })
+  const evidenceCandidates = [
+    {
+      referenceSha256: candidateReferenceSha256,
+      bindingSha256: digest('candidate-binding'),
+    },
+  ]
+  const reconciliationInputSha256 = hashTraceValue({
+    sourcePdfSha256,
+    evidenceGraphSha256: sourceEvidenceGraphSha256,
+    candidateSetSha256: sourceEvidence.candidateSetSha256,
+    structSha256: structure.artifact.sha256,
+    epubSha256,
+    renderObservationReceiptSha256: renderedEpub.receiptSha256,
+  })
+  return createReconstructionAttemptTrace({
+    schemaVersion: RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
+    attemptId: 'attempt-document-a-0',
+    lineage: {
+      attemptIndex: 0,
+      parentTraceSha256: null,
+      immutablePriorTraceSha256: null,
+      appliedRepair: null,
+    },
+    sourcePdf: {
+      artifact: { sha256: sourcePdfSha256, byteLength: 1_000 },
+      pageCount: 1,
+      pageRenders: [
+        {
+          page: 1,
+          sourcePdfSha256,
+          image: { sha256: digest('source-page-1'), byteLength: 500 },
+          mediaType: 'image/png',
+          width: 600,
+          height: 800,
+        },
+      ],
+    },
+    evidenceGraph: {
+      schemaVersion: '1.0.0',
+      artifact: {
+        sha256: sourceEvidenceGraphSha256,
+        byteLength: new TextEncoder().encode('source-evidence-graph').byteLength,
+      },
+      sourcePdfSha256,
+    },
+    sourceEvidence,
+    evidenceCandidates,
+    structure,
+    epub,
+    renderedEpub,
+    mappings,
+    comparisonEvidence: { sourceRegions, observations },
+    providerReceipts: [
+      {
+        id: 'provider-source-evidence',
+        role: 'source-evidence',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'provider-neutral-evidence-adapter',
+        receiptSha256: digest('provider-source-receipt'),
+        inputSha256: sourcePdfSha256,
+        outputSha256: sourceEvidence.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-actual-render',
+        role: 'actual-render',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: 'owner-local-chromium',
+        receiptSha256: digest('provider-render-receipt'),
+        inputSha256: epubSha256,
+        outputSha256: renderedEpub.receiptSha256,
+        status: 'succeeded',
+      },
+      {
+        id: 'provider-codex-reconciliation',
+        role: 'owner-local-codex-reconciliation',
+        required: true,
+        enabledBeforeRun: true,
+        providerId: identity.server.id,
+        identitySha256: hashTraceValue(identity),
+        receiptSha256: digest('provider-codex-reconciliation-receipt'),
+        inputSha256: reconciliationInputSha256,
+        outputSha256: hashTraceValue(comparator),
+        prompt: identity.prompt,
+        tool: identity.tool,
+        model: identity.model,
+        server: identity.server,
+        status: 'succeeded',
+      },
+    ],
+    comparator,
+    critiqueRepair: null,
+    budget: { policy: candidateContract.budget, usage },
+    terminalState,
+  })
+}
+
+function patchFor(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+): StructEvidencePatch {
+  return createStructEvidencePatch({
+    schemaVersion: '1.0.0',
+    documentId: candidateContract.documentId,
+    sourcePdfSha256,
+    sourceEvidenceGraphSha256,
+    baseStructSha256: candidate.binding.canonicalStruct.sha256,
+    priorTraceSha256: digest('prior-trace'),
+    taskIdSha256: digest('fresh-task'),
+    operations: [
+      {
+        op: 'select-evidence-candidate',
+        targetKind: 'relationship',
+        targetId: 'figure-relationship-1',
+        candidateReferenceSha256,
+      },
+    ],
+  })
+}
+
+function applicationFor(
+  candidateContract: ReconstructionCandidateContract,
+  candidate: ReconstructionCandidate,
+  proposal: StructEvidencePatch,
+  resultingStructJson =
+    '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"resolved"}]}',
+) {
+  const resultingCanonicalStructBytes = new TextEncoder().encode(
+    resultingStructJson,
+  )
+  const resultingCanonicalStruct = {
+    sha256: digest(resultingCanonicalStructBytes),
+    byteLength: resultingCanonicalStructBytes.byteLength,
+  }
+  const beforeProjections = deriveStructRepairProjections(
+    candidate.canonicalStructBytes,
+    proposal.operations,
+  )
+  const resultingProjections = deriveStructRepairProjections(
+    resultingCanonicalStructBytes,
+    proposal.operations,
+  )
+  const operationTargetSetSha256 = hashTraceValue(
+    proposal.operations.map(({ targetKind, targetId }) => ({
+      targetKind,
+      targetId,
+    })),
+  )
+  const candidateReferenceSetSha256 = hashTraceValue(
+    proposal.operations.map(({ candidateReferenceSha256: reference }) =>
+      reference,
+    ),
+  )
+  const candidateBindingSha256 = digest('candidate-binding')
+  const candidatePayloadBytes = new TextEncoder().encode(
+    '{"selectedStatus":"resolved"}',
+  )
+  const candidatePayload = {
+    sha256: digest(candidatePayloadBytes),
+    byteLength: candidatePayloadBytes.byteLength,
+  }
+  const candidateRequest = {
+    schemaVersion: '1.0.0' as const,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    referenceSha256: candidateReferenceSha256,
+    bindingSha256: candidateBindingSha256,
+  }
+  const candidateResolutionProjection = {
+    schemaVersion: '1.0.0' as const,
+    verifierIdentity: sourceEvidenceVerifierIdentity,
+    verifierIdentitySha256: hashTraceValue(sourceEvidenceVerifierIdentity),
+    requestSha256: hashTraceValue(candidateRequest),
+    referenceSha256: candidateReferenceSha256,
+    bindingSha256: candidateBindingSha256,
+    payload: candidatePayload,
+    status: 'succeeded' as const,
+  }
+  const candidateResolution = {
+    ...candidateResolutionProjection,
+    payloadBytes: candidatePayloadBytes,
+    receiptSha256: hashTraceValue(candidateResolutionProjection),
+  }
+  const candidatePayloadSetSha256 = hashTraceValue([
+    {
+      ...candidateResolution,
+      payloadBytes: undefined,
+    },
+  ].map(({ payloadBytes: _payloadBytes, ...value }) => value))
+  const groundingRequestProjection = {
+    schemaVersion: '1.0.0' as const,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: candidate.binding.canonicalStruct,
+    resultingCanonicalStruct,
+    beforeSelectedProjection: beforeProjections.selected,
+    resultingSelectedProjection: resultingProjections.selected,
+    candidatePayloads: [candidateResolution].map(
+      ({ payloadBytes: _payloadBytes, ...value }) => value,
+    ),
+  }
+  const groundedProjection = {
+    schemaVersion: '1.0.0' as const,
+    verifierIdentity,
+    verifierIdentitySha256:
+      candidateContract.authorities.groundedVerifier.identitySha256,
+    sourceEvidenceGraphSha256: candidateContract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operationTargetSetSha256,
+    candidateReferenceSetSha256,
+    candidatePayloadSetSha256,
+    beforeStructSha256: candidate.binding.canonicalStruct.sha256,
+    resultingStructSha256: resultingCanonicalStruct.sha256,
+    beforeSelectedProjectionSha256: beforeProjections.selected.sha256,
+    beforeUnselectedProjectionSha256: beforeProjections.unselected.sha256,
+    resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+    resultingUnselectedProjectionSha256:
+      resultingProjections.unselected.sha256,
+    inputSha256: hashTraceValue(groundingRequestProjection),
+    outputSha256: hashTraceValue({
+      resultingStructSha256: resultingCanonicalStruct.sha256,
+      resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+      resultingUnselectedProjectionSha256:
+        resultingProjections.unselected.sha256,
+    }),
+    status: 'succeeded' as const,
+  }
+  const unchangedProjection = {
+    schemaVersion: '1.0.0' as const,
+    beforeSha256: beforeProjections.unselected.sha256,
+    afterSha256: resultingProjections.unselected.sha256,
+  }
+  const groundedVerifier = {
+    ...groundedProjection,
+    receiptSha256: hashTraceValue(groundedProjection),
+  }
+  const unchangedUnselected = {
+    ...unchangedProjection,
+    receiptSha256: hashTraceValue(unchangedProjection),
+  }
+  const projection = {
+    schemaVersion: '1.0.0' as const,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: candidate.binding.canonicalStruct,
+    beforeSelectedProjection: beforeProjections.selected,
+    beforeUnselectedProjection: beforeProjections.unselected,
+    resultingCanonicalStruct,
+    resultingSelectedProjection: resultingProjections.selected,
+    resultingUnselectedProjection: resultingProjections.unselected,
+    groundedVerifier,
+    unchangedUnselected,
+  }
+  const application: MaterializedRepairApplicationReceipt = {
+    ...projection,
+    beforeCanonicalStructBytes: candidate.canonicalStructBytes,
+    resultingCanonicalStructBytes,
+    receiptSha256: hashTraceValue(projection),
+  }
+  const authorities: MaterializationVerificationAuthorities = {
+    evidenceCandidates: [
+      {
+        referenceSha256: candidateReferenceSha256,
+        bindingSha256: candidateBindingSha256,
+      },
+    ],
+    sourceEvidenceVerifier: {
+      identity: sourceEvidenceVerifierIdentity,
+      verifyExpected: () => {
+        throw new Error('expected-source verification is not used here')
+      },
+      resolveCandidate: () => candidateResolution,
+    },
+    groundedVerifier: {
+      identity: verifierIdentity,
+      verifySelected: () => groundedVerifier,
+    },
+  }
+  return { application, authorities }
+}
+
+function artifactResolver(
+  mutate?: (
+    request: OwnerLocalArtifactResolutionRequest,
+    bytes: Uint8Array,
+  ) => Uint8Array | null,
+): OwnerLocalArtifactResolver {
+  return {
+    identity: artifactResolverIdentity,
+    resolve: (request) => {
+      const source =
+        request.kind === 'epub-download'
+          ? 'epub'
+          : request.kind === 'dom-snapshot'
+            ? 'dom'
+            : 'screenshot'
+      const originalBytes = new TextEncoder().encode(source)
+      const bytes = mutate ? mutate(request, originalBytes) : originalBytes
+      if (bytes === null) return null
+      const projection = {
+        schemaVersion: '1.0.0' as const,
+        resolverIdentity: artifactResolverIdentity,
+        resolverIdentitySha256: hashTraceValue(artifactResolverIdentity),
+        requestSha256: hashTraceValue(request),
+        artifact: request.artifact,
+        status: 'succeeded' as const,
+      }
+      return {
+        ...projection,
+        bytes,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  }
+}
+
+function privateReplayAuthorities(
+  trace: ReconstructionAttemptTrace,
+  mode?: 'lying-source-count' | 'lying-render-count' | 'unrelated-render',
+  resolvedArtifacts = artifactResolver(),
+): PrivateReplayAuthorities {
+  return {
+    artifactResolver: resolvedArtifacts,
+    sourceEvidenceVerifier: {
+      identity: sourceEvidenceVerifierIdentity,
+      verifyExpected: (request) => {
+        const expectedObservationSets =
+          trace.sourceEvidence.expectedObservationSets.map((set, index) => {
+            const labels =
+              set.check === 'figures'
+                ? ['source-figure']
+                : [`value-${set.check}`]
+            let payloadBytes = observationPayloadBytes(set.check, labels)
+            let verifiedSet = { ...set, payloadBytes }
+            if (mode === 'lying-source-count' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 1,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashSourceExpectedObservationSet(verifiedSet)
+            }
+            return verifiedSet
+          })
+        const projection = {
+          schemaVersion: '1.0.0' as const,
+          verifierIdentity: sourceEvidenceVerifierIdentity,
+          verifierIdentitySha256: hashTraceValue(
+            sourceEvidenceVerifierIdentity,
+          ),
+          requestSha256: hashTraceValue(request),
+          evidenceGraph: trace.evidenceGraph.artifact,
+          expectedObservationSets: expectedObservationSets.map(
+            ({ payloadBytes: _payloadBytes, ...set }) => set,
+          ),
+          status: 'succeeded' as const,
+        }
+        return {
+          ...projection,
+          evidenceGraphBytes: new TextEncoder().encode(
+            'source-evidence-graph',
+          ),
+          expectedObservationSets,
+          receiptSha256: hashTraceValue(projection),
+        }
+      },
+      resolveCandidate: () => {
+        throw new Error('candidate resolution is not used by this replay')
+      },
+    },
+    renderObservationExtractor: {
+      identity: renderObservationExtractorIdentity,
+      extract: (request) => {
+        const actualObservationSets =
+          trace.renderedEpub.actualObservationSets.map((set, index) => {
+            const labels =
+              set.itemCount === 0
+                ? []
+                : set.check === 'figures'
+                  ? ['source-figure']
+                  : [`value-${set.check}`]
+            let payloadBytes = observationPayloadBytes(set.check, labels)
+            let verifiedSet = { ...set, payloadBytes }
+            if (mode === 'lying-render-count' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 1,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashRenderedActualObservationSet(verifiedSet)
+            } else if (mode === 'unrelated-render' && index === 0) {
+              payloadBytes = observationPayloadBytes(set.check, [])
+              const payload = {
+                sha256: digest(payloadBytes),
+                byteLength: payloadBytes.byteLength,
+              }
+              verifiedSet = {
+                ...set,
+                setSha256: payload.sha256,
+                itemCount: 0,
+                payload,
+                payloadBytes,
+              }
+              verifiedSet.receiptSha256 =
+                hashRenderedActualObservationSet(verifiedSet)
+            }
+            return verifiedSet
+          })
+        const requestProjection = {
+          ...request,
+          artifacts: request.artifacts.map(
+            ({ bytes: _bytes, ...artifact }) => artifact,
+          ),
+        }
+        const anchorInventorySha256 = hashTraceValue(
+          trace.renderedEpub.domSnapshots
+            .map(({ spineHref, anchors }) => ({
+              spineHref,
+              anchors: [...anchors].sort(),
+            }))
+            .sort((left, right) =>
+              left.spineHref.localeCompare(right.spineHref),
+            ),
+        )
+        const projection = {
+          schemaVersion: '1.0.0' as const,
+          extractorIdentity: renderObservationExtractorIdentity,
+          extractorIdentitySha256: hashTraceValue(
+            renderObservationExtractorIdentity,
+          ),
+          requestSha256: hashTraceValue(requestProjection),
+          anchorInventorySha256,
+          actualObservationSets: actualObservationSets.map(
+            ({ payloadBytes: _payloadBytes, ...set }) => set,
+          ),
+          status: 'succeeded' as const,
+        }
+        return {
+          ...projection,
+          actualObservationSets,
+          receiptSha256: hashTraceValue(projection),
+        }
+      },
+    },
+    groundedVerifier: {
+      identity: verifierIdentity,
+      verifySelected: () => {
+        throw new Error('selected grounding is not used without applications')
+      },
+    },
+  }
+}
+
+describe('bounded reconstruction refinement', () => {
+  it('rejects a malformed runtime contract before budget access', async () => {
+    const result = await runReconstructionRefinement({
+      contract: { budget: null } as unknown as ReconstructionCandidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {} as never,
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      status: 'failed',
+      failureCode: 'invalid-candidate-contract',
+    })
+  })
+
+  it('rejects public garbage without inspecting events', () => {
+    expect(replayRefinementRun(null)).toBe(false)
+    expect(replayRefinementRun({ events: null })).toBe(false)
+    expect(replayRefinementRun({ events: 'private-source-text' })).toBe(false)
+  })
+
+  it('rejects a coordinator client identity mismatch before evaluation', async () => {
+    const candidateContract = contract()
+    const evaluate = vi.fn(async () => {
+      throw new Error('must not evaluate with a drifted Codex client')
+    })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => {
+          throw new Error('must not materialize')
+        },
+        codex: {
+          identity: {
+            ...identity,
+            model: { ...identity.model, version: '2026-08-02' },
+          },
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(result.publicReceipt.failureCode).toBe('codex-identity-mismatch')
+    expect(evaluate).not.toHaveBeenCalled()
+  })
+
+  it('maps malformed unknown Codex output to a failed receipt without materialization', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const materializeRepair = vi.fn(async () => {
+      throw new Error('must not materialize malformed output')
+    })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(candidateContract, candidate, context.usage),
+        materializeRepair,
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async (request) => ({
+            taskIdSha256: digest('fresh-task'),
+            documentId: candidateContract.documentId,
+            runId: candidateContract.runId,
+            fresh: true,
+            parentTaskId: null,
+            contextPolicy: 'immutable-prior-trace-only',
+            acceptedTraceSha256: request.priorTraceSha256,
+            identity,
+          }),
+          proposeRepair: async () => ({ proposal: null, usage: 'not-usage' }),
+        },
+      },
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      status: 'failed',
+      failureCode: 'invalid-repair-proposal',
+    })
+    expect(materializeRepair).not.toHaveBeenCalled()
+  })
+
+  it('rejects an internally consistent invented public success receipt', () => {
+    const candidateContract = contract()
+    const traceSha256 = digest('invented-trace')
+    const projection: Omit<RefinementRunReceipt, 'receiptSha256'> = {
+      schemaVersion: '1.0.0',
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      contractSha256: candidateContract.contractSha256,
+      status: 'publication-ready',
+      failureCode: null,
+      attempts: [
+        {
+          traceSha256,
+          sourcePdfSha256,
+          sourceEvidenceGraphSha256,
+          canonicalStructSha256: digest('invented-struct'),
+          attemptIndex: 0,
+          parentTraceSha256: null,
+          terminalStatus: 'publication-ready',
+          firstCause: null,
+          evidenceCandidateReferences: [candidateReferenceSha256],
+          policy: candidateContract.budget,
+          usage: {
+            refinements: 0,
+            freshTasks: 0,
+            tokens: 0,
+            durationMs: 0,
+          },
+        },
+      ],
+      proposalSha256s: [],
+      freshTaskCount: 0,
+      refinementCount: 0,
+      usage: { inputTokens: 0, outputTokens: 0, elapsedMs: 0 },
+      events: [
+        {
+          sequence: 0,
+          kind: 'server-verified',
+          attemptIndex: 0,
+          taskIdentitySha256: digest('invented-codex-identity'),
+        },
+        {
+          sequence: 1,
+          kind: 'rendered-and-compared',
+          attemptIndex: 0,
+          traceSha256,
+        },
+        {
+          sequence: 2,
+          kind: 'publication-ready',
+          attemptIndex: 0,
+          traceSha256,
+        },
+      ],
+    }
+    const receipt: RefinementRunReceipt = {
+      ...projection,
+      receiptSha256: reconstructionRefinementHash(projection),
+    }
+
+    expect(replayRefinementRun(receipt)).toBe(false)
+  })
+
+  it('accepts a closed grounded materialization receipt and rejects a fully rehashed whole-document replacement', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+    const { application, authorities } = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+    )
+
+    expect(
+      parseMaterializedRepairApplicationReceipt(
+        application,
+        candidate,
+        proposal,
+        candidateContract,
+        authorities,
+      ),
+    ).toEqual(application)
+
+    const tamperedFixture = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+      '{"assets":[],"blocks":[{"id":"unselected-replacement"}],"relationships":[{"id":"figure-relationship-1","status":"resolved"}]}',
+    )
+    const tampered = tamperedFixture.application
+    const unchangedProjection = {
+      schemaVersion: '1.0.0' as const,
+      beforeSha256: tampered.beforeUnselectedProjection.sha256,
+      afterSha256: tampered.beforeUnselectedProjection.sha256,
+    }
+    tampered.unchangedUnselected = {
+      ...unchangedProjection,
+      receiptSha256: hashTraceValue(unchangedProjection),
+    }
+    const { receiptSha256: _receiptSha256, ...tamperedProjection } = tampered
+    delete (tamperedProjection as Partial<typeof tamperedProjection>)
+      .beforeCanonicalStructBytes
+    delete (tamperedProjection as Partial<typeof tamperedProjection>)
+      .resultingCanonicalStructBytes
+    tampered.receiptSha256 = hashTraceValue(tamperedProjection)
+
+    expect(() =>
+      parseMaterializedRepairApplicationReceipt(
+        tampered,
+        candidate,
+        proposal,
+        candidateContract,
+        tamperedFixture.authorities,
+      ),
+    ).toThrow(/INVALID_MATERIALIZED/iu)
+  })
+
+  it('rejects self-hashed copied verifier identity over hallucinated selected JSON', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+    const trusted = applicationFor(candidateContract, candidate, proposal)
+    const hallucinated = applicationFor(
+      candidateContract,
+      candidate,
+      proposal,
+      '{"assets":[],"blocks":[],"relationships":[{"id":"figure-relationship-1","status":"hallucinated"}]}',
+    )
+
+    expect(() =>
+      parseMaterializedRepairApplicationReceipt(
+        hallucinated.application,
+        candidate,
+        proposal,
+        candidateContract,
+        trusted.authorities,
+      ),
+    ).toThrow(/INVALID_MATERIALIZED/iu)
+  })
+
+  it('reopens and rehashes private EPUB, DOM, and screenshot artifacts before replay', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(
+            candidateContract,
+            candidate,
+            context.usage,
+            'publication-ready',
+          ),
+        materializeRepair: async () => {
+          throw new Error('publication-ready must not materialize')
+        },
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(result.publicReceipt).toMatchObject({
+      status: 'publication-ready',
+      failureCode: null,
+    })
+    expect(
+      replayPrivateRefinementRun(
+        candidateContract,
+        result,
+        privateReplayAuthorities(result.privateEvidence.traces[0]!),
+      ),
+    ).toBe(true)
+
+    for (const kind of [
+      'epub-download',
+      'dom-snapshot',
+      'screenshot',
+    ] as const) {
+      expect(
+        replayPrivateRefinementRun(
+          candidateContract,
+          result,
+          privateReplayAuthorities(
+            result.privateEvidence.traces[0]!,
+            undefined,
+            artifactResolver((request) =>
+              request.kind === kind
+                ? new TextEncoder().encode(`tampered-${kind}`)
+                : new TextEncoder().encode(
+                    request.kind === 'epub-download'
+                      ? 'epub'
+                      : request.kind === 'dom-snapshot'
+                        ? 'dom'
+                        : 'screenshot',
+                  ),
+            ),
+          ),
+        ),
+      ).toBe(false)
+    }
+    expect(
+      replayPrivateRefinementRun(
+        candidateContract,
+        result,
+        privateReplayAuthorities(
+          result.privateEvidence.traces[0]!,
+          undefined,
+          artifactResolver((request, bytes) =>
+            request.kind === 'epub-download' ? null : bytes,
+          ),
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects lying source or render counts and observations derived from unrelated DOM', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate: async (_candidate, context) =>
+          attemptTrace(
+            candidateContract,
+            candidate,
+            context.usage,
+            'publication-ready',
+          ),
+        materializeRepair: async () => {
+          throw new Error('publication-ready must not materialize')
+        },
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    const trace = result.privateEvidence.traces[0]!
+
+    for (const mode of [
+      'lying-source-count',
+      'lying-render-count',
+      'unrelated-render',
+    ] as const) {
+      expect(
+        replayPrivateRefinementRun(
+          candidateContract,
+          result,
+          privateReplayAuthorities(trace, mode),
+        ),
+      ).toBe(false)
+    }
+  })
+
+  it('enforces the coordinator deadline across the initial Codex probe', async () => {
+    const candidateContract = contract({ maxDurationMs: 5 })
+    const result = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: initialCandidate(),
+      dependencies: {
+        evaluate: async () => {
+          throw new Error('must not evaluate after a timed-out probe')
+        },
+        materializeRepair: async () => {
+          throw new Error('must not materialize after a timed-out probe')
+        },
+        codex: {
+          identity,
+          probe: async (signal, lease) =>
+            new Promise(() => {
+              signal.addEventListener(
+                'abort',
+                () => lease.acknowledgeAbort(),
+                { once: true },
+              )
+            }),
+          createFreshTask: async () => {
+            throw new Error('must not create a task after a timed-out probe')
+          },
+          proposeRepair: async () => {
+            throw new Error('must not propose after a timed-out probe')
+          },
+        },
+      },
+    })
+
+    expect(result.publicReceipt.failureCode).toBe('codex-probe-timeout')
+  })
+
+  it('fences a concurrent duplicate run without invoking a second coordinator', async () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const firstController = new AbortController()
+    let blockedLease: import('./reconstruction-refinement').CoordinatorStageLease | undefined
+    let releaseProbe: (() => void) | undefined
+    const evaluate = vi.fn(async () => {
+      throw new Error('a blocked probe must not evaluate')
+    })
+    const first = runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      signal: firstController.signal,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async (_signal, lease) =>
+            new Promise((resolve) => {
+              blockedLease = lease
+              releaseProbe = () => resolve({ available: true })
+            }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    const duplicate = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async () => ({ available: true }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+
+    expect(duplicate.publicReceipt.failureCode).toBe('concurrent-run')
+    expect(duplicate.privateEvidence.traces).toEqual([])
+    expect(evaluate).not.toHaveBeenCalled()
+    firstController.abort()
+    expect((await first).publicReceipt.failureCode).toBe('interrupted')
+    expect(blockedLease!.tryCommit()).toBe(false)
+
+    const stillFenced = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async () => ({ available: false }),
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    expect(stillFenced.publicReceipt.failureCode).toBe('concurrent-run')
+
+    const priorGenerationSha256 = blockedLease!.generationSha256
+    releaseProbe!()
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    let retryGenerationSha256: string | undefined
+    const retry = await runReconstructionRefinement({
+      contract: candidateContract,
+      initialCandidate: candidate,
+      dependencies: {
+        evaluate,
+        materializeRepair: async () => null,
+        codex: {
+          identity,
+          probe: async (_signal, lease) => {
+            retryGenerationSha256 = lease.generationSha256
+            return { available: false }
+          },
+          createFreshTask: async () => null,
+          proposeRepair: async () => null,
+        },
+      },
+    })
+    expect(retry.publicReceipt.failureCode).toBe('codex-server-unavailable')
+    expect(retryGenerationSha256).not.toBe(priorGenerationSha256)
+  })
+
+  it.each([
+    ['evaluate', 'evaluation-timeout'],
+    ['createFreshTask', 'fresh-task-timeout'],
+    ['proposeRepair', 'repair-proposal-timeout'],
+    ['materialize', 'repair-application-timeout'],
+  ] as const)(
+    'uses the cumulative deadline for %s and ignores its late result',
+    async (stage, expectedFailureCode) => {
+      vi.useFakeTimers()
+      try {
+        const candidateContract = contract({ maxDurationMs: 50 })
+        const candidate = initialCandidate()
+        let lateLease: import('./reconstruction-refinement').CoordinatorStageLease | undefined
+        let releaseLateResult: (() => void) | undefined
+        const lateResult = new Promise<unknown>((resolve) => {
+          releaseLateResult = () => resolve(null)
+        })
+        const run = runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async (_candidate, context) => {
+              if (stage === 'evaluate') {
+                lateLease = context.lease
+                return lateResult as Promise<ReconstructionAttemptTrace>
+              }
+              return attemptTrace(candidateContract, candidate, context.usage)
+            },
+            materializeRepair: async (_candidate, _proposal, _signal, lease) => {
+              if (stage === 'materialize') {
+                lateLease = lease
+                return lateResult
+              }
+              return null
+            },
+            codex: {
+              identity,
+              probe: async () => ({ available: true }),
+              createFreshTask: async (request, _signal, lease) => {
+                if (stage === 'createFreshTask') {
+                  lateLease = lease
+                  return lateResult
+                }
+                return {
+                      taskIdSha256: digest('fresh-task'),
+                      documentId: candidateContract.documentId,
+                      runId: candidateContract.runId,
+                      fresh: true,
+                      parentTaskId: null,
+                      contextPolicy: 'immutable-prior-trace-only',
+                      acceptedTraceSha256: request.priorTraceSha256,
+                      identity,
+                    }
+              },
+              proposeRepair: async (request, _signal, lease) => {
+                if (stage === 'proposeRepair') {
+                  lateLease = lease
+                  return lateResult
+                }
+                return {
+                      proposal: createStructEvidencePatch({
+                        schemaVersion: '1.0.0',
+                        documentId: candidateContract.documentId,
+                        sourcePdfSha256,
+                        sourceEvidenceGraphSha256,
+                        baseStructSha256:
+                          candidate.binding.canonicalStruct.sha256,
+                        priorTraceSha256: request.priorTraceSha256,
+                        taskIdSha256: request.task.taskIdSha256,
+                        operations: [
+                          {
+                            op: 'select-evidence-candidate',
+                            targetKind: 'relationship',
+                            targetId: 'figure-relationship-1',
+                            candidateReferenceSha256,
+                          },
+                        ],
+                      }),
+                      usage: {
+                        inputTokens: 1,
+                        outputTokens: 1,
+                        elapsedMs: 1,
+                      },
+                    }
+              },
+            },
+          },
+        })
+
+        await vi.advanceTimersByTimeAsync(51)
+        const result = await run
+        expect(result.publicReceipt.failureCode).toBe(expectedFailureCode)
+        const frozenResultSha256 = hashTraceValue(result.publicReceipt)
+        expect(lateLease!.tryCommit()).toBe(false)
+
+        const duplicate = await runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async () => {
+              throw new Error('fenced duplicate must not evaluate')
+            },
+            materializeRepair: async () => null,
+            codex: {
+              identity,
+              probe: async () => ({ available: false }),
+              createFreshTask: async () => null,
+              proposeRepair: async () => null,
+            },
+          },
+        })
+        expect(duplicate.publicReceipt.failureCode).toBe('concurrent-run')
+
+        const expiredGenerationSha256 = lateLease!.generationSha256
+        releaseLateResult!()
+        await vi.runAllTimersAsync()
+        expect(hashTraceValue(result.publicReceipt)).toBe(frozenResultSha256)
+        expect(result.privateEvidence.applications).toEqual([])
+        if (stage === 'evaluate') {
+          expect(result.privateEvidence.traces).toEqual([])
+        } else if (stage === 'createFreshTask') {
+          expect(result.publicReceipt.freshTaskCount).toBe(0)
+        } else if (stage === 'proposeRepair') {
+          expect(result.publicReceipt.proposalSha256s).toEqual([])
+        } else {
+          expect(result.publicReceipt.refinementCount).toBe(0)
+        }
+
+        let retryGenerationSha256: string | undefined
+        const retry = await runReconstructionRefinement({
+          contract: candidateContract,
+          initialCandidate: candidate,
+          dependencies: {
+            evaluate: async () => {
+              throw new Error('unavailable retry must not evaluate')
+            },
+            materializeRepair: async () => null,
+            codex: {
+              identity,
+              probe: async (_signal, lease) => {
+                retryGenerationSha256 = lease.generationSha256
+                return { available: false }
+              },
+              createFreshTask: async () => null,
+              proposeRepair: async () => null,
+            },
+          },
+        })
+        expect(retry.publicReceipt.failureCode).toBe(
+          'codex-server-unavailable',
+        )
+        expect(retryGenerationSha256).not.toBe(expiredGenerationSha256)
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
+
+  it('keeps candidate references provider-neutral and opaque', () => {
+    const candidateContract = contract()
+    const candidate = initialCandidate()
+    const proposal = patchFor(candidateContract, candidate)
+
+    expect(candidateContract.repairScope[0]!.candidateReferenceSha256s).toEqual(
+      [candidateReferenceSha256],
+    )
+    expect(proposal.operations[0]!.candidateReferenceSha256).toBe(
+      candidateReferenceSha256,
+    )
+    expect(JSON.stringify({ candidateContract, proposal })).not.toMatch(
+      /mineru|candidateId|privateSource/iu,
+    )
+  })
+})

--- a/src/research/reconstruction-refinement.ts
+++ b/src/research/reconstruction-refinement.ts
@@ -1,0 +1,2939 @@
+import { z } from 'zod'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET,
+  canonicalTraceJson,
+  hashTraceValue,
+  parseCanonicalObservationPayloadBytes,
+  parseStructEvidencePatch,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  structEvidencePatchOperationSchema,
+  parseReconstructionAttemptTrace,
+  parseReconstructionAttemptTraceLineage,
+  toRefinementTraceBinding,
+  validateReconstructionAttemptRefinementTraceBindingLineage,
+  type HashedArtifact,
+  type RenderedActualObservationSet,
+  type ReconstructionAttemptBudget,
+  type ReconstructionAttemptRefinementTraceBinding,
+  type ReconstructionAttemptTrace,
+  type StructEvidencePatch,
+  type StructEvidencePatchOperation,
+  type SourceExpectedObservationSet,
+} from './reconstruction-attempt-trace'
+import { compareSourceToRenderedEpub } from './source-epub-comparator'
+
+export const RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION = '1.0.0' as const
+export const STRUCT_EVIDENCE_PATCH_SCHEMA_VERSION = '1.0.0' as const
+
+export const DEFAULT_RECONSTRUCTION_REFINEMENT_BUDGET =
+  RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u
+const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/+\-]{0,191}$/u
+const PLACEHOLDER_IDENTITY_PATTERN =
+  /(?:^|[._:@/+\-])(demo|dummy|fake|fixture|mock|placeholder|recorded-stub|sample|stub|synthetic|test|unknown)(?:$|[._:@/+\-])/iu
+
+export type ReconstructionRefinementBudget =
+  ReconstructionAttemptBudget['policy']
+
+export type StructRepairTargetKind = 'block' | 'asset' | 'relationship'
+
+export type StructRepairScope = {
+  targetKind: StructRepairTargetKind
+  targetId: string
+  candidateReferenceSha256s: string[]
+}
+
+export type ReconstructionCandidateContract = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  runId: string
+  documentId: string
+  sourcePdfSha256: string
+  sourceEvidenceGraph: {
+    schemaVersion: string
+    sha256: string
+  }
+  authorities: {
+    codex: {
+      identity: OwnerLocalCodexIdentity
+      identitySha256: string
+    }
+    groundedVerifier: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+    artifactResolver: {
+      identity: OwnerLocalArtifactResolverIdentity
+      identitySha256: string
+    }
+    sourceEvidenceVerifier: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+    renderObservationExtractor: {
+      identity: GroundedVerifierIdentity
+      identitySha256: string
+    }
+  }
+  budget: ReconstructionRefinementBudget
+  repairScope: StructRepairScope[]
+  contractSha256: string
+}
+
+export type { StructEvidencePatch, StructEvidencePatchOperation }
+
+export type ReconstructionCandidateBinding = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  sourcePdfSha256: string
+  sourceEvidenceGraphSha256: string
+  canonicalStruct: HashedArtifact
+  selections: StructEvidencePatchOperation[]
+  bindingSha256: string
+}
+
+export type ReconstructionCandidate = {
+  binding: ReconstructionCandidateBinding
+  canonicalStructBytes: Uint8Array
+}
+
+export type GroundedVerifierIdentity = {
+  id: string
+  version: string
+  configurationSha256: string
+  executableSha256: string
+}
+
+export type OwnerLocalArtifactResolverIdentity = {
+  id: string
+  version: string
+  configurationSha256: string
+}
+
+export type OwnerLocalArtifactKind =
+  | 'epub-download'
+  | 'dom-snapshot'
+  | 'screenshot'
+
+export type OwnerLocalArtifactResolutionRequest = {
+  schemaVersion: '1.0.0'
+  runId: string
+  attemptTraceSha256: string
+  kind: OwnerLocalArtifactKind
+  logicalId: string
+  artifact: HashedArtifact
+}
+
+export type OwnerLocalArtifactVerificationReceipt = {
+  schemaVersion: '1.0.0'
+  resolverIdentity: OwnerLocalArtifactResolverIdentity
+  resolverIdentitySha256: string
+  requestSha256: string
+  artifact: HashedArtifact
+  bytes: Uint8Array
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type OwnerLocalArtifactResolver = {
+  identity: OwnerLocalArtifactResolverIdentity
+  resolve: (request: OwnerLocalArtifactResolutionRequest) => unknown
+}
+
+type VerifiedObservationSet<
+  TSet extends SourceExpectedObservationSet | RenderedActualObservationSet,
+> = TSet & { payloadBytes: Uint8Array }
+
+export type SourceEvidenceVerificationRequest = {
+  schemaVersion: '1.0.0'
+  sourcePdfSha256: string
+  evidenceGraph: HashedArtifact
+  sourceObligationsSha256: string
+}
+
+export type SourceEvidenceVerificationReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  requestSha256: string
+  evidenceGraph: HashedArtifact
+  evidenceGraphBytes: Uint8Array
+  expectedObservationSets: Array<
+    VerifiedObservationSet<SourceExpectedObservationSet>
+  >
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type EvidenceCandidateResolutionRequest = {
+  schemaVersion: '1.0.0'
+  sourceEvidenceGraphSha256: string
+  referenceSha256: string
+  bindingSha256: string
+}
+
+export type EvidenceCandidateResolutionReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  requestSha256: string
+  referenceSha256: string
+  bindingSha256: string
+  payload: HashedArtifact
+  payloadBytes: Uint8Array
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type SourceEvidenceVerifier = {
+  identity: GroundedVerifierIdentity
+  verifyExpected: (request: SourceEvidenceVerificationRequest) => unknown
+  resolveCandidate: (request: EvidenceCandidateResolutionRequest) => unknown
+}
+
+export type SelectedGroundingVerificationRequest = {
+  schemaVersion: '1.0.0'
+  sourceEvidenceGraphSha256: string
+  proposalSha256: string
+  operations: StructEvidencePatchOperation[]
+  beforeCanonicalStruct: HashedArtifact
+  beforeCanonicalStructBytes: Uint8Array
+  resultingCanonicalStruct: HashedArtifact
+  resultingCanonicalStructBytes: Uint8Array
+  beforeSelectedProjection: HashedArtifact
+  beforeSelectedProjectionBytes: Uint8Array
+  resultingSelectedProjection: HashedArtifact
+  resultingSelectedProjectionBytes: Uint8Array
+  candidatePayloads: EvidenceCandidateResolutionReceipt[]
+}
+
+export type SelectedGroundingVerifier = {
+  identity: GroundedVerifierIdentity
+  verifySelected: (request: SelectedGroundingVerificationRequest) => unknown
+}
+
+export type MaterializationVerificationAuthorities = {
+  sourceEvidenceVerifier: SourceEvidenceVerifier
+  groundedVerifier: SelectedGroundingVerifier
+  evidenceCandidates: Array<{
+    referenceSha256: string
+    bindingSha256: string
+  }>
+}
+
+export type ResolvedRenderArtifact = OwnerLocalArtifactResolutionRequest & {
+  bytes: Uint8Array
+  verificationReceiptSha256: string
+}
+
+export type RenderObservationExtractionRequest = {
+  schemaVersion: '1.0.0'
+  runId: string
+  attemptTraceSha256: string
+  renderedEpubReceiptSha256: string
+  artifacts: ResolvedRenderArtifact[]
+}
+
+export type RenderObservationExtractionReceipt = {
+  schemaVersion: '1.0.0'
+  extractorIdentity: GroundedVerifierIdentity
+  extractorIdentitySha256: string
+  requestSha256: string
+  anchorInventorySha256: string
+  actualObservationSets: Array<
+    VerifiedObservationSet<RenderedActualObservationSet>
+  >
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type RenderObservationExtractor = {
+  identity: GroundedVerifierIdentity
+  extract: (request: RenderObservationExtractionRequest) => unknown
+}
+
+export type PrivateReplayAuthorities = {
+  artifactResolver: OwnerLocalArtifactResolver
+  sourceEvidenceVerifier: SourceEvidenceVerifier
+  renderObservationExtractor: RenderObservationExtractor
+  groundedVerifier: SelectedGroundingVerifier
+}
+
+export type GroundedVerifierReceipt = {
+  schemaVersion: '1.0.0'
+  verifierIdentity: GroundedVerifierIdentity
+  verifierIdentitySha256: string
+  sourceEvidenceGraphSha256: string
+  proposalSha256: string
+  operationTargetSetSha256: string
+  candidateReferenceSetSha256: string
+  candidatePayloadSetSha256: string
+  beforeStructSha256: string
+  resultingStructSha256: string
+  beforeSelectedProjectionSha256: string
+  beforeUnselectedProjectionSha256: string
+  resultingSelectedProjectionSha256: string
+  resultingUnselectedProjectionSha256: string
+  inputSha256: string
+  outputSha256: string
+  status: 'succeeded'
+  receiptSha256: string
+}
+
+export type UnchangedUnselectedProof = {
+  schemaVersion: '1.0.0'
+  beforeSha256: string
+  afterSha256: string
+  receiptSha256: string
+}
+
+export type MaterializedRepairApplicationReceipt = {
+  schemaVersion: '1.0.0'
+  proposalSha256: string
+  operations: StructEvidencePatchOperation[]
+  beforeCanonicalStruct: HashedArtifact
+  beforeCanonicalStructBytes: Uint8Array
+  beforeSelectedProjection: HashedArtifact
+  beforeUnselectedProjection: HashedArtifact
+  resultingCanonicalStruct: HashedArtifact
+  resultingCanonicalStructBytes: Uint8Array
+  resultingSelectedProjection: HashedArtifact
+  resultingUnselectedProjection: HashedArtifact
+  groundedVerifier: GroundedVerifierReceipt
+  unchangedUnselected: UnchangedUnselectedProof
+  receiptSha256: string
+}
+
+export type OwnerLocalCodexIdentity = {
+  server: {
+    id: string
+    version: string
+    transport: string
+    executableSha256: string
+  }
+  model: {
+    id: string
+    version: string
+    sha256: string
+  }
+  prompt: {
+    id: string
+    version: string
+    sha256: string
+  }
+  tool: {
+    id: 'codex'
+    version: string
+  }
+}
+
+export type RefinementTraceBinding =
+  ReconstructionAttemptRefinementTraceBinding
+
+export type RefinementTask = {
+  taskIdSha256: string
+  documentId: string
+  runId: string
+  fresh: true
+  parentTaskId: null
+  contextPolicy: 'immutable-prior-trace-only'
+  acceptedTraceSha256: string
+  identity: OwnerLocalCodexIdentity
+}
+
+export type RefinementUsage = {
+  inputTokens: number
+  outputTokens: number
+  elapsedMs: number
+}
+
+export type CoordinatorStageLease = {
+  runId: string
+  generationSha256: string
+  stageSha256: string
+  tryCommit: () => boolean
+  acknowledgeAbort: () => boolean
+}
+
+export type RefinementEvent = {
+  sequence: number
+  kind:
+    | 'server-verified'
+    | 'rendered-and-compared'
+    | 'fresh-task-created'
+    | 'repair-proposed'
+    | 'repair-verified'
+    | 'repair-applied'
+    | 'publication-ready'
+    | 'failed'
+  attemptIndex: number
+  traceSha256?: string
+  firstCauseCode?: string
+  taskIdentitySha256?: string
+  proposalSha256?: string
+  failureCode?: RefinementFailureCode
+}
+
+export type RefinementFailureCode =
+  | 'invalid-candidate-contract'
+  | 'codex-server-unavailable'
+  | 'codex-identity-mismatch'
+  | 'concurrent-run'
+  | 'codex-probe-timeout'
+  | 'evaluation-timeout'
+  | 'fresh-task-timeout'
+  | 'repair-proposal-timeout'
+  | 'repair-application-timeout'
+  | 'evaluation-failed'
+  | 'stale-trace'
+  | 'missing-first-cause'
+  | 'fresh-task-budget-exhausted'
+  | 'fresh-task-invalid'
+  | 'task-timeout'
+  | 'token-budget-exhausted'
+  | 'invalid-repair-proposal'
+  | 'repair-application-failed'
+  | 'refinement-budget-exhausted'
+  | 'interrupted'
+
+const REFINEMENT_FAILURE_CODES: readonly RefinementFailureCode[] = [
+  'invalid-candidate-contract',
+  'codex-server-unavailable',
+  'codex-identity-mismatch',
+  'concurrent-run',
+  'codex-probe-timeout',
+  'evaluation-timeout',
+  'fresh-task-timeout',
+  'repair-proposal-timeout',
+  'repair-application-timeout',
+  'evaluation-failed',
+  'stale-trace',
+  'missing-first-cause',
+  'fresh-task-budget-exhausted',
+  'fresh-task-invalid',
+  'task-timeout',
+  'token-budget-exhausted',
+  'invalid-repair-proposal',
+  'repair-application-failed',
+  'refinement-budget-exhausted',
+  'interrupted',
+]
+
+export type RefinementRunReceipt = {
+  schemaVersion: typeof RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION
+  authority: 'diagnostic-only'
+  promotionAllowed: false
+  contractSha256: string
+  status: 'publication-ready' | 'failed'
+  failureCode: RefinementFailureCode | null
+  attempts: ReconstructionAttemptRefinementTraceBinding[]
+  proposalSha256s: string[]
+  freshTaskCount: number
+  refinementCount: number
+  usage: RefinementUsage
+  events: RefinementEvent[]
+  receiptSha256: string
+}
+
+export type RefinementCodexClient = {
+  identity: OwnerLocalCodexIdentity
+  probe: (
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<{ available: boolean }>
+  createFreshTask: (
+    request: {
+      documentId: string
+      runId: string
+      immutablePriorTrace: Readonly<ReconstructionAttemptTrace>
+      priorTraceSha256: string
+      firstCause: NonNullable<RefinementTraceBinding['firstCause']>
+      budget: ReconstructionRefinementBudget
+    },
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+  proposeRepair: (
+    request: {
+      task: RefinementTask
+      immutablePriorTrace: Readonly<ReconstructionAttemptTrace>
+      priorTraceSha256: string
+      firstCause: NonNullable<RefinementTraceBinding['firstCause']>
+      remainingTokens: number
+      remainingTimeMs: number
+    },
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+}
+
+export type ReconstructionRefinementDependencies = {
+  evaluate: (
+    candidate: ReconstructionCandidate,
+    context: {
+      attemptIndex: number
+      parentTraceSha256: string | null
+      usage: Readonly<RefinementTraceBinding['usage']>
+      signal: AbortSignal
+      lease: CoordinatorStageLease
+    },
+  ) => Promise<ReconstructionAttemptTrace>
+  materializeRepair: (
+    candidate: Readonly<ReconstructionCandidate>,
+    proposal: StructEvidencePatch,
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<unknown>
+  codex?: RefinementCodexClient
+  materializationVerification?: Omit<
+    MaterializationVerificationAuthorities,
+    'evidenceCandidates'
+  >
+}
+
+export type PrivateRefinementRunEvidence = {
+  initialCandidate: ReconstructionCandidate
+  traces: ReconstructionAttemptTrace[]
+  applications: MaterializedRepairApplicationReceipt[]
+}
+
+export type ReconstructionRefinementRunResult = {
+  publicReceipt: RefinementRunReceipt
+  privateEvidence: PrivateRefinementRunEvidence
+}
+
+export function reconstructionRefinementHash(value: unknown) {
+  return hashTraceValue(value)
+}
+
+const sha256ValueSchema = z.string().regex(SHA256_PATTERN)
+const hashedArtifactValueSchema = z
+  .object({
+    sha256: sha256ValueSchema,
+    byteLength: z.number().int().nonnegative(),
+  })
+  .strict()
+const refinementUsageSchema = z
+  .object({
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    elapsedMs: z.number().finite().nonnegative(),
+  })
+  .strict()
+const refinementTaskSchema = z
+  .object({
+    taskIdSha256: sha256ValueSchema,
+    documentId: z.string().regex(SAFE_ID_PATTERN),
+    runId: z.string().regex(SAFE_ID_PATTERN),
+    fresh: z.literal(true),
+    parentTaskId: z.null(),
+    contextPolicy: z.literal('immutable-prior-trace-only'),
+    acceptedTraceSha256: sha256ValueSchema,
+    identity: z.unknown(),
+  })
+  .strict()
+const groundedVerifierReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: z
+      .object({
+        id: z.string().regex(SAFE_ID_PATTERN),
+        version: z.string().regex(SAFE_ID_PATTERN),
+        configurationSha256: sha256ValueSchema,
+        executableSha256: sha256ValueSchema,
+      })
+      .strict(),
+    verifierIdentitySha256: sha256ValueSchema,
+    sourceEvidenceGraphSha256: sha256ValueSchema,
+    proposalSha256: sha256ValueSchema,
+    operationTargetSetSha256: sha256ValueSchema,
+    candidateReferenceSetSha256: sha256ValueSchema,
+    candidatePayloadSetSha256: sha256ValueSchema,
+    beforeStructSha256: sha256ValueSchema,
+    resultingStructSha256: sha256ValueSchema,
+    beforeSelectedProjectionSha256: sha256ValueSchema,
+    beforeUnselectedProjectionSha256: sha256ValueSchema,
+    resultingSelectedProjectionSha256: sha256ValueSchema,
+    resultingUnselectedProjectionSha256: sha256ValueSchema,
+    inputSha256: sha256ValueSchema,
+    outputSha256: sha256ValueSchema,
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const unchangedUnselectedProofSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    beforeSha256: sha256ValueSchema,
+    afterSha256: sha256ValueSchema,
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const materializedRepairApplicationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    proposalSha256: sha256ValueSchema,
+    operations: z.array(structEvidencePatchOperationSchema).min(1),
+    beforeCanonicalStruct: hashedArtifactValueSchema,
+    beforeCanonicalStructBytes: z.instanceof(Uint8Array),
+    beforeSelectedProjection: hashedArtifactValueSchema,
+    beforeUnselectedProjection: hashedArtifactValueSchema,
+    resultingCanonicalStruct: hashedArtifactValueSchema,
+    resultingCanonicalStructBytes: z.instanceof(Uint8Array),
+    resultingSelectedProjection: hashedArtifactValueSchema,
+    resultingUnselectedProjection: hashedArtifactValueSchema,
+    groundedVerifier: groundedVerifierReceiptSchema,
+    unchangedUnselected: unchangedUnselectedProofSchema,
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const ownerLocalArtifactVerificationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    resolverIdentity: z
+      .object({
+        id: z.string().regex(SAFE_ID_PATTERN),
+        version: z.string().regex(SAFE_ID_PATTERN),
+        configurationSha256: sha256ValueSchema,
+      })
+      .strict(),
+    resolverIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    artifact: hashedArtifactValueSchema,
+    bytes: z.instanceof(Uint8Array),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const frozenExecutionIdentitySchema = z
+  .object({
+    id: z.string().regex(SAFE_ID_PATTERN),
+    version: z.string().regex(SAFE_ID_PATTERN),
+    configurationSha256: sha256ValueSchema,
+    executableSha256: sha256ValueSchema,
+  })
+  .strict()
+const verifiedExpectedObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256ValueSchema,
+    itemCount: z.number().int().nonnegative(),
+    payload: hashedArtifactValueSchema,
+    sourceRegionIds: z.array(z.string().regex(SAFE_ID_PATTERN)),
+    receiptSha256: sha256ValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+  })
+  .strict()
+const verifiedActualObservationSetSchema = z
+  .object({
+    check: z.enum(SOURCE_EPUB_OBSERVATION_CHECK_IDS),
+    setSha256: sha256ValueSchema,
+    itemCount: z.number().int().nonnegative(),
+    payload: hashedArtifactValueSchema,
+    receiptSha256: sha256ValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+  })
+  .strict()
+const sourceEvidenceVerificationReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: frozenExecutionIdentitySchema,
+    verifierIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    evidenceGraph: hashedArtifactValueSchema,
+    evidenceGraphBytes: z.instanceof(Uint8Array),
+    expectedObservationSets: z
+      .array(verifiedExpectedObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const evidenceCandidateResolutionReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    verifierIdentity: frozenExecutionIdentitySchema,
+    verifierIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    referenceSha256: sha256ValueSchema,
+    bindingSha256: sha256ValueSchema,
+    payload: hashedArtifactValueSchema,
+    payloadBytes: z.instanceof(Uint8Array),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const renderObservationExtractionReceiptSchema = z
+  .object({
+    schemaVersion: z.literal('1.0.0'),
+    extractorIdentity: frozenExecutionIdentitySchema,
+    extractorIdentitySha256: sha256ValueSchema,
+    requestSha256: sha256ValueSchema,
+    anchorInventorySha256: sha256ValueSchema,
+    actualObservationSets: z
+      .array(verifiedActualObservationSetSchema)
+      .length(SOURCE_EPUB_OBSERVATION_CHECK_IDS.length),
+    status: z.literal('succeeded'),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+const codexProposalResponseSchema = z
+  .object({ proposal: z.unknown(), usage: refinementUsageSchema })
+  .strict()
+const refinementEventEnvelopeSchema = z
+  .object({
+    sequence: z.number().int().nonnegative(),
+    kind: z.enum([
+      'server-verified',
+      'rendered-and-compared',
+      'fresh-task-created',
+      'repair-proposed',
+      'repair-verified',
+      'repair-applied',
+      'publication-ready',
+      'failed',
+    ]),
+    attemptIndex: z.number().int().nonnegative(),
+    traceSha256: sha256ValueSchema.optional(),
+    firstCauseCode: z.string().regex(SAFE_ID_PATTERN).optional(),
+    taskIdentitySha256: sha256ValueSchema.optional(),
+    proposalSha256: sha256ValueSchema.optional(),
+    failureCode: z.enum(REFINEMENT_FAILURE_CODES as [
+      RefinementFailureCode,
+      ...RefinementFailureCode[],
+    ]).optional(),
+  })
+  .strict()
+const refinementRunReceiptEnvelopeSchema = z
+  .object({
+    schemaVersion: z.literal(RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION),
+    authority: z.literal('diagnostic-only'),
+    promotionAllowed: z.literal(false),
+    contractSha256: sha256ValueSchema,
+    status: z.enum(['publication-ready', 'failed']),
+    failureCode: z
+      .enum(REFINEMENT_FAILURE_CODES as [
+        RefinementFailureCode,
+        ...RefinementFailureCode[],
+      ])
+      .nullable(),
+    attempts: z.array(z.unknown()),
+    proposalSha256s: z.array(sha256ValueSchema),
+    freshTaskCount: z.number().int().nonnegative(),
+    refinementCount: z.number().int().nonnegative(),
+    usage: refinementUsageSchema,
+    events: z.array(refinementEventEnvelopeSchema),
+    receiptSha256: sha256ValueSchema,
+  })
+  .strict()
+
+function exactKeys(value: unknown, keys: readonly string[]) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const actual = Object.keys(value).sort()
+  const expected = [...keys].sort()
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  )
+}
+
+function safeId(value: unknown): value is string {
+  return typeof value === 'string' && SAFE_ID_PATTERN.test(value)
+}
+
+function sha256(value: unknown): value is string {
+  return typeof value === 'string' && SHA256_PATTERN.test(value)
+}
+
+function positiveInteger(value: unknown) {
+  return Number.isSafeInteger(value) && Number(value) > 0
+}
+
+function nonNegativeInteger(value: unknown) {
+  return Number.isSafeInteger(value) && Number(value) >= 0
+}
+
+export function validateReconstructionRefinementBudget(
+  input: unknown,
+) {
+  if (!exactKeys(input, [
+    'maxRefinements',
+    'maxFreshTasks',
+    'maxTokens',
+    'maxDurationMs',
+    'repairPolicySha256',
+  ])) return false
+  const value = input as ReconstructionRefinementBudget
+  return (
+    nonNegativeInteger(value.maxRefinements) &&
+    positiveInteger(value.maxFreshTasks) &&
+    positiveInteger(value.maxTokens) &&
+    positiveInteger(value.maxDurationMs) &&
+    sha256(value.repairPolicySha256)
+  )
+}
+
+function candidateContractProjection(
+  value: Omit<ReconstructionCandidateContract, 'contractSha256'>,
+) {
+  return value
+}
+
+export function createReconstructionCandidateContract(
+  input: Omit<ReconstructionCandidateContract, 'contractSha256'>,
+): ReconstructionCandidateContract {
+  const contract = {
+    ...structuredClone(input),
+    contractSha256: reconstructionRefinementHash(
+      candidateContractProjection(input),
+    ),
+  }
+  if (!validateReconstructionCandidateContract(contract)) {
+    throw new Error('INVALID_RECONSTRUCTION_CANDIDATE_CONTRACT')
+  }
+  return contract
+}
+
+export function validateReconstructionCandidateContract(
+  input: unknown,
+) {
+  if (!exactKeys(input, [
+    'schemaVersion',
+    'runId',
+    'documentId',
+    'sourcePdfSha256',
+    'sourceEvidenceGraph',
+    'authorities',
+    'budget',
+    'repairScope',
+    'contractSha256',
+  ])) return false
+  const value = input as ReconstructionCandidateContract
+  if (
+    value.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    !safeId(value.runId) ||
+    !safeId(value.documentId) ||
+    !sha256(value.sourcePdfSha256) ||
+    !exactKeys(value.sourceEvidenceGraph, ['schemaVersion', 'sha256']) ||
+    !safeId(value.sourceEvidenceGraph.schemaVersion) ||
+    !sha256(value.sourceEvidenceGraph.sha256) ||
+    !exactKeys(value.authorities, [
+      'codex',
+      'groundedVerifier',
+      'artifactResolver',
+      'sourceEvidenceVerifier',
+      'renderObservationExtractor',
+    ]) ||
+    !exactKeys(value.authorities.codex, ['identity', 'identitySha256']) ||
+    !validateOwnerLocalCodexIdentity(value.authorities.codex.identity) ||
+    value.authorities.codex.identitySha256 !==
+      reconstructionRefinementHash(value.authorities.codex.identity) ||
+    !validGroundedVerifierAuthority(value.authorities.groundedVerifier) ||
+    !validArtifactResolverAuthority(value.authorities.artifactResolver) ||
+    !validGroundedVerifierAuthority(
+      value.authorities.sourceEvidenceVerifier,
+    ) ||
+    !validGroundedVerifierAuthority(
+      value.authorities.renderObservationExtractor,
+    ) ||
+    !validateReconstructionRefinementBudget(value.budget) ||
+    !Array.isArray(value.repairScope) ||
+    !sha256(value.contractSha256)
+  ) {
+    return false
+  }
+  const targets = new Set<string>()
+  for (const scope of value.repairScope) {
+    if (
+      !exactKeys(scope, [
+        'targetKind',
+        'targetId',
+        'candidateReferenceSha256s',
+      ]) ||
+      !['block', 'asset', 'relationship'].includes(scope.targetKind) ||
+      !safeId(scope.targetId) ||
+      !Array.isArray(scope.candidateReferenceSha256s) ||
+      scope.candidateReferenceSha256s.length < 1 ||
+      scope.candidateReferenceSha256s.some((candidate) => !sha256(candidate)) ||
+      new Set(scope.candidateReferenceSha256s).size !==
+        scope.candidateReferenceSha256s.length
+    ) {
+      return false
+    }
+    const target = `${scope.targetKind}:${scope.targetId}`
+    if (targets.has(target)) return false
+    targets.add(target)
+  }
+  const { contractSha256, ...projection } = value
+  return contractSha256 === reconstructionRefinementHash(projection)
+}
+
+function selectionKey(value: StructEvidencePatchOperation) {
+  return `${value.targetKind}:${value.targetId}`
+}
+
+function compareSelections(
+  left: StructEvidencePatchOperation,
+  right: StructEvidencePatchOperation,
+) {
+  const leftKey = `${selectionKey(left)}:${left.candidateReferenceSha256}`
+  const rightKey = `${selectionKey(right)}:${right.candidateReferenceSha256}`
+  return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+}
+
+export function createReconstructionCandidateBinding(
+  input: Omit<ReconstructionCandidateBinding, 'bindingSha256'>,
+): ReconstructionCandidateBinding {
+  const projection = structuredClone(input)
+  projection.selections.sort(compareSelections)
+  return {
+    ...projection,
+    bindingSha256: reconstructionRefinementHash(projection),
+  }
+}
+
+export function validateReconstructionCandidateBinding(
+  value: ReconstructionCandidateBinding,
+  contract: ReconstructionCandidateContract,
+) {
+  if (
+    !exactKeys(value, [
+      'schemaVersion',
+      'sourcePdfSha256',
+      'sourceEvidenceGraphSha256',
+      'canonicalStruct',
+      'selections',
+      'bindingSha256',
+    ]) ||
+    value.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    value.sourcePdfSha256 !== contract.sourcePdfSha256 ||
+    value.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    !hashedArtifactValueSchema.safeParse(value.canonicalStruct).success ||
+    !sha256(value.bindingSha256) ||
+    !Array.isArray(value.selections)
+  ) {
+    return false
+  }
+  const keys = new Set<string>()
+  for (const selection of value.selections) {
+    if (
+      !structEvidencePatchOperationSchema.safeParse(selection).success
+    ) {
+      return false
+    }
+    const scope = contract.repairScope.find(
+      (candidate) =>
+        candidate.targetKind === selection.targetKind &&
+        candidate.targetId === selection.targetId,
+    )
+    const key = selectionKey(selection)
+    if (
+      !scope?.candidateReferenceSha256s.includes(
+        selection.candidateReferenceSha256,
+      ) ||
+      keys.has(key)
+    ) {
+      return false
+    }
+    keys.add(key)
+  }
+  const { bindingSha256, ...projection } = value
+  return (
+    value.selections.every(
+      (selection, index) =>
+        index === 0 ||
+        compareSelections(value.selections[index - 1]!, selection) < 0,
+    ) &&
+    bindingSha256 === reconstructionRefinementHash(projection)
+  )
+}
+
+export function validateReconstructionCandidate(
+  value: ReconstructionCandidate,
+  contract: ReconstructionCandidateContract,
+) {
+  return (
+    exactKeys(value, ['binding', 'canonicalStructBytes']) &&
+    value.canonicalStructBytes instanceof Uint8Array &&
+    validateReconstructionCandidateBinding(value.binding, contract) &&
+    value.binding.canonicalStruct.byteLength ===
+      value.canonicalStructBytes.byteLength &&
+    value.binding.canonicalStruct.sha256 ===
+      sha256HexSync(value.canonicalStructBytes)
+  )
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array) {
+  return (
+    left.byteLength === right.byteLength &&
+    left.every((byte, index) => byte === right[index])
+  )
+}
+
+function projectionArtifact(value: unknown) {
+  const bytes = new TextEncoder().encode(canonicalTraceJson(value))
+  return {
+    artifact: { sha256: sha256HexSync(bytes), byteLength: bytes.byteLength },
+    bytes,
+  }
+}
+
+function parseCanonicalStructBytes(bytes: Uint8Array) {
+  let text: string
+  let value: unknown
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+    value = JSON.parse(text)
+  } catch {
+    throw new TypeError('INVALID_CANONICAL_STRUCT_BYTES')
+  }
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    canonicalTraceJson(value) !== text
+  ) {
+    throw new TypeError('INVALID_CANONICAL_STRUCT_BYTES')
+  }
+  return value as Record<string, unknown>
+}
+
+/** #200 may use this exact projection algorithm when materializing a patch. */
+export function deriveStructRepairProjections(
+  bytes: Uint8Array,
+  operations: readonly StructEvidencePatchOperation[],
+) {
+  const value = parseCanonicalStructBytes(bytes)
+  const unselected = structuredClone(value)
+  const selected: Array<{
+    targetKind: StructRepairTargetKind
+    targetId: string
+    value: unknown
+  }> = []
+  const collectionNames: Record<StructRepairTargetKind, string> = {
+    block: 'blocks',
+    asset: 'assets',
+    relationship: 'relationships',
+  }
+  for (const operation of [...operations].sort(compareSelections)) {
+    const collectionName = collectionNames[operation.targetKind]
+    const collection = value[collectionName]
+    const unselectedCollection = unselected[collectionName]
+    if (!Array.isArray(collection) || !Array.isArray(unselectedCollection)) {
+      throw new TypeError('INVALID_CANONICAL_STRUCT_TARGET_COLLECTION')
+    }
+    const matches = collection.flatMap((candidate, index) =>
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      !Array.isArray(candidate) &&
+      (candidate as Record<string, unknown>).id === operation.targetId
+        ? [index]
+        : [],
+    )
+    if (matches.length !== 1) {
+      throw new TypeError('INVALID_CANONICAL_STRUCT_TARGET')
+    }
+    const index = matches[0]!
+    selected.push({
+      targetKind: operation.targetKind,
+      targetId: operation.targetId,
+      value: collection[index],
+    })
+    unselectedCollection[index] = {
+      __selectedRepairTarget__: `${operation.targetKind}:${operation.targetId}`,
+    }
+  }
+  const selectedProjection = projectionArtifact(selected)
+  const unselectedProjection = projectionArtifact(unselected)
+  return {
+    selected: selectedProjection.artifact,
+    selectedBytes: selectedProjection.bytes,
+    unselected: unselectedProjection.artifact,
+    unselectedBytes: unselectedProjection.bytes,
+  }
+}
+
+function applicationReceiptProjection(
+  receipt: MaterializedRepairApplicationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    proposalSha256: receipt.proposalSha256,
+    operations: receipt.operations,
+    beforeCanonicalStruct: receipt.beforeCanonicalStruct,
+    beforeSelectedProjection: receipt.beforeSelectedProjection,
+    beforeUnselectedProjection: receipt.beforeUnselectedProjection,
+    resultingCanonicalStruct: receipt.resultingCanonicalStruct,
+    resultingSelectedProjection: receipt.resultingSelectedProjection,
+    resultingUnselectedProjection: receipt.resultingUnselectedProjection,
+    groundedVerifier: receipt.groundedVerifier,
+    unchangedUnselected: receipt.unchangedUnselected,
+  }
+}
+
+function evidenceCandidateResolutionProjection(
+  receipt: EvidenceCandidateResolutionReceipt,
+) {
+  const {
+    payloadBytes: _payloadBytes,
+    receiptSha256: _receiptSha256,
+    ...projection
+  } = receipt
+  return projection
+}
+
+function evidenceCandidateResolutionBinding(
+  receipt: EvidenceCandidateResolutionReceipt,
+) {
+  const { payloadBytes: _payloadBytes, ...binding } = receipt
+  return binding
+}
+
+function resolveEvidenceCandidatePayloads(
+  contract: ReconstructionCandidateContract,
+  proposal: StructEvidencePatch,
+  authorities: MaterializationVerificationAuthorities,
+) {
+  const expectedIdentitySha256 =
+    contract.authorities.sourceEvidenceVerifier.identitySha256
+  if (
+    !validGroundedVerifierIdentity(authorities.sourceEvidenceVerifier.identity) ||
+    hashTraceValue(authorities.sourceEvidenceVerifier.identity) !==
+      expectedIdentitySha256
+  ) {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  const references = [
+    ...new Set(
+      proposal.operations.map(
+        ({ candidateReferenceSha256 }) => candidateReferenceSha256,
+      ),
+    ),
+  ].sort()
+  return references.map((referenceSha256) => {
+    const bindings = authorities.evidenceCandidates.filter(
+      (candidate) => candidate.referenceSha256 === referenceSha256,
+    )
+    if (bindings.length !== 1) {
+      throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+    }
+    const request: EvidenceCandidateResolutionRequest = {
+      schemaVersion: '1.0.0',
+      sourceEvidenceGraphSha256: contract.sourceEvidenceGraph.sha256,
+      referenceSha256,
+      bindingSha256: bindings[0]!.bindingSha256,
+    }
+    const receipt = evidenceCandidateResolutionReceiptSchema.parse(
+      authorities.sourceEvidenceVerifier.resolveCandidate(
+        structuredClone(request),
+      ),
+    ) as EvidenceCandidateResolutionReceipt
+    if (
+      hashTraceValue(receipt.verifierIdentity) !== expectedIdentitySha256 ||
+      receipt.verifierIdentitySha256 !== expectedIdentitySha256 ||
+      receipt.requestSha256 !== hashTraceValue(request) ||
+      receipt.referenceSha256 !== request.referenceSha256 ||
+      receipt.bindingSha256 !== request.bindingSha256 ||
+      receipt.payload.byteLength !== receipt.payloadBytes.byteLength ||
+      receipt.payload.sha256 !== sha256HexSync(receipt.payloadBytes) ||
+      receipt.receiptSha256 !==
+        hashTraceValue(evidenceCandidateResolutionProjection(receipt))
+    ) {
+      throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+    }
+    return receipt
+  })
+}
+
+function selectedGroundingRequestProjection(
+  request: SelectedGroundingVerificationRequest,
+) {
+  return {
+    schemaVersion: request.schemaVersion,
+    sourceEvidenceGraphSha256: request.sourceEvidenceGraphSha256,
+    proposalSha256: request.proposalSha256,
+    operations: request.operations,
+    beforeCanonicalStruct: request.beforeCanonicalStruct,
+    resultingCanonicalStruct: request.resultingCanonicalStruct,
+    beforeSelectedProjection: request.beforeSelectedProjection,
+    resultingSelectedProjection: request.resultingSelectedProjection,
+    candidatePayloads: request.candidatePayloads.map(
+      evidenceCandidateResolutionBinding,
+    ),
+  }
+}
+
+export function parseMaterializedRepairApplicationReceipt(
+  input: unknown,
+  before: ReconstructionCandidate,
+  proposal: StructEvidencePatch,
+  contract: ReconstructionCandidateContract,
+  authorities: MaterializationVerificationAuthorities,
+) {
+  const receipt = materializedRepairApplicationReceiptSchema.parse(
+    input,
+  ) as MaterializedRepairApplicationReceipt
+  let beforeProjections: ReturnType<typeof deriveStructRepairProjections>
+  let resultingProjections: ReturnType<typeof deriveStructRepairProjections>
+  try {
+    beforeProjections = deriveStructRepairProjections(
+      before.canonicalStructBytes,
+      proposal.operations,
+    )
+    resultingProjections = deriveStructRepairProjections(
+      receipt.resultingCanonicalStructBytes,
+      proposal.operations,
+    )
+  } catch {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  const operationTargetSetSha256 = hashTraceValue(
+    proposal.operations
+      .map(({ targetKind, targetId }) => ({ targetKind, targetId }))
+      .sort((left, right) =>
+        left.targetKind === right.targetKind
+          ? left.targetId.localeCompare(right.targetId)
+          : left.targetKind.localeCompare(right.targetKind),
+      ),
+  )
+  const candidateReferenceSetSha256 = hashTraceValue(
+    proposal.operations
+      .map(({ candidateReferenceSha256 }) => candidateReferenceSha256)
+      .sort(),
+  )
+  const candidatePayloads = resolveEvidenceCandidatePayloads(
+    contract,
+    proposal,
+    authorities,
+  )
+  const candidatePayloadSetSha256 = hashTraceValue(
+    candidatePayloads.map(evidenceCandidateResolutionBinding),
+  )
+  const groundingRequest: SelectedGroundingVerificationRequest = {
+    schemaVersion: '1.0.0',
+    sourceEvidenceGraphSha256: contract.sourceEvidenceGraph.sha256,
+    proposalSha256: proposal.proposalSha256,
+    operations: proposal.operations,
+    beforeCanonicalStruct: before.binding.canonicalStruct,
+    beforeCanonicalStructBytes: before.canonicalStructBytes,
+    resultingCanonicalStruct: receipt.resultingCanonicalStruct,
+    resultingCanonicalStructBytes: receipt.resultingCanonicalStructBytes,
+    beforeSelectedProjection: beforeProjections.selected,
+    beforeSelectedProjectionBytes: beforeProjections.selectedBytes,
+    resultingSelectedProjection: resultingProjections.selected,
+    resultingSelectedProjectionBytes: resultingProjections.selectedBytes,
+    candidatePayloads,
+  }
+  const groundedInputSha256 = hashTraceValue(
+    selectedGroundingRequestProjection(groundingRequest),
+  )
+  const groundedOutputSha256 = hashTraceValue({
+    resultingStructSha256: receipt.resultingCanonicalStruct.sha256,
+    resultingSelectedProjectionSha256: resultingProjections.selected.sha256,
+    resultingUnselectedProjectionSha256:
+      resultingProjections.unselected.sha256,
+  })
+  const executedGrounding = groundedVerifierReceiptSchema.parse(
+    authorities.groundedVerifier.verifySelected(
+      structuredClone(groundingRequest),
+    ),
+  ) as GroundedVerifierReceipt
+  const { receiptSha256: groundedReceiptSha256, ...groundedProjection } =
+    receipt.groundedVerifier
+  const {
+    receiptSha256: unchangedReceiptSha256,
+    ...unchangedProjection
+  } = receipt.unchangedUnselected
+  if (
+    receipt.proposalSha256 !== proposal.proposalSha256 ||
+    hashTraceValue(receipt.operations) !== hashTraceValue(proposal.operations) ||
+    hashTraceValue(receipt.beforeCanonicalStruct) !==
+      hashTraceValue(before.binding.canonicalStruct) ||
+    !sameBytes(before.canonicalStructBytes, receipt.beforeCanonicalStructBytes) ||
+    receipt.beforeCanonicalStructBytes.byteLength !==
+      receipt.beforeCanonicalStruct.byteLength ||
+    sha256HexSync(receipt.beforeCanonicalStructBytes) !==
+      receipt.beforeCanonicalStruct.sha256 ||
+    receipt.resultingCanonicalStructBytes.byteLength !==
+      receipt.resultingCanonicalStruct.byteLength ||
+    sha256HexSync(receipt.resultingCanonicalStructBytes) !==
+      receipt.resultingCanonicalStruct.sha256 ||
+    receipt.resultingCanonicalStruct.sha256 ===
+      receipt.beforeCanonicalStruct.sha256 ||
+    hashTraceValue(receipt.beforeSelectedProjection) !==
+      hashTraceValue(beforeProjections.selected) ||
+    hashTraceValue(receipt.beforeUnselectedProjection) !==
+      hashTraceValue(beforeProjections.unselected) ||
+    hashTraceValue(receipt.resultingSelectedProjection) !==
+      hashTraceValue(resultingProjections.selected) ||
+    hashTraceValue(receipt.resultingUnselectedProjection) !==
+      hashTraceValue(resultingProjections.unselected) ||
+    receipt.beforeUnselectedProjection.sha256 !==
+      receipt.resultingUnselectedProjection.sha256 ||
+    receipt.beforeUnselectedProjection.byteLength !==
+      receipt.resultingUnselectedProjection.byteLength ||
+    hashTraceValue(receipt.groundedVerifier.verifierIdentity) !==
+      hashTraceValue(contract.authorities.groundedVerifier.identity) ||
+    receipt.groundedVerifier.verifierIdentitySha256 !==
+      contract.authorities.groundedVerifier.identitySha256 ||
+    receipt.groundedVerifier.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    receipt.groundedVerifier.proposalSha256 !== proposal.proposalSha256 ||
+    receipt.groundedVerifier.operationTargetSetSha256 !==
+      operationTargetSetSha256 ||
+    receipt.groundedVerifier.candidateReferenceSetSha256 !==
+      candidateReferenceSetSha256 ||
+    receipt.groundedVerifier.candidatePayloadSetSha256 !==
+      candidatePayloadSetSha256 ||
+    receipt.groundedVerifier.beforeStructSha256 !==
+      before.binding.canonicalStruct.sha256 ||
+    receipt.groundedVerifier.resultingStructSha256 !==
+      receipt.resultingCanonicalStruct.sha256 ||
+    receipt.groundedVerifier.beforeSelectedProjectionSha256 !==
+      beforeProjections.selected.sha256 ||
+    receipt.groundedVerifier.beforeUnselectedProjectionSha256 !==
+      beforeProjections.unselected.sha256 ||
+    receipt.groundedVerifier.resultingSelectedProjectionSha256 !==
+      resultingProjections.selected.sha256 ||
+    receipt.groundedVerifier.resultingUnselectedProjectionSha256 !==
+      resultingProjections.unselected.sha256 ||
+    receipt.groundedVerifier.inputSha256 !== groundedInputSha256 ||
+    receipt.groundedVerifier.outputSha256 !== groundedOutputSha256 ||
+    hashTraceValue(authorities.groundedVerifier.identity) !==
+      contract.authorities.groundedVerifier.identitySha256 ||
+    hashTraceValue(executedGrounding) !==
+      hashTraceValue(receipt.groundedVerifier) ||
+    groundedReceiptSha256 !== hashTraceValue(groundedProjection) ||
+    receipt.unchangedUnselected.beforeSha256 !==
+      beforeProjections.unselected.sha256 ||
+    receipt.unchangedUnselected.afterSha256 !==
+      resultingProjections.unselected.sha256 ||
+    unchangedReceiptSha256 !== hashTraceValue(unchangedProjection) ||
+    receipt.receiptSha256 !== hashTraceValue(applicationReceiptProjection(receipt))
+  ) {
+    throw new TypeError('INVALID_MATERIALIZED_REPAIR_APPLICATION_RECEIPT')
+  }
+  return receipt
+}
+
+function candidateAfterApplication(
+  before: ReconstructionCandidate,
+  receipt: MaterializedRepairApplicationReceipt,
+  proposal: StructEvidencePatch,
+) {
+  const patchedTargets = new Set(proposal.operations.map(selectionKey))
+  return {
+    binding: createReconstructionCandidateBinding({
+      schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+      sourcePdfSha256: before.binding.sourcePdfSha256,
+      sourceEvidenceGraphSha256: before.binding.sourceEvidenceGraphSha256,
+      canonicalStruct: receipt.resultingCanonicalStruct,
+      selections: [
+        ...before.binding.selections.filter(
+          (selection) => !patchedTargets.has(selectionKey(selection)),
+        ),
+        ...proposal.operations,
+      ],
+    }),
+    canonicalStructBytes: receipt.resultingCanonicalStructBytes,
+  } satisfies ReconstructionCandidate
+}
+
+function validLoopbackTransport(transport: string) {
+  if (transport.startsWith('unix://')) {
+    const path = transport.slice('unix://'.length)
+    return (
+      path.startsWith('/') &&
+      !path.includes('\0') &&
+      !path.split('/').includes('..')
+    )
+  }
+  try {
+    const url = new URL(transport)
+    return (
+      ['http:', 'https:'].includes(url.protocol) &&
+      ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname) &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+function nonPlaceholderIdentity(value: string) {
+  return safeId(value) && !PLACEHOLDER_IDENTITY_PATTERN.test(value)
+}
+
+export function validateOwnerLocalCodexIdentity(
+  value: OwnerLocalCodexIdentity,
+) {
+  return (
+    exactKeys(value, ['server', 'model', 'prompt', 'tool']) &&
+    exactKeys(value.server, [
+      'id',
+      'version',
+      'transport',
+      'executableSha256',
+    ]) &&
+    nonPlaceholderIdentity(value.server.id) &&
+    nonPlaceholderIdentity(value.server.version) &&
+    validLoopbackTransport(value.server.transport) &&
+    sha256(value.server.executableSha256) &&
+    exactKeys(value.model, ['id', 'version', 'sha256']) &&
+    nonPlaceholderIdentity(value.model.id) &&
+    nonPlaceholderIdentity(value.model.version) &&
+    sha256(value.model.sha256) &&
+    exactKeys(value.prompt, ['id', 'version', 'sha256']) &&
+    nonPlaceholderIdentity(value.prompt.id) &&
+    nonPlaceholderIdentity(value.prompt.version) &&
+    sha256(value.prompt.sha256) &&
+    exactKeys(value.tool, ['id', 'version']) &&
+    value.tool.id === 'codex' &&
+    nonPlaceholderIdentity(value.tool.version)
+  )
+}
+
+export function hashOwnerLocalCodexIdentity(value: OwnerLocalCodexIdentity) {
+  return reconstructionRefinementHash(value)
+}
+
+function validGroundedVerifierIdentity(
+  value: GroundedVerifierIdentity,
+) {
+  return (
+    exactKeys(value, [
+      'id',
+      'version',
+      'configurationSha256',
+      'executableSha256',
+    ]) &&
+    nonPlaceholderIdentity(value.id) &&
+    nonPlaceholderIdentity(value.version) &&
+    sha256(value.configurationSha256) &&
+    sha256(value.executableSha256)
+  )
+}
+
+function validGroundedVerifierAuthority(
+  value: ReconstructionCandidateContract['authorities']['groundedVerifier'],
+) {
+  return (
+    exactKeys(value, ['identity', 'identitySha256']) &&
+    validGroundedVerifierIdentity(value.identity) &&
+    value.identitySha256 === reconstructionRefinementHash(value.identity)
+  )
+}
+
+function validArtifactResolverIdentity(
+  value: OwnerLocalArtifactResolverIdentity,
+) {
+  return (
+    exactKeys(value, ['id', 'version', 'configurationSha256']) &&
+    nonPlaceholderIdentity(value.id) &&
+    nonPlaceholderIdentity(value.version) &&
+    sha256(value.configurationSha256)
+  )
+}
+
+function validArtifactResolverAuthority(
+  value: ReconstructionCandidateContract['authorities']['artifactResolver'],
+) {
+  return (
+    exactKeys(value, ['identity', 'identitySha256']) &&
+    validArtifactResolverIdentity(value.identity) &&
+    value.identitySha256 === reconstructionRefinementHash(value.identity)
+  )
+}
+
+function artifactVerificationProjection(
+  receipt: OwnerLocalArtifactVerificationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    resolverIdentity: receipt.resolverIdentity,
+    resolverIdentitySha256: receipt.resolverIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    artifact: receipt.artifact,
+    status: receipt.status,
+  }
+}
+
+function verifyOwnerLocalArtifact(
+  contract: ReconstructionCandidateContract,
+  resolver: OwnerLocalArtifactResolver,
+  request: OwnerLocalArtifactResolutionRequest,
+) {
+  const receipt = ownerLocalArtifactVerificationReceiptSchema.parse(
+    resolver.resolve(structuredClone(request)),
+  ) as OwnerLocalArtifactVerificationReceipt
+  return (
+    hashTraceValue(resolver.identity) ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    hashTraceValue(receipt.resolverIdentity) ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    receipt.resolverIdentitySha256 ===
+      contract.authorities.artifactResolver.identitySha256 &&
+    receipt.requestSha256 === hashTraceValue(request) &&
+    hashTraceValue(receipt.artifact) === hashTraceValue(request.artifact) &&
+    receipt.bytes.byteLength === request.artifact.byteLength &&
+    sha256HexSync(receipt.bytes) === request.artifact.sha256 &&
+    receipt.receiptSha256 ===
+      hashTraceValue(artifactVerificationProjection(receipt))
+  )
+    ? receipt
+    : null
+}
+
+function verifyTraceArtifacts(
+  contract: ReconstructionCandidateContract,
+  resolver: OwnerLocalArtifactResolver,
+  trace: ReconstructionAttemptTrace,
+) {
+  if (
+    !validArtifactResolverIdentity(resolver.identity) ||
+    hashTraceValue(resolver.identity) !==
+      contract.authorities.artifactResolver.identitySha256
+  ) {
+    return false
+  }
+  const requests: OwnerLocalArtifactResolutionRequest[] = [
+    {
+      schemaVersion: '1.0.0',
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'epub-download',
+      logicalId: 'epub-download',
+      artifact: trace.renderedEpub.download.artifact,
+    },
+    ...trace.renderedEpub.domSnapshots.map(({ spineHref, dom }, index) => ({
+      schemaVersion: '1.0.0' as const,
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'dom-snapshot' as const,
+      logicalId: `dom-snapshot:${index}:${spineHref}`,
+      artifact: dom,
+    })),
+    ...trace.renderedEpub.screenshots.map(({ id, image }) => ({
+      schemaVersion: '1.0.0' as const,
+      runId: contract.runId,
+      attemptTraceSha256: trace.traceSha256,
+      kind: 'screenshot' as const,
+      logicalId: `screenshot:${id}`,
+      artifact: image,
+    })),
+  ]
+  const resolved = requests.map((request) => {
+    const receipt = verifyOwnerLocalArtifact(contract, resolver, request)
+    return receipt
+      ? {
+          ...request,
+          bytes: receipt.bytes,
+          verificationReceiptSha256: receipt.receiptSha256,
+        }
+      : null
+  })
+  return resolved.every(
+    (artifact): artifact is ResolvedRenderArtifact => artifact !== null,
+  )
+    ? resolved
+    : null
+}
+
+function observationSetWithoutBytes<
+  TSet extends SourceExpectedObservationSet | RenderedActualObservationSet,
+>({ payloadBytes: _payloadBytes, ...set }: VerifiedObservationSet<TSet>) {
+  return set
+}
+
+function validVerifiedObservationSet(
+  value: VerifiedObservationSet<
+    SourceExpectedObservationSet | RenderedActualObservationSet
+  >,
+) {
+  const payload = parseCanonicalObservationPayloadBytes(value.payloadBytes)
+  return (
+    payload.check === value.check &&
+    payload.items.length === value.itemCount &&
+    value.payload.byteLength === value.payloadBytes.byteLength &&
+    value.payload.sha256 === sha256HexSync(value.payloadBytes) &&
+    value.setSha256 === value.payload.sha256
+  )
+}
+
+function sourceEvidenceVerificationProjection(
+  receipt: SourceEvidenceVerificationReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    verifierIdentity: receipt.verifierIdentity,
+    verifierIdentitySha256: receipt.verifierIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    evidenceGraph: receipt.evidenceGraph,
+    expectedObservationSets: receipt.expectedObservationSets.map(
+      observationSetWithoutBytes,
+    ),
+    status: receipt.status,
+  }
+}
+
+function verifySourceEvidenceAuthority(
+  contract: ReconstructionCandidateContract,
+  verifier: SourceEvidenceVerifier,
+  trace: ReconstructionAttemptTrace,
+) {
+  const request: SourceEvidenceVerificationRequest = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+    evidenceGraph: trace.evidenceGraph.artifact,
+    sourceObligationsSha256:
+      trace.sourceEvidence.sourceObligations.obligationsSha256,
+  }
+  const receipt = sourceEvidenceVerificationReceiptSchema.parse(
+    verifier.verifyExpected(structuredClone(request)),
+  ) as SourceEvidenceVerificationReceipt
+  const expectedIdentitySha256 =
+    contract.authorities.sourceEvidenceVerifier.identitySha256
+  return (
+    validGroundedVerifierIdentity(verifier.identity) &&
+    hashTraceValue(verifier.identity) === expectedIdentitySha256 &&
+    hashTraceValue(receipt.verifierIdentity) === expectedIdentitySha256 &&
+    receipt.verifierIdentitySha256 === expectedIdentitySha256 &&
+    receipt.requestSha256 === hashTraceValue(request) &&
+    hashTraceValue(receipt.evidenceGraph) ===
+      hashTraceValue(trace.evidenceGraph.artifact) &&
+    receipt.evidenceGraphBytes.byteLength ===
+      trace.evidenceGraph.artifact.byteLength &&
+    sha256HexSync(receipt.evidenceGraphBytes) ===
+      trace.evidenceGraph.artifact.sha256 &&
+    receipt.expectedObservationSets.every(
+      (set, index) =>
+        set.check === SOURCE_EPUB_OBSERVATION_CHECK_IDS[index] &&
+        validVerifiedObservationSet(set) &&
+        hashTraceValue(observationSetWithoutBytes(set)) ===
+          hashTraceValue(trace.sourceEvidence.expectedObservationSets[index]),
+    ) &&
+    receipt.receiptSha256 ===
+      hashTraceValue(sourceEvidenceVerificationProjection(receipt))
+  )
+}
+
+function renderExtractionRequestProjection(
+  request: RenderObservationExtractionRequest,
+) {
+  return {
+    schemaVersion: request.schemaVersion,
+    runId: request.runId,
+    attemptTraceSha256: request.attemptTraceSha256,
+    renderedEpubReceiptSha256: request.renderedEpubReceiptSha256,
+    artifacts: request.artifacts.map(
+      ({ bytes: _bytes, ...artifact }) => artifact,
+    ),
+  }
+}
+
+function renderObservationExtractionProjection(
+  receipt: RenderObservationExtractionReceipt,
+) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    extractorIdentity: receipt.extractorIdentity,
+    extractorIdentitySha256: receipt.extractorIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    anchorInventorySha256: receipt.anchorInventorySha256,
+    actualObservationSets: receipt.actualObservationSets.map(
+      observationSetWithoutBytes,
+    ),
+    status: receipt.status,
+  }
+}
+
+function verifyRenderObservationAuthority(
+  contract: ReconstructionCandidateContract,
+  extractor: RenderObservationExtractor,
+  trace: ReconstructionAttemptTrace,
+  artifacts: ResolvedRenderArtifact[],
+) {
+  const request: RenderObservationExtractionRequest = {
+    schemaVersion: '1.0.0',
+    runId: contract.runId,
+    attemptTraceSha256: trace.traceSha256,
+    renderedEpubReceiptSha256: trace.renderedEpub.receiptSha256,
+    artifacts,
+  }
+  const receipt = renderObservationExtractionReceiptSchema.parse(
+    extractor.extract(structuredClone(request)),
+  ) as RenderObservationExtractionReceipt
+  const expectedIdentitySha256 =
+    contract.authorities.renderObservationExtractor.identitySha256
+  const anchorInventorySha256 = hashTraceValue(
+    trace.renderedEpub.domSnapshots
+      .map(({ spineHref, anchors }) => ({
+        spineHref,
+        anchors: [...anchors].sort(),
+      }))
+      .sort((left, right) => left.spineHref.localeCompare(right.spineHref)),
+  )
+  const renderedAnchorIds = new Set(
+    trace.renderedEpub.domSnapshots.flatMap(({ anchors }) => anchors),
+  )
+  return (
+    validGroundedVerifierIdentity(extractor.identity) &&
+    hashTraceValue(extractor.identity) === expectedIdentitySha256 &&
+    hashTraceValue(receipt.extractorIdentity) === expectedIdentitySha256 &&
+    receipt.extractorIdentitySha256 === expectedIdentitySha256 &&
+    receipt.requestSha256 === hashTraceValue(renderExtractionRequestProjection(request)) &&
+    receipt.anchorInventorySha256 === anchorInventorySha256 &&
+    receipt.actualObservationSets.every(
+      (set, index) =>
+        set.check === SOURCE_EPUB_OBSERVATION_CHECK_IDS[index] &&
+        validVerifiedObservationSet(set) &&
+        parseCanonicalObservationPayloadBytes(set.payloadBytes).items.every(
+          ({ anchorIds }) =>
+            anchorIds.every((anchorId) => renderedAnchorIds.has(anchorId)),
+        ) &&
+        hashTraceValue(observationSetWithoutBytes(set)) ===
+          hashTraceValue(trace.renderedEpub.actualObservationSets[index]),
+    ) &&
+    receipt.receiptSha256 ===
+      hashTraceValue(renderObservationExtractionProjection(receipt))
+  )
+}
+
+function patchProjection(value: Omit<StructEvidencePatch, 'proposalSha256'>) {
+  return value
+}
+
+export function createStructEvidencePatch(
+  input: Omit<StructEvidencePatch, 'proposalSha256'>,
+) {
+  return parseStructEvidencePatch({
+    ...structuredClone(input),
+    proposalSha256: reconstructionRefinementHash(patchProjection(input)),
+  })
+}
+
+export function validateStructEvidencePatch(
+  proposal: StructEvidencePatch,
+  contract: ReconstructionCandidateContract,
+  trace: RefinementTraceBinding,
+  task: RefinementTask,
+) {
+  try {
+    proposal = parseStructEvidencePatch(proposal)
+  } catch {
+    return false
+  }
+  if (
+    proposal.schemaVersion !== STRUCT_EVIDENCE_PATCH_SCHEMA_VERSION ||
+    proposal.documentId !== contract.documentId ||
+    proposal.sourcePdfSha256 !== contract.sourcePdfSha256 ||
+    proposal.sourceEvidenceGraphSha256 !==
+      contract.sourceEvidenceGraph.sha256 ||
+    proposal.baseStructSha256 !== trace.canonicalStructSha256 ||
+    proposal.priorTraceSha256 !== trace.traceSha256 ||
+    proposal.taskIdSha256 !== task.taskIdSha256
+  ) {
+    return false
+  }
+  const traceCandidates = new Set(trace.evidenceCandidateReferences)
+  const operationKeys = new Set<string>()
+  for (const operation of proposal.operations) {
+    if (
+      !structEvidencePatchOperationSchema.safeParse(operation).success ||
+      !traceCandidates.has(operation.candidateReferenceSha256)
+    ) {
+      return false
+    }
+    const scope = contract.repairScope.find(
+      (candidate) =>
+        candidate.targetKind === operation.targetKind &&
+        candidate.targetId === operation.targetId,
+    )
+    if (
+      !scope?.candidateReferenceSha256s.includes(
+        operation.candidateReferenceSha256,
+      )
+    ) {
+      return false
+    }
+    const key = `${operation.targetKind}:${operation.targetId}`
+    if (operationKeys.has(key)) return false
+    operationKeys.add(key)
+  }
+  return true
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested)
+    }
+  }
+  return value
+}
+
+function immutableClone<T>(value: T) {
+  return deepFreeze(structuredClone(value))
+}
+
+function zeroUsage(): RefinementUsage {
+  return { inputTokens: 0, outputTokens: 0, elapsedMs: 0 }
+}
+
+function validUsage(value: RefinementUsage) {
+  return (
+    exactKeys(value, ['inputTokens', 'outputTokens', 'elapsedMs']) &&
+    nonNegativeInteger(value.inputTokens) &&
+    nonNegativeInteger(value.outputTokens) &&
+    Number.isFinite(value.elapsedMs) &&
+    value.elapsedMs >= 0
+  )
+}
+
+function combinedTokens(usage: RefinementUsage) {
+  return usage.inputTokens + usage.outputTokens
+}
+
+function aborted(signal: AbortSignal) {
+  if (!signal.aborted) return
+  const error = new Error('INTERRUPTED')
+  error.name = 'AbortError'
+  throw error
+}
+
+function linkedAbortController(signal: AbortSignal) {
+  const controller = new AbortController()
+  const abort = () => controller.abort()
+  signal.addEventListener('abort', abort, { once: true })
+  if (signal.aborted) controller.abort()
+  return {
+    controller,
+    dispose: () => signal.removeEventListener('abort', abort),
+  }
+}
+
+type ActiveRefinementRun = {
+  runId: string
+  generationSha256: string
+  nextStageIndex: number
+  pendingStages: Set<symbol>
+  finished: boolean
+}
+
+const activeRefinementRuns = new Map<string, ActiveRefinementRun>()
+const refinementRunGenerations = new Map<string, number>()
+
+function releaseRefinementRunWhenSettled(run: ActiveRefinementRun) {
+  if (
+    run.finished &&
+    run.pendingStages.size === 0 &&
+    activeRefinementRuns.get(run.runId) === run
+  ) {
+    activeRefinementRuns.delete(run.runId)
+  }
+}
+
+type GuardedStageResult<T> = {
+  value: T
+  accept: <TResult>(commit: () => TResult) => TResult
+  discard: () => void
+}
+
+async function withTaskDeadline<T>(
+  operation: (
+    signal: AbortSignal,
+    lease: CoordinatorStageLease,
+  ) => Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal,
+  run: ActiveRefinementRun,
+  stage: string,
+): Promise<GuardedStageResult<T>> {
+  aborted(signal)
+  const { controller, dispose } = linkedAbortController(signal)
+  const pendingStage = Symbol(stage)
+  const stageIndex = run.nextStageIndex
+  run.nextStageIndex += 1
+  let active = true
+  let abortAcknowledged = false
+  const current = () =>
+    active &&
+    !controller.signal.aborted &&
+    activeRefinementRuns.get(run.runId) === run
+  const settle = () => {
+    run.pendingStages.delete(pendingStage)
+    releaseRefinementRunWhenSettled(run)
+  }
+  const lease: CoordinatorStageLease = Object.freeze({
+    runId: run.runId,
+    generationSha256: run.generationSha256,
+    stageSha256: hashTraceValue({
+      generationSha256: run.generationSha256,
+      stage,
+      stageIndex,
+    }),
+    tryCommit: () => current(),
+    acknowledgeAbort: () => {
+      if (!controller.signal.aborted || abortAcknowledged) return false
+      abortAcknowledged = true
+      settle()
+      return true
+    },
+  })
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const interrupted = new Promise<never>((_resolve, reject) => {
+    controller.signal.addEventListener(
+      'abort',
+      () => {
+        active = false
+        const error = new Error('INTERRUPTED')
+        error.name = 'AbortError'
+        reject(error)
+      },
+      { once: true },
+    )
+  })
+  try {
+    run.pendingStages.add(pendingStage)
+    const operationPromise = Promise.resolve().then(() =>
+      operation(controller.signal, lease),
+    )
+    void operationPromise.then(settle, settle)
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () => {
+          active = false
+          reject(new Error('TASK_TIMEOUT'))
+          controller.abort()
+        },
+        Math.max(1, timeoutMs),
+      )
+    })
+    const value = await Promise.race([
+      operationPromise,
+      timeout,
+      interrupted,
+    ])
+    return {
+      value,
+      accept: (commit) => {
+        if (!current()) throw new Error('STALE_RUN_GENERATION')
+        try {
+          return commit()
+        } finally {
+          active = false
+        }
+      },
+      discard: () => {
+        active = false
+      },
+    }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+    dispose()
+  }
+}
+
+function validateTraceBinding(
+  value: RefinementTraceBinding,
+  contract: ReconstructionCandidateContract,
+  attemptIndex: number,
+  parentTraceSha256: string | null,
+  expectedUsage: RefinementTraceBinding['usage'],
+) {
+  return (
+    exactKeys(value, [
+      'traceSha256',
+      'sourcePdfSha256',
+      'sourceEvidenceGraphSha256',
+      'canonicalStructSha256',
+      'attemptIndex',
+      'parentTraceSha256',
+      'terminalStatus',
+      'firstCause',
+      'evidenceCandidateReferences',
+      'policy',
+      'usage',
+    ]) &&
+    sha256(value.traceSha256) &&
+    value.sourcePdfSha256 === contract.sourcePdfSha256 &&
+    value.sourceEvidenceGraphSha256 === contract.sourceEvidenceGraph.sha256 &&
+    sha256(value.canonicalStructSha256) &&
+    value.attemptIndex === attemptIndex &&
+    value.parentTraceSha256 === parentTraceSha256 &&
+    ['publication-ready', 'failed'].includes(value.terminalStatus) &&
+    (value.firstCause === null ||
+      (exactKeys(value.firstCause, ['failureReferenceSha256', 'code']) &&
+        sha256(value.firstCause.failureReferenceSha256) &&
+        safeId(value.firstCause.code))) &&
+    Array.isArray(value.evidenceCandidateReferences) &&
+    value.evidenceCandidateReferences.length > 0 &&
+    value.evidenceCandidateReferences.every(sha256) &&
+    new Set(value.evidenceCandidateReferences).size ===
+      value.evidenceCandidateReferences.length &&
+    exactKeys(value.policy, [
+      'repairPolicySha256',
+      'maxRefinements',
+      'maxFreshTasks',
+      'maxTokens',
+      'maxDurationMs',
+    ]) &&
+    value.policy.repairPolicySha256 === contract.budget.repairPolicySha256 &&
+    value.policy.maxRefinements === contract.budget.maxRefinements &&
+    value.policy.maxFreshTasks === contract.budget.maxFreshTasks &&
+    value.policy.maxTokens === contract.budget.maxTokens &&
+    value.policy.maxDurationMs === contract.budget.maxDurationMs &&
+    exactKeys(value.usage, [
+      'refinements',
+      'freshTasks',
+      'tokens',
+      'durationMs',
+    ]) &&
+    value.usage.refinements === expectedUsage.refinements &&
+    value.usage.freshTasks === expectedUsage.freshTasks &&
+    value.usage.tokens === expectedUsage.tokens &&
+    value.usage.durationMs === expectedUsage.durationMs
+  )
+}
+
+function validTask(
+  task: RefinementTask,
+  contract: ReconstructionCandidateContract,
+  trace: RefinementTraceBinding,
+  expectedIdentity: OwnerLocalCodexIdentity,
+) {
+  return (
+    refinementTaskSchema.safeParse(task).success &&
+    task.documentId === contract.documentId &&
+    task.runId === contract.runId &&
+    task.fresh === true &&
+    task.parentTaskId === null &&
+    task.contextPolicy === 'immutable-prior-trace-only' &&
+    task.acceptedTraceSha256 === trace.traceSha256 &&
+    reconstructionRefinementHash(task.identity) ===
+      reconstructionRefinementHash(expectedIdentity)
+  )
+}
+
+function traceMatchesCodexAuthority(
+  trace: ReconstructionAttemptTrace,
+  contract: ReconstructionCandidateContract,
+) {
+  const expected = contract.authorities.codex.identitySha256
+  const reconciliation = trace.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-reconciliation',
+  )
+  const repair = trace.providerReceipts.find(
+    ({ role }) => role === 'owner-local-codex-repair',
+  )
+  return (
+    reconciliation?.identitySha256 === expected &&
+    (!repair || repair.identitySha256 === expected)
+  )
+}
+
+function receiptProjection(
+  value: Omit<RefinementRunReceipt, 'receiptSha256'>,
+) {
+  return value
+}
+
+function finalizeReceipt(
+  input: Omit<RefinementRunReceipt, 'receiptSha256'>,
+): RefinementRunReceipt {
+  const projection = structuredClone(input)
+  return {
+    ...projection,
+    receiptSha256: reconstructionRefinementHash(receiptProjection(projection)),
+  }
+}
+
+function validRefinementEvent(value: RefinementEvent) {
+  if (
+    !Number.isSafeInteger(value.sequence) ||
+    value.sequence < 0 ||
+    !Number.isSafeInteger(value.attemptIndex) ||
+    value.attemptIndex < 0
+  ) {
+    return false
+  }
+  const base = ['sequence', 'kind', 'attemptIndex']
+  switch (value.kind) {
+    case 'server-verified':
+      return (
+        exactKeys(value, [...base, 'taskIdentitySha256']) &&
+        sha256(value.taskIdentitySha256)
+      )
+    case 'rendered-and-compared':
+      return (
+        exactKeys(value, [
+          ...base,
+          'traceSha256',
+          ...(value.firstCauseCode === undefined ? [] : ['firstCauseCode']),
+        ]) &&
+        sha256(value.traceSha256) &&
+        (value.firstCauseCode === undefined || safeId(value.firstCauseCode))
+      )
+    case 'fresh-task-created':
+      return (
+        exactKeys(value, [
+          ...base,
+          'traceSha256',
+          'taskIdentitySha256',
+        ]) &&
+        sha256(value.traceSha256) &&
+        sha256(value.taskIdentitySha256)
+      )
+    case 'repair-proposed':
+    case 'repair-verified':
+    case 'repair-applied':
+      return (
+        exactKeys(value, [...base, 'traceSha256', 'proposalSha256']) &&
+        sha256(value.traceSha256) &&
+        sha256(value.proposalSha256)
+      )
+    case 'publication-ready':
+      return (
+        exactKeys(value, [...base, 'traceSha256']) &&
+        sha256(value.traceSha256)
+      )
+    case 'failed':
+      return (
+        exactKeys(value, [...base, 'failureCode']) &&
+        REFINEMENT_FAILURE_CODES.includes(value.failureCode!)
+      )
+  }
+}
+
+function validatePublicRefinementReceipt(input: unknown) {
+  const parsed = refinementRunReceiptEnvelopeSchema.safeParse(input)
+  if (!parsed.success) return false
+  const receipt = parsed.data as unknown as RefinementRunReceipt
+  const { receiptSha256, ...projection } = receipt
+  const freshTaskEvents = receipt.events.filter(
+    (event) => event.kind === 'fresh-task-created',
+  )
+  const verifiedRepairEvents = receipt.events.filter(
+    (event) => event.kind === 'repair-verified',
+  )
+  const appliedRepairEvents = receipt.events.filter(
+    (event) => event.kind === 'repair-applied',
+  )
+  const renderedEvents = receipt.events.filter(
+    (event) => event.kind === 'rendered-and-compared',
+  )
+  const terminalEvents = receipt.events.filter(
+    (event) => event.kind === 'publication-ready' || event.kind === 'failed',
+  )
+  if (
+    !exactKeys(receipt, [
+      'schemaVersion',
+      'authority',
+      'promotionAllowed',
+      'contractSha256',
+      'status',
+      'failureCode',
+      'attempts',
+      'proposalSha256s',
+      'freshTaskCount',
+      'refinementCount',
+      'usage',
+      'events',
+      'receiptSha256',
+    ]) ||
+    receipt.schemaVersion !== RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION ||
+    receipt.authority !== 'diagnostic-only' ||
+    receipt.promotionAllowed !== false ||
+    !['publication-ready', 'failed'].includes(receipt.status) ||
+    !sha256(receipt.contractSha256) ||
+    !sha256(receiptSha256) ||
+    receiptSha256 !== reconstructionRefinementHash(projection) ||
+    !Array.isArray(receipt.attempts) ||
+    !Array.isArray(receipt.proposalSha256s) ||
+    !Array.isArray(receipt.events) ||
+    !nonNegativeInteger(receipt.freshTaskCount) ||
+    !nonNegativeInteger(receipt.refinementCount) ||
+    !validUsage(receipt.usage) ||
+    receipt.events.some((event) => !validRefinementEvent(event)) ||
+    receipt.events.some((event, index) => event.sequence !== index) ||
+    receipt.events.some(
+      (event, index) =>
+        event.attemptIndex < 0 ||
+        !Number.isSafeInteger(event.attemptIndex) ||
+        (index > 0 &&
+          event.attemptIndex < receipt.events[index - 1]!.attemptIndex),
+    ) ||
+    (receipt.attempts.length > 0 &&
+      !validateReconstructionAttemptRefinementTraceBindingLineage(
+        receipt.attempts,
+      )) ||
+    receipt.proposalSha256s.some((proposalSha256) => !sha256(proposalSha256)) ||
+    renderedEvents.length !== receipt.attempts.length ||
+    renderedEvents.some((event, index) => {
+      const attempt = receipt.attempts[index]
+      return (
+        event.traceSha256 !== attempt?.traceSha256 ||
+        event.attemptIndex !== attempt?.attemptIndex ||
+        event.firstCauseCode !== (attempt?.firstCause?.code ?? undefined)
+      )
+    }) ||
+    receipt.proposalSha256s.length !== verifiedRepairEvents.length ||
+    receipt.proposalSha256s.some(
+      (proposalSha256, index) =>
+        verifiedRepairEvents[index]?.proposalSha256 !== proposalSha256,
+    ) ||
+    receipt.refinementCount !== appliedRepairEvents.length ||
+    appliedRepairEvents.length > verifiedRepairEvents.length ||
+    appliedRepairEvents.some(
+      (event, index) =>
+        event.proposalSha256 !== verifiedRepairEvents[index]?.proposalSha256,
+    ) ||
+    receipt.freshTaskCount !== freshTaskEvents.length ||
+    terminalEvents.length !== 1 ||
+    terminalEvents[0] !== receipt.events.at(-1) ||
+    (receipt.status === 'publication-ready' && receipt.attempts.length === 0) ||
+    (receipt.status === 'publication-ready' &&
+      terminalEvents[0]?.kind !== 'publication-ready') ||
+    (receipt.status === 'failed' && terminalEvents[0]?.kind !== 'failed') ||
+    (receipt.status === 'publication-ready' && receipt.failureCode !== null) ||
+    (receipt.status === 'failed' && receipt.failureCode === null) ||
+    (receipt.status === 'publication-ready' &&
+      appliedRepairEvents.length !== verifiedRepairEvents.length)
+  ) {
+    return false
+  }
+  const finalAttempt = receipt.attempts.at(-1)
+  if (
+    receipt.status === 'publication-ready' &&
+    (finalAttempt?.terminalStatus !== 'publication-ready' ||
+      terminalEvents[0]?.traceSha256 !== finalAttempt.traceSha256)
+  ) {
+    return false
+  }
+  return true
+}
+
+/** Public diagnostics are never sufficient evidence for promotion. */
+export function replayRefinementRun(receipt: unknown) {
+  return (
+    validatePublicRefinementReceipt(receipt) &&
+    (receipt as RefinementRunReceipt).status === 'failed'
+  )
+}
+
+/**
+ * Promotion replay is private and authoritative: it requires the complete
+ * owner-local trace and application chain, never the public projection alone.
+ */
+export function replayPrivateRefinementRun(
+  contract: ReconstructionCandidateContract,
+  result: ReconstructionRefinementRunResult,
+  authorities: PrivateReplayAuthorities,
+) {
+  try {
+    const { publicReceipt, privateEvidence } = result
+    if (
+      !validateReconstructionCandidateContract(contract) ||
+      !validatePublicRefinementReceipt(publicReceipt) ||
+      publicReceipt.status !== 'publication-ready' ||
+      publicReceipt.contractSha256 !== contract.contractSha256 ||
+      !validateReconstructionCandidate(
+        privateEvidence.initialCandidate,
+        contract,
+      )
+    ) {
+      return false
+    }
+
+    const traces = parseReconstructionAttemptTraceLineage(
+      privateEvidence.traces,
+    )
+    if (
+      traces.length !== publicReceipt.attempts.length ||
+      privateEvidence.applications.length !== traces.length - 1 ||
+      publicReceipt.refinementCount !== privateEvidence.applications.length ||
+      traces[0]?.structure.artifact.sha256 !==
+        privateEvidence.initialCandidate.binding.canonicalStruct.sha256
+    ) {
+      return false
+    }
+
+    for (const [index, trace] of traces.entries()) {
+      const resolvedRenderArtifacts = verifyTraceArtifacts(
+        contract,
+        authorities.artifactResolver,
+        trace,
+      )
+      if (
+        !resolvedRenderArtifacts ||
+        !verifySourceEvidenceAuthority(
+          contract,
+          authorities.sourceEvidenceVerifier,
+          trace,
+        ) ||
+        !verifyRenderObservationAuthority(
+          contract,
+          authorities.renderObservationExtractor,
+          trace,
+          resolvedRenderArtifacts,
+        ) ||
+        hashTraceValue(toRefinementTraceBinding(trace)) !==
+          hashTraceValue(publicReceipt.attempts[index]) ||
+        hashTraceValue(
+          compareSourceToRenderedEpub({
+            sourcePdfSha256: trace.sourcePdf.artifact.sha256,
+            sourceEvidence: trace.sourceEvidence,
+            structure: trace.structure,
+            epub: trace.epub,
+            renderedEpub: trace.renderedEpub,
+            sourceRegions: trace.comparisonEvidence.sourceRegions,
+            mappings: trace.mappings,
+            observations: trace.comparisonEvidence.observations,
+          }),
+        ) !== hashTraceValue(trace.comparator)
+      ) {
+        return false
+      }
+    }
+
+    let candidate = structuredClone(privateEvidence.initialCandidate)
+    const replayedProposalSha256s: string[] = []
+    for (const [index, application] of privateEvidence.applications.entries()) {
+      const child = traces[index + 1]
+      const proposal = child?.critiqueRepair?.proposal
+      if (!child || !proposal) return false
+      const verifiedApplication = parseMaterializedRepairApplicationReceipt(
+        application,
+        candidate,
+        proposal,
+        contract,
+        {
+          sourceEvidenceVerifier: authorities.sourceEvidenceVerifier,
+          groundedVerifier: authorities.groundedVerifier,
+          evidenceCandidates: traces[0]!.evidenceCandidates,
+        },
+      )
+      candidate = candidateAfterApplication(
+        candidate,
+        verifiedApplication,
+        proposal,
+      )
+      replayedProposalSha256s.push(proposal.proposalSha256)
+      if (
+        candidate.binding.canonicalStruct.sha256 !==
+          child.structure.artifact.sha256 ||
+        child.lineage.appliedRepair?.applicationReceiptSha256 !==
+          verifiedApplication.receiptSha256 ||
+        child.lineage.appliedRepair?.groundedVerifierReceiptSha256 !==
+          verifiedApplication.groundedVerifier.receiptSha256
+      ) {
+        return false
+      }
+    }
+
+    const finalTrace = traces.at(-1)
+    return (
+      finalTrace?.terminalState === 'publication-ready' &&
+      publicReceipt.proposalSha256s.length ===
+        replayedProposalSha256s.length &&
+      publicReceipt.proposalSha256s.every(
+        (proposalSha256, index) =>
+          proposalSha256 === replayedProposalSha256s[index],
+      ) &&
+      publicReceipt.freshTaskCount === (traces.length > 1 ? 1 : 0) &&
+      publicReceipt.usage.inputTokens + publicReceipt.usage.outputTokens ===
+        finalTrace.budget.usage.tokens &&
+      Math.ceil(publicReceipt.usage.elapsedMs) >=
+        finalTrace.budget.usage.durationMs
+    )
+  } catch {
+    return false
+  }
+}
+
+function invalidContractRunResult(
+  initialCandidate: ReconstructionCandidate,
+): ReconstructionRefinementRunResult {
+  const publicReceipt = finalizeReceipt({
+    schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+    authority: 'diagnostic-only',
+    promotionAllowed: false,
+    contractSha256: reconstructionRefinementHash({
+      kind: 'invalid-runtime-contract',
+    }),
+    status: 'failed',
+    failureCode: 'invalid-candidate-contract',
+    attempts: [],
+    proposalSha256s: [],
+    freshTaskCount: 0,
+    refinementCount: 0,
+    usage: zeroUsage(),
+    events: [
+      {
+        sequence: 0,
+        kind: 'failed',
+        attemptIndex: 0,
+        failureCode: 'invalid-candidate-contract',
+      },
+    ],
+  })
+  return {
+    publicReceipt,
+    privateEvidence: {
+      initialCandidate: structuredClone(initialCandidate),
+      traces: [],
+      applications: [],
+    },
+  }
+}
+
+function concurrentRunResult(
+  contract: ReconstructionCandidateContract,
+  initialCandidate: ReconstructionCandidate,
+): ReconstructionRefinementRunResult {
+  const publicReceipt = finalizeReceipt({
+    schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+    authority: 'diagnostic-only',
+    promotionAllowed: false,
+    contractSha256: contract.contractSha256,
+    status: 'failed',
+    failureCode: 'concurrent-run',
+    attempts: [],
+    proposalSha256s: [],
+    freshTaskCount: 0,
+    refinementCount: 0,
+    usage: zeroUsage(),
+    events: [
+      {
+        sequence: 0,
+        kind: 'failed',
+        attemptIndex: 0,
+        failureCode: 'concurrent-run',
+      },
+    ],
+  })
+  return {
+    publicReceipt,
+    privateEvidence: {
+      initialCandidate: structuredClone(initialCandidate),
+      traces: [],
+      applications: [],
+    },
+  }
+}
+
+type ReconstructionRefinementRunInput = {
+  contract: ReconstructionCandidateContract
+  initialCandidate: ReconstructionCandidate
+  dependencies: ReconstructionRefinementDependencies
+  signal?: AbortSignal
+}
+
+async function runReconstructionRefinementExclusive(
+  {
+    contract,
+    initialCandidate,
+    dependencies,
+    signal = new AbortController().signal,
+  }: ReconstructionRefinementRunInput,
+  runLease: ActiveRefinementRun,
+): Promise<ReconstructionRefinementRunResult> {
+  if (!validateReconstructionCandidateContract(contract)) {
+    return invalidContractRunResult(initialCandidate)
+  }
+  const privateTraces: ReconstructionAttemptTrace[] = []
+  const applications: MaterializedRepairApplicationReceipt[] = []
+  const frozenInitialCandidate = structuredClone(initialCandidate)
+  const attempts: ReconstructionAttemptRefinementTraceBinding[] = []
+  const proposalSha256s: string[] = []
+  const events: RefinementEvent[] = []
+  let usage = zeroUsage()
+  let freshTaskCount = 0
+  let refinementCount = 0
+  let candidate = initialCandidate
+  let task: RefinementTask | undefined
+  let parentTraceSha256: string | null = null
+  const startedAt = Date.now()
+  const deadlineAt = startedAt + contract.budget.maxDurationMs
+  const measuredElapsedMs = () => Math.max(0, Date.now() - startedAt)
+  const remainingTimeMs = () => Math.max(0, deadlineAt - Date.now())
+  const refreshElapsedUsage = () => {
+    usage = { ...usage, elapsedMs: measuredElapsedMs() }
+  }
+
+  const event = (value: Omit<RefinementEvent, 'sequence'>): RefinementEvent => {
+    const recorded = { sequence: events.length, ...value }
+    events.push(recorded)
+    return recorded
+  }
+  const finish = (
+    status: RefinementRunReceipt['status'],
+    failureCode: RefinementFailureCode | null,
+  ) => {
+    refreshElapsedUsage()
+    const publicReceipt = finalizeReceipt({
+      schemaVersion: RECONSTRUCTION_REFINEMENT_SCHEMA_VERSION,
+      authority: 'diagnostic-only',
+      promotionAllowed: false,
+      contractSha256: contract.contractSha256,
+      status,
+      failureCode,
+      attempts,
+      proposalSha256s,
+      freshTaskCount,
+      refinementCount,
+      usage,
+      events,
+    })
+    return {
+      publicReceipt,
+      privateEvidence: {
+        initialCandidate: frozenInitialCandidate,
+        traces: structuredClone(privateTraces),
+        applications: structuredClone(applications),
+      },
+    }
+  }
+  const fail = (code: RefinementFailureCode, attemptIndex: number) => {
+    refreshElapsedUsage()
+    event({ kind: 'failed', attemptIndex, failureCode: code })
+    return finish('failed', code)
+  }
+
+  if (
+    !validateReconstructionCandidate(initialCandidate, contract)
+  ) {
+    return fail('invalid-candidate-contract', 0)
+  }
+  const codex = dependencies.codex
+  if (!codex) {
+    return fail('codex-server-unavailable', 0)
+  }
+  if (
+    !validateOwnerLocalCodexIdentity(codex.identity) ||
+    hashOwnerLocalCodexIdentity(codex.identity) !==
+      contract.authorities.codex.identitySha256
+  ) {
+    return fail('codex-identity-mismatch', 0)
+  }
+  try {
+    const remaining = remainingTimeMs()
+    if (remaining < 1) return fail('codex-probe-timeout', 0)
+    const guardedProbe = await withTaskDeadline(
+      (taskSignal, lease) => codex.probe(taskSignal, lease),
+      remaining,
+      signal,
+      runLease,
+      'codex-probe',
+    )
+    if (!guardedProbe.value.available) {
+      guardedProbe.discard()
+      return fail('codex-server-unavailable', 0)
+    }
+    guardedProbe.accept(() =>
+      event({
+        kind: 'server-verified',
+        attemptIndex: 0,
+        taskIdentitySha256: reconstructionRefinementHash(codex.identity),
+      }),
+    )
+  } catch (error) {
+    if (
+      signal.aborted ||
+      (error instanceof Error && error.name === 'AbortError')
+    ) {
+      return fail('interrupted', 0)
+    }
+    if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+      return fail('codex-probe-timeout', 0)
+    }
+    return fail('codex-server-unavailable', 0)
+  }
+  for (
+    let attemptIndex = 0;
+    attemptIndex <= contract.budget.maxRefinements;
+    attemptIndex += 1
+  ) {
+    let trace: ReconstructionAttemptTrace
+    let binding: RefinementTraceBinding
+    let guardedEvaluation: GuardedStageResult<ReconstructionAttemptTrace> | undefined
+    try {
+      aborted(signal)
+      refreshElapsedUsage()
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('evaluation-timeout', attemptIndex)
+      guardedEvaluation = await withTaskDeadline(
+        (taskSignal, lease) =>
+          dependencies.evaluate(candidate, {
+            attemptIndex,
+            parentTraceSha256,
+            usage: {
+              refinements: refinementCount,
+              freshTasks: freshTaskCount,
+              tokens: combinedTokens(usage),
+              durationMs: Math.ceil(usage.elapsedMs),
+            },
+            signal: taskSignal,
+            lease,
+          }),
+        remaining,
+        signal,
+        runLease,
+        `evaluate:${attemptIndex}`,
+      )
+      trace = parseReconstructionAttemptTrace(guardedEvaluation.value)
+      if (!traceMatchesCodexAuthority(trace, contract)) {
+        guardedEvaluation.discard()
+        return fail('codex-identity-mismatch', attemptIndex)
+      }
+      binding = toRefinementTraceBinding(trace)
+    } catch (error) {
+      guardedEvaluation?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('evaluation-timeout', attemptIndex)
+      }
+      return fail('evaluation-failed', attemptIndex)
+    }
+    if (
+      !validateTraceBinding(
+        binding,
+        contract,
+        attemptIndex,
+        parentTraceSha256,
+        {
+          refinements: refinementCount,
+          freshTasks: freshTaskCount,
+          tokens: combinedTokens(usage),
+          durationMs: Math.ceil(usage.elapsedMs),
+        },
+      ) ||
+      binding.canonicalStructSha256 !==
+        candidate.binding.canonicalStruct.sha256
+    ) {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    if (
+      (binding.terminalStatus === 'publication-ready' &&
+        binding.firstCause !== null) ||
+      (binding.terminalStatus === 'failed' && binding.firstCause === null)
+    ) {
+      guardedEvaluation.discard()
+      return fail('missing-first-cause', attemptIndex)
+    }
+    const priorApplication = applications[attemptIndex - 1]
+    if (
+      attemptIndex > 0 &&
+      (!priorApplication ||
+        trace.lineage.appliedRepair?.applicationReceiptSha256 !==
+          priorApplication.receiptSha256 ||
+        trace.lineage.appliedRepair?.groundedVerifierReceiptSha256 !==
+          priorApplication.groundedVerifier.receiptSha256 ||
+        trace.lineage.appliedRepair?.resultingStructSha256 !==
+          priorApplication.resultingCanonicalStruct.sha256)
+    ) {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    try {
+      parseReconstructionAttemptTraceLineage([...privateTraces, trace])
+    } catch {
+      guardedEvaluation.discard()
+      return fail('stale-trace', attemptIndex)
+    }
+    try {
+      guardedEvaluation.accept(() => {
+        privateTraces.push(trace)
+        attempts.push(binding)
+        event({
+          kind: 'rendered-and-compared',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          ...(binding.firstCause
+            ? { firstCauseCode: binding.firstCause.code }
+            : {}),
+        })
+        if (binding.terminalStatus === 'publication-ready') {
+          event({
+            kind: 'publication-ready',
+            attemptIndex,
+            traceSha256: binding.traceSha256,
+          })
+        }
+      })
+    } catch {
+      return fail('interrupted', attemptIndex)
+    }
+    if (binding.terminalStatus === 'publication-ready') {
+      return finish('publication-ready', null)
+    }
+    if (!binding.firstCause) return fail('missing-first-cause', attemptIndex)
+    if (attemptIndex >= contract.budget.maxRefinements) {
+      return fail('refinement-budget-exhausted', attemptIndex)
+    }
+
+    const immutablePriorTrace = immutableClone(trace)
+    if (!task) {
+      if (freshTaskCount >= contract.budget.maxFreshTasks) {
+        return fail('fresh-task-budget-exhausted', attemptIndex)
+      }
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('fresh-task-timeout', attemptIndex)
+      let guardedTask: GuardedStageResult<unknown> | undefined
+      let parsedTask: RefinementTask
+      try {
+        guardedTask = await withTaskDeadline(
+          (taskSignal, lease) =>
+              codex.createFreshTask(
+                {
+                  documentId: contract.documentId,
+                  runId: contract.runId,
+                  immutablePriorTrace,
+                  priorTraceSha256: binding.traceSha256,
+                  firstCause: binding.firstCause!,
+                  budget: { ...contract.budget },
+                },
+                taskSignal,
+                lease,
+              ),
+          remaining,
+          signal,
+          runLease,
+          `create-fresh-task:${attemptIndex}`,
+        )
+        parsedTask = refinementTaskSchema.parse(
+          guardedTask.value,
+        ) as RefinementTask
+      } catch (error) {
+        guardedTask?.discard()
+        if (
+          signal.aborted ||
+          (error instanceof Error && error.name === 'AbortError')
+        ) {
+          return fail('interrupted', attemptIndex)
+        }
+        if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+          return fail('fresh-task-timeout', attemptIndex)
+        }
+        return fail('fresh-task-invalid', attemptIndex)
+      }
+      if (!validTask(parsedTask, contract, binding, codex.identity)) {
+        guardedTask.discard()
+        return fail('fresh-task-invalid', attemptIndex)
+      }
+      try {
+        guardedTask.accept(() => {
+          task = parsedTask
+          freshTaskCount += 1
+          event({
+            kind: 'fresh-task-created',
+            attemptIndex,
+            traceSha256: binding.traceSha256,
+            taskIdentitySha256: reconstructionRefinementHash(task.identity),
+          })
+        })
+      } catch {
+        return fail('interrupted', attemptIndex)
+      }
+    }
+
+    const remainingTokens = contract.budget.maxTokens - combinedTokens(usage)
+    const remaining = remainingTimeMs()
+    if (remainingTokens < 1) {
+      return fail('token-budget-exhausted', attemptIndex)
+    }
+    if (remaining < 1) return fail('repair-proposal-timeout', attemptIndex)
+    let proposed: { proposal: StructEvidencePatch; usage: RefinementUsage }
+    let guardedProposal: GuardedStageResult<unknown> | undefined
+    try {
+      guardedProposal = await withTaskDeadline(
+        (taskSignal, lease) =>
+          codex.proposeRepair(
+            {
+              task: structuredClone(task!),
+              immutablePriorTrace,
+              priorTraceSha256: binding.traceSha256,
+              firstCause: binding.firstCause!,
+              remainingTokens,
+              remainingTimeMs: remaining,
+            },
+            taskSignal,
+            lease,
+          ),
+        remaining,
+        signal,
+        runLease,
+        `propose-repair:${attemptIndex}`,
+      )
+      const parsedResponse = codexProposalResponseSchema.parse(
+        guardedProposal.value,
+      )
+      proposed = {
+        proposal: parseStructEvidencePatch(parsedResponse.proposal),
+        usage: parsedResponse.usage as RefinementUsage,
+      }
+    } catch (error) {
+      guardedProposal?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('repair-proposal-timeout', attemptIndex)
+      }
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    if (!validUsage(proposed.usage)) {
+      guardedProposal.discard()
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    const nextUsage = {
+      inputTokens: usage.inputTokens + proposed.usage.inputTokens,
+      outputTokens: usage.outputTokens + proposed.usage.outputTokens,
+      elapsedMs: measuredElapsedMs(),
+    }
+    if (combinedTokens(nextUsage) > contract.budget.maxTokens) {
+      guardedProposal.discard()
+      return fail('token-budget-exhausted', attemptIndex)
+    }
+    if (nextUsage.elapsedMs > contract.budget.maxDurationMs) {
+      guardedProposal.discard()
+      return fail('repair-proposal-timeout', attemptIndex)
+    }
+    if (
+      !validateStructEvidencePatch(proposed.proposal, contract, binding, task!)
+    ) {
+      guardedProposal.discard()
+      return fail('invalid-repair-proposal', attemptIndex)
+    }
+    try {
+      guardedProposal.accept(() => {
+        usage = nextUsage
+        proposalSha256s.push(proposed.proposal.proposalSha256)
+        event({
+          kind: 'repair-proposed',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+        event({
+          kind: 'repair-verified',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+      })
+    } catch {
+      return fail('interrupted', attemptIndex)
+    }
+    const before = candidate
+    let guardedApplication: GuardedStageResult<unknown> | undefined
+    try {
+      aborted(signal)
+      const remaining = remainingTimeMs()
+      if (remaining < 1) return fail('repair-application-timeout', attemptIndex)
+      guardedApplication = await withTaskDeadline(
+        (taskSignal, lease) =>
+            dependencies.materializeRepair(
+              before,
+              structuredClone(proposed.proposal),
+              taskSignal,
+              lease,
+            ),
+        remaining,
+        signal,
+        runLease,
+        `materialize-repair:${attemptIndex}`,
+      )
+      const application: MaterializedRepairApplicationReceipt =
+        parseMaterializedRepairApplicationReceipt(
+        guardedApplication.value,
+        before,
+        proposed.proposal,
+        contract,
+        {
+          ...dependencies.materializationVerification!,
+          evidenceCandidates: trace.evidenceCandidates,
+        },
+      )
+      const resultingCandidate = candidateAfterApplication(
+        before,
+        application,
+        proposed.proposal,
+      )
+      guardedApplication.accept(() => {
+        applications.push(application)
+        candidate = resultingCandidate
+        refinementCount += 1
+        event({
+          kind: 'repair-applied',
+          attemptIndex,
+          traceSha256: binding.traceSha256,
+          proposalSha256: proposed.proposal.proposalSha256,
+        })
+        parentTraceSha256 = binding.traceSha256
+      })
+    } catch (error) {
+      guardedApplication?.discard()
+      if (
+        signal.aborted ||
+        (error instanceof Error && error.name === 'AbortError')
+      ) {
+        return fail('interrupted', attemptIndex)
+      }
+      if (error instanceof Error && error.message === 'TASK_TIMEOUT') {
+        return fail('repair-application-timeout', attemptIndex)
+      }
+      return fail('repair-application-failed', attemptIndex)
+    }
+  }
+
+  return fail('refinement-budget-exhausted', contract.budget.maxRefinements)
+}
+
+export async function runReconstructionRefinement(
+  input: ReconstructionRefinementRunInput,
+): Promise<ReconstructionRefinementRunResult> {
+  if (!validateReconstructionCandidateContract(input.contract)) {
+    return invalidContractRunResult(input.initialCandidate)
+  }
+  const runId = input.contract.runId
+  if (activeRefinementRuns.has(runId)) {
+    return concurrentRunResult(input.contract, input.initialCandidate)
+  }
+  const generation = (refinementRunGenerations.get(runId) ?? 0) + 1
+  refinementRunGenerations.set(runId, generation)
+  const runLease: ActiveRefinementRun = {
+    runId,
+    generationSha256: hashTraceValue({
+      runId,
+      contractSha256: input.contract.contractSha256,
+      generation,
+    }),
+    nextStageIndex: 0,
+    pendingStages: new Set(),
+    finished: false,
+  }
+  activeRefinementRuns.set(runId, runLease)
+  try {
+    return await runReconstructionRefinementExclusive(input, runLease)
+  } finally {
+    runLease.finished = true
+    releaseRefinementRunWhenSettled(runLease)
+  }
+}

--- a/src/research/source-epub-comparator.test.ts
+++ b/src/research/source-epub-comparator.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from 'vitest'
+import { sha256HexSync } from '../struct/sha256'
+import {
+  DETERMINISTIC_CHECK_IDS,
+  encodeCanonicalObservationPayload,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  type RenderedEpubEvidence,
+  type SourceLocation,
+} from './reconstruction-attempt-trace'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+  type SourceEpubComparisonInput,
+} from './source-epub-comparator'
+
+const digest = (value: string) => hashTraceValue(value)
+const spineHref = 'EPUB/content.xhtml'
+const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+const source: SourceLocation = {
+  page: 2,
+  boxes: [{ page: 2, x: 10, y: 20, width: 300, height: 400, rotation: 0 }],
+  sourceRegionIds: ['region-1'],
+}
+
+function observationPayload(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+  labels: string[],
+) {
+  const bytes = encodeCanonicalObservationPayload({
+    schemaVersion: '1.0.0',
+    check,
+    items: labels.map((label) => ({
+      idSha256: digest(`item-${check}-${label}`),
+      valueSha256: digest(`value-${check}-${label}`),
+      anchorIds: ['struct-figure-1'],
+    })),
+  })
+  return { sha256: sha256HexSync(bytes), byteLength: bytes.byteLength }
+}
+
+function renderedReceipt({
+  sourcePdfSha256,
+  epubSha256,
+  sourceRegions,
+  actualObservationSets,
+}: {
+  sourcePdfSha256: string
+  epubSha256: string
+  sourceRegions: SourceEpubComparisonInput['sourceRegions']
+  actualObservationSets: RenderedEpubEvidence['actualObservationSets']
+}): RenderedEpubEvidence {
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const withoutReceipt: Omit<RenderedEpubEvidence, 'receiptSha256'> = {
+    epubSha256,
+    download: {
+      artifact: { sha256: epubSha256, byteLength: 500 },
+      verificationReceiptSha256: digest('download-verification'),
+    },
+    sourceObligations: {
+      ...obligationProjection,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    actualObservationSets,
+    renderer: {
+      id: 'chromium',
+      version: '1',
+      configurationSha256: digest('render-config'),
+    },
+    domSnapshots: [
+      {
+        spineHref,
+        dom: { sha256: digest('rendered-dom'), byteLength: 200 },
+        anchors: ['struct-figure-1'],
+      },
+    ],
+    screenshots: [
+      {
+        id: 'screen-1',
+        spineHref,
+        domSha256: digest('rendered-dom'),
+        image: { sha256: digest('screen'), byteLength: 800 },
+        mediaType: 'image/png',
+        width: 800,
+        height: 1_000,
+        viewport,
+        fullPage: true,
+      },
+    ],
+  }
+  const candidate = {
+    ...withoutReceipt,
+    receiptSha256: digest('placeholder'),
+  }
+  candidate.receiptSha256 = hashRenderedEpubEvidence(candidate)
+  return candidate
+}
+
+function comparisonInput(): SourceEpubComparisonInput {
+  const sourcePdfSha256 = digest('source-pdf')
+  const structSha256 = digest('struct')
+  const epubSha256 = digest('epub')
+  const sourceRegions = [{ id: 'region-1', source }]
+  const obligationProjection = {
+    sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sourceRegions),
+    obligationCount: sourceRegions.length,
+  }
+  const expectedObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const payload = observationPayload(check, [`source-${check}`])
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+        sourceRegionIds: ['region-1'],
+      }
+      return {
+        ...projection,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  )
+  const actualObservationSets = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check) => {
+      const payload = observationPayload(check, [`source-${check}`])
+      const projection = {
+        check,
+        setSha256: payload.sha256,
+        itemCount: 1,
+        payload,
+      }
+      return {
+        ...projection,
+        receiptSha256: hashTraceValue(projection),
+      }
+    },
+  )
+  const sourceEvidenceWithoutReceipt = {
+    schemaVersion: '1.0.0',
+    sourcePdfSha256,
+    evidenceGraphSha256: digest('evidence-graph'),
+    candidateSetSha256: digest('candidate-set'),
+    sourceObligations: {
+      obligationsSha256: obligationProjection.obligationsSha256,
+      obligationCount: obligationProjection.obligationCount,
+      receiptSha256: hashTraceValue(obligationProjection),
+    },
+    expectedObservationSets,
+  }
+  const sourceEvidence = {
+    ...sourceEvidenceWithoutReceipt,
+    receiptSha256: hashTraceValue(sourceEvidenceWithoutReceipt),
+  }
+  const renderedEpub = renderedReceipt({
+    sourcePdfSha256,
+    epubSha256,
+    sourceRegions,
+    actualObservationSets,
+  })
+  const mappings: SourceEpubComparisonInput['mappings'] = [
+    {
+      id: 'mapping-1',
+      obligationId: 'obligation-1',
+      source,
+      output: [
+        {
+          spineHref,
+          anchorId: 'struct-figure-1',
+          rendered: {
+            screenshotId: 'screen-1',
+            viewport,
+            rect: { x: 10, y: 20, width: 300, height: 400 },
+          },
+        },
+      ],
+      status: 'mapped',
+    },
+  ]
+  return {
+    sourcePdfSha256,
+    sourceEvidence,
+    structure: {
+      schemaVersion: '0.2.0',
+      documentId: 'document-1',
+      sourcePdfSha256,
+      artifact: { sha256: structSha256, byteLength: 300 },
+      generatedSha256: digest('generated-struct'),
+      assets: [],
+    },
+    epub: {
+      bytes: { sha256: epubSha256, byteLength: 500 },
+      mediaType: 'application/epub+zip',
+      structSha256,
+      epubCheck: {
+        toolId: 'epubcheck',
+        toolVersion: '5.3.0',
+        reportSha256: digest('epubcheck-report'),
+        status: 'passed',
+        errorCount: 0,
+        warningCount: 0,
+      },
+    },
+    renderedEpub,
+    sourceRegions,
+    mappings,
+    observations: SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+      createDeterministicObservationReceipt({
+        idSha256: digest(`observation-${check}`),
+        check,
+        mappingIds: ['mapping-1'],
+        expectedSetReceiptSha256: expectedObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+        actualSetReceiptSha256: actualObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+      }),
+    ),
+  }
+}
+
+function mismatch(
+  check: (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+) {
+  const input = comparisonInput()
+  const index = input.observations.findIndex(
+    (candidate) => candidate.check === check,
+  )
+  const observation = input.observations[index]!
+  const { receiptSha256: _receiptSha256, ...observationCore } = observation
+  const actual = input.renderedEpub.actualObservationSets.find(
+    (candidate) => candidate.check === check,
+  )!
+  actual.payload = observationPayload(check, [])
+  actual.setSha256 = actual.payload.sha256
+  actual.itemCount = 0
+  actual.receiptSha256 = hashRenderedActualObservationSet(actual)
+  input.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+    input.renderedEpub,
+  )
+  input.observations[index] = createDeterministicObservationReceipt({
+    ...observationCore,
+    source,
+    actualSetReceiptSha256: actual.receiptSha256,
+  })
+  return compareSourceToRenderedEpub(input)
+}
+
+describe('source to rendered EPUB comparator', () => {
+  it('passes only a complete hash-bound renderer and source receipt set', () => {
+    const result = compareSourceToRenderedEpub(comparisonInput())
+
+    expect(result.status).toBe('publication-ready')
+    expect(new Set(result.checkResults.map(({ check }) => check))).toEqual(
+      new Set(DETERMINISTIC_CHECK_IDS),
+    )
+    expect(result.denominator).toBe(result.passed)
+    expect(result.renderObservationReceiptSha256).toMatch(/^[a-f0-9]{64}$/u)
+  })
+
+  it('rejects zero-observation self-attestation for source-bearing evidence', () => {
+    const raw = comparisonInput() as unknown as {
+      observations: Array<Record<string, unknown>>
+    }
+    raw.observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) => ({
+      idSha256: digest(`raw-${check}`),
+      check,
+      mappingIds: ['mapping-1'],
+      expected: [],
+      actual: [],
+    }))
+    expect(() => compareSourceToRenderedEpub(raw)).toThrow(
+      /required/iu,
+    )
+
+    const unproved = comparisonInput()
+    const expected = unproved.sourceEvidence.expectedObservationSets[0]!
+    expected.payload = observationPayload(expected.check, [])
+    expected.setSha256 = expected.payload.sha256
+    expected.itemCount = 0
+    expected.receiptSha256 = hashSourceExpectedObservationSet(expected)
+    unproved.sourceEvidence.receiptSha256 = hashSourceEvidenceReceipt(
+      unproved.sourceEvidence,
+    )
+    const observation = unproved.observations.find(
+      ({ check }) => check === expected.check,
+    )!
+    const { receiptSha256: _receiptSha256, ...observationCore } = observation
+    Object.assign(
+      observation,
+      createDeterministicObservationReceipt({
+        ...observationCore,
+        expectedSetReceiptSha256: expected.receiptSha256,
+      }),
+    )
+    expect(() => compareSourceToRenderedEpub(unproved)).toThrow(/self-attests zero/iu)
+  })
+
+  it.each([
+    'figures',
+    'captions',
+    'reading-order',
+    'code-preformatted',
+  ] as const)('fails and locates a proven %s mismatch', (check) => {
+    const result = mismatch(check)
+    const firstCause = result.failures.find(
+      ({ id }) => id === result.firstCauseFailureId,
+    )
+    expect(result.status).toBe('failed')
+    expect(firstCause).toMatchObject({ check, mappingIds: ['mapping-1'] })
+  })
+
+  it('rejects nonexistent anchors and empty or out-of-bounds locators', () => {
+    const missingAnchor = comparisonInput()
+    missingAnchor.mappings[0]!.output[0]!.anchorId = 'missing-anchor'
+    expect(() => compareSourceToRenderedEpub(missingAnchor)).toThrow(
+      /nonexistent anchor/iu,
+    )
+
+    const zeroArea = comparisonInput()
+    zeroArea.mappings[0]!.output[0]!.rendered!.rect.width = 0
+    expect(() => compareSourceToRenderedEpub(zeroArea)).toThrow(/empty/iu)
+
+    const outOfBounds = comparisonInput()
+    outOfBounds.mappings[0]!.output[0]!.rendered!.rect.x = 700
+    outOfBounds.mappings[0]!.output[0]!.rendered!.rect.width = 200
+    expect(() => compareSourceToRenderedEpub(outOfBounds)).toThrow(
+      /out-of-bounds/iu,
+    )
+  })
+
+  it('rejects stale render/source receipts and fails EPUBCheck warnings', () => {
+    const staleRender = comparisonInput()
+    staleRender.renderedEpub.download.artifact.sha256 = digest('other-epub')
+    expect(() => compareSourceToRenderedEpub(staleRender)).toThrow(
+      /downloaded EPUB/iu,
+    )
+
+    const staleSource = comparisonInput()
+    staleSource.renderedEpub.sourceObligations.obligationCount = 2
+    staleSource.renderedEpub.receiptSha256 = hashRenderedEpubEvidence(
+      staleSource.renderedEpub,
+    )
+    expect(() => compareSourceToRenderedEpub(staleSource)).toThrow(
+      /source-obligation/iu,
+    )
+
+    const warning = comparisonInput()
+    warning.epub.epubCheck.warningCount = 1
+    expect(compareSourceToRenderedEpub(warning).failures[0]).toMatchObject({
+      check: 'epub-package',
+    })
+  })
+})

--- a/src/research/source-epub-comparator.ts
+++ b/src/research/source-epub-comparator.ts
@@ -1,0 +1,539 @@
+import { z } from 'zod'
+import {
+  SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION,
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  compareComparisonFailures,
+  epubBindingSchema,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  observationReceiptCoreSchema,
+  observationReceiptSchema,
+  renderedEpubSchema,
+  sourceEvidenceReceiptSchema,
+  sourceRegionObligationSchema,
+  sourceOutputMappingSchema,
+  structBindingSchema,
+  type ComparisonFailure,
+  type DeterministicCheckId,
+  type DeterministicComparisonObservation,
+  type EpubArtifactBinding,
+  type RenderedEpubEvidence,
+  type SourceEpubComparatorResult,
+  type SourceLocation,
+  type SourceOutputMapping,
+  type SourceRegionObligation,
+  type SourceEvidenceReceiptBinding,
+  type StructArtifactBinding,
+} from './reconstruction-attempt-trace'
+
+export type {
+  DeterministicComparisonObservation,
+  SourceRegionObligation,
+} from './reconstruction-attempt-trace'
+export { SOURCE_EPUB_OBSERVATION_CHECK_IDS } from './reconstruction-attempt-trace'
+
+const sha256ValueSchema = z.string().regex(/^[a-f0-9]{64}$/u)
+
+const comparisonInputSchema = z
+  .object({
+    sourcePdfSha256: sha256ValueSchema,
+    sourceEvidence: sourceEvidenceReceiptSchema,
+    structure: structBindingSchema,
+    epub: epubBindingSchema,
+    renderedEpub: renderedEpubSchema,
+    sourceRegions: z.array(sourceRegionObligationSchema).min(1),
+    mappings: z.array(sourceOutputMappingSchema).min(1),
+    observations: z
+      .array(
+        observationReceiptSchema.refine(
+          ({ check }) =>
+            SOURCE_EPUB_OBSERVATION_CHECK_IDS.includes(
+              check as (typeof SOURCE_EPUB_OBSERVATION_CHECK_IDS)[number],
+            ),
+          'Unsupported source/EPUB observation check.',
+        ),
+      )
+      .min(1),
+  })
+  .strict()
+export type SourceEpubComparisonInput = {
+  sourcePdfSha256: string
+  sourceEvidence: SourceEvidenceReceiptBinding
+  structure: StructArtifactBinding
+  epub: EpubArtifactBinding
+  renderedEpub: RenderedEpubEvidence
+  sourceRegions: SourceRegionObligation[]
+  mappings: SourceOutputMapping[]
+  observations: DeterministicComparisonObservation[]
+}
+
+function compareCodeUnits(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function inputError(message: string): never {
+  throw new TypeError(`Invalid source/EPUB comparison input: ${message}`)
+}
+
+function assertUnique(values: readonly string[], label: string) {
+  if (new Set(values).size !== values.length) {
+    inputError(`${label} must contain unique ids`)
+  }
+}
+
+function observationCore(
+  input: Omit<DeterministicComparisonObservation, 'receiptSha256'>,
+) {
+  return input
+}
+
+export function createDeterministicObservationReceipt(
+  input: Omit<DeterministicComparisonObservation, 'receiptSha256'>,
+) {
+  const core = observationReceiptCoreSchema.parse(input)
+  return observationReceiptSchema.parse({
+    ...core,
+    receiptSha256: hashTraceValue(core),
+  })
+}
+
+function sortedSourceObligations(input: SourceRegionObligation[]) {
+  return [...input].sort((left, right) => compareCodeUnits(left.id, right.id))
+}
+
+function assertInput(input: SourceEpubComparisonInput) {
+  if (
+    input.sourceEvidence.sourcePdfSha256 !== input.sourcePdfSha256 ||
+    input.sourceEvidence.receiptSha256 !==
+      hashSourceEvidenceReceipt(input.sourceEvidence)
+  ) {
+    inputError('source-evidence receipt is stale or unrelated')
+  }
+  if (input.structure.sourcePdfSha256 !== input.sourcePdfSha256) {
+    inputError('STRUCT is not bound to the source PDF')
+  }
+  if (input.epub.structSha256 !== input.structure.artifact.sha256) {
+    inputError('EPUB is not bound to the exact STRUCT artifact')
+  }
+  if (
+    input.renderedEpub.epubSha256 !== input.epub.bytes.sha256 ||
+    hashTraceValue(input.renderedEpub.download.artifact) !==
+      hashTraceValue(input.epub.bytes) ||
+    input.renderedEpub.receiptSha256 !==
+      hashRenderedEpubEvidence(input.renderedEpub)
+  ) {
+    inputError('renderer receipt is not bound to the downloaded EPUB bytes')
+  }
+  const obligationProjection = {
+    sourcePdfSha256: input.sourcePdfSha256,
+    obligationsSha256: hashTraceValue(sortedSourceObligations(input.sourceRegions)),
+    obligationCount: input.sourceRegions.length,
+  }
+  if (
+    input.sourceEvidence.sourceObligations.obligationsSha256 !==
+      obligationProjection.obligationsSha256 ||
+    input.sourceEvidence.sourceObligations.obligationCount !==
+      obligationProjection.obligationCount ||
+    input.sourceEvidence.sourceObligations.receiptSha256 !==
+      hashTraceValue(obligationProjection) ||
+    input.renderedEpub.sourceObligations.sourcePdfSha256 !==
+      obligationProjection.sourcePdfSha256 ||
+    input.renderedEpub.sourceObligations.obligationsSha256 !==
+      obligationProjection.obligationsSha256 ||
+    input.renderedEpub.sourceObligations.obligationCount !==
+      obligationProjection.obligationCount ||
+    input.renderedEpub.sourceObligations.receiptSha256 !==
+      hashTraceValue(obligationProjection)
+  ) {
+    inputError('source-obligation receipt is stale or unrelated')
+  }
+
+  assertUnique(
+    input.sourceRegions.map(({ id }) => id),
+    'sourceRegions',
+  )
+  assertUnique(
+    input.mappings.map(({ id }) => id),
+    'mappings',
+  )
+  assertUnique(
+    input.observations.map(({ idSha256 }) => idSha256),
+    'observations',
+  )
+  assertUnique(
+    input.observations.map(({ check }) => check),
+    'observation categories',
+  )
+  assertUnique(
+    input.sourceEvidence.expectedObservationSets.map(({ check }) => check),
+    'expected observation categories',
+  )
+  assertUnique(
+    input.renderedEpub.actualObservationSets.map(({ check }) => check),
+    'actual observation categories',
+  )
+
+  const expectedSets = new Map(
+    input.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    input.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  if (
+    SOURCE_EPUB_OBSERVATION_CHECK_IDS.some(
+      (check) =>
+        !expectedSets.has(check) ||
+        !actualSets.has(check) ||
+        !input.observations.some((observation) => observation.check === check),
+    )
+  ) {
+    inputError('every observation category requires one expected, actual, and selection receipt')
+  }
+  const sourceRegionIds = new Set(input.sourceRegions.map(({ id }) => id))
+  for (const expected of input.sourceEvidence.expectedObservationSets) {
+    if (
+      expected.receiptSha256 !== hashSourceExpectedObservationSet(expected) ||
+      expected.setSha256 !== expected.payload.sha256 ||
+      new Set(expected.sourceRegionIds).size !== expected.sourceRegionIds.length ||
+      expected.sourceRegionIds.some((id) => !sourceRegionIds.has(id)) ||
+      (expected.sourceRegionIds.length > 0 && expected.itemCount === 0)
+    ) {
+      inputError(
+        `expected ${expected.check} set is stale, ungrounded, or self-attests zero source-bearing items`,
+      )
+    }
+  }
+  for (const actual of input.renderedEpub.actualObservationSets) {
+    if (
+      actual.receiptSha256 !== hashRenderedActualObservationSet(actual) ||
+      actual.setSha256 !== actual.payload.sha256
+    ) {
+      inputError(`actual ${actual.check} set receipt is stale`)
+    }
+  }
+
+  for (const [index, region] of input.sourceRegions.entries()) {
+    if (
+      region.source.sourceRegionIds.length !== 1 ||
+      region.source.sourceRegionIds[0] !== region.id ||
+      !input.mappings.some(({ source }) =>
+        source.sourceRegionIds.includes(region.id),
+      )
+    ) {
+      inputError(`sourceRegions.${index} is not singly and explicitly mapped`)
+    }
+  }
+  for (const [index, observation] of input.observations.entries()) {
+    const { receiptSha256, ...core } = observation
+    const expected = expectedSets.get(observation.check)
+    const actual = actualSets.get(observation.check)
+    if (
+      receiptSha256 !== hashTraceValue(observationCore(core)) ||
+      observation.expectedSetReceiptSha256 !== expected?.receiptSha256 ||
+      observation.actualSetReceiptSha256 !== actual?.receiptSha256
+    ) {
+      inputError(
+        `observations.${index} lacks source-derived or renderer-derived proof`,
+      )
+    }
+  }
+  const doms = new Map(
+    input.renderedEpub.domSnapshots.map((snapshot) => [
+      snapshot.spineHref,
+      snapshot,
+    ]),
+  )
+  const screenshots = new Map(
+    input.renderedEpub.screenshots.map((screenshot) => [
+      screenshot.id,
+      screenshot,
+    ]),
+  )
+  for (const [index, mapping] of input.mappings.entries()) {
+    const cardinalityValid =
+      (mapping.status === 'mapped' && mapping.output.length === 1) ||
+      (mapping.status === 'missing' && mapping.output.length === 0) ||
+      (mapping.status === 'duplicate' && mapping.output.length >= 2)
+    if (!cardinalityValid) {
+      inputError(`mappings.${index} has invalid status/output cardinality`)
+    }
+    if (mapping.output.some((output) => !output.rendered)) {
+      inputError(`mappings.${index} is missing screenshot locator evidence`)
+    }
+    for (const [outputIndex, output] of mapping.output.entries()) {
+      const dom = doms.get(output.spineHref)
+      const rendered = output.rendered!
+      const screenshot = screenshots.get(rendered.screenshotId)
+      const { rect } = rendered
+      if (!dom?.anchors.includes(output.anchorId)) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} names a nonexistent anchor`,
+        )
+      }
+      if (
+        !screenshot ||
+        screenshot.spineHref !== output.spineHref ||
+        screenshot.domSha256 !== dom.dom.sha256 ||
+        hashTraceValue(rendered.viewport) !== hashTraceValue(screenshot.viewport)
+      ) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} is not bound to its screenshot`,
+        )
+      }
+      if (
+        rect.x < 0 ||
+        rect.y < 0 ||
+        rect.width <= 0 ||
+        rect.height <= 0 ||
+        rect.x + rect.width > rendered.viewport.width ||
+        rect.y + rect.height > rendered.viewport.height
+      ) {
+        inputError(
+          `mappings.${index}.output.${outputIndex} has an empty or out-of-bounds locator`,
+        )
+      }
+    }
+  }
+}
+
+type PendingCheck = {
+  id: string
+  check: DeterministicCheckId
+  passed: boolean
+  expectedSha256: string
+  actualSha256: string
+  mappingIds: string[]
+  source?: SourceLocation
+  output: SourceOutputMapping['output']
+  message: string
+}
+
+function outputForMappings(
+  mappingIds: readonly string[],
+  mappingsById: ReadonlyMap<string, SourceOutputMapping>,
+) {
+  return mappingIds.flatMap((id) => mappingsById.get(id)?.output ?? [])
+}
+
+function receiptCheck({
+  id,
+  check,
+  expected,
+  actual,
+  mappingIds,
+  source,
+  output,
+  message,
+  evidenceValid = true,
+}: Omit<PendingCheck, 'passed' | 'expectedSha256' | 'actualSha256'> & {
+  expected: unknown
+  actual: unknown
+  evidenceValid?: boolean
+}): PendingCheck {
+  const expectedSha256 = hashTraceValue(expected)
+  const actualSha256 = hashTraceValue(actual)
+  return {
+    id,
+    check,
+    passed: evidenceValid && expectedSha256 === actualSha256,
+    expectedSha256,
+    actualSha256,
+    mappingIds,
+    ...(source ? { source } : {}),
+    output,
+    message,
+  }
+}
+
+function renderBindingCheck(input: SourceEpubComparisonInput): PendingCheck {
+  const navigation = input.mappings[0]!
+  return receiptCheck({
+    id: 'render-binding',
+    check: 'render-binding',
+    expected: {
+      epub: input.epub.bytes,
+      sourcePdfSha256: input.sourcePdfSha256,
+      sourceObligationCount: input.sourceRegions.length,
+      invalidLocatorCount: 0,
+    },
+    actual: {
+      epub: input.renderedEpub.download.artifact,
+      sourcePdfSha256:
+        input.renderedEpub.sourceObligations.sourcePdfSha256,
+      sourceObligationCount:
+        input.renderedEpub.sourceObligations.obligationCount,
+      invalidLocatorCount: 0,
+    },
+    mappingIds: [navigation.id],
+    source: navigation.source as SourceLocation,
+    output: navigation.output,
+    message:
+      'Actual-render receipt must bind downloaded EPUB bytes, DOM anchors, screenshots, and source obligations.',
+  })
+}
+
+function epubPackageCheck(input: SourceEpubComparisonInput): PendingCheck {
+  const navigation = input.mappings[0]!
+  return receiptCheck({
+    id: 'epub-package',
+    check: 'epub-package',
+    expected: { status: 'passed', errorCount: 0, warningCount: 0 },
+    actual: {
+      status: input.epub.epubCheck.status,
+      errorCount: input.epub.epubCheck.errorCount,
+      warningCount: input.epub.epubCheck.warningCount,
+    },
+    mappingIds: [navigation.id],
+    source: navigation.source as SourceLocation,
+    output: navigation.output,
+    message: 'EPUBCheck must pass with no errors or warnings.',
+  })
+}
+
+function sourceRegionChecks(input: SourceEpubComparisonInput): PendingCheck[] {
+  const claims = new Map<string, SourceOutputMapping[]>()
+  for (const mapping of input.mappings) {
+    for (const regionId of new Set(mapping.source.sourceRegionIds)) {
+      claims.set(regionId, [...(claims.get(regionId) ?? []), mapping])
+    }
+  }
+  return sortedSourceObligations(input.sourceRegions).map((region) => {
+    const regionClaims = claims.get(region.id) ?? []
+    const successful = regionClaims.filter(
+      ({ status, output }) => status === 'mapped' && output.length === 1,
+    )
+    return receiptCheck({
+      id: `source-region-${region.id}`,
+      check: 'source-region-conservation',
+      expected: { claimCount: 1, successfulClaimCount: 1 },
+      actual: {
+        claimCount: regionClaims.length,
+        successfulClaimCount: successful.length,
+      },
+      mappingIds: regionClaims.map(({ id }) => id).sort(compareCodeUnits),
+      source: region.source as SourceLocation,
+      output: regionClaims.flatMap(({ output }) => output),
+      message: `Source region ${region.id} must map to one output anchor.`,
+    })
+  })
+}
+
+function observationChecks(input: SourceEpubComparisonInput): PendingCheck[] {
+  const mappings = new Map(input.mappings.map((mapping) => [mapping.id, mapping]))
+  const expectedSets = new Map(
+    input.sourceEvidence.expectedObservationSets.map((set) => [set.check, set]),
+  )
+  const actualSets = new Map(
+    input.renderedEpub.actualObservationSets.map((set) => [set.check, set]),
+  )
+  return input.observations.map((observation): PendingCheck => {
+    const cited = observation.mappingIds.map((id) => mappings.get(id))
+    const expected = expectedSets.get(observation.check)!
+    const actual = actualSets.get(observation.check)!
+    const evidenceValid = cited.every(
+      (mapping) =>
+        mapping?.status === 'mapped' && mapping.output.length === 1,
+    )
+    return {
+      id: observation.idSha256,
+      check: observation.check,
+      passed:
+        evidenceValid &&
+        expected.setSha256 === actual.setSha256 &&
+        expected.itemCount === actual.itemCount,
+      expectedSha256: hashTraceValue(expected),
+      actualSha256: hashTraceValue(actual),
+      mappingIds: [...observation.mappingIds].sort(compareCodeUnits),
+      source: (observation.source ?? cited.find(Boolean)?.source) as
+        | SourceLocation
+        | undefined,
+      output: outputForMappings(observation.mappingIds, mappings),
+      message: evidenceValid
+        ? `${observation.check} source-derived and renderer-derived receipts must match.`
+        : `${observation.check} cites missing or duplicate mapping evidence.`,
+    }
+  })
+}
+
+function failureFor(check: PendingCheck): ComparisonFailure {
+  return {
+    id: `failure-${hashTraceValue({
+      check: check.check,
+      id: check.id,
+      source: check.source ?? null,
+    }).slice(0, 24)}`,
+    check: check.check,
+    origin: 'deterministic',
+    message: check.message,
+    mappingIds: check.mappingIds,
+    ...(check.source ? { source: check.source } : {}),
+    output: check.output,
+  }
+}
+
+/**
+ * Compare #198 source-derived receipts with observations from a strict actual-
+ * render adapter. Raw caller expected/actual values are not accepted.
+ */
+export function compareSourceToRenderedEpub(
+  unknownInput: unknown,
+): SourceEpubComparatorResult {
+  const parsed = comparisonInputSchema.safeParse(unknownInput)
+  if (!parsed.success) inputError(parsed.error.issues[0]?.message ?? 'invalid schema')
+  const input = parsed.data as SourceEpubComparisonInput
+  assertInput(input)
+
+  const pending = [
+    renderBindingCheck(input),
+    epubPackageCheck(input),
+    ...sourceRegionChecks(input),
+    ...observationChecks(input),
+  ].sort((left, right) =>
+    compareComparisonFailures(failureFor(left), failureFor(right)),
+  )
+  const failures = pending
+    .filter(({ passed }) => !passed)
+    .map(failureFor)
+    .sort(compareComparisonFailures)
+  const failuresById = new Map(
+    pending.filter(({ passed }) => !passed).map((check) => [check.id, failureFor(check)]),
+  )
+  const checkResults = pending.map((check) => {
+    const failure = failuresById.get(check.id)
+    return {
+      id: check.id,
+      check: check.check,
+      origin: 'deterministic' as const,
+      status: check.passed ? ('passed' as const) : ('failed' as const),
+      expectedSha256: check.expectedSha256,
+      actualSha256: check.actualSha256,
+      mappingIds: check.mappingIds,
+      ...(check.source ? { source: check.source } : {}),
+      message: check.message,
+      ...(failure ? { failureId: failure.id } : {}),
+    }
+  })
+  return {
+    schemaVersion: SOURCE_EPUB_COMPARATOR_SCHEMA_VERSION,
+    sourcePdfSha256: input.sourcePdfSha256,
+    structSha256: input.structure.artifact.sha256,
+    epubSha256: input.epub.bytes.sha256,
+    renderObservationReceiptSha256: input.renderedEpub.receiptSha256,
+    observationSetSha256: hashTraceValue(
+      [...input.observations].sort((left, right) =>
+        compareCodeUnits(left.idSha256, right.idSha256),
+      ),
+    ),
+    status: failures.length === 0 ? 'publication-ready' : 'failed',
+    denominator: checkResults.length,
+    passed: checkResults.length - failures.length,
+    failed: failures.length,
+    checkResults,
+    judgeResults: [],
+    failures,
+    firstCauseFailureId: failures[0]?.id ?? null,
+  }
+}

--- a/src/research/source-evidence-assembler.test.ts
+++ b/src/research/source-evidence-assembler.test.ts
@@ -1,0 +1,388 @@
+import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PdfReconstruction } from './import-types'
+import { normalizeMineruRunArtifacts } from './mineru-owner-local-runner'
+import {
+  MINERU_MAX_OWNER_CACHE_BYTES,
+  MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+} from './mineru-source-evidence'
+import { sha256HexSync } from './sha256-sync'
+import { assembleProductionSourceEvidence } from './source-evidence-assembler'
+
+const roots: string[] = []
+const sourcePdfPath = [
+  new URL('../../tests/fixtures/pdf/born-digital.pdf', import.meta.url),
+  new URL('../../../../tests/fixtures/pdf/born-digital.pdf', import.meta.url),
+]
+  .map((url) => fileURLToPath(url))
+  .find(existsSync)!
+const sourceSha256 =
+  '50874645b2cec033726018c86974241db2048ac46291e02fcb25d3cb7fbaa907'
+const pageRenderBytes = new TextEncoder().encode('source page render')
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+function hash(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+async function mineruRun() {
+  const root = await realpath(
+    await mkdtemp(join(tmpdir(), 'mineru-assembler-test-')),
+  )
+  roots.push(root)
+  await chmod(root, 0o700)
+  const output = join(root, 'raw-output', 'document', 'vlm')
+  await mkdir(output, { recursive: true, mode: 0o700 })
+  const records = [
+    {
+      type: 'text',
+      page_idx: 0,
+      bbox: [50, 50, 950, 120],
+      text: 'A Reconstructed Research Paper',
+    },
+  ]
+  await writeFile(join(output, 'document.md'), '# Paper\n')
+  await writeFile(
+    join(output, 'document_content_list.json'),
+    JSON.stringify(records),
+  )
+  await writeFile(
+    join(output, 'document_content_list_v2.json'),
+    JSON.stringify(records),
+  )
+  await writeFile(join(output, 'document_middle.json'), '{}')
+  await writeFile(join(output, 'document_model.json'), '{}')
+  await writeFile(join(output, 'document_layout.pdf'), '%PDF-1.7\n%%EOF\n')
+  const cacheInventorySha256 = hash('cache')
+  const rootRef = `cache-${cacheInventorySha256.slice(0, 32)}`
+  const manifest = await normalizeMineruRunArtifacts({
+    sourcePdfPath,
+    runDirectory: root,
+    outputRoot: join(root, 'raw-output'),
+    maximumCacheBytes: MINERU_MAX_OWNER_CACHE_BYTES,
+    identity: {
+      rootRef,
+      mineruExecutableSha256: hash('mineru'),
+      mineruConfigSha256: hash('mineru-config'),
+      modelConfigSha256: hash('model-config'),
+      runtimeInventorySha256: hash('runtime-inventory'),
+      runtimeTreeByteLength: 4096,
+      cacheInventorySha256,
+      cacheByteLength: MINERU_PRODUCTION_MODEL_BYTE_LENGTH,
+      execution: {
+        hostClass: 'owner-laptop',
+        operatingSystem: 'macOS-15.6',
+        architecture: 'arm64',
+        runtime: 'python-3.12',
+        backend: 'mlx-vlm',
+        backendVersion: 'mlx-vlm-0.3.12+mlx-0.31.1',
+        runtimeSha256: hash('runtime'),
+        backendSha256: hash('backend'),
+        packageSetSha256: hash('packages'),
+        cacheNamespaceSha256: hash(
+          `{"namespace":"mineru-production","rootRef":"${rootRef}"}`,
+        ),
+        networkIsolation: 'macos-sandbox-exec-deny-network-v1',
+        networkIsolationSha256: hash('sandbox-exec-deny-network-policy'),
+      },
+    },
+  })
+  return {
+    schemaVersion: '1.0.0' as const,
+    runDirectory: root,
+    manifestPath: join(root, 'manifest.json'),
+    manifest,
+  }
+}
+
+function reconstruction(
+  byteLength: number,
+  kind: PdfReconstruction['pages'][number]['kind'] = 'born-digital',
+): PdfReconstruction {
+  return {
+    source: {
+      fileName: 'private-input.pdf',
+      byteLength,
+      sha256: sourceSha256,
+      pageCount: 1,
+      localOnly: true,
+    },
+    paper: { id: 'source-bound-document' },
+    pages: [
+      {
+        page: 1,
+        kind,
+        width: 612,
+        height: 792,
+        rotation: 0,
+        textCharacters: 30,
+        imageCount: 0,
+        runs: [
+          {
+            page: 1,
+            text: 'A Reconstructed Research Paper',
+            x: 0.05,
+            y: 0.05,
+            width: 0.9,
+            height: 0.07,
+            rotation: 0,
+            method: 'pdf-text',
+            fontName: 'Fixture Serif',
+            fontSize: 18,
+            confidence: 1,
+          },
+        ],
+      },
+    ],
+    regions: [],
+    readingOrder: { edges: [] },
+    noteRelationships: [],
+    citationRelationships: [],
+    crossReferenceRelationships: [],
+    visualRelationships: [],
+    assets: [],
+  } as unknown as PdfReconstruction
+}
+
+function addLocalOcr(input: PdfReconstruction) {
+  input.pages[0]!.ocr = {
+    engine: 'owner-local-ocr',
+    engineVersion: '1.0.0',
+    model: 'fixture-ocr-model',
+    modelVersion: '1',
+    languages: ['eng'],
+    languageMode: 'explicit',
+    sourceSha256,
+    rasterSha256: sha256HexSync(pageRenderBytes),
+    confidence: 0.95,
+    words: [
+      {
+        text: 'A Reconstructed Research Paper',
+        confidence: 0.95,
+        lineId: 'local-line-1',
+        box: {
+          page: 1,
+          x: 0.05,
+          y: 0.05,
+          width: 0.9,
+          height: 0.07,
+          rotation: 0,
+          method: 'ocr',
+        },
+        mergeStatus: 'accepted',
+      },
+    ],
+    lines: [
+      {
+        id: 'local-line-1',
+        text: 'A Reconstructed Research Paper',
+        confidence: 0.95,
+        box: {
+          page: 1,
+          x: 0.05,
+          y: 0.05,
+          width: 0.9,
+          height: 0.07,
+          rotation: 0,
+          method: 'ocr',
+        },
+      },
+    ],
+  }
+}
+
+function expectExactEvidenceOwnership(
+  graph: Awaited<ReturnType<typeof assembleProductionSourceEvidence>>['graph'],
+) {
+  for (const field of ['sourceIds', 'artifactIds', 'candidateIds'] as const) {
+    const owned = graph.obligations.flatMap((obligation) => obligation[field])
+    const expected = graph.bundles.flatMap((bundle) => {
+      if (field === 'sourceIds') return bundle.sources.map(({ id }) => id)
+      if (field === 'artifactIds') return bundle.artifacts.map(({ id }) => id)
+      return bundle.candidates.map(({ id }) => id)
+    })
+    expect(owned).toHaveLength(expected.length)
+    expect(new Set(owned)).toEqual(new Set(expected))
+  }
+}
+
+describe('production source-evidence assembler', () => {
+  it('requires and authenticates both deterministic and MinerU arms', async () => {
+    const run = await mineruRun()
+    const result = await assembleProductionSourceEvidence(
+      {
+        reconstruction: reconstruction(run.manifest.document.byteLength),
+        deterministic: {
+          pageRenders: [
+            {
+              page: 1,
+              mediaType: 'image/png',
+              sha256: sha256HexSync(pageRenderBytes),
+              byteLength: pageRenderBytes.byteLength,
+              width: 1224,
+              height: 1584,
+              bytes: pageRenderBytes,
+            },
+          ],
+        },
+        mineru: {
+          pdfPath: sourcePdfPath,
+          runRoot: run.runDirectory,
+          mineruExecutable: '/private/pinned/mineru',
+          pythonExecutable: '/private/pinned/python3.12',
+          configPath: '/private/pinned/mineru.json',
+          modelRoot: '/private/pinned/model',
+        },
+      },
+      { runMineru: async () => run },
+    )
+
+    expect(result.graph.arms).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'deterministic',
+          requirement: 'required',
+        }),
+        expect.objectContaining({ id: 'mineru', requirement: 'required' }),
+      ]),
+    )
+    expect(
+      result.graph.obligations.find(({ kind }) => kind === 'source-text')
+        ?.candidateIds.length,
+    ).toBeGreaterThan(1)
+    expectExactEvidenceOwnership(result.graph)
+  })
+
+  it('rejects a MinerU receipt bound to different source bytes', async () => {
+    const run = await mineruRun()
+    await expect(
+      assembleProductionSourceEvidence(
+        {
+          reconstruction: reconstruction(run.manifest.document.byteLength + 1),
+          deterministic: {
+            pageRenders: [
+              {
+                page: 1,
+                mediaType: 'image/png',
+                sha256: sha256HexSync(pageRenderBytes),
+                byteLength: pageRenderBytes.byteLength,
+                width: 1224,
+                height: 1584,
+                bytes: pageRenderBytes,
+              },
+            ],
+          },
+          mineru: {
+            pdfPath: sourcePdfPath,
+            runRoot: run.runDirectory,
+            mineruExecutable: '/private/pinned/mineru',
+            pythonExecutable: '/private/pinned/python3.12',
+            configPath: '/private/pinned/mineru.json',
+            modelRoot: '/private/pinned/model',
+          },
+        },
+        { runMineru: async () => run },
+      ),
+    ).rejects.toThrow(/SOURCE_IDENTITY_MISMATCH/u)
+  })
+
+  it('requires configured local OCR even when MinerU evidence exists', async () => {
+    const run = await mineruRun()
+    const input = reconstruction(run.manifest.document.byteLength, 'ocr-required')
+    input.pages[0]!.runs = []
+    await expect(
+      assembleProductionSourceEvidence(
+        {
+          reconstruction: input,
+          deterministic: {
+            pageRenders: [
+              {
+                page: 1,
+                mediaType: 'image/png',
+                sha256: sha256HexSync(pageRenderBytes),
+                byteLength: pageRenderBytes.byteLength,
+                width: 1224,
+                height: 1584,
+                bytes: pageRenderBytes,
+              },
+            ],
+          },
+          mineru: {
+            pdfPath: sourcePdfPath,
+            runRoot: run.runDirectory,
+            mineruExecutable: '/private/pinned/mineru',
+            pythonExecutable: '/private/pinned/python3.12',
+            configPath: '/private/pinned/mineru.json',
+            modelRoot: '/private/pinned/model',
+          },
+        },
+        { runMineru: async () => run },
+      ),
+    ).rejects.toThrow('PDF_LOCAL_OCR_EVIDENCE_REQUIRED')
+  })
+
+  it('requires a source-preserved page candidate plus local OCR and grounded MinerU alternatives for a scan', async () => {
+    const run = await mineruRun()
+    const input = reconstruction(run.manifest.document.byteLength, 'ocr-required')
+    input.pages[0]!.runs = []
+    addLocalOcr(input)
+
+    const result = await assembleProductionSourceEvidence(
+      {
+        reconstruction: input,
+        deterministic: {
+          pageRenders: [
+            {
+              page: 1,
+              mediaType: 'image/png',
+              sha256: sha256HexSync(pageRenderBytes),
+              byteLength: pageRenderBytes.byteLength,
+              width: 1224,
+              height: 1584,
+              bytes: pageRenderBytes,
+            },
+          ],
+        },
+        mineru: {
+          pdfPath: sourcePdfPath,
+          runRoot: run.runDirectory,
+          mineruExecutable: '/private/pinned/mineru',
+          pythonExecutable: '/private/pinned/python3.12',
+          configPath: '/private/pinned/mineru.json',
+          modelRoot: '/private/pinned/model',
+        },
+      },
+      { runMineru: async () => run },
+    )
+
+    const fallback = result.graph.obligations.find(
+      ({ kind }) => kind === 'source-preserved-page',
+    )
+    expect(fallback).toMatchObject({ page: 1, required: true, semantic: true })
+    expect(
+      fallback?.candidateIds.some((id) =>
+        id.startsWith('pdfjs-candidate-page-render-'),
+      ),
+    ).toBe(true)
+    expect(result.graph.bundles.some(({ armId }) => armId === 'mineru')).toBe(
+      true,
+    )
+    expect(
+      result.graph.obligations.some(
+        ({ candidateIds }) =>
+          candidateIds.some((id) => id.startsWith('mineru:')),
+      ),
+    ).toBe(true)
+    expectExactEvidenceOwnership(result.graph)
+  })
+})

--- a/src/research/source-evidence-assembler.ts
+++ b/src/research/source-evidence-assembler.ts
@@ -1,0 +1,493 @@
+import type { PdfReconstruction } from './import-types'
+import {
+  inspectMineruSourceEvidence,
+  type MineruArtifactManifest,
+} from './mineru-source-evidence'
+import {
+  runOwnerLocalMineru,
+  type OwnerLocalMineruRun,
+  type OwnerLocalMineruRunnerOptions,
+} from './mineru-owner-local-runner'
+import {
+  pdfEvidenceBundlesFromReconstruction,
+  type PdfDeterministicEvidenceOptions,
+} from './pdf-source-evidence'
+import { sha256HexSync } from './sha256-sync'
+import {
+  SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  type PdfEvidenceArmState,
+  type PdfEvidenceBox,
+  type PdfEvidenceBundle,
+  type PdfEvidenceCandidate,
+  type PdfEvidenceDisagreement,
+  type PdfEvidenceObligation,
+  type PdfEvidenceObservationCategory,
+  type SourceEvidenceGraph,
+} from './source-evidence-graph'
+
+type CandidateCategory =
+  | 'text'
+  | 'reading-order'
+  | 'table'
+  | 'formula'
+  | 'figure'
+  | 'link'
+  | 'page-render'
+  | 'other'
+
+const TEXT_KINDS = new Set([
+  'text',
+  'title',
+  'paragraph',
+  'heading',
+  'code',
+  'text-glyph-run',
+  'ocr-word',
+  'ocr-line',
+])
+const TABLE_KINDS = new Set(['table', 'table-body', 'table-caption'])
+const FORMULA_KINDS = new Set([
+  'formula',
+  'equation',
+  'interline-equation',
+  'interline_equation',
+])
+const FIGURE_KINDS = new Set(['figure', 'image', 'chart'])
+const LINK_KINDS = new Set([
+  'annotation-link-destination',
+  'link',
+  'external-link',
+  'internal-link',
+])
+
+function candidateObservationCategories(
+  candidate: PdfEvidenceCandidate,
+): PdfEvidenceObservationCategory[] {
+  const classified = category(candidate.kind)
+  switch (classified) {
+    case 'text':
+      return [
+        'text-exactness',
+        'reading-order',
+        ...(candidate.kind === 'title' || candidate.kind === 'heading'
+          ? (['hierarchy'] as const)
+          : []),
+        ...(candidate.kind === 'code' ? (['code-preformatted'] as const) : []),
+        'clipping',
+        'overflow',
+      ]
+    case 'reading-order':
+      return ['reading-order', 'clipping', 'overflow']
+    case 'table':
+      return [
+        'object-counts',
+        'table-cells',
+        'table-spans',
+        'table-headers',
+        'captions',
+        'clipping',
+        'overflow',
+      ]
+    case 'formula':
+      return ['object-counts', 'formulas', 'clipping', 'overflow']
+    case 'figure':
+      return ['object-counts', 'figures', 'captions', 'clipping', 'overflow']
+    case 'link':
+      return ['links', 'clipping', 'overflow', 'dangling-targets']
+    case 'page-render':
+      return ['object-counts', 'asset-bytes', 'clipping', 'overflow']
+    case 'other':
+      return []
+  }
+}
+
+export type SourceEvidenceAssemblerOptions = {
+  reconstruction: PdfReconstruction
+  deterministic: PdfDeterministicEvidenceOptions
+  mineru: OwnerLocalMineruRunnerOptions
+}
+
+export type SourceEvidenceAssemblerResult = {
+  graph: SourceEvidenceGraph
+  mineruRun: OwnerLocalMineruRun
+}
+
+export type SourceEvidenceAssemblerDependencies = {
+  runMineru?: (
+    options: OwnerLocalMineruRunnerOptions,
+  ) => Promise<OwnerLocalMineruRun>
+}
+
+function category(kind: string): CandidateCategory {
+  if (TEXT_KINDS.has(kind)) return 'text'
+  if (
+    kind === 'reading-order' ||
+    kind === 'reading-order-edge' ||
+    kind === 'layout-region'
+  ) {
+    return 'reading-order'
+  }
+  if (TABLE_KINDS.has(kind)) return 'table'
+  if (FORMULA_KINDS.has(kind)) return 'formula'
+  if (FIGURE_KINDS.has(kind)) return 'figure'
+  if (LINK_KINDS.has(kind)) return 'link'
+  if (kind === 'full-page-render' || kind === 'page-render') {
+    return 'page-render'
+  }
+  return 'other'
+}
+
+function overlap(left: PdfEvidenceBox, right: PdfEvidenceBox) {
+  if (left.page !== right.page) return 0
+  const width = Math.max(
+    0,
+    Math.min(left.x + left.width, right.x + right.width) -
+      Math.max(left.x, right.x),
+  )
+  const height = Math.max(
+    0,
+    Math.min(left.y + left.height, right.y + right.height) -
+      Math.max(left.y, right.y),
+  )
+  const intersection = width * height
+  if (intersection === 0) return 0
+  return (
+    intersection /
+    Math.min(left.width * left.height, right.width * right.height)
+  )
+}
+
+function compatible(
+  obligation: PdfEvidenceObligation,
+  deterministic: PdfEvidenceCandidate,
+  mineru: PdfEvidenceCandidate,
+) {
+  const expected = category(deterministic.kind)
+  if (expected === 'other' || category(mineru.kind) !== expected) return false
+  if (obligation.page !== undefined && mineru.page !== obligation.page)
+    return false
+  if (expected === 'reading-order') return obligation.page === mineru.page
+  const deterministicBoxes = deterministic.boxes ?? []
+  const mineruBoxes = mineru.boxes ?? []
+  return (
+    deterministicBoxes.length > 0 &&
+    mineruBoxes.length > 0 &&
+    deterministicBoxes.some((left) =>
+      mineruBoxes.some((right) => overlap(left, right) >= 0.25),
+    )
+  )
+}
+
+function payloadDigest(candidate: PdfEvidenceCandidate) {
+  return sha256HexSync(JSON.stringify(candidate.payload ?? null))
+}
+
+function groundedCandidate(candidate: PdfEvidenceCandidate) {
+  return (
+    candidate.payload !== null &&
+    typeof candidate.payload === 'object' &&
+    !Array.isArray(candidate.payload) &&
+    candidate.payload.grounded === true
+  )
+}
+
+function attachMineruAlternatives(
+  obligations: PdfEvidenceObligation[],
+  disagreements: PdfEvidenceDisagreement[],
+  allCandidates: PdfEvidenceCandidate[],
+  mineruCandidates: PdfEvidenceCandidate[],
+) {
+  const byId = new Map(
+    allCandidates.map((candidate) => [candidate.id, candidate]),
+  )
+  const claimedCandidates = new Set(
+    obligations.flatMap(({ candidateIds }) => candidateIds),
+  )
+  for (const obligation of obligations) {
+    const deterministic = obligation.candidateIds
+      .map((id) => byId.get(id))
+      .find((candidate) => candidate?.providerId.startsWith('pdfjs'))
+    if (!deterministic) continue
+    const alternatives = mineruCandidates.filter(
+      (candidate) =>
+        !claimedCandidates.has(candidate.id) &&
+        compatible(obligation, deterministic, candidate),
+    )
+    for (const alternative of alternatives) {
+      obligation.candidateIds.push(alternative.id)
+      claimedCandidates.add(alternative.id)
+      obligation.observationCategories = [
+        ...new Set([
+          ...obligation.observationCategories,
+          ...candidateObservationCategories(alternative),
+        ]),
+      ]
+    }
+    const divergent = alternatives.filter(
+      (candidate) => payloadDigest(candidate) !== payloadDigest(deterministic),
+    )
+    if (divergent.length === 0) continue
+    const candidateIds = [deterministic.id, ...divergent.map(({ id }) => id)]
+    const providerIds = [
+      ...new Set(
+        candidateIds.map((id) => byId.get(id)?.providerId).filter(Boolean),
+      ),
+    ] as string[]
+    disagreements.push({
+      id: `disagreement-cross-arm-${obligation.id}`,
+      kind: `cross-arm-${category(deterministic.kind)}`,
+      obligationIds: [obligation.id],
+      candidateIds,
+      providerIds,
+      reason:
+        'deterministic and MinerU candidates remain distinct until grounded reconciliation',
+    })
+  }
+}
+
+function mergeCategories(
+  obligation: PdfEvidenceObligation,
+  categories: readonly PdfEvidenceObservationCategory[],
+) {
+  obligation.observationCategories = [
+    ...new Set([...obligation.observationCategories, ...categories]),
+  ]
+}
+
+function genericObservationCategories(
+  kind: string,
+  includesArtifact: boolean,
+): PdfEvidenceObservationCategory[] {
+  const classified = category(kind)
+  if (classified !== 'other') {
+    const candidate = {
+      kind,
+      artifactIds: includesArtifact ? ['retained-artifact'] : undefined,
+    } as PdfEvidenceCandidate
+    return candidateObservationCategories(candidate)
+  }
+  return [
+    'object-counts',
+    ...(includesArtifact ? (['asset-bytes'] as const) : []),
+    'clipping',
+    'overflow',
+  ]
+}
+
+/**
+ * The provider adapters expose evidence facts, while this production assembler
+ * makes their exact ownership explicit. This is intentionally not part of the
+ * generic graph validator: callers cannot turn a partial graph into a complete
+ * one by merely invoking validation.
+ */
+function completeEvidenceObligations(
+  bundles: readonly PdfEvidenceBundle[],
+  obligations: PdfEvidenceObligation[],
+) {
+  const sources = bundles.flatMap(({ sources }) => sources)
+  const artifacts = bundles.flatMap(({ artifacts }) => artifacts)
+  const candidates = bundles.flatMap(({ candidates }) => candidates)
+  const byObligationId = new Map(
+    obligations.map((obligation) => [obligation.id, obligation]),
+  )
+  const sourceOwners = new Map<string, string>()
+  const artifactOwners = new Map<string, string>()
+  const candidateOwners = new Map<string, string>()
+  for (const obligation of obligations) {
+    for (const id of obligation.sourceIds) sourceOwners.set(id, obligation.id)
+    for (const id of obligation.artifactIds)
+      artifactOwners.set(id, obligation.id)
+    for (const id of obligation.candidateIds)
+      candidateOwners.set(id, obligation.id)
+  }
+
+  const obligationFor = (id: string | undefined) =>
+    id === undefined ? undefined : byObligationId.get(id)
+  const firstOwner = (ids: readonly string[], owners: Map<string, string>) =>
+    ids.map((id) => owners.get(id)).find((owner) => owner !== undefined)
+
+  for (const candidate of candidates) {
+    if (candidateOwners.has(candidate.id)) continue
+    let obligation = obligationFor(
+      firstOwner(candidate.sourceIds, sourceOwners) ??
+        firstOwner(candidate.artifactIds ?? [], artifactOwners),
+    )
+    if (!obligation) {
+      const sourceIds = candidate.sourceIds.filter(
+        (sourceId) => !sourceOwners.has(sourceId),
+      )
+      if (sourceIds.length === 0) {
+        throw new Error('EVIDENCE_CANDIDATE_SOURCE_OWNERSHIP_REQUIRED')
+      }
+      const candidateDigest = sha256HexSync(candidate.id).slice(0, 24)
+      obligation = {
+        id: `obligation-provider-candidate-${candidateDigest}`,
+        kind: `provider-${category(candidate.kind)}-evidence`,
+        ...(candidate.page === undefined ? {} : { page: candidate.page }),
+        sourceIds,
+        artifactIds: [],
+        candidateIds: [],
+        observationCategories: genericObservationCategories(
+          candidate.kind,
+          (candidate.artifactIds?.length ?? 0) > 0,
+        ),
+        required: groundedCandidate(candidate),
+        semantic: groundedCandidate(candidate),
+      }
+      obligations.push(obligation)
+      byObligationId.set(obligation.id, obligation)
+      for (const sourceId of sourceIds) {
+        sourceOwners.set(sourceId, obligation.id)
+      }
+    }
+    obligation.candidateIds.push(candidate.id)
+    candidateOwners.set(candidate.id, obligation.id)
+    mergeCategories(
+      obligation,
+      genericObservationCategories(
+        candidate.kind,
+        (candidate.artifactIds?.length ?? 0) > 0,
+      ),
+    )
+    if (groundedCandidate(candidate)) {
+      obligation.required = true
+      obligation.semantic = true
+    }
+  }
+
+  for (const source of sources) {
+    if (sourceOwners.has(source.id)) continue
+    const candidateOwner = candidates
+      .filter(({ sourceIds }) => sourceIds.includes(source.id))
+      .map(({ id }) => candidateOwners.get(id))
+      .find((owner) => owner !== undefined)
+    const parentOwner = firstOwner(source.parentSourceIds ?? [], sourceOwners)
+    const artifactOwner = firstOwner(source.artifactIds ?? [], artifactOwners)
+    let obligation = obligationFor(candidateOwner ?? parentOwner ?? artifactOwner)
+    if (!obligation) {
+      const sourceDigest = sha256HexSync(source.id).slice(0, 24)
+      obligation = {
+        id: `obligation-provider-source-${sourceDigest}`,
+        kind: 'provider-source-fact',
+        ...(source.page === undefined ? {} : { page: source.page }),
+        sourceIds: [],
+        artifactIds: [],
+        candidateIds: [],
+        observationCategories: genericObservationCategories(
+          source.kind,
+          (source.artifactIds?.length ?? 0) > 0,
+        ),
+        required: false,
+        semantic: false,
+      }
+      obligations.push(obligation)
+      byObligationId.set(obligation.id, obligation)
+    }
+    obligation.sourceIds.push(source.id)
+    sourceOwners.set(source.id, obligation.id)
+    mergeCategories(
+      obligation,
+      genericObservationCategories(
+        source.kind,
+        (source.artifactIds?.length ?? 0) > 0,
+      ),
+    )
+  }
+
+  for (const artifact of artifacts) {
+    if (artifactOwners.has(artifact.id)) continue
+    const candidateOwner = candidates
+      .filter(({ artifactIds }) => artifactIds?.includes(artifact.id))
+      .map(({ id }) => candidateOwners.get(id))
+      .find((owner) => owner !== undefined)
+    const sourceOwner = sources
+      .filter(
+        (source) =>
+          source.artifactIds?.includes(artifact.id) ||
+          artifact.sourceIds?.includes(source.id),
+      )
+      .map(({ id }) => sourceOwners.get(id))
+      .find((owner) => owner !== undefined)
+    const providerOwner = sources
+      .filter(({ providerId }) => providerId === artifact.providerId)
+      .map(({ id }) => sourceOwners.get(id))
+      .find((owner) => owner !== undefined)
+    const obligation = obligationFor(
+      candidateOwner ?? sourceOwner ?? providerOwner,
+    )
+    if (!obligation) throw new Error('EVIDENCE_ARTIFACT_OWNER_REQUIRED')
+    obligation.artifactIds.push(artifact.id)
+    artifactOwners.set(artifact.id, obligation.id)
+    mergeCategories(obligation, ['asset-bytes', 'clipping', 'overflow'])
+  }
+}
+
+export async function assembleProductionSourceEvidence(
+  options: SourceEvidenceAssemblerOptions,
+  dependencies: SourceEvidenceAssemblerDependencies = {},
+): Promise<SourceEvidenceAssemblerResult> {
+  const deterministic = pdfEvidenceBundlesFromReconstruction(
+    options.reconstruction,
+    options.deterministic,
+  )
+  const deterministicBundle = deterministic.bundles.find(
+    ({ armId }) => armId === 'deterministic',
+  )
+  if (!deterministicBundle) throw new Error('DETERMINISTIC_EVIDENCE_REQUIRED')
+  const mineruRun = await (dependencies.runMineru ?? runOwnerLocalMineru)(
+    options.mineru,
+  )
+  if (
+    mineruRun.manifest.document.sha256 !== deterministicBundle.source.sha256 ||
+    mineruRun.manifest.document.byteLength !==
+      deterministicBundle.source.byteLength ||
+    mineruRun.manifest.document.pageCount !==
+      deterministicBundle.source.pageCount
+  ) {
+    throw new Error('MINERU_DETERMINISTIC_SOURCE_IDENTITY_MISMATCH')
+  }
+  const inspectedMineru = await inspectMineruSourceEvidence({
+    artifactRoot: mineruRun.runDirectory,
+    manifest: mineruRun.manifest,
+  })
+  const mineruBundle = {
+    ...inspectedMineru,
+    source: structuredClone(deterministicBundle.source),
+  }
+  const bundles = [...deterministic.bundles, mineruBundle]
+  const obligations = structuredClone(deterministic.obligations)
+  const disagreements = structuredClone(deterministic.disagreements)
+  const candidates = bundles.flatMap((bundle) => bundle.candidates)
+  attachMineruAlternatives(
+    obligations,
+    disagreements,
+    candidates,
+    mineruBundle.candidates,
+  )
+  completeEvidenceObligations(bundles, obligations)
+  const arms: PdfEvidenceArmState[] = bundles.map((bundle) => ({
+    id: bundle.armId,
+    requirement:
+      bundle.armId === 'deterministic' || bundle.armId === 'mineru'
+        ? 'required'
+        : 'optional',
+    status: 'enabled',
+    frozen: true,
+    providerId: bundle.provider.id,
+  }))
+  const graph = buildSourceEvidenceGraph({
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source: structuredClone(deterministicBundle.source),
+    deterministicContext:
+      deterministicContextReceiptForBundle(deterministicBundle),
+    arms,
+    bundles,
+    obligations,
+    disagreements,
+  })
+  return { graph, mineruRun }
+}
+
+export type { MineruArtifactManifest }

--- a/src/research/source-evidence-contract.test.ts
+++ b/src/research/source-evidence-contract.test.ts
@@ -76,6 +76,28 @@ function graphInput(): SourceEvidenceGraphInput {
             artifactIds: ['page-render'],
             payload: { text: 'Any incoming PDF text.' },
           },
+          {
+            id: 'page-geometry-source',
+            providerId: 'pdfjs-provider',
+            kind: 'page-geometry',
+            page: 1,
+            payload: { width: 612, height: 792, rotation: 0 },
+          },
+          {
+            id: 'font-source',
+            providerId: 'pdfjs-provider',
+            kind: 'font',
+            page: 1,
+            payload: { family: 'Fixture Serif' },
+          },
+          {
+            id: 'excluded-decoration-source',
+            providerId: 'pdfjs-provider',
+            kind: 'excluded-decoration',
+            page: 1,
+            box: { ...box, y: 0.95, height: 0.02 },
+            payload: { text: 'Running footer' },
+          },
         ],
         candidates: [
           {
@@ -178,6 +200,39 @@ function graphInput(): SourceEvidenceGraphInput {
         required: true,
         semantic: true,
       },
+      {
+        id: 'page-geometry-context',
+        kind: 'page-geometry',
+        page: 1,
+        sourceIds: ['page-geometry-source'],
+        artifactIds: [],
+        candidateIds: [],
+        observationCategories: ['clipping', 'overflow'],
+        required: true,
+        semantic: false,
+      },
+      {
+        id: 'font-context',
+        kind: 'font-context',
+        page: 1,
+        sourceIds: ['font-source'],
+        artifactIds: [],
+        candidateIds: [],
+        observationCategories: ['text-exactness'],
+        required: true,
+        semantic: false,
+      },
+      {
+        id: 'excluded-decoration-context',
+        kind: 'excluded-decoration',
+        page: 1,
+        sourceIds: ['excluded-decoration-source'],
+        artifactIds: [],
+        candidateIds: [],
+        observationCategories: ['object-counts'],
+        required: false,
+        semantic: false,
+      },
     ],
     disagreements: [],
   }
@@ -208,22 +263,33 @@ describe('source evidence contract for #199', () => {
         ({ check }) => check === 'text-exactness',
       )?.itemCount,
     ).toBe(1)
-    expect(contract.sourceRegions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'text-source',
-          source: expect.objectContaining({
-            page: 1,
-            sourceRegionIds: ['text-source'],
-          }),
+    expect(contract.sourceRegions).toEqual([
+      expect.objectContaining({
+        id: 'text-obligation',
+        source: expect.objectContaining({
+          page: 1,
+          sourceRegionIds: ['text-obligation'],
         }),
-        expect.objectContaining({ id: 'mineru-source' }),
-      ]),
-    )
-    expect(contract.sourceRegions.map(({ id }) => id)).toEqual([
-      'mineru-source',
-      'text-source',
+      }),
     ])
+    expect(
+      contract.graph.bundles
+        .flatMap(({ sources }) => sources)
+        .filter(({ id }) =>
+          [
+            'page-geometry-source',
+            'font-source',
+            'excluded-decoration-source',
+          ].includes(id),
+        )
+        .map(({ kind }) => kind)
+        .sort(),
+    ).toEqual(['excluded-decoration', 'font', 'page-geometry'])
+    expect(
+      contract.expectedObservationSets
+        .flatMap(({ sourceRegionIds }) => sourceRegionIds)
+        .every((id) => id === 'text-obligation'),
+    ).toBe(true)
     expect(contract.evidenceCandidates).toEqual(
       contract.candidateReferences.map(
         ({ referenceSha256, bindingSha256 }) => ({
@@ -292,6 +358,58 @@ describe('source evidence contract for #199', () => {
         ])
       }
     }
+  })
+
+  it('authenticates context-only evidence without inventing output-region obligations', () => {
+    const graph = buildSourceEvidenceGraph(graphInput())
+    const contract = createSourceEvidenceContract(graph, verifierIdentity)
+
+    expect(contract.graphArtifact.sha256).toBe(graph.graphSha256)
+    expect(
+      contract.graph.bundles
+        .flatMap(({ sources }) => sources)
+        .filter(({ id }) =>
+          [
+            'page-geometry-source',
+            'font-source',
+            'excluded-decoration-source',
+          ].includes(id),
+        )
+        .map(({ kind }) => kind)
+        .sort(),
+    ).toEqual(['excluded-decoration', 'font', 'page-geometry'])
+    expect(contract.sourceRegions.map(({ id }) => id)).toEqual([
+      'text-obligation',
+    ])
+    expect(
+      contract.expectedObservationSets
+        .flatMap(({ sourceRegionIds }) => sourceRegionIds)
+        .every((id) => id === 'text-obligation'),
+    ).toBe(true)
+
+    const alteredInput = graphInput()
+    const deterministicBundle = alteredInput.bundles.find(
+      ({ armId }) => armId === 'deterministic',
+    )!
+    deterministicBundle.sources.find(
+      ({ id }) => id === 'font-source',
+    )!.payload = { family: 'Changed fixture font' }
+    alteredInput.deterministicContext =
+      deterministicContextReceiptForBundle(deterministicBundle)
+    expect(buildSourceEvidenceGraph(alteredInput).graphSha256).not.toBe(
+      graph.graphSha256,
+    )
+
+    const noOutputObligation = graphInput()
+    noOutputObligation.obligations.find(
+      ({ id }) => id === 'text-obligation',
+    )!.required = false
+    expect(() =>
+      createSourceEvidenceContract(
+        buildSourceEvidenceGraph(noOutputObligation),
+        verifierIdentity,
+      ),
+    ).toThrow('SOURCE_EVIDENCE_OBLIGATIONS_REQUIRED')
   })
 
   it('returns only a hash-bound source-backed candidate payload and rejects drift', () => {

--- a/src/research/source-evidence-contract.test.ts
+++ b/src/research/source-evidence-contract.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it } from 'vitest'
+import { sha256HexSync } from './sha256-sync'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  hashEpubBytes,
+  hashRenderedActualObservationSet,
+  hashRenderedEpubEvidence,
+  hashTraceValue,
+  parseCanonicalObservationPayloadBytes,
+  sourceRegionObligationSchema,
+} from './reconstruction-attempt-trace'
+import {
+  compareSourceToRenderedEpub,
+  createDeterministicObservationReceipt,
+} from './source-epub-comparator'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  type PdfEvidenceBundle,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+import { createSourceEvidenceContract } from './source-evidence-contract'
+
+const source = {
+  documentId: 'ordinary-input',
+  sha256: '1'.repeat(64),
+  byteLength: 4_096,
+  pageCount: 1,
+}
+
+function graphInput(): SourceEvidenceGraphInput {
+  const box = {
+    page: 1,
+    x: 0.1,
+    y: 0.1,
+    width: 0.7,
+    height: 0.1,
+    rotation: 0,
+    method: 'pdf-text' as const,
+  }
+  const bundles: PdfEvidenceBundle[] = [
+      {
+        schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        id: 'pdfjs-bundle',
+        armId: 'deterministic',
+        source,
+        provider: {
+          id: 'pdfjs-provider',
+          kind: 'pdfjs',
+          name: 'pdfjs-dist',
+          version: '5.4.624',
+        },
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'page-render',
+            providerId: 'pdfjs-provider',
+            kind: 'full-page-render',
+            mediaType: 'image/png',
+            sha256: '2'.repeat(64),
+            byteLength: 128,
+            page: 1,
+            box: { ...box, x: 0, y: 0, width: 1, height: 1 },
+            sourceIds: ['text-source'],
+          },
+        ],
+        sources: [
+          {
+            id: 'text-source',
+            providerId: 'pdfjs-provider',
+            kind: 'text-run',
+            page: 1,
+            box,
+            artifactIds: ['page-render'],
+            payload: { text: 'Any incoming PDF text.' },
+          },
+        ],
+        candidates: [
+          {
+            id: 'text-candidate',
+            providerId: 'pdfjs-provider',
+            kind: 'text-run',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['text-source'],
+            artifactIds: ['page-render'],
+            payload: { text: 'Any incoming PDF text.' },
+          },
+        ],
+      },
+      {
+        schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        id: 'mineru-bundle',
+        armId: 'mineru',
+        source,
+        provider: {
+          id: 'mineru-provider',
+          kind: 'mineru',
+          name: 'MinerU',
+          version: '3.4.4',
+        },
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'mineru-artifact',
+            providerId: 'mineru-provider',
+            kind: 'content-list-v2',
+            mediaType: 'application/json',
+            sha256: '5'.repeat(64),
+            byteLength: 64,
+            page: 1,
+            box,
+            sourceIds: ['mineru-source'],
+          },
+        ],
+        sources: [
+          {
+            id: 'mineru-source',
+            providerId: 'mineru-provider',
+            kind: 'title',
+            page: 1,
+            box,
+            artifactIds: ['mineru-artifact'],
+            payload: { text: 'Any incoming PDF text.' },
+          },
+        ],
+        candidates: [
+          {
+            id: 'mineru-candidate',
+            providerId: 'mineru-provider',
+            kind: 'title',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['mineru-source'],
+            artifactIds: ['mineru-artifact'],
+            payload: { text: 'Any incoming PDF text.', grounded: true },
+          },
+        ],
+      },
+    ]
+  return {
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source,
+    deterministicContext: deterministicContextReceiptForBundle(bundles[0]!),
+    arms: [
+      {
+        id: 'deterministic',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: 'pdfjs-provider',
+      },
+      {
+        id: 'mineru',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: 'mineru-provider',
+      },
+    ],
+    bundles,
+    obligations: [
+      {
+        id: 'text-obligation',
+        kind: 'text',
+        page: 1,
+        sourceIds: ['text-source', 'mineru-source'],
+        artifactIds: ['page-render', 'mineru-artifact'],
+        candidateIds: ['text-candidate', 'mineru-candidate'],
+        observationCategories: [
+          'text-exactness',
+          'object-counts',
+          'clipping',
+          'overflow',
+        ],
+        required: true,
+        semantic: true,
+      },
+    ],
+    disagreements: [],
+  }
+}
+
+const verifierIdentity = {
+  id: 'source-evidence-verifier',
+  version: '1.0.0',
+  configurationSha256: '3'.repeat(64),
+  executableSha256: '4'.repeat(64),
+}
+
+describe('source evidence contract for #199', () => {
+  it('commits all 19 source-derived expected sets and reopens exact graph bytes', () => {
+    const graph = buildSourceEvidenceGraph(graphInput())
+    const contract = createSourceEvidenceContract(graph, verifierIdentity)
+
+    expect(contract.sourceEvidenceReceipt.expectedObservationSets).toHaveLength(
+      19,
+    )
+    expect(
+      contract.sourceEvidenceReceipt.expectedObservationSets.map(
+        ({ check }) => check,
+      ),
+    ).toEqual(SOURCE_EPUB_OBSERVATION_CHECK_IDS)
+    expect(
+      contract.sourceEvidenceReceipt.expectedObservationSets.find(
+        ({ check }) => check === 'text-exactness',
+      )?.itemCount,
+    ).toBe(1)
+    expect(contract.sourceRegions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'text-source',
+          source: expect.objectContaining({
+            page: 1,
+            sourceRegionIds: ['text-source'],
+          }),
+        }),
+        expect.objectContaining({ id: 'mineru-source' }),
+      ]),
+    )
+    expect(contract.sourceRegions.map(({ id }) => id)).toEqual([
+      'mineru-source',
+      'text-source',
+    ])
+    expect(contract.evidenceCandidates).toEqual(
+      contract.candidateReferences.map(
+        ({ referenceSha256, bindingSha256 }) => ({
+          referenceSha256,
+          bindingSha256,
+        }),
+      ),
+    )
+    expect(contract.sourceEvidenceReceipt.candidateSetSha256).toBe(
+      hashTraceValue(contract.evidenceCandidates),
+    )
+    expect(contract.sourceEvidenceReceipt.sourceObligations).toEqual({
+      obligationsSha256: hashTraceValue(contract.sourceRegions),
+      obligationCount: contract.sourceRegions.length,
+      receiptSha256: hashTraceValue({
+        sourcePdfSha256: graph.source.sha256,
+        obligationsSha256: hashTraceValue(contract.sourceRegions),
+        obligationCount: contract.sourceRegions.length,
+      }),
+    })
+    const regionIds = new Set(
+      contract.sourceRegions.map((region) => {
+        expect(() => sourceRegionObligationSchema.parse(region)).not.toThrow()
+        return region.id
+      }),
+    )
+    for (const set of contract.expectedObservationSets) {
+      for (const regionId of set.sourceRegionIds) {
+        expect(regionIds.has(regionId)).toBe(true)
+      }
+    }
+    expect(
+      contract.sourceEvidenceReceipt.expectedObservationSets.find(
+        ({ check }) => check === 'object-counts',
+      )?.itemCount,
+    ).toBe(1)
+
+    const request = {
+      schemaVersion: '1.0.0' as const,
+      sourcePdfSha256: graph.source.sha256,
+      evidenceGraph: contract.graphArtifact,
+      sourceObligationsSha256:
+        contract.sourceEvidenceReceipt.sourceObligations.obligationsSha256,
+    }
+    const receipt = contract.verifier.verifyExpected(request)
+    expect(receipt).toMatchObject({
+      status: 'succeeded',
+      requestSha256: hashTraceValue(request),
+      evidenceGraph: contract.graphArtifact,
+    })
+    const typed = receipt as ReturnType<
+      typeof contract.verifier.verifyExpected
+    > & {
+      evidenceGraphBytes: Uint8Array
+      expectedObservationSets: Array<{ payloadBytes: Uint8Array }>
+    }
+    expect(sha256HexSync(typed.evidenceGraphBytes)).toBe(graph.graphSha256)
+    for (const [index, set] of typed.expectedObservationSets.entries()) {
+      const payload = parseCanonicalObservationPayloadBytes(set.payloadBytes)
+      expect(payload.check).toBe(SOURCE_EPUB_OBSERVATION_CHECK_IDS[index])
+      if (payload.check === 'text-exactness') {
+        expect(payload.items).toEqual([
+          expect.objectContaining({
+            anchorIds: ['mineru-source', 'text-source'],
+          }),
+        ])
+      }
+    }
+  })
+
+  it('returns only a hash-bound source-backed candidate payload and rejects drift', () => {
+    const graph = buildSourceEvidenceGraph(graphInput())
+    const contract = createSourceEvidenceContract(graph, verifierIdentity)
+    const reference = contract.candidateReferences[0]!
+    const request = {
+      schemaVersion: '1.0.0' as const,
+      sourceEvidenceGraphSha256: graph.graphSha256,
+      referenceSha256: reference.referenceSha256,
+      bindingSha256: reference.bindingSha256,
+    }
+    const receipt = contract.verifier.resolveCandidate(request) as {
+      status: string
+      payload: { sha256: string; byteLength: number }
+      payloadBytes: Uint8Array
+    }
+    expect(receipt.status).toBe('succeeded')
+    expect(sha256HexSync(receipt.payloadBytes)).toBe(receipt.payload.sha256)
+    expect(new TextDecoder().decode(receipt.payloadBytes)).toContain(
+      'Any incoming PDF text.',
+    )
+    expect(() =>
+      contract.verifier.resolveCandidate({
+        ...request,
+        bindingSha256: 'f'.repeat(64),
+      }),
+    ).toThrow(/SOURCE_EVIDENCE_CANDIDATE_REQUEST_MISMATCH/u)
+  })
+
+  it('feeds canonical #198 candidates and source regions into the exact #203 comparator', () => {
+    const graph = buildSourceEvidenceGraph(graphInput())
+    const contract = createSourceEvidenceContract(graph, verifierIdentity)
+    const epubBytes = new TextEncoder().encode('exact synthetic EPUB bytes')
+    const epubSha256 = hashEpubBytes(epubBytes)
+    const structSha256 = sha256HexSync('exact synthetic STRUCT bytes')
+    const viewport = { width: 800, height: 1_000, deviceScaleFactor: 1 }
+    const actualObservationSets = contract.expectedObservationSets.map(
+      ({ check, setSha256, itemCount, payload }) => {
+        const projection = { check, setSha256, itemCount, payload }
+        return {
+          ...projection,
+          receiptSha256: hashRenderedActualObservationSet({
+            ...projection,
+            receiptSha256: '0'.repeat(64),
+          }),
+        }
+      },
+    )
+    const sourceObligations = {
+      sourcePdfSha256: graph.source.sha256,
+      ...contract.sourceEvidenceReceipt.sourceObligations,
+    }
+    const renderedEpub = {
+      epubSha256,
+      download: {
+        artifact: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+        verificationReceiptSha256: sha256HexSync('download verification'),
+      },
+      sourceObligations,
+      actualObservationSets,
+      renderer: {
+        id: 'fixture-renderer',
+        version: '1.0.0',
+        executableSha256: sha256HexSync('fixture renderer'),
+        configurationSha256: sha256HexSync('fixture render configuration'),
+      },
+      domSnapshots: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          dom: { sha256: sha256HexSync('fixture DOM'), byteLength: 11 },
+          anchors: ['fixture-anchor'],
+        },
+      ],
+      screenshots: [
+        {
+          id: 'fixture-screenshot',
+          spineHref: 'EPUB/content.xhtml',
+          domSha256: sha256HexSync('fixture DOM'),
+          image: { sha256: sha256HexSync('fixture screenshot'), byteLength: 19 },
+          mediaType: 'image/png' as const,
+          width: viewport.width,
+          height: viewport.height,
+          viewport,
+          fullPage: true,
+        },
+      ],
+      receiptSha256: '0'.repeat(64),
+    }
+    renderedEpub.receiptSha256 = hashRenderedEpubEvidence(renderedEpub)
+    const mappings = contract.sourceRegions.map((region, index) => ({
+      id: `mapping-${index + 1}`,
+      obligationId: region.id,
+      source: region.source,
+      output: [
+        {
+          spineHref: 'EPUB/content.xhtml',
+          anchorId: 'fixture-anchor',
+          rendered: {
+            screenshotId: 'fixture-screenshot',
+            viewport,
+            rect: { x: 10, y: 10 + index * 20, width: 100, height: 10 },
+          },
+        },
+      ],
+      status: 'mapped' as const,
+    }))
+    const observations = SOURCE_EPUB_OBSERVATION_CHECK_IDS.map((check) =>
+      createDeterministicObservationReceipt({
+        idSha256: sha256HexSync(`observation-${check}`),
+        check,
+        source: contract.sourceRegions[0]!.source,
+        mappingIds: [mappings[0]!.id],
+        expectedSetReceiptSha256: contract.expectedObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+        actualSetReceiptSha256: actualObservationSets.find(
+          (set) => set.check === check,
+        )!.receiptSha256,
+      }),
+    )
+    const comparator = compareSourceToRenderedEpub({
+      sourcePdfSha256: graph.source.sha256,
+      sourceEvidence: contract.sourceEvidenceReceipt,
+      structure: {
+        schemaVersion: '0.2.0',
+        documentId: graph.source.documentId,
+        sourcePdfSha256: graph.source.sha256,
+        artifact: { sha256: structSha256, byteLength: 128 },
+        generatedSha256: sha256HexSync('generated STRUCT'),
+        assets: [],
+      },
+      epub: {
+        bytes: { sha256: epubSha256, byteLength: epubBytes.byteLength },
+        mediaType: 'application/epub+zip',
+        structSha256,
+        epubCheck: {
+          toolId: 'epubcheck',
+          toolVersion: '5.3.0',
+          reportSha256: sha256HexSync('EPUBCheck report'),
+          status: 'passed',
+          errorCount: 0,
+          warningCount: 0,
+        },
+      },
+      renderedEpub,
+      sourceRegions: contract.sourceRegions,
+      mappings,
+      observations,
+    })
+    expect(comparator.status).toBe('publication-ready')
+    expect(contract.sourceEvidenceReceipt.candidateSetSha256).toBe(
+      hashTraceValue(contract.evidenceCandidates),
+    )
+  })
+})

--- a/src/research/source-evidence-contract.ts
+++ b/src/research/source-evidence-contract.ts
@@ -68,20 +68,42 @@ function sourceObligationProjection(obligations: PdfEvidenceObligation[]) {
   }))
 }
 
+function outputRequiredSemanticObligations(graph: SourceEvidenceGraph) {
+  return graph.obligations.filter(
+    ({ required, semantic }) => required && semantic,
+  )
+}
+
 function sourceRegions(graph: SourceEvidenceGraph): SourceRegionObligation[] {
   const reader = readSourceEvidenceGraph(graph)
-  const candidates = reader.allCandidates()
-  return graph.bundles
-    .flatMap(({ sources }) => sources)
-    .map((source) => {
-      const candidateBoxes = candidates
-        .filter(({ sourceIds }) => sourceIds.includes(source.id))
-        .flatMap(({ boxes }) => boxes ?? [])
-      const boxes = source.box ? [source.box] : candidateBoxes
+  return outputRequiredSemanticObligations(graph)
+    .map((obligation) => {
+      const boxes = [
+        ...obligation.sourceIds.flatMap((id) => {
+          const box = reader.sourceItem(id)!.box
+          return box ? [box] : []
+        }),
+        ...obligation.candidateIds.flatMap(
+          (id) => reader.candidate(id)!.boxes ?? [],
+        ),
+        ...obligation.artifactIds.flatMap((id) => {
+          const box = reader.artifact(id)!.box
+          return box ? [box] : []
+        }),
+      ].filter(
+        (box, index, all) =>
+          all.findIndex(
+            (candidate) =>
+              canonicalTraceJson(candidate) === canonicalTraceJson(box),
+          ) === index,
+      )
       const page =
-        source.page ?? boxes[0]?.page ?? graph.bundles[0]?.pages[0]?.page ?? 1
+        obligation.page ??
+        boxes[0]?.page ??
+        graph.bundles[0]?.pages[0]?.page ??
+        1
       return {
-        id: source.id,
+        id: obligation.id,
         source: {
           page,
           boxes: boxes
@@ -94,7 +116,7 @@ function sourceRegions(graph: SourceEvidenceGraph): SourceRegionObligation[] {
               height,
               rotation,
             })),
-          sourceRegionIds: [source.id],
+          sourceRegionIds: [obligation.id],
         },
       }
     })
@@ -171,8 +193,8 @@ function expectedSets(
   )
   return SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
     (check): VerifiedExpectedObservationSet => {
-      const applicable = graph.obligations.filter((obligation) =>
-        obligation.observationCategories.includes(check),
+      const applicable = outputRequiredSemanticObligations(graph).filter(
+        (obligation) => obligation.observationCategories.includes(check),
       )
       const payload: CanonicalObservationPayload = {
         schemaVersion: '1.0.0',
@@ -248,7 +270,7 @@ function expectedSets(
           byteLength: payloadBytes.byteLength,
         },
         sourceRegionIds: [
-          ...new Set(applicable.flatMap(({ sourceIds }) => sourceIds)),
+          ...new Set(applicable.map(({ id }) => id)),
         ].sort(),
       }
       const set: SourceExpectedObservationSet = {

--- a/src/research/source-evidence-contract.ts
+++ b/src/research/source-evidence-contract.ts
@@ -1,0 +1,434 @@
+import { sha256HexSync } from './sha256-sync'
+import {
+  SOURCE_EPUB_OBSERVATION_CHECK_IDS,
+  canonicalTraceJson,
+  encodeCanonicalObservationPayload,
+  hashSourceEvidenceReceipt,
+  hashSourceExpectedObservationSet,
+  hashTraceValue,
+  type CanonicalObservationPayload,
+  type EvidenceCandidateReference,
+  type SourceRegionObligation,
+  type SourceEvidenceReceiptBinding,
+  type SourceExpectedObservationSet,
+} from './reconstruction-attempt-trace'
+import type {
+  EvidenceCandidateResolutionReceipt,
+  GroundedVerifierIdentity,
+  SourceEvidenceVerificationReceipt,
+  SourceEvidenceVerifier,
+} from './reconstruction-refinement'
+import {
+  readSourceEvidenceGraph,
+  serializeSourceEvidenceGraph,
+  PDF_EVIDENCE_OBSERVATION_CATEGORIES,
+  type PdfEvidenceCandidate,
+  type PdfEvidenceObligation,
+  type SourceEvidenceGraph,
+} from './source-evidence-graph'
+
+export const SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION = '1.0.0' as const
+
+export type SourceEvidenceCandidateReference = {
+  candidateId: string
+  referenceSha256: string
+  bindingSha256: string
+  payload: { sha256: string; byteLength: number }
+  payloadBytes: Uint8Array
+}
+
+export type VerifiedExpectedObservationSet = SourceExpectedObservationSet & {
+  payloadBytes: Uint8Array
+}
+
+export type SourceEvidenceContract = {
+  schemaVersion: typeof SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION
+  graph: SourceEvidenceGraph
+  graphArtifact: { sha256: string; byteLength: number }
+  graphBytes: Uint8Array
+  sourceEvidenceReceipt: SourceEvidenceReceiptBinding
+  sourceRegions: SourceRegionObligation[]
+  evidenceCandidates: EvidenceCandidateReference[]
+  expectedObservationSets: VerifiedExpectedObservationSet[]
+  candidateReferences: SourceEvidenceCandidateReference[]
+  verifier: SourceEvidenceVerifier
+}
+
+function sourceObligationProjection(obligations: PdfEvidenceObligation[]) {
+  return obligations.map((obligation) => ({
+    id: obligation.id,
+    kind: obligation.kind,
+    ...(obligation.page === undefined ? {} : { page: obligation.page }),
+    sourceIds: [...obligation.sourceIds].sort(),
+    artifactIds: [...obligation.artifactIds].sort(),
+    candidateIds: [...obligation.candidateIds].sort(),
+    observationCategories: [...obligation.observationCategories].sort(),
+    required: obligation.required,
+    semantic: obligation.semantic,
+  }))
+}
+
+function sourceRegions(graph: SourceEvidenceGraph): SourceRegionObligation[] {
+  const reader = readSourceEvidenceGraph(graph)
+  const candidates = reader.allCandidates()
+  return graph.bundles
+    .flatMap(({ sources }) => sources)
+    .map((source) => {
+      const candidateBoxes = candidates
+        .filter(({ sourceIds }) => sourceIds.includes(source.id))
+        .flatMap(({ boxes }) => boxes ?? [])
+      const boxes = source.box ? [source.box] : candidateBoxes
+      const page =
+        source.page ?? boxes[0]?.page ?? graph.bundles[0]?.pages[0]?.page ?? 1
+      return {
+        id: source.id,
+        source: {
+          page,
+          boxes: boxes
+            .filter((box) => box.page === page)
+            .map(({ page: boxPage, x, y, width, height, rotation }) => ({
+              page: boxPage,
+              x,
+              y,
+              width,
+              height,
+              rotation,
+            })),
+          sourceRegionIds: [source.id],
+        },
+      }
+    })
+    .sort((left, right) =>
+      left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+    )
+}
+
+function candidatePayload(
+  graph: SourceEvidenceGraph,
+  candidate: PdfEvidenceCandidate,
+  reader: ReturnType<typeof readSourceEvidenceGraph>,
+) {
+  const sources = candidate.sourceIds.map((id) => reader.sourceItem(id)!)
+  const artifacts = (candidate.artifactIds ?? []).map((id) =>
+    reader.artifact(id)!,
+  )
+  return {
+    schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+    sourceEvidenceGraphSha256: graph.graphSha256,
+    candidate,
+    sources,
+    artifacts,
+  }
+}
+
+function candidateReferences(graph: SourceEvidenceGraph) {
+  const reader = readSourceEvidenceGraph(graph)
+  return reader
+    .allCandidates()
+    .map((candidate): SourceEvidenceCandidateReference => {
+      const payloadBytes = new TextEncoder().encode(
+        canonicalTraceJson(candidatePayload(graph, candidate, reader)),
+      )
+      const payload = {
+        sha256: sha256HexSync(payloadBytes),
+        byteLength: payloadBytes.byteLength,
+      }
+      const referenceSha256 = hashTraceValue({
+        schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+        sourceEvidenceGraphSha256: graph.graphSha256,
+        candidateId: candidate.id,
+        payload,
+      })
+      return {
+        candidateId: candidate.id,
+        referenceSha256,
+        bindingSha256: hashTraceValue({
+          schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+          sourcePdfSha256: graph.source.sha256,
+          sourceEvidenceGraphSha256: graph.graphSha256,
+          referenceSha256,
+          providerId: candidate.providerId,
+          sourceIds: [...candidate.sourceIds].sort(),
+          artifactIds: [...(candidate.artifactIds ?? [])].sort(),
+          payload,
+        }),
+        payload,
+        payloadBytes,
+      }
+    })
+    .sort((left, right) =>
+      left.referenceSha256 < right.referenceSha256 ? -1 : 1,
+    )
+}
+
+function expectedSets(
+  graph: SourceEvidenceGraph,
+  references: SourceEvidenceCandidateReference[],
+) {
+  const reader = readSourceEvidenceGraph(graph)
+  const referenceByCandidate = new Map(
+    references.map((reference) => [reference.candidateId, reference]),
+  )
+  return SOURCE_EPUB_OBSERVATION_CHECK_IDS.map(
+    (check): VerifiedExpectedObservationSet => {
+      const applicable = graph.obligations.filter((obligation) =>
+        obligation.observationCategories.includes(check),
+      )
+      const payload: CanonicalObservationPayload = {
+        schemaVersion: '1.0.0',
+        check,
+        items: applicable
+          .map((obligation) => {
+            const candidates = obligation.candidateIds.map((id) =>
+              reader.candidate(id)!,
+            )
+            const sourceIds = [
+              ...new Set([
+                ...obligation.sourceIds,
+                ...candidates.flatMap(({ sourceIds }) => sourceIds),
+              ]),
+            ].sort()
+            const artifacts = [
+              ...new Set(
+                candidates.flatMap(({ artifactIds }) => artifactIds ?? []),
+              ),
+            ]
+              .sort()
+              .map((id) => reader.artifact(id)!)
+            return {
+              idSha256: hashTraceValue({ check, obligationId: obligation.id }),
+              valueSha256: hashTraceValue({
+                schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+                sourcePdfSha256: graph.source.sha256,
+                check,
+                obligation: sourceObligationProjection([obligation])[0],
+                sourceAnchors: sourceIds.map((id) => {
+                  const source = reader.sourceItem(id)!
+                  return {
+                    id: source.id,
+                    kind: source.kind,
+                    page: source.page ?? null,
+                    box: source.box ?? null,
+                    payload: source.payload ?? null,
+                  }
+                }),
+                candidates: candidates.map((candidate) => ({
+                  id: candidate.id,
+                  kind: candidate.kind,
+                  page: candidate.page ?? null,
+                  boxes: candidate.boxes ?? [],
+                  sourceIds: [...candidate.sourceIds].sort(),
+                  artifactIds: [...(candidate.artifactIds ?? [])].sort(),
+                  payload: candidate.payload ?? null,
+                  referenceSha256: referenceByCandidate.get(candidate.id)!
+                    .referenceSha256,
+                })),
+                artifacts: artifacts.map((artifact) => ({
+                  id: artifact.id,
+                  kind: artifact.kind,
+                  mediaType: artifact.mediaType,
+                  sha256: artifact.sha256,
+                  byteLength: artifact.byteLength,
+                  page: artifact.page ?? null,
+                  box: artifact.box ?? null,
+                })),
+              }),
+              anchorIds: sourceIds,
+            }
+          })
+          .sort((left, right) => (left.idSha256 < right.idSha256 ? -1 : 1)),
+      }
+      const payloadBytes = encodeCanonicalObservationPayload(payload)
+      const base = {
+        check,
+        setSha256: sha256HexSync(payloadBytes),
+        itemCount: payload.items.length,
+        payload: {
+          sha256: sha256HexSync(payloadBytes),
+          byteLength: payloadBytes.byteLength,
+        },
+        sourceRegionIds: [
+          ...new Set(applicable.flatMap(({ sourceIds }) => sourceIds)),
+        ].sort(),
+      }
+      const set: SourceExpectedObservationSet = {
+        ...base,
+        receiptSha256: hashSourceExpectedObservationSet({
+          ...base,
+          receiptSha256: '0'.repeat(64),
+        }),
+      }
+      return { ...set, payloadBytes }
+    },
+  )
+}
+
+function identitySha256(identity: GroundedVerifierIdentity) {
+  return hashTraceValue(identity)
+}
+
+function verificationProjection(receipt: SourceEvidenceVerificationReceipt) {
+  return {
+    schemaVersion: receipt.schemaVersion,
+    verifierIdentity: receipt.verifierIdentity,
+    verifierIdentitySha256: receipt.verifierIdentitySha256,
+    requestSha256: receipt.requestSha256,
+    evidenceGraph: receipt.evidenceGraph,
+    expectedObservationSets: receipt.expectedObservationSets.map(
+      ({ payloadBytes: _payloadBytes, ...set }) => set,
+    ),
+    status: receipt.status,
+  }
+}
+
+function candidateResolutionProjection(
+  receipt: EvidenceCandidateResolutionReceipt,
+) {
+  const {
+    payloadBytes: _payloadBytes,
+    receiptSha256: _receiptSha256,
+    ...projection
+  } = receipt
+  return projection
+}
+
+export function createSourceEvidenceContract(
+  graph: SourceEvidenceGraph,
+  verifierIdentity: GroundedVerifierIdentity,
+): SourceEvidenceContract {
+  if (
+    hashTraceValue(PDF_EVIDENCE_OBSERVATION_CATEGORIES) !==
+    hashTraceValue(SOURCE_EPUB_OBSERVATION_CHECK_IDS)
+  ) {
+    throw new TypeError('SOURCE_OBSERVATION_CATEGORY_CONTRACT_MISMATCH')
+  }
+  const graphBytes = serializeSourceEvidenceGraph(graph)
+  const graphArtifact = {
+    sha256: graph.graphSha256,
+    byteLength: graphBytes.byteLength,
+  }
+  const references = candidateReferences(graph)
+  const evidenceCandidates: EvidenceCandidateReference[] = references.map(
+    ({ referenceSha256, bindingSha256 }) => ({
+      referenceSha256,
+      bindingSha256,
+    }),
+  )
+  const sets = expectedSets(graph, references)
+  const regions = sourceRegions(graph)
+  const obligationProjection = regions
+  if (obligationProjection.length === 0) {
+    throw new TypeError('SOURCE_EVIDENCE_OBLIGATIONS_REQUIRED')
+  }
+  const sourceObligationBase = {
+    obligationsSha256: hashTraceValue(obligationProjection),
+    obligationCount: obligationProjection.length,
+  }
+  const sourceObligations = {
+    ...sourceObligationBase,
+    receiptSha256: hashTraceValue({
+      sourcePdfSha256: graph.source.sha256,
+      ...sourceObligationBase,
+    }),
+  }
+  const receiptBase = {
+    schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+    sourcePdfSha256: graph.source.sha256,
+    evidenceGraphSha256: graph.graphSha256,
+    candidateSetSha256: hashTraceValue(evidenceCandidates),
+    sourceObligations,
+    expectedObservationSets: sets.map(
+      ({ payloadBytes: _payloadBytes, ...set }) => set,
+    ),
+  }
+  const sourceEvidenceReceipt: SourceEvidenceReceiptBinding = {
+    ...receiptBase,
+    receiptSha256: hashSourceEvidenceReceipt({
+      ...receiptBase,
+      receiptSha256: '0'.repeat(64),
+    }),
+  }
+  const identityHash = identitySha256(verifierIdentity)
+  const referenceByHash = new Map(
+    references.map((reference) => [reference.referenceSha256, reference]),
+  )
+  const verifier: SourceEvidenceVerifier = {
+    identity: structuredClone(verifierIdentity),
+    verifyExpected(request): SourceEvidenceVerificationReceipt {
+      if (
+        request.schemaVersion !== '1.0.0' ||
+        request.sourcePdfSha256 !== graph.source.sha256 ||
+        request.evidenceGraph.sha256 !== graphArtifact.sha256 ||
+        request.evidenceGraph.byteLength !== graphArtifact.byteLength ||
+        request.sourceObligationsSha256 !== sourceObligations.obligationsSha256
+      ) {
+        throw new TypeError('SOURCE_EVIDENCE_VERIFICATION_REQUEST_MISMATCH')
+      }
+      const base = {
+        schemaVersion: '1.0.0' as const,
+        verifierIdentity: structuredClone(verifierIdentity),
+        verifierIdentitySha256: identityHash,
+        requestSha256: hashTraceValue(request),
+        evidenceGraph: graphArtifact,
+        evidenceGraphBytes: graphBytes.slice(),
+        expectedObservationSets: sets.map((set) => ({
+          ...set,
+          payloadBytes: set.payloadBytes.slice(),
+        })),
+        status: 'succeeded' as const,
+      }
+      return {
+        ...base,
+        receiptSha256: hashTraceValue(
+          verificationProjection({
+            ...base,
+            receiptSha256: '0'.repeat(64),
+          }),
+        ),
+      }
+    },
+    resolveCandidate(request): EvidenceCandidateResolutionReceipt {
+      const reference = referenceByHash.get(request.referenceSha256)
+      if (
+        request.schemaVersion !== '1.0.0' ||
+        request.sourceEvidenceGraphSha256 !== graph.graphSha256 ||
+        !reference ||
+        request.bindingSha256 !== reference.bindingSha256
+      ) {
+        throw new TypeError('SOURCE_EVIDENCE_CANDIDATE_REQUEST_MISMATCH')
+      }
+      const base = {
+        schemaVersion: '1.0.0' as const,
+        verifierIdentity: structuredClone(verifierIdentity),
+        verifierIdentitySha256: identityHash,
+        requestSha256: hashTraceValue(request),
+        referenceSha256: reference.referenceSha256,
+        bindingSha256: reference.bindingSha256,
+        payload: reference.payload,
+        payloadBytes: reference.payloadBytes.slice(),
+        status: 'succeeded' as const,
+      }
+      return {
+        ...base,
+        receiptSha256: hashTraceValue(
+          candidateResolutionProjection({
+            ...base,
+            receiptSha256: '0'.repeat(64),
+          }),
+        ),
+      }
+    },
+  }
+  return Object.freeze({
+    schemaVersion: SOURCE_EVIDENCE_CONTRACT_SCHEMA_VERSION,
+    graph,
+    graphArtifact,
+    graphBytes,
+    sourceEvidenceReceipt,
+    sourceRegions: regions,
+    evidenceCandidates,
+    expectedObservationSets: sets,
+    candidateReferences: references,
+    verifier,
+  })
+}

--- a/src/research/source-evidence-graph.test.ts
+++ b/src/research/source-evidence-graph.test.ts
@@ -1,0 +1,689 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  readSourceEvidenceGraph,
+  sourceEvidenceCandidateSetSha256,
+  sourceEvidenceGraphSha256,
+  validatePdfEvidenceBundle,
+  validateSourceEvidenceGraph,
+  type PdfEvidenceBox,
+  type PdfEvidenceBundle,
+  type PdfEvidenceProviderIdentity,
+  type SourceEvidenceGraph,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+
+const source = {
+  documentId: 'fixture-paper',
+  sha256: '1'.repeat(64),
+  byteLength: 8_192,
+  pageCount: 2,
+} as const
+
+function box(page: number, x: number): PdfEvidenceBox {
+  return {
+    page,
+    x,
+    y: 0.1,
+    width: 0.2,
+    height: 0.05,
+    rotation: 0,
+    method: 'pdf-text',
+  }
+}
+
+function provider(
+  id: string,
+  kind: PdfEvidenceProviderIdentity['kind'],
+): PdfEvidenceProviderIdentity {
+  return {
+    id,
+    kind,
+    name: kind === 'mineru' ? 'MinerU' : 'PDF.js',
+    version: kind === 'mineru' ? '3.4.4' : '5.4.624',
+    implementationSha256: (kind === 'mineru' ? 'a' : 'b').repeat(64),
+    ...(kind === 'mineru'
+      ? {
+          model: {
+            id: 'opendatalab/MinerU2.5-Pro-2605-1.2B',
+            revision: 'bff20d4',
+            digestSha256: 'c'.repeat(64),
+            license: 'Apache-2.0',
+            architecture: 'Qwen2VL',
+          },
+        }
+      : {}),
+  }
+}
+
+function bundle(
+  id: string,
+  armId: string,
+  providerIdentity: PdfEvidenceProviderIdentity,
+  candidateText: string,
+): PdfEvidenceBundle {
+  const sourceId = `${id}-source`
+  const artifactId = `${id}-artifact`
+  return {
+    schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+    id,
+    armId,
+    source: { ...source },
+    provider: providerIdentity,
+    pages: [
+      { page: 1, width: 612, height: 792, rotation: 0 },
+      { page: 2, width: 612, height: 792, rotation: 0 },
+    ],
+    artifacts: [
+      {
+        id: artifactId,
+        providerId: providerIdentity.id,
+        kind: 'content-list-json',
+        mediaType: 'application/json',
+        sha256: (providerIdentity.kind === 'mineru' ? 'd' : 'e').repeat(64),
+        byteLength: 64,
+        page: 1,
+        box: box(1, providerIdentity.kind === 'mineru' ? 0.11 : 0.1),
+        sourceIds: [sourceId],
+      },
+    ],
+    sources: [
+      {
+        id: sourceId,
+        providerId: providerIdentity.id,
+        kind: 'text-run',
+        page: 1,
+        box: box(1, providerIdentity.kind === 'mineru' ? 0.11 : 0.1),
+        artifactIds: [artifactId],
+        parentSourceIds: [],
+        payload: { text: candidateText, tokens: ['grounded', 'source'] },
+      },
+    ],
+    candidates: [
+      {
+        id: `${id}-candidate`,
+        providerId: providerIdentity.id,
+        kind: 'text',
+        page: 1,
+        boxes: [box(1, providerIdentity.kind === 'mineru' ? 0.11 : 0.1)],
+        sourceIds: [sourceId],
+        artifactIds: [artifactId],
+        payload: { text: candidateText },
+      },
+    ],
+  }
+}
+
+function input(): SourceEvidenceGraphInput {
+  const pdfjs = bundle(
+    'pdfjs-bundle',
+    'deterministic',
+    provider('pdfjs-provider', 'pdfjs'),
+    'Grounded source text.',
+  )
+  const mineru = bundle(
+    'mineru-bundle',
+    'mineru',
+    provider('mineru-provider', 'mineru'),
+    'Grounded source text',
+  )
+  return {
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source: { ...source },
+    deterministicContext: deterministicContextReceiptForBundle(pdfjs),
+    arms: [
+      {
+        id: 'deterministic',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: 'pdfjs-provider',
+      },
+      {
+        id: 'mineru',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: 'mineru-provider',
+      },
+      {
+        id: 'optional-ocr',
+        requirement: 'optional',
+        status: 'disabled',
+        frozen: true,
+        reason: 'disabled before the evidence run',
+      },
+    ],
+    bundles: [pdfjs, mineru],
+    obligations: [
+      {
+        id: 'body-text-obligation',
+        kind: 'text',
+        page: 1,
+        sourceIds: ['pdfjs-bundle-source', 'mineru-bundle-source'],
+        artifactIds: ['pdfjs-bundle-artifact', 'mineru-bundle-artifact'],
+        candidateIds: ['pdfjs-bundle-candidate', 'mineru-bundle-candidate'],
+        observationCategories: ['text-exactness'],
+        required: true,
+        semantic: true,
+      },
+    ],
+    disagreements: [
+      {
+        id: 'terminal-punctuation-disagreement',
+        kind: 'text',
+        obligationIds: ['body-text-obligation'],
+        candidateIds: ['pdfjs-bundle-candidate', 'mineru-bundle-candidate'],
+        providerIds: ['pdfjs-provider', 'mineru-provider'],
+        reason: 'Providers disagree about terminal punctuation.',
+      },
+    ],
+  }
+}
+
+function cloneInput(value: SourceEvidenceGraphInput = input()) {
+  return structuredClone(value)
+}
+
+describe('source evidence graph', () => {
+  it('builds a provider-bound graph and exposes an immutable typed reader', () => {
+    const mutableInput = input()
+    const graph = buildSourceEvidenceGraph(mutableInput)
+    const reader = readSourceEvidenceGraph(graph)
+
+    expect(() => validateSourceEvidenceGraph(graph)).not.toThrow()
+    expect(() => validatePdfEvidenceBundle(graph.bundles[0])).not.toThrow()
+    expect(graph.graphSha256).toMatch(/^[a-f0-9]{64}$/u)
+    expect(reader.source).toEqual(source)
+    expect(reader.provider('mineru-provider')?.model).toMatchObject({
+      revision: 'bff20d4',
+      architecture: 'Qwen2VL',
+    })
+    expect(reader.sourceItem('pdfjs-bundle-source')?.kind).toBe('text-run')
+    expect(reader.artifact('mineru-bundle-artifact')?.mediaType).toBe(
+      'application/json',
+    )
+    expect(reader.candidate('pdfjs-bundle-candidate')?.sourceIds).toEqual([
+      'pdfjs-bundle-source',
+    ])
+    expect(reader.page(1)).toHaveLength(2)
+    expect(reader.candidatesForObligation('body-text-obligation')).toHaveLength(
+      2,
+    )
+    expect(
+      reader.disagreement('terminal-punctuation-disagreement'),
+    ).not.toHaveProperty('acceptedCandidateId')
+    expect(reader.graph).not.toHaveProperty('attempts')
+    expect(reader.graph).not.toHaveProperty('comparator')
+    expect(Object.isFrozen(reader)).toBe(true)
+    expect(Object.isFrozen(reader.graph)).toBe(true)
+    expect(Object.isFrozen(reader.graph.bundles[0]?.candidates[0])).toBe(true)
+    expect(() => {
+      reader.graph.bundles[0]!.candidates[0]!.kind = 'authored'
+    }).toThrow()
+
+    mutableInput.bundles[0]!.provider.name = 'mutated after build'
+    expect(reader.provider('pdfjs-provider')?.name).toBe('PDF.js')
+  })
+
+  it('canonicalizes set-like ordering while retaining payload sequence meaning', () => {
+    const first = input()
+    const reordered = cloneInput(first)
+    reordered.arms.reverse()
+    reordered.bundles.reverse()
+    reordered.bundles.forEach((item) => {
+      item.pages.reverse()
+      item.artifacts.reverse()
+      item.sources.reverse()
+      item.candidates.reverse()
+    })
+    reordered.obligations[0]!.sourceIds.reverse()
+    reordered.obligations[0]!.artifactIds.reverse()
+    reordered.obligations[0]!.candidateIds.reverse()
+    reordered.disagreements[0]!.candidateIds.reverse()
+    reordered.disagreements[0]!.providerIds.reverse()
+
+    const firstGraph = buildSourceEvidenceGraph(first)
+    const reorderedGraph = buildSourceEvidenceGraph(reordered)
+    expect(reorderedGraph).toEqual(firstGraph)
+    expect(sourceEvidenceGraphSha256(reordered)).toBe(firstGraph.graphSha256)
+
+    const changedPayloadOrder = cloneInput(first)
+    const payload = changedPayloadOrder.bundles[0]!.sources[0]!.payload as {
+      text: string
+      tokens: string[]
+    }
+    payload.tokens.reverse()
+    changedPayloadOrder.deterministicContext =
+      deterministicContextReceiptForBundle(changedPayloadOrder.bundles[0]!)
+    expect(buildSourceEvidenceGraph(changedPayloadOrder).graphSha256).not.toBe(
+      firstGraph.graphSha256,
+    )
+  })
+
+  it('hashes explicit candidate sets against the graph and rejects bad sets', () => {
+    const graph = buildSourceEvidenceGraph(input())
+    const reader = readSourceEvidenceGraph(graph)
+    const ids = ['pdfjs-bundle-candidate', 'mineru-bundle-candidate']
+
+    expect(reader.candidateSetSha256(ids)).toBe(
+      sourceEvidenceCandidateSetSha256(graph, [...ids].reverse()),
+    )
+    expect(() => reader.candidateSetSha256([ids[0]!, ids[0]!])).toThrow(
+      /duplicate id/u,
+    )
+    expect(() => reader.candidateSetSha256(['unknown-candidate'])).toThrow(
+      /unknown candidate/u,
+    )
+  })
+
+  it('rejects same-ID deterministic source content swapped after context binding', () => {
+    const swapped = cloneInput()
+    const sourceItem = swapped.bundles[0]!.sources[0]!
+    sourceItem.payload = {
+      ...(sourceItem.payload as Record<string, unknown>),
+      text: 'Different text under the same source ID and PDF identity.',
+    } as typeof sourceItem.payload
+
+    expect(() => buildSourceEvidenceGraph(swapped)).toThrow(
+      /deterministicContext does not match the exact normalized deterministic bundle/u,
+    )
+  })
+
+  it('detects content changed after the graph hash was frozen', () => {
+    const graph = buildSourceEvidenceGraph(input())
+    const tampered = structuredClone(graph) as SourceEvidenceGraph
+    tampered.bundles[0]!.candidates[0]!.payload = { text: 'Invented' }
+
+    expect(() => validateSourceEvidenceGraph(tampered)).toThrow(
+      /graphSha256 does not match/u,
+    )
+  })
+
+  it.each([
+    {
+      level: 'graph',
+      locate: (graph: SourceEvidenceGraph) => graph,
+    },
+    {
+      level: 'source identity',
+      locate: (graph: SourceEvidenceGraph) => graph.source,
+    },
+    {
+      level: 'arm',
+      locate: (graph: SourceEvidenceGraph) => graph.arms[0]!,
+    },
+    {
+      level: 'bundle',
+      locate: (graph: SourceEvidenceGraph) => graph.bundles[0]!,
+    },
+    {
+      level: 'provider',
+      locate: (graph: SourceEvidenceGraph) =>
+        graph.bundles.find(({ provider }) => provider.kind === 'mineru')!
+          .provider,
+    },
+    {
+      level: 'provider model',
+      locate: (graph: SourceEvidenceGraph) =>
+        graph.bundles.find(({ provider }) => provider.kind === 'mineru')!
+          .provider.model!,
+    },
+    {
+      level: 'page',
+      locate: (graph: SourceEvidenceGraph) => graph.bundles[0]!.pages[0]!,
+    },
+    {
+      level: 'box',
+      locate: (graph: SourceEvidenceGraph) =>
+        graph.bundles[0]!.artifacts[0]!.box!,
+    },
+    {
+      level: 'artifact',
+      locate: (graph: SourceEvidenceGraph) => graph.bundles[0]!.artifacts[0]!,
+    },
+    {
+      level: 'source item',
+      locate: (graph: SourceEvidenceGraph) => graph.bundles[0]!.sources[0]!,
+    },
+    {
+      level: 'candidate',
+      locate: (graph: SourceEvidenceGraph) => graph.bundles[0]!.candidates[0]!,
+    },
+    {
+      level: 'obligation',
+      locate: (graph: SourceEvidenceGraph) => graph.obligations[0]!,
+    },
+    {
+      level: 'disagreement',
+      locate: (graph: SourceEvidenceGraph) => graph.disagreements[0]!,
+    },
+  ])('rejects unhashed extra state at the $level level', ({ locate }) => {
+    const installed = structuredClone(
+      buildSourceEvidenceGraph(input()),
+    ) as SourceEvidenceGraph
+    const oldHash = installed.graphSha256
+    const target = locate(installed) as unknown as Record<string, unknown>
+    target.injectedState = 'not represented by the old canonical hash'
+
+    expect(installed.graphSha256).toBe(oldHash)
+    expect(() => validateSourceEvidenceGraph(installed)).toThrow(
+      /unsupported field injectedState/u,
+    )
+  })
+
+  it('rejects hidden, symbolic, accessor-backed, and payload container state', () => {
+    const hidden = structuredClone(
+      buildSourceEvidenceGraph(input()),
+    ) as SourceEvidenceGraph
+    Object.defineProperty(hidden.bundles[0]!.candidates[0]!, 'hiddenState', {
+      value: true,
+      enumerable: false,
+    })
+    expect(() => validateSourceEvidenceGraph(hidden)).toThrow(
+      /unsupported field hiddenState/u,
+    )
+
+    const symbolic = structuredClone(
+      buildSourceEvidenceGraph(input()),
+    ) as SourceEvidenceGraph
+    Object.defineProperty(symbolic.obligations[0]!, Symbol('hidden'), {
+      value: true,
+      enumerable: true,
+    })
+    expect(() => validateSourceEvidenceGraph(symbolic)).toThrow(
+      /unsupported field Symbol\(hidden\)/u,
+    )
+
+    const accessor = structuredClone(
+      buildSourceEvidenceGraph(input()),
+    ) as SourceEvidenceGraph
+    Object.defineProperty(accessor.bundles[0]!.candidates[0]!, 'kind', {
+      get: () => 'text',
+      enumerable: true,
+      configurable: true,
+    })
+    expect(() => validateSourceEvidenceGraph(accessor)).toThrow(
+      /kind must be an enumerable data property/u,
+    )
+
+    const payload = structuredClone(
+      buildSourceEvidenceGraph(input()),
+    ) as SourceEvidenceGraph
+    Object.defineProperty(
+      payload.bundles[0]!.sources[0]!.payload as object,
+      'hiddenPayloadState',
+      { value: true, enumerable: false },
+    )
+    expect(() => validateSourceEvidenceGraph(payload)).toThrow(
+      /hiddenPayloadState must be an enumerable data property/u,
+    )
+  })
+
+  it('rejects extra state before building a graph', () => {
+    const unbuilt = input() as SourceEvidenceGraphInput & {
+      installedState?: string
+    }
+    unbuilt.installedState = 'must not be normalized away'
+    expect(() => buildSourceEvidenceGraph(unbuilt)).toThrow(
+      /unsupported field installedState/u,
+    )
+  })
+
+  it.each([
+    {
+      name: 'a mismatched bundle source',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.source.sha256 = '9'.repeat(64)
+      },
+      expected: /source identity does not match/u,
+    },
+    {
+      name: 'a missing page',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.pages.pop()
+      },
+      expected: /every source page exactly once/u,
+    },
+    {
+      name: 'an out-of-page box',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.sources[0]!.box!.width = 1
+      },
+      expected: /exceeds normalized page bounds/u,
+    },
+    {
+      name: 'a provider mismatch',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.candidates[0]!.providerId = 'mineru-provider'
+      },
+      expected: /does not match bundle provider/u,
+    },
+    {
+      name: 'a dangling candidate source',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.candidates[0]!.sourceIds = ['missing-source']
+      },
+      expected: /unknown source/u,
+    },
+    {
+      name: 'a duplicate global candidate id',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[1]!.candidates[0]!.id =
+          value.bundles[0]!.candidates[0]!.id
+      },
+      expected: /duplicate candidate id/u,
+    },
+    {
+      name: 'a source-parent cycle',
+      mutate: (value: SourceEvidenceGraphInput) => {
+        value.bundles[0]!.sources[0]!.parentSourceIds = [
+          'pdfjs-bundle-source-2',
+        ]
+        value.bundles[0]!.sources.push({
+          id: 'pdfjs-bundle-source-2',
+          providerId: 'pdfjs-provider',
+          kind: 'text-run',
+          page: 1,
+          parentSourceIds: ['pdfjs-bundle-source'],
+        })
+      },
+      expected: /source parent cycle/u,
+    },
+  ])('rejects $name', ({ mutate, expected }) => {
+    const invalid = cloneInput()
+    mutate(invalid)
+    expect(() => buildSourceEvidenceGraph(invalid)).toThrow(expected)
+  })
+
+  it('requires optional-arm state to be frozen before the evidence run', () => {
+    const disabledWithBundle = cloneInput()
+    disabledWithBundle.arms[1] = {
+      id: 'mineru',
+      requirement: 'optional',
+      status: 'disabled',
+      frozen: true,
+      reason: 'operator disabled it before the run',
+    }
+    expect(() => buildSourceEvidenceGraph(disabledWithBundle)).toThrow(
+      /required evidence arm mineru/u,
+    )
+
+    const enabledWithoutBundle = cloneInput()
+    enabledWithoutBundle.bundles.pop()
+    expect(() => buildSourceEvidenceGraph(enabledWithoutBundle)).toThrow(
+      /must have exactly one evidence bundle/u,
+    )
+
+    const notFrozen = cloneInput()
+    ;(notFrozen.arms[2] as { frozen: boolean }).frozen = false
+    expect(() => buildSourceEvidenceGraph(notFrozen)).toThrow(
+      /frozen must be true/u,
+    )
+  })
+
+  it('requires deterministic and MinerU arms independently of caller declarations', () => {
+    const missingMineru = cloneInput()
+    missingMineru.arms.splice(1, 1)
+    missingMineru.bundles.splice(1, 1)
+    missingMineru.obligations[0]!.sourceIds = ['pdfjs-bundle-source']
+    missingMineru.obligations[0]!.artifactIds = ['pdfjs-bundle-artifact']
+    missingMineru.obligations[0]!.candidateIds = ['pdfjs-bundle-candidate']
+    missingMineru.disagreements = []
+    expect(() => buildSourceEvidenceGraph(missingMineru)).toThrow(
+      /required evidence arm mineru/u,
+    )
+
+    const callerDowngradedMineru = cloneInput()
+    callerDowngradedMineru.arms[1]!.requirement = 'optional'
+    expect(() => buildSourceEvidenceGraph(callerDowngradedMineru)).toThrow(
+      /required evidence arm mineru/u,
+    )
+  })
+
+  it('rejects empty required evidence arms and the historical partial-graph attack', () => {
+    const emptyMineru = cloneInput()
+    emptyMineru.bundles[1]!.sources = []
+    emptyMineru.bundles[1]!.artifacts = []
+    emptyMineru.bundles[1]!.candidates = []
+    emptyMineru.obligations[0]!.sourceIds = ['pdfjs-bundle-source']
+    emptyMineru.obligations[0]!.artifactIds = ['pdfjs-bundle-artifact']
+    emptyMineru.obligations[0]!.candidateIds = ['pdfjs-bundle-candidate']
+    emptyMineru.disagreements = []
+    expect(() => buildSourceEvidenceGraph(emptyMineru)).toThrow(
+      /required arm mineru.*must contain evidence/u,
+    )
+
+    const partial18 = cloneInput()
+    const mineru = partial18.bundles[1]!
+    for (let index = 1; index <= 18; index += 1) {
+      const id = `partial-${index}`
+      mineru.sources.push({
+        id: `${id}-source`,
+        providerId: mineru.provider.id,
+        kind: 'text-run',
+        page: 1,
+        box: box(1, 0.2),
+      })
+      mineru.artifacts.push({
+        id: `${id}-artifact`,
+        providerId: mineru.provider.id,
+        kind: 'content-list-json',
+        mediaType: 'application/json',
+        sha256: index.toString(16).padStart(64, '0'),
+        byteLength: 1,
+        page: 1,
+      })
+      mineru.candidates.push({
+        id: `${id}-candidate`,
+        providerId: mineru.provider.id,
+        kind: 'text',
+        page: 1,
+        sourceIds: [`${id}-source`],
+        artifactIds: [`${id}-artifact`],
+      })
+    }
+    expect(() => buildSourceEvidenceGraph(partial18)).toThrow(
+      /candidate partial-1-candidate is not owned by an obligation/u,
+    )
+  })
+
+  it('requires every candidate, source fact, and artifact to be owned exactly once', () => {
+    const uncoveredCandidate = cloneInput()
+    uncoveredCandidate.obligations[0]!.candidateIds = [
+      'pdfjs-bundle-candidate',
+    ]
+    expect(() => buildSourceEvidenceGraph(uncoveredCandidate)).toThrow(
+      /candidate mineru-bundle-candidate is not owned by an obligation/u,
+    )
+
+    const uncoveredSource = cloneInput()
+    uncoveredSource.obligations[0]!.sourceIds = ['pdfjs-bundle-source']
+    expect(() => buildSourceEvidenceGraph(uncoveredSource)).toThrow(
+      /source mineru-bundle-source is not owned by an obligation/u,
+    )
+
+    const uncoveredArtifact = cloneInput()
+    uncoveredArtifact.obligations[0]!.artifactIds = ['pdfjs-bundle-artifact']
+    expect(() => buildSourceEvidenceGraph(uncoveredArtifact)).toThrow(
+      /artifact mineru-bundle-artifact is not owned by an obligation/u,
+    )
+
+    const duplicate = cloneInput()
+    duplicate.bundles[0]!.sources.push({
+      id: 'duplicate-owner-source',
+      providerId: 'pdfjs-provider',
+      kind: 'ownership-fixture',
+      page: 1,
+    })
+    duplicate.bundles[0]!.artifacts.push({
+      id: 'duplicate-owner-artifact',
+      providerId: 'pdfjs-provider',
+      kind: 'ownership-fixture',
+      mediaType: 'application/json',
+      sha256: 'f'.repeat(64),
+      byteLength: 1,
+      page: 1,
+    })
+    duplicate.bundles[0]!.candidates.push({
+      id: 'duplicate-owner-fixture-candidate',
+      providerId: 'pdfjs-provider',
+      kind: 'ownership-fixture',
+      page: 1,
+      sourceIds: ['duplicate-owner-source'],
+      artifactIds: ['duplicate-owner-artifact'],
+    })
+    duplicate.obligations.push({
+      id: 'duplicate-ownership',
+      kind: 'ownership-fixture',
+      page: 1,
+      sourceIds: ['duplicate-owner-source'],
+      artifactIds: ['duplicate-owner-artifact'],
+      candidateIds: [
+        'pdfjs-bundle-candidate',
+        'duplicate-owner-fixture-candidate',
+      ],
+      observationCategories: ['object-counts'],
+      required: true,
+      semantic: true,
+    })
+    expect(() => buildSourceEvidenceGraph(duplicate)).toThrow(
+      /candidate .* is owned by multiple obligations/u,
+    )
+  })
+
+  it('keeps disagreements separate and validates all of their references', () => {
+    const wrongProviders = cloneInput()
+    wrongProviders.disagreements[0]!.providerIds = ['pdfjs-provider']
+    expect(() => buildSourceEvidenceGraph(wrongProviders)).toThrow(
+      /providerIds do not match/u,
+    )
+
+    const oneCandidate = cloneInput()
+    oneCandidate.disagreements[0]!.candidateIds = ['pdfjs-bundle-candidate']
+    oneCandidate.disagreements[0]!.providerIds = ['pdfjs-provider']
+    expect(() => buildSourceEvidenceGraph(oneCandidate)).toThrow(
+      /at least two candidates/u,
+    )
+
+    const missingObligation = cloneInput()
+    missingObligation.disagreements[0]!.obligationIds = ['missing-obligation']
+    expect(() => buildSourceEvidenceGraph(missingObligation)).toThrow(
+      /unknown obligation/u,
+    )
+  })
+
+  it('allows a relationship candidate to carry source boxes from several pages', () => {
+    const multiPage = cloneInput()
+    multiPage.bundles[0]!.candidates[0]!.kind = 'citation-relationship'
+    multiPage.bundles[0]!.candidates[0]!.boxes = [box(1, 0.1), box(2, 0.2)]
+    multiPage.deterministicContext = deterministicContextReceiptForBundle(
+      multiPage.bundles[0]!,
+    )
+
+    expect(() => buildSourceEvidenceGraph(multiPage)).not.toThrow()
+  })
+})

--- a/src/research/source-evidence-graph.ts
+++ b/src/research/source-evidence-graph.ts
@@ -1,0 +1,1644 @@
+import { sha256HexSync } from './sha256-sync.ts'
+
+export const PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION = '1.0.0' as const
+
+export const PDF_EVIDENCE_OBSERVATION_CATEGORIES = [
+  'text-exactness',
+  'reading-order',
+  'hierarchy',
+  'object-counts',
+  'table-cells',
+  'table-spans',
+  'table-headers',
+  'figures',
+  'diagrams',
+  'captions',
+  'formulas',
+  'code-preformatted',
+  'notes',
+  'citations',
+  'links',
+  'asset-bytes',
+  'clipping',
+  'overflow',
+  'dangling-targets',
+] as const
+
+export type PdfEvidenceObservationCategory =
+  (typeof PDF_EVIDENCE_OBSERVATION_CATEGORIES)[number]
+export const SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION = '1.0.0' as const
+export const DETERMINISTIC_CONTEXT_RECEIPT_SCHEMA_VERSION = '1.0.0' as const
+export const REQUIRED_PDF_EVIDENCE_ARMS = ['deterministic', 'mineru'] as const
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u
+const ID_PATTERN = /^[^\u0000-\u001f\u007f]+$/u
+const BOX_EPSILON = 1e-9
+
+export type PdfEvidenceJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | PdfEvidenceJsonValue[]
+  | { [key: string]: PdfEvidenceJsonValue }
+
+export type PdfEvidenceSourceIdentity = {
+  documentId: string
+  sha256: string
+  byteLength: number
+  pageCount: number
+}
+
+export type PdfEvidenceProviderKind =
+  'pdfjs' | 'mineru' | 'ocr' | 'local-codex' | 'other'
+
+export type PdfEvidenceProviderModelIdentity = {
+  id: string
+  revision: string
+  digestSha256?: string
+  license?: string
+  architecture?: string
+}
+
+export type PdfEvidenceProviderExecutionIdentity = {
+  hostClass: 'owner-laptop' | 'trusted-vm'
+  operatingSystem: string
+  architecture: string
+  runtime: string
+  backend: string
+  backendVersion: string
+  runtimeSha256: string
+  backendSha256: string
+  packageSetSha256: string
+  cacheNamespaceSha256: string
+  networkIsolation:
+    | 'macos-sandbox-exec-deny-network-v1'
+    | 'linux-user-netns-loopback-only-v1'
+  networkIsolationSha256: string
+}
+
+export type PdfEvidenceProviderIdentity = {
+  id: string
+  kind: PdfEvidenceProviderKind
+  name: string
+  version: string
+  implementationSha256?: string
+  model?: PdfEvidenceProviderModelIdentity
+  execution?: PdfEvidenceProviderExecutionIdentity
+}
+
+/** A page-normalized source box. Coordinates and extents are in [0, 1]. */
+export type PdfEvidenceBox = {
+  page: number
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation: number
+  method: 'pdf-text' | 'pdf-object' | 'pdf-link' | 'ocr'
+}
+
+export type PdfEvidencePageGeometry = {
+  page: number
+  width: number
+  height: number
+  rotation: number
+}
+
+export type PdfEvidenceArtifact = {
+  id: string
+  providerId: string
+  kind: string
+  mediaType: string
+  sha256: string
+  byteLength: number
+  page?: number
+  box?: PdfEvidenceBox
+  sourceIds?: string[]
+}
+
+/**
+ * A provider-native source item. Candidates cite these records instead of
+ * copying source text, bytes, geometry, or destinations into an answer.
+ */
+export type PdfEvidenceSource = {
+  id: string
+  providerId: string
+  kind: string
+  page?: number
+  box?: PdfEvidenceBox
+  artifactIds?: string[]
+  parentSourceIds?: string[]
+  payload?: PdfEvidenceJsonValue
+}
+
+/** A selectable interpretation backed by one or more provider source items. */
+export type PdfEvidenceCandidate = {
+  id: string
+  providerId: string
+  kind: string
+  page?: number
+  boxes?: PdfEvidenceBox[]
+  sourceIds: string[]
+  artifactIds?: string[]
+  payload?: PdfEvidenceJsonValue
+}
+
+export type PdfEvidenceBundle = {
+  schemaVersion: typeof PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION
+  id: string
+  armId: string
+  source: PdfEvidenceSourceIdentity
+  provider: PdfEvidenceProviderIdentity
+  pages: PdfEvidencePageGeometry[]
+  artifacts: PdfEvidenceArtifact[]
+  sources: PdfEvidenceSource[]
+  candidates: PdfEvidenceCandidate[]
+}
+
+export type PdfEvidenceArmState =
+  | {
+      id: string
+      requirement: 'required' | 'optional'
+      status: 'enabled'
+      frozen: true
+      providerId: string
+    }
+  | {
+      id: string
+      requirement: 'optional'
+      status: 'disabled'
+      frozen: true
+      reason: string
+    }
+
+/** A source obligation may remain unclosed, but it may never dangle. */
+export type PdfEvidenceObligation = {
+  id: string
+  kind: string
+  page?: number
+  sourceIds: string[]
+  artifactIds: string[]
+  candidateIds: string[]
+  observationCategories: PdfEvidenceObservationCategory[]
+  required: boolean
+  semantic: boolean
+}
+
+/**
+ * Disagreements are evidence, not resolutions. Selection belongs to a later
+ * grounded verifier, so this record intentionally has no accepted candidate.
+ */
+export type PdfEvidenceDisagreement = {
+  id: string
+  kind: string
+  obligationIds: string[]
+  candidateIds: string[]
+  providerIds: string[]
+  reason: string
+}
+
+/**
+ * Hashes the exact normalized deterministic arm, not just its caller-chosen
+ * IDs. This binds page geometry, source text/payloads, bounds, assets, and
+ * candidates to the graph source identity before another arm is reconciled.
+ */
+export type PdfDeterministicContextReceipt = {
+  schemaVersion: typeof DETERMINISTIC_CONTEXT_RECEIPT_SCHEMA_VERSION
+  sourceIdentitySha256: string
+  pageSetSha256: string
+  pageCount: number
+  sourceSetSha256: string
+  sourceCount: number
+  artifactSetSha256: string
+  artifactCount: number
+  candidateSetSha256: string
+  candidateCount: number
+  contextSha256: string
+}
+
+export type SourceEvidenceGraph = {
+  schemaVersion: typeof SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION
+  source: PdfEvidenceSourceIdentity
+  deterministicContext: PdfDeterministicContextReceipt
+  arms: PdfEvidenceArmState[]
+  bundles: PdfEvidenceBundle[]
+  obligations: PdfEvidenceObligation[]
+  disagreements: PdfEvidenceDisagreement[]
+  graphSha256: string
+}
+
+export type SourceEvidenceGraphInput = Omit<SourceEvidenceGraph, 'graphSha256'>
+
+export type PdfEvidencePageView = {
+  bundleId: string
+  providerId: string
+  geometry: PdfEvidencePageGeometry
+}
+
+export type SourceEvidenceGraphReader = {
+  readonly graph: SourceEvidenceGraph
+  readonly source: PdfEvidenceSourceIdentity
+  readonly graphSha256: string
+  provider(id: string): PdfEvidenceProviderIdentity | undefined
+  sourceItem(id: string): PdfEvidenceSource | undefined
+  artifact(id: string): PdfEvidenceArtifact | undefined
+  candidate(id: string): PdfEvidenceCandidate | undefined
+  obligation(id: string): PdfEvidenceObligation | undefined
+  disagreement(id: string): PdfEvidenceDisagreement | undefined
+  page(page: number): readonly PdfEvidencePageView[]
+  allCandidates(): readonly PdfEvidenceCandidate[]
+  candidatesForObligation(id: string): readonly PdfEvidenceCandidate[]
+  candidateSetSha256(candidateIds?: readonly string[]): string
+}
+
+function fail(message: string): never {
+  throw new Error(`Invalid source evidence graph: ${message}`)
+}
+
+function assertRecord(value: unknown, label: string): asserts value is object {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${label} must be an object`)
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail(`${label} must be a plain object`)
+  }
+}
+
+function assertAllowedKeys(
+  value: object,
+  allowedKeys: readonly string[],
+  label: string,
+) {
+  const allowed = new Set(allowedKeys)
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string' || !allowed.has(key)) {
+      fail(`${label} contains unsupported field ${String(key)}`)
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !('value' in descriptor)) {
+      fail(`${label}.${key} must be an enumerable data property`)
+    }
+  }
+}
+
+function assertPlainArray(
+  value: unknown,
+  label: string,
+): asserts value is unknown[] {
+  if (!Array.isArray(value)) fail(`${label} must be an array`)
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) fail(`${label} must not contain holes`)
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === 'length') continue
+    if (
+      typeof key !== 'string' ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(key) ||
+      Number(key) >= value.length
+    ) {
+      fail(`${label} contains unsupported field ${String(key)}`)
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !('value' in descriptor)) {
+      fail(`${label}[${key}] must be an enumerable data property`)
+    }
+  }
+}
+
+function assertId(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 512 ||
+    !ID_PATTERN.test(value)
+  ) {
+    fail(`${label} must be a non-empty identifier without control characters`)
+  }
+}
+
+function assertNonEmptyString(
+  value: unknown,
+  label: string,
+): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    fail(`${label} must be a non-empty string`)
+  }
+}
+
+function assertSha256(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !SHA256_PATTERN.test(value)) {
+    fail(`${label} must be a lowercase SHA-256 digest`)
+  }
+}
+
+function assertFiniteNumber(
+  value: unknown,
+  label: string,
+): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${label} must be a finite number`)
+  }
+}
+
+function assertNonNegativeInteger(
+  value: unknown,
+  label: string,
+): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    fail(`${label} must be a non-negative safe integer`)
+  }
+}
+
+function assertPageNumber(value: unknown, pageCount: number, label: string) {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < 1 ||
+    (value as number) > pageCount
+  ) {
+    fail(`${label} must be an integer between 1 and ${pageCount}`)
+  }
+}
+
+function assertStringArray(
+  value: unknown,
+  label: string,
+  options: { nonEmpty?: boolean } = {},
+): asserts value is string[] {
+  assertPlainArray(value, label)
+  if (options.nonEmpty && value.length === 0)
+    fail(`${label} must be a non-empty array`)
+  const seen = new Set<string>()
+  for (const [index, item] of value.entries()) {
+    assertId(item, `${label}[${index}]`)
+    if (seen.has(item)) fail(`${label} contains duplicate id ${item}`)
+    seen.add(item)
+  }
+}
+
+function assertJsonValue(
+  value: unknown,
+  label: string,
+  seen = new Set<object>(),
+) {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail(`${label} contains a non-finite number`)
+    return
+  }
+  if (!value || typeof value !== 'object') {
+    fail(`${label} must contain only JSON values`)
+  }
+  if (seen.has(value)) fail(`${label} must not contain a cycle`)
+  seen.add(value)
+  if (Array.isArray(value)) {
+    assertPlainArray(value, label)
+    value.forEach((item, index) =>
+      assertJsonValue(item, `${label}[${index}]`, seen),
+    )
+  } else {
+    assertRecord(value, label)
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') {
+        fail(`${label} contains unsupported field ${String(key)}`)
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !('value' in descriptor)) {
+        fail(`${label}.${key} must be an enumerable data property`)
+      }
+    }
+    for (const [key, item] of Object.entries(value)) {
+      if (key.length === 0) fail(`${label} contains an empty object key`)
+      assertJsonValue(item, `${label}.${key}`, seen)
+    }
+  }
+  seen.delete(value)
+}
+
+function assertSourceIdentity(
+  source: unknown,
+  label: string,
+): asserts source is PdfEvidenceSourceIdentity {
+  assertRecord(source, label)
+  assertAllowedKeys(
+    source,
+    ['documentId', 'sha256', 'byteLength', 'pageCount'],
+    label,
+  )
+  const candidate = source as Partial<PdfEvidenceSourceIdentity>
+  assertId(candidate.documentId, `${label}.documentId`)
+  assertSha256(candidate.sha256, `${label}.sha256`)
+  assertNonNegativeInteger(candidate.byteLength, `${label}.byteLength`)
+  if (candidate.byteLength === 0) fail(`${label}.byteLength must be positive`)
+  assertNonNegativeInteger(candidate.pageCount, `${label}.pageCount`)
+  if (candidate.pageCount === 0) fail(`${label}.pageCount must be positive`)
+}
+
+function sameSource(
+  left: PdfEvidenceSourceIdentity,
+  right: PdfEvidenceSourceIdentity,
+) {
+  return (
+    left.documentId === right.documentId &&
+    left.sha256 === right.sha256 &&
+    left.byteLength === right.byteLength &&
+    left.pageCount === right.pageCount
+  )
+}
+
+function assertProviderIdentity(
+  provider: unknown,
+  label: string,
+): asserts provider is PdfEvidenceProviderIdentity {
+  assertRecord(provider, label)
+  assertAllowedKeys(
+    provider,
+    [
+      'id',
+      'kind',
+      'name',
+      'version',
+      'implementationSha256',
+      'model',
+      'execution',
+    ],
+    label,
+  )
+  const candidate = provider as Partial<PdfEvidenceProviderIdentity>
+  assertId(candidate.id, `${label}.id`)
+  if (
+    candidate.kind !== 'pdfjs' &&
+    candidate.kind !== 'mineru' &&
+    candidate.kind !== 'ocr' &&
+    candidate.kind !== 'local-codex' &&
+    candidate.kind !== 'other'
+  ) {
+    fail(`${label}.kind is unsupported`)
+  }
+  assertNonEmptyString(candidate.name, `${label}.name`)
+  assertNonEmptyString(candidate.version, `${label}.version`)
+  if (candidate.implementationSha256 !== undefined) {
+    assertSha256(
+      candidate.implementationSha256,
+      `${label}.implementationSha256`,
+    )
+  }
+  if (candidate.model !== undefined) {
+    assertRecord(candidate.model, `${label}.model`)
+    assertAllowedKeys(
+      candidate.model,
+      ['id', 'revision', 'digestSha256', 'license', 'architecture'],
+      `${label}.model`,
+    )
+    assertNonEmptyString(candidate.model.id, `${label}.model.id`)
+    assertNonEmptyString(candidate.model.revision, `${label}.model.revision`)
+    if (candidate.model.digestSha256 !== undefined) {
+      assertSha256(candidate.model.digestSha256, `${label}.model.digestSha256`)
+    }
+    if (candidate.model.license !== undefined) {
+      assertNonEmptyString(candidate.model.license, `${label}.model.license`)
+    }
+    if (candidate.model.architecture !== undefined) {
+      assertNonEmptyString(
+        candidate.model.architecture,
+        `${label}.model.architecture`,
+      )
+    }
+  }
+  if (candidate.execution !== undefined) {
+    const executionLabel = `${label}.execution`
+    assertRecord(candidate.execution, executionLabel)
+    assertAllowedKeys(
+      candidate.execution,
+      [
+        'hostClass',
+        'operatingSystem',
+        'architecture',
+        'runtime',
+        'backend',
+        'backendVersion',
+        'runtimeSha256',
+        'backendSha256',
+        'packageSetSha256',
+        'cacheNamespaceSha256',
+        'networkIsolation',
+        'networkIsolationSha256',
+      ],
+      executionLabel,
+    )
+    if (
+      candidate.execution.hostClass !== 'owner-laptop' &&
+      candidate.execution.hostClass !== 'trusted-vm'
+    ) {
+      fail(`${executionLabel}.hostClass is unsupported`)
+    }
+    for (const key of [
+      'operatingSystem',
+      'architecture',
+      'runtime',
+      'backend',
+      'backendVersion',
+    ] as const) {
+      assertNonEmptyString(candidate.execution[key], `${executionLabel}.${key}`)
+    }
+    for (const key of [
+      'runtimeSha256',
+      'backendSha256',
+      'packageSetSha256',
+      'cacheNamespaceSha256',
+      'networkIsolationSha256',
+    ] as const) {
+      assertSha256(candidate.execution[key], `${executionLabel}.${key}`)
+    }
+    if (
+      candidate.execution.networkIsolation !==
+        'macos-sandbox-exec-deny-network-v1' &&
+      candidate.execution.networkIsolation !==
+        'linux-user-netns-loopback-only-v1'
+    ) {
+      fail(`${executionLabel}.networkIsolation is unsupported`)
+    }
+  }
+}
+
+function assertBox(box: unknown, pageCount: number, label: string) {
+  assertRecord(box, label)
+  assertAllowedKeys(
+    box,
+    ['page', 'x', 'y', 'width', 'height', 'rotation', 'method'],
+    label,
+  )
+  const candidate = box as Partial<PdfEvidenceBox>
+  assertPageNumber(candidate.page, pageCount, `${label}.page`)
+  for (const key of ['x', 'y', 'width', 'height', 'rotation'] as const) {
+    assertFiniteNumber(candidate[key], `${label}.${key}`)
+  }
+  if (candidate.x! < 0 || candidate.y! < 0) {
+    fail(`${label} has a negative normalized origin`)
+  }
+  if (candidate.width! < 0 || candidate.height! < 0) {
+    fail(`${label} has a negative extent`)
+  }
+  if (
+    candidate.x! + candidate.width! > 1 + BOX_EPSILON ||
+    candidate.y! + candidate.height! > 1 + BOX_EPSILON
+  ) {
+    fail(`${label} exceeds normalized page bounds`)
+  }
+  if (
+    candidate.method !== 'pdf-text' &&
+    candidate.method !== 'pdf-object' &&
+    candidate.method !== 'pdf-link' &&
+    candidate.method !== 'ocr'
+  ) {
+    fail(`${label}.method is unsupported`)
+  }
+}
+
+function assertOptionalEntityPageAndBox(
+  entity: { page?: number; box?: PdfEvidenceBox },
+  pageCount: number,
+  label: string,
+) {
+  if (entity.page !== undefined) {
+    assertPageNumber(entity.page, pageCount, `${label}.page`)
+  }
+  if (entity.box !== undefined) {
+    assertBox(entity.box, pageCount, `${label}.box`)
+    if (entity.page === undefined) {
+      fail(`${label}.page is required when box is present`)
+    }
+    if (entity.box.page !== entity.page) {
+      fail(`${label}.box.page must equal ${label}.page`)
+    }
+  }
+}
+
+function assertUniqueIds<T extends { id: string }>(items: T[], label: string) {
+  const seen = new Set<string>()
+  for (const item of items) {
+    assertId(item.id, `${label}.id`)
+    if (seen.has(item.id)) fail(`duplicate ${label} id ${item.id}`)
+    seen.add(item.id)
+  }
+}
+
+function validateBundleShape(
+  bundle: unknown,
+): asserts bundle is PdfEvidenceBundle {
+  assertRecord(bundle, 'bundle')
+  assertAllowedKeys(
+    bundle,
+    [
+      'schemaVersion',
+      'id',
+      'armId',
+      'source',
+      'provider',
+      'pages',
+      'artifacts',
+      'sources',
+      'candidates',
+    ],
+    'bundle',
+  )
+  const candidate = bundle as Partial<PdfEvidenceBundle>
+  if (candidate.schemaVersion !== PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION) {
+    fail(`bundle.schemaVersion must be ${PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION}`)
+  }
+  assertId(candidate.id, 'bundle.id')
+  assertId(candidate.armId, 'bundle.armId')
+  assertSourceIdentity(candidate.source, 'bundle.source')
+  const pageCount = candidate.source.pageCount
+  assertProviderIdentity(candidate.provider, 'bundle.provider')
+  assertPlainArray(candidate.pages, 'bundle.pages')
+  assertPlainArray(candidate.artifacts, 'bundle.artifacts')
+  assertPlainArray(candidate.sources, 'bundle.sources')
+  assertPlainArray(candidate.candidates, 'bundle.candidates')
+
+  const pagesSeen = new Set<number>()
+  for (const [index, page] of candidate.pages.entries()) {
+    assertRecord(page, `bundle.pages[${index}]`)
+    assertAllowedKeys(
+      page,
+      ['page', 'width', 'height', 'rotation'],
+      `bundle.pages[${index}]`,
+    )
+    assertPageNumber(page.page, pageCount, `bundle.pages[${index}].page`)
+    assertFiniteNumber(page.width, `bundle.pages[${index}].width`)
+    assertFiniteNumber(page.height, `bundle.pages[${index}].height`)
+    assertFiniteNumber(page.rotation, `bundle.pages[${index}].rotation`)
+    if (page.width <= 0 || page.height <= 0) {
+      fail(`bundle.pages[${index}] dimensions must be positive`)
+    }
+    if (!Number.isInteger(page.rotation) || page.rotation % 90 !== 0) {
+      fail(`bundle.pages[${index}].rotation must be an integer multiple of 90`)
+    }
+    if (pagesSeen.has(page.page)) fail(`bundle has duplicate page ${page.page}`)
+    pagesSeen.add(page.page)
+  }
+  if (pagesSeen.size !== pageCount) {
+    fail('bundle.pages must contain every source page exactly once')
+  }
+
+  assertUniqueIds(candidate.artifacts, 'artifact')
+  assertUniqueIds(candidate.sources, 'source')
+  assertUniqueIds(candidate.candidates, 'candidate')
+
+  for (const [index, artifact] of candidate.artifacts.entries()) {
+    const label = `bundle.artifacts[${index}]`
+    assertRecord(artifact, label)
+    assertAllowedKeys(
+      artifact,
+      [
+        'id',
+        'providerId',
+        'kind',
+        'mediaType',
+        'sha256',
+        'byteLength',
+        'page',
+        'box',
+        'sourceIds',
+      ],
+      label,
+    )
+    assertId(artifact.id, `${label}.id`)
+    assertId(artifact.providerId, `${label}.providerId`)
+    if (artifact.providerId !== candidate.provider.id) {
+      fail(`${label}.providerId does not match bundle provider`)
+    }
+    assertNonEmptyString(artifact.kind, `${label}.kind`)
+    assertNonEmptyString(artifact.mediaType, `${label}.mediaType`)
+    assertSha256(artifact.sha256, `${label}.sha256`)
+    assertNonNegativeInteger(artifact.byteLength, `${label}.byteLength`)
+    assertOptionalEntityPageAndBox(artifact, pageCount, label)
+    if (artifact.sourceIds !== undefined) {
+      assertStringArray(artifact.sourceIds, `${label}.sourceIds`)
+    }
+  }
+
+  for (const [index, source] of candidate.sources.entries()) {
+    const label = `bundle.sources[${index}]`
+    assertRecord(source, label)
+    assertAllowedKeys(
+      source,
+      [
+        'id',
+        'providerId',
+        'kind',
+        'page',
+        'box',
+        'artifactIds',
+        'parentSourceIds',
+        'payload',
+      ],
+      label,
+    )
+    assertId(source.id, `${label}.id`)
+    assertId(source.providerId, `${label}.providerId`)
+    if (source.providerId !== candidate.provider.id) {
+      fail(`${label}.providerId does not match bundle provider`)
+    }
+    assertNonEmptyString(source.kind, `${label}.kind`)
+    assertOptionalEntityPageAndBox(source, pageCount, label)
+    if (source.artifactIds !== undefined) {
+      assertStringArray(source.artifactIds, `${label}.artifactIds`)
+    }
+    if (source.parentSourceIds !== undefined) {
+      assertStringArray(source.parentSourceIds, `${label}.parentSourceIds`)
+      if (source.parentSourceIds.includes(source.id)) {
+        fail(`${label}.parentSourceIds must not contain itself`)
+      }
+    }
+    if (source.payload !== undefined) {
+      assertJsonValue(source.payload, `${label}.payload`)
+    }
+  }
+
+  for (const [index, evidenceCandidate] of candidate.candidates.entries()) {
+    const label = `bundle.candidates[${index}]`
+    assertRecord(evidenceCandidate, label)
+    assertAllowedKeys(
+      evidenceCandidate,
+      [
+        'id',
+        'providerId',
+        'kind',
+        'page',
+        'boxes',
+        'sourceIds',
+        'artifactIds',
+        'payload',
+      ],
+      label,
+    )
+    assertId(evidenceCandidate.id, `${label}.id`)
+    assertId(evidenceCandidate.providerId, `${label}.providerId`)
+    if (evidenceCandidate.providerId !== candidate.provider.id) {
+      fail(`${label}.providerId does not match bundle provider`)
+    }
+    assertNonEmptyString(evidenceCandidate.kind, `${label}.kind`)
+    if (evidenceCandidate.page !== undefined) {
+      assertPageNumber(evidenceCandidate.page, pageCount, `${label}.page`)
+    }
+    if (evidenceCandidate.boxes !== undefined) {
+      assertPlainArray(evidenceCandidate.boxes, `${label}.boxes`)
+      if (evidenceCandidate.boxes.length === 0) {
+        fail(`${label}.boxes must be a non-empty array when present`)
+      }
+      evidenceCandidate.boxes.forEach((box, boxIndex) => {
+        assertBox(box, pageCount, `${label}.boxes[${boxIndex}]`)
+      })
+    }
+    assertStringArray(evidenceCandidate.sourceIds, `${label}.sourceIds`, {
+      nonEmpty: true,
+    })
+    if (evidenceCandidate.artifactIds !== undefined) {
+      assertStringArray(evidenceCandidate.artifactIds, `${label}.artifactIds`)
+    }
+    if (evidenceCandidate.payload !== undefined) {
+      assertJsonValue(evidenceCandidate.payload, `${label}.payload`)
+    }
+  }
+}
+
+function assertNoSourceCycles(sources: ReadonlyMap<string, PdfEvidenceSource>) {
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const visit = (id: string) => {
+    if (visited.has(id)) return
+    if (visiting.has(id)) fail(`source parent cycle includes ${id}`)
+    visiting.add(id)
+    for (const parentId of sources.get(id)?.parentSourceIds ?? [])
+      visit(parentId)
+    visiting.delete(id)
+    visited.add(id)
+  }
+  for (const id of sources.keys()) visit(id)
+}
+
+function validateGraphShape(
+  graph: unknown,
+  options: { requireHash: boolean },
+): asserts graph is SourceEvidenceGraph | SourceEvidenceGraphInput {
+  assertRecord(graph, 'graph')
+  assertAllowedKeys(
+    graph,
+    [
+      'schemaVersion',
+      'source',
+      'deterministicContext',
+      'arms',
+      'bundles',
+      'obligations',
+      'disagreements',
+      'graphSha256',
+    ],
+    'graph',
+  )
+  const candidate = graph as Partial<SourceEvidenceGraph>
+  if (candidate.schemaVersion !== SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION) {
+    fail(`graph.schemaVersion must be ${SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION}`)
+  }
+  assertSourceIdentity(candidate.source, 'graph.source')
+  assertRecord(candidate.deterministicContext, 'graph.deterministicContext')
+  assertAllowedKeys(
+    candidate.deterministicContext,
+    [
+      'schemaVersion',
+      'sourceIdentitySha256',
+      'pageSetSha256',
+      'pageCount',
+      'sourceSetSha256',
+      'sourceCount',
+      'artifactSetSha256',
+      'artifactCount',
+      'candidateSetSha256',
+      'candidateCount',
+      'contextSha256',
+    ],
+    'graph.deterministicContext',
+  )
+  const deterministicContext =
+    candidate.deterministicContext as Partial<PdfDeterministicContextReceipt>
+  if (
+    deterministicContext.schemaVersion !==
+    DETERMINISTIC_CONTEXT_RECEIPT_SCHEMA_VERSION
+  ) {
+    fail(
+      `graph.deterministicContext.schemaVersion must be ${DETERMINISTIC_CONTEXT_RECEIPT_SCHEMA_VERSION}`,
+    )
+  }
+  for (const key of [
+    'sourceIdentitySha256',
+    'pageSetSha256',
+    'sourceSetSha256',
+    'artifactSetSha256',
+    'candidateSetSha256',
+    'contextSha256',
+  ] as const) {
+    assertSha256(deterministicContext[key], `graph.deterministicContext.${key}`)
+  }
+  for (const key of [
+    'pageCount',
+    'sourceCount',
+    'artifactCount',
+    'candidateCount',
+  ] as const) {
+    assertNonNegativeInteger(
+      deterministicContext[key],
+      `graph.deterministicContext.${key}`,
+    )
+  }
+  assertPlainArray(candidate.arms, 'graph.arms')
+  assertPlainArray(candidate.bundles, 'graph.bundles')
+  assertPlainArray(candidate.obligations, 'graph.obligations')
+  assertPlainArray(candidate.disagreements, 'graph.disagreements')
+  if (options.requireHash)
+    assertSha256(candidate.graphSha256, 'graph.graphSha256')
+
+  assertUniqueIds(candidate.arms, 'arm')
+  assertUniqueIds(candidate.bundles, 'bundle')
+  assertUniqueIds(candidate.obligations, 'obligation')
+  assertUniqueIds(candidate.disagreements, 'disagreement')
+
+  const arms = new Map<string, PdfEvidenceArmState>()
+  for (const [index, arm] of candidate.arms.entries()) {
+    const label = `graph.arms[${index}]`
+    assertRecord(arm, label)
+    assertAllowedKeys(
+      arm,
+      ['id', 'requirement', 'status', 'frozen', 'providerId', 'reason'],
+      label,
+    )
+    assertId(arm.id, `${label}.id`)
+    if (arm.frozen !== true) fail(`${label}.frozen must be true`)
+    if (arm.status === 'enabled') {
+      assertAllowedKeys(
+        arm,
+        ['id', 'requirement', 'status', 'frozen', 'providerId'],
+        label,
+      )
+      if (arm.requirement !== 'required' && arm.requirement !== 'optional') {
+        fail(`${label}.requirement is unsupported`)
+      }
+      assertId(arm.providerId, `${label}.providerId`)
+    } else if (arm.status === 'disabled') {
+      assertAllowedKeys(
+        arm,
+        ['id', 'requirement', 'status', 'frozen', 'reason'],
+        label,
+      )
+      if (arm.requirement !== 'optional') {
+        fail(`${label} may be disabled only when optional`)
+      }
+      assertNonEmptyString(arm.reason, `${label}.reason`)
+      if ('providerId' in arm)
+        fail(`${label} disabled arm must not name a provider`)
+    } else {
+      fail(`${label}.status is unsupported`)
+    }
+    arms.set(arm.id, arm as PdfEvidenceArmState)
+  }
+
+  const providers = new Map<string, PdfEvidenceProviderIdentity>()
+  const bundlesByArm = new Map<string, PdfEvidenceBundle[]>()
+  const sources = new Map<string, PdfEvidenceSource>()
+  const artifacts = new Map<string, PdfEvidenceArtifact>()
+  const evidenceCandidates = new Map<string, PdfEvidenceCandidate>()
+
+  for (const requiredArmId of REQUIRED_PDF_EVIDENCE_ARMS) {
+    const arm = arms.get(requiredArmId)
+    if (!arm || arm.status !== 'enabled' || arm.requirement !== 'required') {
+      fail(
+        `required evidence arm ${requiredArmId} must be enabled and required`,
+      )
+    }
+  }
+
+  for (const bundle of candidate.bundles) {
+    validateBundleShape(bundle)
+    if (!sameSource(bundle.source, candidate.source)) {
+      fail(`bundle ${bundle.id} source identity does not match graph source`)
+    }
+    if (providers.has(bundle.provider.id)) {
+      fail(`duplicate provider id ${bundle.provider.id}`)
+    }
+    providers.set(bundle.provider.id, bundle.provider)
+    const arm = arms.get(bundle.armId)
+    if (!arm) fail(`bundle ${bundle.id} references unknown arm ${bundle.armId}`)
+    if (arm.status !== 'enabled') {
+      fail(`bundle ${bundle.id} references disabled arm ${bundle.armId}`)
+    }
+    if (arm.providerId !== bundle.provider.id) {
+      fail(`bundle ${bundle.id} provider does not match arm ${bundle.armId}`)
+    }
+    const armBundles = bundlesByArm.get(bundle.armId) ?? []
+    armBundles.push(bundle)
+    bundlesByArm.set(bundle.armId, armBundles)
+
+    for (const source of bundle.sources) {
+      if (sources.has(source.id)) fail(`duplicate source id ${source.id}`)
+      sources.set(source.id, source)
+    }
+    for (const artifact of bundle.artifacts) {
+      if (artifacts.has(artifact.id))
+        fail(`duplicate artifact id ${artifact.id}`)
+      artifacts.set(artifact.id, artifact)
+    }
+    for (const item of bundle.candidates) {
+      if (evidenceCandidates.has(item.id))
+        fail(`duplicate candidate id ${item.id}`)
+      evidenceCandidates.set(item.id, item)
+    }
+  }
+
+  for (const arm of arms.values()) {
+    const bundleCount = bundlesByArm.get(arm.id)?.length ?? 0
+    if (arm.status === 'enabled' && bundleCount !== 1) {
+      fail(`enabled arm ${arm.id} must have exactly one evidence bundle`)
+    }
+    if (arm.status === 'disabled' && bundleCount !== 0) {
+      fail(`disabled arm ${arm.id} must not have an evidence bundle`)
+    }
+    if (arm.status === 'enabled' && arm.requirement === 'required') {
+      const bundle = bundlesByArm.get(arm.id)?.[0]
+      if (
+        !bundle ||
+        bundle.sources.length === 0 ||
+        bundle.artifacts.length === 0 ||
+        bundle.candidates.length === 0
+      ) {
+        fail(`required arm ${arm.id} evidence bundle must contain evidence`)
+      }
+    }
+  }
+
+  for (const bundle of candidate.bundles) {
+    for (const source of bundle.sources) {
+      for (const artifactId of source.artifactIds ?? []) {
+        const artifact = artifacts.get(artifactId)
+        if (!artifact)
+          fail(`source ${source.id} references unknown artifact ${artifactId}`)
+        if (artifact.providerId !== source.providerId) {
+          fail(`source ${source.id} references artifact from another provider`)
+        }
+      }
+      for (const parentId of source.parentSourceIds ?? []) {
+        const parent = sources.get(parentId)
+        if (!parent)
+          fail(
+            `source ${source.id} references unknown parent source ${parentId}`,
+          )
+        if (parent.providerId !== source.providerId) {
+          fail(`source ${source.id} references parent from another provider`)
+        }
+      }
+    }
+    for (const artifact of bundle.artifacts) {
+      for (const sourceId of artifact.sourceIds ?? []) {
+        const source = sources.get(sourceId)
+        if (!source)
+          fail(`artifact ${artifact.id} references unknown source ${sourceId}`)
+        if (source.providerId !== artifact.providerId) {
+          fail(
+            `artifact ${artifact.id} references source from another provider`,
+          )
+        }
+      }
+    }
+    for (const item of bundle.candidates) {
+      for (const sourceId of item.sourceIds) {
+        const source = sources.get(sourceId)
+        if (!source)
+          fail(`candidate ${item.id} references unknown source ${sourceId}`)
+        if (source.providerId !== item.providerId) {
+          fail(`candidate ${item.id} references source from another provider`)
+        }
+      }
+      for (const artifactId of item.artifactIds ?? []) {
+        const artifact = artifacts.get(artifactId)
+        if (!artifact)
+          fail(`candidate ${item.id} references unknown artifact ${artifactId}`)
+        if (artifact.providerId !== item.providerId) {
+          fail(`candidate ${item.id} references artifact from another provider`)
+        }
+      }
+    }
+  }
+  assertNoSourceCycles(sources)
+
+  const obligations = new Map<string, PdfEvidenceObligation>()
+  const candidateOwners = new Map<string, string>()
+  const sourceOwners = new Map<string, string>()
+  const artifactOwners = new Map<string, string>()
+  for (const [index, obligation] of candidate.obligations.entries()) {
+    const label = `graph.obligations[${index}]`
+    assertRecord(obligation, label)
+    assertAllowedKeys(
+      obligation,
+      [
+        'id',
+        'kind',
+        'page',
+        'sourceIds',
+        'artifactIds',
+        'candidateIds',
+        'observationCategories',
+        'required',
+        'semantic',
+      ],
+      label,
+    )
+    assertId(obligation.id, `${label}.id`)
+    assertNonEmptyString(obligation.kind, `${label}.kind`)
+    if (obligation.page !== undefined) {
+      assertPageNumber(
+        obligation.page,
+        candidate.source.pageCount,
+        `${label}.page`,
+      )
+    }
+    assertStringArray(obligation.sourceIds, `${label}.sourceIds`, {
+      nonEmpty: true,
+    })
+    assertStringArray(obligation.artifactIds, `${label}.artifactIds`)
+    assertStringArray(obligation.candidateIds, `${label}.candidateIds`)
+    assertPlainArray(
+      obligation.observationCategories,
+      `${label}.observationCategories`,
+    )
+    if (obligation.observationCategories.length === 0) {
+      fail(`${label}.observationCategories must be non-empty`)
+    }
+    const categorySet = new Set(PDF_EVIDENCE_OBSERVATION_CATEGORIES)
+    const seenCategories = new Set<string>()
+    for (const observationCategory of obligation.observationCategories) {
+      if (
+        typeof observationCategory !== 'string' ||
+        !categorySet.has(
+          observationCategory as PdfEvidenceObservationCategory,
+        ) ||
+        seenCategories.has(observationCategory)
+      ) {
+        fail(`${label}.observationCategories contains an invalid category`)
+      }
+      seenCategories.add(observationCategory)
+    }
+    if (typeof obligation.required !== 'boolean')
+      fail(`${label}.required must be boolean`)
+    if (typeof obligation.semantic !== 'boolean')
+      fail(`${label}.semantic must be boolean`)
+    for (const sourceId of obligation.sourceIds) {
+      if (!sources.has(sourceId)) {
+        fail(
+          `obligation ${obligation.id} references unknown source ${sourceId}`,
+        )
+      }
+      const owner = sourceOwners.get(sourceId)
+      if (owner) {
+        fail(
+          `source ${sourceId} is owned by multiple obligations ${owner} and ${obligation.id}`,
+        )
+      }
+      sourceOwners.set(sourceId, obligation.id)
+    }
+    for (const artifactId of obligation.artifactIds) {
+      if (!artifacts.has(artifactId)) {
+        fail(
+          `obligation ${obligation.id} references unknown artifact ${artifactId}`,
+        )
+      }
+      const owner = artifactOwners.get(artifactId)
+      if (owner) {
+        fail(
+          `artifact ${artifactId} is owned by multiple obligations ${owner} and ${obligation.id}`,
+        )
+      }
+      artifactOwners.set(artifactId, obligation.id)
+    }
+    for (const candidateId of obligation.candidateIds) {
+      if (!evidenceCandidates.has(candidateId)) {
+        fail(
+          `obligation ${obligation.id} references unknown candidate ${candidateId}`,
+        )
+      }
+      const owner = candidateOwners.get(candidateId)
+      if (owner) {
+        fail(
+          `candidate ${candidateId} is owned by multiple obligations ${owner} and ${obligation.id}`,
+        )
+      }
+      candidateOwners.set(candidateId, obligation.id)
+    }
+    obligations.set(obligation.id, obligation)
+  }
+
+  for (const candidateId of evidenceCandidates.keys()) {
+    if (!candidateOwners.has(candidateId)) {
+      fail(`candidate ${candidateId} is not owned by an obligation`)
+    }
+  }
+  for (const sourceId of sources.keys()) {
+    if (!sourceOwners.has(sourceId)) {
+      fail(`source ${sourceId} is not owned by an obligation`)
+    }
+  }
+  for (const artifactId of artifacts.keys()) {
+    if (!artifactOwners.has(artifactId)) {
+      fail(`artifact ${artifactId} is not owned by an obligation`)
+    }
+  }
+
+  for (const [index, disagreement] of candidate.disagreements.entries()) {
+    const label = `graph.disagreements[${index}]`
+    assertRecord(disagreement, label)
+    assertAllowedKeys(
+      disagreement,
+      ['id', 'kind', 'obligationIds', 'candidateIds', 'providerIds', 'reason'],
+      label,
+    )
+    assertId(disagreement.id, `${label}.id`)
+    assertNonEmptyString(disagreement.kind, `${label}.kind`)
+    assertStringArray(disagreement.obligationIds, `${label}.obligationIds`, {
+      nonEmpty: true,
+    })
+    assertStringArray(disagreement.candidateIds, `${label}.candidateIds`, {
+      nonEmpty: true,
+    })
+    if (disagreement.candidateIds.length < 2) {
+      fail(`${label}.candidateIds must contain at least two candidates`)
+    }
+    assertStringArray(disagreement.providerIds, `${label}.providerIds`, {
+      nonEmpty: true,
+    })
+    assertNonEmptyString(disagreement.reason, `${label}.reason`)
+    for (const obligationId of disagreement.obligationIds) {
+      if (!obligations.has(obligationId)) {
+        fail(
+          `disagreement ${disagreement.id} references unknown obligation ${obligationId}`,
+        )
+      }
+    }
+    const referencedProviderIds = new Set<string>()
+    for (const candidateId of disagreement.candidateIds) {
+      const item = evidenceCandidates.get(candidateId)
+      if (!item) {
+        fail(
+          `disagreement ${disagreement.id} references unknown candidate ${candidateId}`,
+        )
+      }
+      referencedProviderIds.add(item.providerId)
+    }
+    const declaredProviders = [...disagreement.providerIds].sort()
+    const referencedProviders = [...referencedProviderIds].sort()
+    if (stableJson(declaredProviders) !== stableJson(referencedProviders)) {
+      fail(
+        `disagreement ${disagreement.id} providerIds do not match its candidates`,
+      )
+    }
+  }
+
+  const deterministicBundles = bundlesByArm.get('deterministic') ?? []
+  if (deterministicBundles.length === 1) {
+    const expected = deterministicContextReceiptForBundle(
+      deterministicBundles[0]!,
+    )
+    if (stableJson(candidate.deterministicContext) !== stableJson(expected)) {
+      fail(
+        'graph.deterministicContext does not match the exact normalized deterministic bundle',
+      )
+    }
+  }
+}
+
+function cloneJsonValue(value: PdfEvidenceJsonValue): PdfEvidenceJsonValue {
+  if (Array.isArray(value)) return value.map(cloneJsonValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        cloneJsonValue(nested),
+      ]),
+    )
+  }
+  return value
+}
+
+function copyOptional<T extends object, K extends keyof T>(
+  output: T,
+  source: T,
+  key: K,
+) {
+  if (source[key] !== undefined) output[key] = source[key]
+}
+
+function normalizeStringSet(values: readonly string[] | undefined) {
+  return values ? [...values].sort() : undefined
+}
+
+function normalizeBox(box: PdfEvidenceBox): PdfEvidenceBox {
+  return { ...box }
+}
+
+function normalizeSourceIdentity(
+  source: PdfEvidenceSourceIdentity,
+): PdfEvidenceSourceIdentity {
+  return { ...source }
+}
+
+function normalizeProvider(
+  provider: PdfEvidenceProviderIdentity,
+): PdfEvidenceProviderIdentity {
+  const output: PdfEvidenceProviderIdentity = {
+    id: provider.id,
+    kind: provider.kind,
+    name: provider.name,
+    version: provider.version,
+  }
+  copyOptional(output, provider, 'implementationSha256')
+  if (provider.model) output.model = { ...provider.model }
+  if (provider.execution) output.execution = { ...provider.execution }
+  return output
+}
+
+function normalizeArtifact(artifact: PdfEvidenceArtifact): PdfEvidenceArtifact {
+  const output: PdfEvidenceArtifact = {
+    id: artifact.id,
+    providerId: artifact.providerId,
+    kind: artifact.kind,
+    mediaType: artifact.mediaType,
+    sha256: artifact.sha256,
+    byteLength: artifact.byteLength,
+  }
+  copyOptional(output, artifact, 'page')
+  if (artifact.box) output.box = normalizeBox(artifact.box)
+  const sourceIds = normalizeStringSet(artifact.sourceIds)
+  if (sourceIds) output.sourceIds = sourceIds
+  return output
+}
+
+function normalizeSource(source: PdfEvidenceSource): PdfEvidenceSource {
+  const output: PdfEvidenceSource = {
+    id: source.id,
+    providerId: source.providerId,
+    kind: source.kind,
+  }
+  copyOptional(output, source, 'page')
+  if (source.box) output.box = normalizeBox(source.box)
+  const artifactIds = normalizeStringSet(source.artifactIds)
+  if (artifactIds) output.artifactIds = artifactIds
+  const parentSourceIds = normalizeStringSet(source.parentSourceIds)
+  if (parentSourceIds) output.parentSourceIds = parentSourceIds
+  if (source.payload !== undefined)
+    output.payload = cloneJsonValue(source.payload)
+  return output
+}
+
+function normalizeCandidate(
+  candidate: PdfEvidenceCandidate,
+): PdfEvidenceCandidate {
+  const output: PdfEvidenceCandidate = {
+    id: candidate.id,
+    providerId: candidate.providerId,
+    kind: candidate.kind,
+    sourceIds: [...candidate.sourceIds].sort(),
+  }
+  copyOptional(output, candidate, 'page')
+  if (candidate.boxes) {
+    output.boxes = candidate.boxes
+      .map(normalizeBox)
+      .sort((left, right) => stableJson(left).localeCompare(stableJson(right)))
+  }
+  const artifactIds = normalizeStringSet(candidate.artifactIds)
+  if (artifactIds) output.artifactIds = artifactIds
+  if (candidate.payload !== undefined)
+    output.payload = cloneJsonValue(candidate.payload)
+  return output
+}
+
+function normalizeBundle(bundle: PdfEvidenceBundle): PdfEvidenceBundle {
+  return {
+    schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+    id: bundle.id,
+    armId: bundle.armId,
+    source: normalizeSourceIdentity(bundle.source),
+    provider: normalizeProvider(bundle.provider),
+    pages: bundle.pages
+      .map((page) => ({ ...page }))
+      .sort((a, b) => a.page - b.page),
+    artifacts: bundle.artifacts
+      .map(normalizeArtifact)
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    sources: bundle.sources
+      .map(normalizeSource)
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    candidates: bundle.candidates
+      .map(normalizeCandidate)
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  }
+}
+
+export function deterministicContextReceiptForBundle(
+  bundle: PdfEvidenceBundle,
+): PdfDeterministicContextReceipt {
+  validateBundleShape(bundle)
+  if (bundle.armId !== 'deterministic') {
+    fail('deterministic context receipt requires the deterministic arm')
+  }
+  const normalized = normalizeBundle(bundle)
+  const exactContext = {
+    source: normalized.source,
+    pages: normalized.pages,
+    artifacts: normalized.artifacts,
+    sources: normalized.sources,
+    candidates: normalized.candidates,
+  }
+  return {
+    schemaVersion: DETERMINISTIC_CONTEXT_RECEIPT_SCHEMA_VERSION,
+    sourceIdentitySha256: sha256HexSync(stableJson(normalized.source)),
+    pageSetSha256: sha256HexSync(stableJson(normalized.pages)),
+    pageCount: normalized.pages.length,
+    sourceSetSha256: sha256HexSync(stableJson(normalized.sources)),
+    sourceCount: normalized.sources.length,
+    artifactSetSha256: sha256HexSync(stableJson(normalized.artifacts)),
+    artifactCount: normalized.artifacts.length,
+    candidateSetSha256: sha256HexSync(stableJson(normalized.candidates)),
+    candidateCount: normalized.candidates.length,
+    contextSha256: sha256HexSync(stableJson(exactContext)),
+  }
+}
+
+function normalizeGraphInput(
+  graph: SourceEvidenceGraphInput | SourceEvidenceGraph,
+): SourceEvidenceGraphInput {
+  return {
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source: normalizeSourceIdentity(graph.source),
+    deterministicContext: { ...graph.deterministicContext },
+    arms: graph.arms
+      .map((arm): PdfEvidenceArmState =>
+        arm.status === 'enabled'
+          ? { ...arm }
+          : {
+              id: arm.id,
+              requirement: 'optional',
+              status: 'disabled',
+              frozen: true,
+              reason: arm.reason,
+            },
+      )
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    bundles: graph.bundles
+      .map(normalizeBundle)
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    obligations: graph.obligations
+      .map((obligation) => {
+        const output: PdfEvidenceObligation = {
+          id: obligation.id,
+          kind: obligation.kind,
+          sourceIds: [...obligation.sourceIds].sort(),
+          artifactIds: [...obligation.artifactIds].sort(),
+          candidateIds: [...obligation.candidateIds].sort(),
+          observationCategories: [...obligation.observationCategories].sort(),
+          required: obligation.required,
+          semantic: obligation.semantic,
+        }
+        copyOptional(output, obligation, 'page')
+        return output
+      })
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    disagreements: graph.disagreements
+      .map((disagreement) => ({
+        id: disagreement.id,
+        kind: disagreement.kind,
+        obligationIds: [...disagreement.obligationIds].sort(),
+        candidateIds: [...disagreement.candidateIds].sort(),
+        providerIds: [...disagreement.providerIds].sort(),
+        reason: disagreement.reason,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  }
+}
+
+function stableJson(value: unknown): string {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value))
+      fail('canonical value contains a non-finite number')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+    return `{${entries
+      .map(([key, nested]) => `${JSON.stringify(key)}:${stableJson(nested)}`)
+      .join(',')}}`
+  }
+  fail('canonical value contains a non-JSON value')
+}
+
+function deepFreeze<T>(value: T, seen = new Set<object>()): T {
+  if (!value || typeof value !== 'object' || seen.has(value)) return value
+  seen.add(value)
+  for (const nested of Object.values(value as object)) deepFreeze(nested, seen)
+  return Object.freeze(value)
+}
+
+export function validatePdfEvidenceBundle(
+  bundle: unknown,
+): asserts bundle is PdfEvidenceBundle {
+  validateBundleShape(bundle)
+}
+
+export function sourceEvidenceGraphSha256(
+  graph: SourceEvidenceGraphInput | SourceEvidenceGraph,
+) {
+  validateGraphShape(graph, { requireHash: false })
+  const normalized = normalizeGraphInput(graph)
+  return sha256HexSync(stableJson(normalized))
+}
+
+export function validateSourceEvidenceGraph(
+  graph: unknown,
+): asserts graph is SourceEvidenceGraph {
+  validateGraphShape(graph, { requireHash: true })
+  const typed = graph as SourceEvidenceGraph
+  const expected = sourceEvidenceGraphSha256(typed)
+  if (typed.graphSha256 !== expected) {
+    fail('graph.graphSha256 does not match the canonical graph content')
+  }
+}
+
+export function buildSourceEvidenceGraph(
+  input: SourceEvidenceGraphInput,
+): SourceEvidenceGraph {
+  validateGraphShape(input, { requireHash: false })
+  const normalized = normalizeGraphInput(input)
+  const graph: SourceEvidenceGraph = {
+    ...normalized,
+    graphSha256: sha256HexSync(stableJson(normalized)),
+  }
+  validateSourceEvidenceGraph(graph)
+  return deepFreeze(graph)
+}
+
+/** Exact canonical bytes used by #199's opaque evidence-graph binding. */
+export function serializeSourceEvidenceGraph(graph: SourceEvidenceGraph) {
+  validateSourceEvidenceGraph(graph)
+  const bytes = new TextEncoder().encode(stableJson(normalizeGraphInput(graph)))
+  if (sha256HexSync(bytes) !== graph.graphSha256) {
+    fail('serialized graph bytes do not match graph.graphSha256')
+  }
+  return bytes
+}
+
+function indexesForGraph(graph: SourceEvidenceGraph) {
+  const providers = new Map<string, PdfEvidenceProviderIdentity>()
+  const sources = new Map<string, PdfEvidenceSource>()
+  const artifacts = new Map<string, PdfEvidenceArtifact>()
+  const candidates = new Map<string, PdfEvidenceCandidate>()
+  const pages = new Map<number, PdfEvidencePageView[]>()
+  for (const bundle of graph.bundles) {
+    providers.set(bundle.provider.id, bundle.provider)
+    for (const source of bundle.sources) sources.set(source.id, source)
+    for (const artifact of bundle.artifacts)
+      artifacts.set(artifact.id, artifact)
+    for (const candidate of bundle.candidates)
+      candidates.set(candidate.id, candidate)
+    for (const geometry of bundle.pages) {
+      const views = pages.get(geometry.page) ?? []
+      views.push({
+        bundleId: bundle.id,
+        providerId: bundle.provider.id,
+        geometry,
+      })
+      pages.set(geometry.page, views)
+    }
+  }
+  return {
+    providers,
+    sources,
+    artifacts,
+    candidates,
+    obligations: new Map(graph.obligations.map((item) => [item.id, item])),
+    disagreements: new Map(graph.disagreements.map((item) => [item.id, item])),
+    pages,
+  }
+}
+
+export function sourceEvidenceCandidateSetSha256(
+  graph: SourceEvidenceGraph,
+  candidateIds?: readonly string[],
+) {
+  validateSourceEvidenceGraph(graph)
+  const { candidates } = indexesForGraph(graph)
+  const ids = candidateIds ? [...candidateIds] : [...candidates.keys()]
+  assertStringArray(ids, 'candidateIds')
+  ids.sort()
+  const selected = ids.map((id) => {
+    const candidate = candidates.get(id)
+    if (!candidate) fail(`candidate set references unknown candidate ${id}`)
+    return candidate
+  })
+  return sha256HexSync(
+    stableJson({
+      schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+      graphSha256: graph.graphSha256,
+      candidates: selected,
+    }),
+  )
+}
+
+export function readSourceEvidenceGraph(
+  graph: SourceEvidenceGraph,
+): SourceEvidenceGraphReader {
+  validateSourceEvidenceGraph(graph)
+  const immutableGraph = buildSourceEvidenceGraph(normalizeGraphInput(graph))
+  const indexes = indexesForGraph(immutableGraph)
+  for (const views of indexes.pages.values()) {
+    views.sort((left, right) => left.providerId.localeCompare(right.providerId))
+    deepFreeze(views)
+  }
+
+  return Object.freeze({
+    graph: immutableGraph,
+    source: immutableGraph.source,
+    graphSha256: immutableGraph.graphSha256,
+    provider: (id: string) => indexes.providers.get(id),
+    sourceItem: (id: string) => indexes.sources.get(id),
+    artifact: (id: string) => indexes.artifacts.get(id),
+    candidate: (id: string) => indexes.candidates.get(id),
+    obligation: (id: string) => indexes.obligations.get(id),
+    disagreement: (id: string) => indexes.disagreements.get(id),
+    page: (page: number) => indexes.pages.get(page) ?? Object.freeze([]),
+    allCandidates: () => Object.freeze([...indexes.candidates.values()]),
+    candidatesForObligation: (id: string) => {
+      const obligation = indexes.obligations.get(id)
+      if (!obligation) return Object.freeze([])
+      return Object.freeze(
+        obligation.candidateIds.map((candidateId) =>
+          indexes.candidates.get(candidateId)!,
+        ),
+      )
+    },
+    candidateSetSha256: (candidateIds?: readonly string[]) =>
+      sourceEvidenceCandidateSetSha256(immutableGraph, candidateIds),
+  })
+}

--- a/src/research/source-grounded-struct.test.ts
+++ b/src/research/source-grounded-struct.test.ts
@@ -1,0 +1,635 @@
+import { describe, expect, it } from 'vitest'
+import type { StructuredExtractionContext } from './structured-extraction'
+import {
+  SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION,
+  verifySourceGroundedStructCandidate,
+  type SourceGroundedStructProposal,
+} from './source-grounded-struct'
+import {
+  PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+  SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+  buildSourceEvidenceGraph,
+  deterministicContextReceiptForBundle,
+  sourceEvidenceCandidateSetSha256,
+  type SourceEvidenceGraph,
+  type SourceEvidenceGraphInput,
+} from './source-evidence-graph'
+
+const sourceSha256 = '1'.repeat(64)
+const source = {
+  documentId: 'grounded-document',
+  sha256: sourceSha256,
+  byteLength: 4096,
+  pageCount: 1,
+}
+
+function graphFixture({
+  candidateKind = 'text-glyph-run',
+  obligationKind = 'source-text',
+  semantic = true,
+  convergentMineru = false,
+}: {
+  candidateKind?: string
+  obligationKind?: string
+  semantic?: boolean
+  convergentMineru?: boolean
+} = {}): SourceEvidenceGraph {
+  const provider = {
+    id: 'pdfjs-fixture',
+    kind: 'pdfjs' as const,
+    name: 'pdfjs-dist',
+    version: 'fixture',
+  }
+  const mineruProvider = {
+    id: 'mineru-fixture',
+    kind: 'mineru' as const,
+    name: 'MinerU',
+    version: '3.4.4',
+  }
+  const box = {
+    page: 1,
+    x: 0.1,
+    y: 0.2,
+    width: 0.2,
+    height: 0.02,
+    rotation: 0,
+    method: 'pdf-text' as const,
+  }
+  const candidateBox =
+    candidateKind === 'full-page-render'
+      ? { ...box, x: 0, y: 0, width: 1, height: 1 }
+      : box
+  const graphInput: Omit<
+    SourceEvidenceGraphInput,
+    'deterministicContext'
+  > = {
+    schemaVersion: SOURCE_EVIDENCE_GRAPH_SCHEMA_VERSION,
+    source,
+    arms: [
+      {
+        id: 'deterministic',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: provider.id,
+      },
+      {
+        id: 'mineru',
+        requirement: 'required',
+        status: 'enabled',
+        frozen: true,
+        providerId: mineruProvider.id,
+      },
+    ],
+    bundles: [
+      {
+        schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        id: 'deterministic-bundle',
+        armId: 'deterministic',
+        source,
+        provider,
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'deterministic-artifact',
+            providerId: provider.id,
+            kind:
+              candidateKind === 'full-page-render'
+                ? 'full-page-render'
+                : 'source-run-evidence',
+            mediaType:
+              candidateKind === 'full-page-render'
+                ? 'image/png'
+                : 'application/json',
+            sha256: '2'.repeat(64),
+            byteLength: 128,
+            page: 1,
+            box: candidateBox,
+            sourceIds: ['source-run'],
+          },
+        ],
+        sources: [
+          {
+            id: 'source-run',
+            providerId: provider.id,
+            kind:
+              obligationKind === 'source-preserved-page'
+                ? 'page-geometry'
+                : 'text-glyph-run',
+            page: 1,
+            box: candidateBox,
+            artifactIds: ['deterministic-artifact'],
+            payload:
+              obligationKind === 'source-preserved-page'
+                ? { width: 612, height: 792, rotation: 0 }
+                : { text: 'Grounded text.' },
+          },
+        ],
+        candidates: [
+          {
+            id: 'candidate-run',
+            providerId: provider.id,
+            kind: candidateKind,
+            page: 1,
+            boxes: [candidateBox],
+            sourceIds: ['source-run'],
+            artifactIds: ['deterministic-artifact'],
+            payload:
+              candidateKind === 'full-page-render'
+                ? { completePageRaster: true }
+                : { text: 'Grounded text.' },
+          },
+        ],
+      },
+      {
+        schemaVersion: PDF_EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        id: 'mineru-bundle',
+        armId: 'mineru',
+        source,
+        provider: mineruProvider,
+        pages: [{ page: 1, width: 612, height: 792, rotation: 0 }],
+        artifacts: [
+          {
+            id: 'mineru-artifact',
+            providerId: mineruProvider.id,
+            kind: 'content-list-v2',
+            mediaType: 'application/json',
+            sha256: '3'.repeat(64),
+            byteLength: 64,
+            page: 1,
+            box,
+            sourceIds: ['mineru-source'],
+          },
+        ],
+        sources: [
+          {
+            id: 'mineru-source',
+            providerId: mineruProvider.id,
+            kind: convergentMineru
+              ? 'mineru-native-record'
+              : 'provider-record',
+            page: 1,
+            box,
+            artifactIds: ['mineru-artifact'],
+            ...(convergentMineru
+              ? { payload: { record: { text: 'Grounded text.' } } }
+              : {}),
+          },
+        ],
+        candidates: [
+          {
+            id: 'mineru-candidate',
+            providerId: mineruProvider.id,
+            kind: convergentMineru ? 'text-glyph-run' : 'provider-record',
+            page: 1,
+            boxes: [box],
+            sourceIds: ['mineru-source'],
+            artifactIds: ['mineru-artifact'],
+            payload: convergentMineru
+              ? { text: 'Grounded text.', grounded: true }
+              : { grounded: false },
+          },
+        ],
+      },
+    ],
+    obligations: [
+      {
+        id: 'obligation-run',
+        kind: obligationKind,
+        page: 1,
+        sourceIds: [
+          'source-run',
+          ...(convergentMineru ? ['mineru-source'] : []),
+        ],
+        artifactIds: [
+          'deterministic-artifact',
+          ...(convergentMineru ? ['mineru-artifact'] : []),
+        ],
+        candidateIds: [
+          'candidate-run',
+          ...(convergentMineru ? ['mineru-candidate'] : []),
+        ],
+        observationCategories: ['text-exactness'],
+        required: true,
+        semantic,
+      },
+      ...(!convergentMineru
+        ? [{
+        id: 'mineru-discovery-obligation',
+        kind: 'provider-source-fact',
+        page: 1,
+        sourceIds: ['mineru-source'],
+        artifactIds: ['mineru-artifact'],
+        candidateIds: ['mineru-candidate'],
+        observationCategories: [
+          'object-counts' as const,
+          'asset-bytes' as const,
+        ],
+        required: false,
+        semantic: false,
+      }]
+        : []),
+    ],
+    disagreements: [],
+  }
+  return buildSourceEvidenceGraph({
+    ...graphInput,
+    deterministicContext: deterministicContextReceiptForBundle(
+      graphInput.bundles[0]!,
+    ),
+  })
+}
+
+function context(): StructuredExtractionContext {
+  return {
+    documentId: source.documentId,
+    sourceSha256,
+    split: 'held-out',
+    layout: 'one-column',
+    sourceRuns: [
+      {
+        id: 'source-run',
+        text: 'Grounded text.',
+        page: 1,
+        order: 0,
+        bounds: { x: 0.1, y: 0.2, width: 0.2, height: 0.02 },
+      },
+    ],
+    sourceAssets: [],
+  }
+}
+
+function proposal(graph: SourceEvidenceGraph): SourceGroundedStructProposal {
+  return {
+    schemaVersion: SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION,
+    evidenceGraphSha256: graph.graphSha256,
+    candidateSetSha256: sourceEvidenceCandidateSetSha256(graph),
+    selections: [
+      {
+        obligationId: 'obligation-run',
+        candidateId: 'candidate-run',
+        decision: 'preserve-source' as const,
+        disposition: 'accepted' as const,
+      },
+    ],
+    materializations: [
+      {
+        obligationId: 'obligation-run',
+        candidateId: 'candidate-run',
+        sourceIds: ['source-run'],
+        targets: [{ kind: 'node' as const, id: 'paragraph' }],
+      },
+    ],
+    structuredExtraction: {
+      schemaVersion: '1.0.0' as const,
+      nodes: [
+        {
+          id: 'paragraph',
+          type: 'paragraph' as const,
+          sourceRunIds: ['source-run'],
+          text: 'Grounded text.',
+        },
+      ],
+    },
+  }
+}
+
+describe('source-grounded STRUCT verification', () => {
+  it('emits an immutable candidate only after exact graph obligation closure', () => {
+    const graph = graphFixture()
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      proposal(graph),
+    )
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.readyForStruct).toBe(true)
+      expect(result.output.evidenceGraphSha256).toBe(graph.graphSha256)
+      expect(Object.isFrozen(result.output)).toBe(true)
+      expect(result.output.structuredExtraction.nodes[0]?.text).toBe(
+        'Grounded text.',
+      )
+    }
+  })
+
+  it('accepts convergent deterministic and MinerU sources through unique target-owner sets', () => {
+    const graph = graphFixture({ convergentMineru: true })
+    const candidate = proposal(graph)
+    candidate.materializations[0]!.sourceIds = [
+      'source-run',
+      'mineru-source',
+    ]
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      candidate,
+    )
+
+    expect(result.status).toBe('passed')
+    if (result.status === 'passed') {
+      expect(result.output.providerSourceOwnershipCrosswalks).toEqual([
+        expect.objectContaining({ providerId: 'mineru-fixture', sourceCount: 1 }),
+        expect.objectContaining({ providerId: 'pdfjs-fixture', sourceCount: 1 }),
+      ])
+      expect(
+        result.output.providerSourceOwnershipCrosswalks[0]!.crosswalkSha256,
+      ).not.toBe(
+        result.output.providerSourceOwnershipCrosswalks[1]!.crosswalkSha256,
+      )
+    }
+  })
+
+  it('rejects divergent provider source ownership instead of laundering convergence', () => {
+    const graph = graphFixture({ convergentMineru: true })
+    const divergent = context()
+    divergent.sourceRuns[0]!.text = 'Different deterministic text.'
+    const candidate = proposal(graph)
+    candidate.structuredExtraction.nodes[0]!.text =
+      'Different deterministic text.'
+    candidate.materializations[0]!.sourceIds = [
+      'source-run',
+      'mineru-source',
+    ]
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      divergent,
+      candidate,
+    )
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-source-crosswalk',
+      )
+    }
+  })
+
+  it('rejects stale candidate-set bindings and missing obligation closure', () => {
+    const graph = graphFixture()
+    const candidate = proposal(graph)
+    candidate.candidateSetSha256 = '2'.repeat(64)
+    candidate.selections = []
+    candidate.materializations = []
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      candidate,
+    )
+
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toEqual(
+        expect.arrayContaining(['stale-candidate-set', 'missing-obligation']),
+      )
+    }
+  })
+
+  it('rejects obligation selection without a materialized STRUCT owner', () => {
+    const graph = graphFixture()
+    const candidate = proposal(graph)
+    candidate.materializations = []
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      candidate,
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'missing-materialization',
+      )
+    }
+  })
+
+  it('rejects a materialization receipt that cites unrelated source IDs', () => {
+    const graph = graphFixture()
+    const candidate = proposal(graph)
+    candidate.materializations[0]!.sourceIds = ['unrelated-source']
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      candidate,
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-materialization',
+      )
+    }
+  })
+
+  it('never accepts a full-page raster as reconstructed semantics', () => {
+    const graph = graphFixture({ candidateKind: 'full-page-render' })
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      proposal(graph),
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'full-page-raster-as-semantics',
+      )
+    }
+  })
+
+  it('keeps a table image as a blocking semantic obligation', () => {
+    const graph = graphFixture({
+      candidateKind: 'table-image',
+      obligationKind: 'table-structure',
+    })
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      proposal(graph),
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'unresolved-table-semantics',
+      )
+    }
+  })
+
+  it('rejects heading-role laundering into a paragraph node', () => {
+    const graph = graphFixture({ candidateKind: 'heading' })
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      proposal(graph),
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'semantic-role-mismatch',
+      )
+    }
+  })
+
+  it('rejects duplicate target ownership across source obligations', () => {
+    const graph = graphFixture()
+    const candidate = proposal(graph)
+    candidate.selections.push({
+      obligationId: 'mineru-discovery-obligation',
+      candidateId: 'mineru-candidate',
+      decision: 'preserve-source',
+      disposition: 'accepted',
+    })
+    candidate.materializations.push({
+      obligationId: 'mineru-discovery-obligation',
+      candidateId: 'mineru-candidate',
+      sourceIds: ['mineru-source'],
+      targets: [{ kind: 'node', id: 'paragraph' }],
+    })
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      context(),
+      candidate,
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'duplicate-materialization-target',
+      )
+    }
+  })
+
+  it('rejects two-obligation cross-swap across otherwise valid STRUCT nodes', () => {
+    const frozen = graphFixture()
+    const { graphSha256: _graphSha256, ...input } = structuredClone(frozen)
+    const deterministic = input.bundles.find(
+      ({ armId }) => armId === 'deterministic',
+    )!
+    deterministic.sources.push({
+      id: 'source-run-2',
+      providerId: deterministic.provider.id,
+      kind: 'text-glyph-run',
+      page: 1,
+      box: {
+        page: 1,
+        x: 0.1,
+        y: 0.3,
+        width: 0.2,
+        height: 0.02,
+        rotation: 0,
+        method: 'pdf-text',
+      },
+      payload: { text: 'Second grounded text.' },
+    })
+    deterministic.candidates.push({
+      id: 'candidate-run-2',
+      providerId: deterministic.provider.id,
+      kind: 'text-glyph-run',
+      page: 1,
+      boxes: [deterministic.sources.at(-1)!.box!],
+      sourceIds: ['source-run-2'],
+      payload: { text: 'Second grounded text.' },
+    })
+    input.obligations.push({
+      id: 'obligation-run-2',
+      kind: 'source-text',
+      page: 1,
+      sourceIds: ['source-run-2'],
+      artifactIds: [],
+      candidateIds: ['candidate-run-2'],
+      observationCategories: ['text-exactness'],
+      required: true,
+      semantic: true,
+    })
+    input.deterministicContext = deterministicContextReceiptForBundle(
+      deterministic,
+    )
+    const graph = buildSourceEvidenceGraph(input)
+    const groundedContext = context()
+    groundedContext.sourceRuns.push({
+      id: 'source-run-2',
+      text: 'Second grounded text.',
+      page: 1,
+      order: 1,
+      bounds: { x: 0.1, y: 0.3, width: 0.2, height: 0.02 },
+    })
+    const candidate = proposal(graph)
+    candidate.selections.push({
+      obligationId: 'obligation-run-2',
+      candidateId: 'candidate-run-2',
+      decision: 'preserve-source',
+      disposition: 'accepted',
+    })
+    candidate.structuredExtraction.nodes.push({
+      id: 'paragraph-2',
+      type: 'paragraph',
+      sourceRunIds: ['source-run-2'],
+      text: 'Second grounded text.',
+    })
+    candidate.materializations[0]!.targets = [
+      { kind: 'node', id: 'paragraph-2' },
+    ]
+    candidate.materializations.push({
+      obligationId: 'obligation-run-2',
+      candidateId: 'candidate-run-2',
+      sourceIds: ['source-run-2'],
+      targets: [{ kind: 'node', id: 'paragraph' }],
+    })
+
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      groundedContext,
+      candidate,
+    )
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain(
+        'invalid-source-crosswalk',
+      )
+    }
+  })
+
+  it('accepts a source-preserved scan only when the complete-page artifact is materialized', () => {
+    const graph = graphFixture({
+      candidateKind: 'full-page-render',
+      obligationKind: 'source-preserved-page',
+    })
+    const scanContext = context()
+    scanContext.sourceAssets = [
+      {
+        id: 'source-page-1',
+        kind: 'source-fallback',
+        page: 1,
+        bounds: { x: 0, y: 0, width: 1, height: 1 },
+        bytesSha256: '2'.repeat(64),
+        sourceObjectIds: ['source-page-render'],
+      },
+    ]
+    const candidate = proposal(graph)
+    candidate.materializations[0]!.targets = [
+      { kind: 'asset', id: 'source-page-1' },
+    ]
+    candidate.structuredExtraction.nodes[0] = {
+      id: 'source-page-node',
+      type: 'source-fallback',
+      sourceRunIds: ['source-run'],
+      assetId: 'source-page-1',
+    }
+    const result = verifySourceGroundedStructCandidate(
+      graph,
+      scanContext,
+      candidate,
+    )
+    expect(result.status).toBe('passed')
+
+    scanContext.sourceAssets[0]!.bytesSha256 = '4'.repeat(64)
+    const tampered = verifySourceGroundedStructCandidate(
+      graph,
+      scanContext,
+      candidate,
+    )
+    expect(tampered.status).toBe('failed')
+    if (tampered.status === 'failed') {
+      expect(tampered.issues.map(({ code }) => code)).toContain(
+        'invalid-source-fallback',
+      )
+    }
+  })
+})

--- a/src/research/source-grounded-struct.ts
+++ b/src/research/source-grounded-struct.ts
@@ -1,0 +1,1027 @@
+import {
+  verifyStructuredExtraction,
+  type StructuredExtractionContext,
+  type StructuredExtractionProposal,
+  type VerifiedStructuredExtraction,
+} from './structured-extraction'
+import { sha256HexSync } from './sha256-sync'
+import {
+  readSourceEvidenceGraph,
+  sourceEvidenceCandidateSetSha256,
+  validateSourceEvidenceGraph,
+  type PdfEvidenceCandidate,
+  type PdfEvidenceObligation,
+  type SourceEvidenceGraph,
+} from './source-evidence-graph'
+
+export const SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION = '1.0.0' as const
+
+export const GROUNDED_RECONCILIATION_DECISIONS = [
+  'reading-order',
+  'semantic-type',
+  'join',
+  'caption-asset-association',
+  'table-structure',
+  'formula-representation',
+  'note-association',
+  'citation-association',
+  'link-destination',
+  'boilerplate-classification',
+  'preserve-source',
+] as const
+
+export type GroundedReconciliationDecision =
+  (typeof GROUNDED_RECONCILIATION_DECISIONS)[number]
+
+export type GroundedEvidenceSelection = {
+  obligationId: string
+  candidateId: string
+  decision: GroundedReconciliationDecision
+  disposition: 'accepted' | 'excluded-boilerplate' | 'failed'
+}
+
+export type GroundedObligationMaterialization = {
+  obligationId: string
+  candidateId: string
+  sourceIds: string[]
+  targets: Array<
+    | { kind: 'node'; id: string }
+    | { kind: 'asset'; id: string }
+    | { kind: 'link'; id: string }
+    | { kind: 'relationship'; id: string }
+    | { kind: 'excluded-boilerplate'; id: string }
+  >
+}
+
+export type SourceGroundedStructProposal = {
+  schemaVersion: typeof SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION
+  evidenceGraphSha256: string
+  candidateSetSha256: string
+  selections: GroundedEvidenceSelection[]
+  materializations: GroundedObligationMaterialization[]
+  /** Semantic proposal only; the verifier rematerializes source text/assets. */
+  structuredExtraction: StructuredExtractionProposal
+}
+
+export type SourceGroundingIssueCode =
+  | 'invalid-proposal'
+  | 'stale-evidence-graph'
+  | 'stale-candidate-set'
+  | 'unknown-obligation'
+  | 'unknown-candidate'
+  | 'candidate-does-not-support-obligation'
+  | 'duplicate-obligation'
+  | 'missing-obligation'
+  | 'illegal-boilerplate-exclusion'
+  | 'full-page-raster-as-semantics'
+  | 'unresolved-table-semantics'
+  | 'unresolved-formula-semantics'
+  | 'failed-candidate'
+  | 'missing-materialization'
+  | 'duplicate-materialization'
+  | 'duplicate-materialization-target'
+  | 'invalid-materialization'
+  | 'invalid-source-crosswalk'
+  | 'semantic-role-mismatch'
+  | 'invalid-source-fallback'
+  | 'structured-verification-failed'
+
+export type SourceGroundingIssue = {
+  code: SourceGroundingIssueCode
+  message: string
+  obligationId?: string
+  candidateId?: string
+}
+
+export type VerifiedSourceGroundedStructCandidate = {
+  schemaVersion: typeof SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION
+  evidenceGraphSha256: string
+  candidateSetSha256: string
+  obligationLedgerSha256: string
+  sourceOwnershipCrosswalkSha256: string
+  providerSourceOwnershipCrosswalks: Array<{
+    providerId: string
+    sourceCount: number
+    crosswalkSha256: string
+  }>
+  selections: Array<
+    GroundedEvidenceSelection & {
+      providerId: string
+      sourceIds: string[]
+    }
+  >
+  materializations: GroundedObligationMaterialization[]
+  structuredExtraction: VerifiedStructuredExtraction
+  readyForStruct: true
+}
+
+type SourceOwnership = {
+  providerId: string
+  sourceId: string
+  kind: 'node' | 'asset' | 'link' | 'relationship'
+  targetIds: string[]
+}
+
+export type SourceGroundedStructVerification =
+  | {
+      status: 'passed'
+      output: VerifiedSourceGroundedStructCandidate
+      issues: []
+    }
+  | { status: 'failed'; output: null; issues: SourceGroundingIssue[] }
+
+const SHA256 = /^[a-f0-9]{64}$/u
+const ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]) {
+  const actual = Object.keys(value).sort().join('\0')
+  return actual === [...keys].sort().join('\0')
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(',')}]`
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value) ?? 'null'
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(child)
+    }
+  }
+  return value
+}
+
+function parseProposal(value: unknown): SourceGroundedStructProposal | null {
+  if (
+    !isRecord(value) ||
+    !exactKeys(value, [
+      'schemaVersion',
+      'evidenceGraphSha256',
+      'candidateSetSha256',
+      'selections',
+      'materializations',
+      'structuredExtraction',
+    ]) ||
+    value.schemaVersion !== SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION ||
+    !SHA256.test(String(value.evidenceGraphSha256 ?? '')) ||
+    !SHA256.test(String(value.candidateSetSha256 ?? '')) ||
+    !Array.isArray(value.selections) ||
+    !value.selections.every(
+      (selection) =>
+        isRecord(selection) &&
+        exactKeys(selection, [
+          'obligationId',
+          'candidateId',
+          'decision',
+          'disposition',
+        ]) &&
+        ID.test(String(selection.obligationId ?? '')) &&
+        ID.test(String(selection.candidateId ?? '')) &&
+        (GROUNDED_RECONCILIATION_DECISIONS as readonly unknown[]).includes(
+          selection.decision,
+        ) &&
+        ['accepted', 'excluded-boilerplate', 'failed'].includes(
+          String(selection.disposition),
+        ),
+    ) ||
+    !Array.isArray(value.materializations) ||
+    !value.materializations.every(
+      (materialization) =>
+        isRecord(materialization) &&
+        exactKeys(materialization, [
+          'obligationId',
+          'candidateId',
+          'sourceIds',
+          'targets',
+        ]) &&
+        ID.test(String(materialization.obligationId ?? '')) &&
+        ID.test(String(materialization.candidateId ?? '')) &&
+        Array.isArray(materialization.sourceIds) &&
+        materialization.sourceIds.length > 0 &&
+        materialization.sourceIds.every((sourceId) =>
+          ID.test(String(sourceId)),
+        ) &&
+        Array.isArray(materialization.targets) &&
+        materialization.targets.length > 0 &&
+        materialization.targets.every(
+          (target) =>
+            isRecord(target) &&
+            exactKeys(target, ['kind', 'id']) &&
+            [
+              'node',
+              'asset',
+              'link',
+              'relationship',
+              'excluded-boilerplate',
+            ].includes(String(target.kind)) &&
+            ID.test(String(target.id ?? '')),
+        ),
+    )
+  ) {
+    return null
+  }
+  return structuredClone(value) as SourceGroundedStructProposal
+}
+
+function issue(
+  code: SourceGroundingIssueCode,
+  message: string,
+  details: Pick<SourceGroundingIssue, 'obligationId' | 'candidateId'> = {},
+): SourceGroundingIssue {
+  return { code, message, ...details }
+}
+
+function isFullPageRaster(candidate: PdfEvidenceCandidate) {
+  return (
+    candidate.kind === 'full-page-render' ||
+    (isRecord(candidate.payload) &&
+      candidate.payload.completePageRaster === true)
+  )
+}
+
+function isSemanticStructure(candidate: PdfEvidenceCandidate) {
+  if (
+    /semantic|structure|cells?|latex|mathml|transcript/u.test(candidate.kind)
+  ) {
+    return true
+  }
+  return (
+    isRecord(candidate.payload) &&
+    (candidate.payload.semantic === true ||
+      Array.isArray(candidate.payload.cells) ||
+      typeof candidate.payload.latex === 'string' ||
+      typeof candidate.payload.mathml === 'string')
+  )
+}
+
+function boilerplateObligation(kind: string) {
+  return /boilerplate|furniture|header|footer|page-number/u.test(kind)
+}
+
+function allowedMaterializationKinds(
+  obligation: PdfEvidenceObligation | undefined,
+  candidate: PdfEvidenceCandidate | undefined,
+) {
+  if (!obligation) return new Set<string>()
+  switch (obligation.kind) {
+    case 'source-text':
+    case 'layout-region':
+      return new Set(['node'])
+    case 'ocr-text':
+      return candidate !== undefined && isFullPageRaster(candidate)
+        ? new Set(['asset'])
+        : new Set(['node'])
+    case 'source-object':
+      return new Set(['asset'])
+    case 'source-preserved-page':
+      return candidate !== undefined && isFullPageRaster(candidate)
+        ? new Set(['asset'])
+        : new Set()
+    case 'annotation-destination':
+      return new Set(['link'])
+    case 'reading-order':
+      return new Set(['relationship'])
+    case 'note-relationship':
+    case 'citation-relationship':
+    case 'cross-reference-relationship':
+    case 'figure-relationship':
+    case 'table-relationship':
+    case 'equation-relationship':
+      return new Set(['relationship'])
+    default:
+      return new Set()
+  }
+}
+
+function semanticNodeType(candidate: PdfEvidenceCandidate) {
+  const direct = [
+    'title',
+    'author',
+    'affiliation',
+    'abstract',
+    'heading',
+    'code',
+    'table',
+    'figure',
+    'equation',
+    'footnote',
+    'reference',
+  ].includes(candidate.kind)
+    ? candidate.kind
+    : null
+  if (direct) return direct
+  if (!isRecord(candidate.payload)) return null
+  const declared = [candidate.payload.type, candidate.payload.role].find(
+    (value) => typeof value === 'string',
+  )
+  return typeof declared === 'string' &&
+    [
+      'title',
+      'author',
+      'affiliation',
+      'abstract',
+      'heading',
+      'code',
+      'table',
+      'figure',
+      'equation',
+      'footnote',
+      'reference',
+    ].includes(declared)
+    ? declared
+    : null
+}
+
+function sameBounds(
+  left:
+    | { x: number; y: number; width: number; height: number }
+    | undefined,
+  right:
+    | { x: number; y: number; width: number; height: number }
+    | undefined,
+) {
+  if (!left || !right) return false
+  return (['x', 'y', 'width', 'height'] as const).every(
+    (key) => Math.abs(left[key] - right[key]) <= 1e-9,
+  )
+}
+
+function payloadId(payload: unknown) {
+  if (!isRecord(payload)) return undefined
+  return [
+    payload.id,
+    payload.objectId,
+    payload.regionId,
+    payload.relationshipId,
+  ].find((value): value is string => typeof value === 'string')
+}
+
+/**
+ * Resolve deterministic graph sources back to the exact immutable extraction
+ * owners. The resulting projection is hashed into the verified output; model
+ * materialization receipts never get to declare this ownership themselves.
+ */
+function deterministicSourceOwnership(
+  graph: SourceEvidenceGraph,
+  context: StructuredExtractionContext,
+): SourceOwnership[] {
+  return graph.bundles
+    .flatMap(({ provider, sources }) =>
+      sources.map((source) => ({ providerId: provider.id, source })),
+    )
+    .flatMap(({ providerId, source }): SourceOwnership[] => {
+      if (source.kind === 'text-glyph-run' || source.kind === 'ocr-word') {
+        const text = isRecord(source.payload) ? source.payload.text : undefined
+        const matches = context.sourceRuns.filter(
+          (run) =>
+            run.page === source.page &&
+            run.text === text &&
+            sameBounds(run.bounds, source.box),
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'node',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      if (source.kind === 'mineru-native-record') {
+        const record = isRecord(source.payload) ? source.payload.record : null
+        const text = isRecord(record)
+          ? [record.text, record.content].find(
+              (value): value is string => typeof value === 'string',
+            )
+          : undefined
+        const matches = context.sourceRuns.filter(
+          (run) =>
+            run.page === source.page &&
+            run.text === text &&
+            sameBounds(run.bounds, source.box),
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'node',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      if (source.kind === 'layout-region') {
+        const id = payloadId(source.payload)
+        const targetIds = context.sourceRuns
+          .filter(({ regionId }) => regionId === id)
+          .map(({ id: runId }) => runId)
+          .sort()
+        return targetIds.length > 0
+          ? [{ providerId, sourceId: source.id, kind: 'node', targetIds }]
+          : []
+      }
+      if (source.kind.endsWith('-object')) {
+        const objectId = payloadId(source.payload)
+        const matches = context.sourceAssets.filter(({ sourceObjectIds }) =>
+          objectId === undefined ? false : sourceObjectIds.includes(objectId),
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'asset',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      if (source.kind === 'page-geometry') {
+        const matches = context.sourceAssets.filter(
+          (asset) =>
+            asset.kind === 'source-fallback' &&
+            asset.page === source.page &&
+            asset.bounds.x === 0 &&
+            asset.bounds.y === 0 &&
+            asset.bounds.width === 1 &&
+            asset.bounds.height === 1,
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'asset',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      if (source.kind === 'annotation-link-destination') {
+        const id = payloadId(source.payload)
+        const matches = (context.sourceLinks ?? []).filter(
+          (link) =>
+            (id !== undefined && link.id === id) ||
+            (id === undefined &&
+              link.page === source.page &&
+              sameBounds(link.box, source.box)),
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'link',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      if (
+        source.kind === 'reading-order-edge' ||
+        source.kind.endsWith('-relationship')
+      ) {
+        const id = payloadId(source.payload)
+        const matches = (context.provenArtifacts ?? []).filter(
+          (artifact) => artifact.id === id,
+        )
+        return matches.length === 1
+          ? [
+              {
+                providerId,
+                sourceId: source.id,
+                kind: 'relationship',
+                targetIds: [matches[0]!.id],
+              },
+            ]
+          : []
+      }
+      return []
+    })
+    .sort((left, right) => left.sourceId.localeCompare(right.sourceId))
+}
+
+/**
+ * Close the graph ledger before materializing the existing structured
+ * extraction contract. A failed or merely visual semantic obligation returns
+ * no candidate, so downstream STRUCT code cannot mistake review evidence for
+ * publication-ready semantics.
+ */
+export function verifySourceGroundedStructCandidate(
+  graphInput: SourceEvidenceGraph,
+  context: StructuredExtractionContext,
+  proposalInput: unknown,
+): SourceGroundedStructVerification {
+  let graph: SourceEvidenceGraph
+  try {
+    validateSourceEvidenceGraph(graphInput)
+    graph = graphInput
+  } catch {
+    return {
+      status: 'failed',
+      output: null,
+      issues: [
+        issue('invalid-proposal', 'The source evidence graph is invalid.'),
+      ],
+    }
+  }
+  const proposal = parseProposal(proposalInput)
+  if (!proposal) {
+    return {
+      status: 'failed',
+      output: null,
+      issues: [issue('invalid-proposal', 'The grounded proposal is invalid.')],
+    }
+  }
+  const issues: SourceGroundingIssue[] = []
+  if (
+    proposal.evidenceGraphSha256 !== graph.graphSha256 ||
+    context.sourceSha256 !== graph.source.sha256 ||
+    context.documentId !== graph.source.documentId
+  ) {
+    issues.push(
+      issue(
+        'stale-evidence-graph',
+        'The proposal, deterministic context, and graph source are not the same frozen evidence state.',
+      ),
+    )
+  }
+  const expectedCandidateSetSha256 = sourceEvidenceCandidateSetSha256(graph)
+  if (proposal.candidateSetSha256 !== expectedCandidateSetSha256) {
+    issues.push(
+      issue(
+        'stale-candidate-set',
+        'The proposal candidate set is stale or incomplete.',
+      ),
+    )
+  }
+
+  const reader = readSourceEvidenceGraph(graph)
+  const sourceOwnership = deterministicSourceOwnership(graph, context)
+  const sourceOwnershipById = new Map(
+    sourceOwnership.map((entry) => [entry.sourceId, entry]),
+  )
+  const claimed = new Set<string>()
+  const materializedSelections: VerifiedSourceGroundedStructCandidate['selections'] =
+    []
+  for (const selection of proposal.selections) {
+    const obligation = reader.obligation(selection.obligationId)
+    const candidate = reader.candidate(selection.candidateId)
+    if (!obligation) {
+      issues.push(
+        issue(
+          'unknown-obligation',
+          'The selection names an unknown obligation.',
+          {
+            obligationId: selection.obligationId,
+            candidateId: selection.candidateId,
+          },
+        ),
+      )
+      continue
+    }
+    if (!candidate) {
+      issues.push(
+        issue(
+          'unknown-candidate',
+          'The selection names an unknown candidate.',
+          {
+            obligationId: selection.obligationId,
+            candidateId: selection.candidateId,
+          },
+        ),
+      )
+      continue
+    }
+    if (claimed.has(obligation.id)) {
+      issues.push(
+        issue(
+          'duplicate-obligation',
+          'A source obligation is conserved more than once.',
+          {
+            obligationId: obligation.id,
+            candidateId: candidate.id,
+          },
+        ),
+      )
+      continue
+    }
+    claimed.add(obligation.id)
+    if (!obligation.candidateIds.includes(candidate.id)) {
+      issues.push(
+        issue(
+          'candidate-does-not-support-obligation',
+          'The candidate was not frozen as evidence for this obligation.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    if (
+      selection.disposition === 'excluded-boilerplate' &&
+      (!boilerplateObligation(obligation.kind) ||
+        selection.decision !== 'boilerplate-classification')
+    ) {
+      issues.push(
+        issue(
+          'illegal-boilerplate-exclusion',
+          'Only a source-backed boilerplate obligation may leave body flow.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    if (
+      obligation.semantic &&
+      selection.disposition === 'accepted' &&
+      isFullPageRaster(candidate) &&
+      obligation.kind !== 'source-preserved-page'
+    ) {
+      issues.push(
+        issue(
+          'full-page-raster-as-semantics',
+          'A full-page raster cannot satisfy reconstructed semantics.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    if (
+      obligation.semantic &&
+      /table/u.test(obligation.kind) &&
+      !isSemanticStructure(candidate)
+    ) {
+      issues.push(
+        issue(
+          'unresolved-table-semantics',
+          'A bounded table image preserves loss but does not close table structure.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    if (
+      obligation.semantic &&
+      /formula|equation/u.test(obligation.kind) &&
+      !isSemanticStructure(candidate)
+    ) {
+      issues.push(
+        issue(
+          'unresolved-formula-semantics',
+          'A bounded formula image preserves loss but does not close formula representation.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    if (selection.disposition === 'failed') {
+      issues.push(
+        issue(
+          'failed-candidate',
+          'An ungrounded disagreement remains a failed candidate.',
+          { obligationId: obligation.id, candidateId: candidate.id },
+        ),
+      )
+    }
+    materializedSelections.push({
+      ...selection,
+      providerId: candidate.providerId,
+      sourceIds: [...candidate.sourceIds],
+    })
+  }
+
+  for (const obligation of graph.obligations) {
+    if (obligation.required && !claimed.has(obligation.id)) {
+      issues.push(
+        issue(
+          'missing-obligation',
+          'A required source obligation was not conserved.',
+          { obligationId: obligation.id },
+        ),
+      )
+    }
+  }
+
+  const selectionByObligation = new Map(
+    proposal.selections.map((selection) => [selection.obligationId, selection]),
+  )
+  const materializationByObligation = new Map<
+    string,
+    GroundedObligationMaterialization
+  >()
+  const targetOwners = new Map<string, string>()
+  for (const materialization of proposal.materializations) {
+    if (materializationByObligation.has(materialization.obligationId)) {
+      issues.push(
+        issue(
+          'duplicate-materialization',
+          'A selected source obligation has more than one materialization receipt.',
+          {
+            obligationId: materialization.obligationId,
+            candidateId: materialization.candidateId,
+          },
+        ),
+      )
+      continue
+    }
+    materializationByObligation.set(
+      materialization.obligationId,
+      materialization,
+    )
+    for (const target of materialization.targets) {
+      const key = `${target.kind}:${target.id}`
+      const owner = targetOwners.get(key)
+      if (owner !== undefined) {
+        issues.push(
+          issue(
+            'duplicate-materialization-target',
+            `Materialization target ${key} is already owned by ${owner}.`,
+            {
+              obligationId: materialization.obligationId,
+              candidateId: materialization.candidateId,
+            },
+          ),
+        )
+      } else {
+        targetOwners.set(key, materialization.obligationId)
+      }
+    }
+    const selection = selectionByObligation.get(materialization.obligationId)
+    const obligation = reader.obligation(materialization.obligationId)
+    if (
+      !selection ||
+      !obligation ||
+      selection.candidateId !== materialization.candidateId ||
+      canonicalJson([...materialization.sourceIds].sort()) !==
+        canonicalJson([...obligation.sourceIds].sort()) ||
+      new Set(materialization.sourceIds).size !==
+        materialization.sourceIds.length
+    ) {
+      issues.push(
+        issue(
+          'invalid-materialization',
+          'The materialization receipt must bind the exact selected candidate and source-obligation IDs.',
+          {
+            obligationId: materialization.obligationId,
+            candidateId: materialization.candidateId,
+          },
+        ),
+      )
+    }
+  }
+  for (const selection of proposal.selections) {
+    if (
+      selection.disposition !== 'failed' &&
+      !materializationByObligation.has(selection.obligationId)
+    ) {
+      issues.push(
+        issue(
+          'missing-materialization',
+          'Selecting an obligation is not conservation; an exact materialization receipt is required.',
+          {
+            obligationId: selection.obligationId,
+            candidateId: selection.candidateId,
+          },
+        ),
+      )
+    }
+  }
+
+  const structured = verifyStructuredExtraction(
+    context,
+    proposal.structuredExtraction,
+  )
+  if (structured.status === 'failed') {
+    issues.push(
+      ...structured.issues.map((entry) =>
+        issue(
+          'structured-verification-failed',
+          `${entry.code}: ${entry.message}`,
+        ),
+      ),
+    )
+  } else {
+    const nodeIds = new Set(structured.output.nodes.map(({ id }) => id))
+    const assetIds = new Set(structured.output.assetIds)
+    const linkIds = new Set(
+      structured.output.links.map(({ sourceLinkId }) => sourceLinkId),
+    )
+    const relationshipIds = new Set(structured.output.relationshipIds)
+    const excludedIds = new Set(structured.output.excludedBoilerplateRunIds)
+    const nodesById = new Map(
+      structured.output.nodes.map((node) => [node.id, node]),
+    )
+    const sourceAssetsById = new Map(
+      context.sourceAssets.map((asset) => [asset.id, asset]),
+    )
+    for (const materialization of proposal.materializations) {
+      const selection = selectionByObligation.get(materialization.obligationId)
+      const obligation = reader.obligation(materialization.obligationId)
+      const candidate = reader.candidate(materialization.candidateId)
+      const allowedKinds = allowedMaterializationKinds(obligation, candidate)
+      const ownership = materialization.sourceIds.map((sourceId) =>
+        sourceOwnershipById.get(sourceId),
+      )
+      if (ownership.some((entry) => entry === undefined)) {
+        issues.push(
+          issue(
+            'invalid-source-crosswalk',
+            'Every materialized graph source must reopen to an exact deterministic STRUCT owner.',
+            {
+              obligationId: materialization.obligationId,
+              candidateId: materialization.candidateId,
+            },
+          ),
+        )
+      }
+      for (const target of materialization.targets) {
+        const exists =
+          (target.kind === 'node' && nodeIds.has(target.id)) ||
+          (target.kind === 'asset' && assetIds.has(target.id)) ||
+          (target.kind === 'link' && linkIds.has(target.id)) ||
+          (target.kind === 'relationship' && relationshipIds.has(target.id)) ||
+          (target.kind === 'excluded-boilerplate' && excludedIds.has(target.id))
+        if (
+          !exists ||
+          (target.kind !== 'excluded-boilerplate' &&
+            !allowedKinds.has(target.kind)) ||
+          (selection?.disposition === 'excluded-boilerplate') !==
+            (target.kind === 'excluded-boilerplate')
+        ) {
+          issues.push(
+            issue(
+              'invalid-materialization',
+              'A materialization target must exist in the verified STRUCT output and match its disposition.',
+              {
+                obligationId: materialization.obligationId,
+                candidateId: materialization.candidateId,
+              },
+            ),
+          )
+        }
+        const expectedOwnerKind =
+          target.kind === 'excluded-boilerplate' ? 'node' : target.kind
+        const expectedOwnerIds = [
+          ...new Set(
+            ownership
+              .filter(
+                (entry): entry is SourceOwnership =>
+                  entry !== undefined && entry.kind === expectedOwnerKind,
+              )
+              .flatMap(({ targetIds }) => targetIds),
+          ),
+        ].sort()
+        const actualOwnerIds =
+          target.kind === 'node'
+            ? [
+                ...new Set(
+                  nodesById.get(target.id)?.provenance.sourceRunIds ?? [],
+                ),
+              ].sort()
+            : [target.id]
+        if (
+          expectedOwnerIds.length === 0 ||
+          canonicalJson(actualOwnerIds) !== canonicalJson(expectedOwnerIds)
+        ) {
+          issues.push(
+            issue(
+              'invalid-source-crosswalk',
+              'The selected target does not own the exact deterministic projection of its graph sources.',
+              {
+                obligationId: materialization.obligationId,
+                candidateId: materialization.candidateId,
+              },
+            ),
+          )
+        }
+        if (target.kind === 'node' && candidate) {
+          const expectedType = semanticNodeType(candidate)
+          const node = nodesById.get(target.id)
+          if (expectedType && node?.type !== expectedType) {
+            issues.push(
+              issue(
+                'semantic-role-mismatch',
+                `Candidate semantic role ${expectedType} cannot materialize as ${node?.type ?? 'missing'}.`,
+                {
+                  obligationId: materialization.obligationId,
+                  candidateId: materialization.candidateId,
+                },
+              ),
+            )
+          }
+        }
+        if (
+          obligation?.kind === 'source-preserved-page' &&
+          target.kind === 'asset'
+        ) {
+          const sourceAsset = sourceAssetsById.get(target.id)
+          const artifacts = (candidate?.artifactIds ?? [])
+            .map((id) => reader.artifact(id))
+            .filter((artifact) => artifact !== undefined)
+          const coherent =
+            candidate !== undefined &&
+            isFullPageRaster(candidate) &&
+            sourceAsset?.kind === 'source-fallback' &&
+            sourceAsset.page === obligation.page &&
+            sourceAsset.bounds.x === 0 &&
+            sourceAsset.bounds.y === 0 &&
+            sourceAsset.bounds.width === 1 &&
+            sourceAsset.bounds.height === 1 &&
+            artifacts.some(
+              (artifact) =>
+                artifact.kind === 'full-page-render' &&
+                artifact.page === obligation.page &&
+                artifact.sha256 === sourceAsset.bytesSha256 &&
+                artifact.box?.x === 0 &&
+                artifact.box.y === 0 &&
+                artifact.box.width === 1 &&
+                artifact.box.height === 1,
+            )
+          if (!coherent) {
+            issues.push(
+              issue(
+                'invalid-source-fallback',
+                'A source-preserved page must own the exact complete-page deterministic render.',
+                {
+                  obligationId: materialization.obligationId,
+                  candidateId: materialization.candidateId,
+                },
+              ),
+            )
+          }
+        }
+      }
+    }
+  }
+  if (issues.length > 0 || structured.status === 'failed') {
+    return { status: 'failed', output: null, issues }
+  }
+
+  const selections = materializedSelections.sort((left, right) =>
+    left.obligationId.localeCompare(right.obligationId),
+  )
+  const providerSourceOwnershipCrosswalks = [
+    ...new Set(sourceOwnership.map(({ providerId }) => providerId)),
+  ]
+    .sort()
+    .map((providerId) => {
+      const entries = sourceOwnership.filter(
+        (entry) => entry.providerId === providerId,
+      )
+      return {
+        providerId,
+        sourceCount: entries.length,
+        crosswalkSha256: sha256HexSync(canonicalJson(entries)),
+      }
+    })
+  const output: VerifiedSourceGroundedStructCandidate = {
+    schemaVersion: SOURCE_GROUNDED_STRUCT_SCHEMA_VERSION,
+    evidenceGraphSha256: graph.graphSha256,
+    candidateSetSha256: expectedCandidateSetSha256,
+    obligationLedgerSha256: sha256HexSync(
+      canonicalJson({
+        selections,
+        materializations: proposal.materializations,
+      }),
+    ),
+    sourceOwnershipCrosswalkSha256: sha256HexSync(
+      canonicalJson(sourceOwnership),
+    ),
+    providerSourceOwnershipCrosswalks,
+    selections,
+    materializations: structuredClone(proposal.materializations).sort(
+      (left, right) => left.obligationId.localeCompare(right.obligationId),
+    ),
+    structuredExtraction: structured.output,
+    readyForStruct: true,
+  }
+  return { status: 'passed', output: deepFreeze(output), issues: [] }
+}
+
+export function verifySourceGroundedStructCandidateOrThrow(
+  graph: SourceEvidenceGraph,
+  context: StructuredExtractionContext,
+  proposal: unknown,
+) {
+  const result = verifySourceGroundedStructCandidate(graph, context, proposal)
+  if (result.status === 'failed') {
+    throw new Error(
+      result.issues
+        .map(({ code, message }) => `${code}: ${message}`)
+        .join('\n'),
+    )
+  }
+  return result.output
+}

--- a/src/research/structured-extraction.test.ts
+++ b/src/research/structured-extraction.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   modelInputForStructuredExtraction,
+  structuredExtractionContextFromReconstruction,
   verifyStructuredExtraction,
   type StructuredExtractionContext,
   type StructuredExtractionProposal,
 } from './structured-extraction'
+import type { PdfReconstruction } from './import-types'
 
 const sourceSha256 = '1'.repeat(64)
 const assetSha256 = '2'.repeat(64)
@@ -73,6 +75,12 @@ function validProposal(): StructuredExtractionProposal {
         sourceRunIds: ['body-run'],
         text: 'A continuous paragraph.',
       },
+      {
+        id: 'table-source-text',
+        type: 'paragraph',
+        sourceRunIds: ['table-head', 'table-value'],
+        text: 'Measure 42',
+      },
     ],
     assetIds: ['figure-asset'],
     excludedBoilerplateRunIds: ['running-head'],
@@ -80,6 +88,292 @@ function validProposal(): StructuredExtractionProposal {
 }
 
 describe('source-backed structured extraction verifier', () => {
+  it('retains every physical-page run even when region extraction omits one', () => {
+    const retained = {
+      page: 1,
+      text: 'Retained body.',
+      x: 0.1,
+      y: 0.2,
+      width: 0.3,
+      height: 0.03,
+      rotation: 0,
+      method: 'pdf-text' as const,
+      fontName: 'Fixture',
+      fontSize: 10,
+      confidence: 1,
+      sourceSequenceIndex: 0,
+    }
+    const omitted = {
+      ...retained,
+      text: 'Right column heading',
+      x: 0.7,
+      y: 0.1,
+      fontSize: 14,
+      sourceSequenceIndex: 1,
+    }
+    const reconstruction = {
+      source: {
+        fileName: 'private.pdf',
+        byteLength: 100,
+        sha256: sourceSha256,
+        pageCount: 1,
+        localOnly: true,
+      },
+      pages: [
+        {
+          page: 1,
+          kind: 'born-digital',
+          width: 612,
+          height: 792,
+          rotation: 0,
+          textCharacters: retained.text.length + omitted.text.length,
+          imageCount: 0,
+          runs: [retained, omitted],
+        },
+      ],
+      regions: [
+        {
+          id: 'body-region',
+          kind: 'paragraph',
+          page: 1,
+          column: 0,
+          box: retained,
+          text: retained.text,
+          confidence: 1,
+          includedInReadingOrder: true,
+          lines: [
+            {
+              id: 'body-line',
+              text: retained.text,
+              box: retained,
+              runs: [retained],
+            },
+          ],
+        },
+      ],
+      assets: [],
+      readingOrder: { edges: [] },
+      lineBoundaryDecisions: [],
+      noteRelationships: [],
+      citationRelationships: [],
+      crossReferenceRelationships: [],
+      visualRelationships: [],
+      provenance: {},
+    } as unknown as PdfReconstruction
+    const extracted = structuredExtractionContextFromReconstruction({
+      reconstruction,
+      split: 'development',
+      layout: 'multi-region',
+    })
+    expect(extracted.sourceRuns.map(({ text }) => text)).toEqual([
+      retained.text,
+      omitted.text,
+    ])
+    expect(new Set(extracted.sourceRuns.map(({ id }) => id)).size).toBe(2)
+  })
+
+  it('orders orphan physical-page runs by sourceSequenceIndex rather than array position', () => {
+    const run = (text: string, sourceSequenceIndex: number) => ({
+      page: 1,
+      text,
+      x: 0.1,
+      y: 0.1 + sourceSequenceIndex / 100,
+      width: 0.3,
+      height: 0.03,
+      rotation: 0,
+      method: 'pdf-text' as const,
+      fontName: 'Fixture',
+      fontSize: 10,
+      confidence: 1,
+      sourceSequenceIndex,
+    })
+    const reconstruction = {
+      source: {
+        fileName: 'private.pdf',
+        byteLength: 100,
+        sha256: sourceSha256,
+        pageCount: 1,
+        localOnly: true,
+      },
+      pages: [
+        {
+          page: 1,
+          kind: 'born-digital',
+          width: 612,
+          height: 792,
+          rotation: 0,
+          textCharacters: 10,
+          imageCount: 0,
+          runs: [run('Later orphan', 9), run('Earlier orphan', 2)],
+        },
+      ],
+      regions: [],
+      assets: [],
+      readingOrder: { edges: [] },
+      lineBoundaryDecisions: [],
+      noteRelationships: [],
+      citationRelationships: [],
+      crossReferenceRelationships: [],
+      visualRelationships: [],
+      provenance: {},
+    } as unknown as PdfReconstruction
+    const extracted = structuredExtractionContextFromReconstruction({
+      reconstruction,
+      split: 'development',
+      layout: 'multi-region',
+    })
+
+    expect(
+      extracted.sourceRuns.map(({ text, order, sourceSequenceIndex }) => ({
+        text,
+        order,
+        sourceSequenceIndex,
+      })),
+    ).toEqual([
+      { text: 'Earlier orphan', order: 0, sourceSequenceIndex: 2 },
+      { text: 'Later orphan', order: 1, sourceSequenceIndex: 9 },
+    ])
+  })
+
+  it('derives exact deterministic asset and source-object ownership for an image-only link', () => {
+    const box = {
+      page: 1,
+      x: 0.1,
+      y: 0.2,
+      width: 0.3,
+      height: 0.2,
+      rotation: 0,
+      method: 'pdf-object' as const,
+    }
+    const reconstruction = {
+      source: {
+        fileName: 'image-link.pdf',
+        byteLength: 100,
+        sha256: sourceSha256,
+        pageCount: 1,
+        localOnly: true,
+      },
+      pages: [
+        {
+          page: 1,
+          kind: 'born-digital',
+          width: 612,
+          height: 792,
+          rotation: 0,
+          textCharacters: 0,
+          imageCount: 1,
+          runs: [],
+          links: [
+            {
+              id: 'image-link',
+              page: 1,
+              status: 'external',
+              url: 'https://example.test/image',
+              box,
+            },
+          ],
+        },
+      ],
+      regions: [],
+      assets: [
+        {
+          id: 'exact-image-asset',
+          href: 'assets/image.png',
+          mediaType: 'image/png',
+          kind: 'raster',
+          rendition: 'source-preserved',
+          bytes: new Uint8Array([1]),
+          sha256: assetSha256,
+          sourceObjectIds: ['native-image-object'],
+          sourceBoxes: [box],
+          sourceCropBox: box,
+        },
+      ],
+      readingOrder: { edges: [] },
+      lineBoundaryDecisions: [],
+      noteRelationships: [],
+      citationRelationships: [],
+      crossReferenceRelationships: [],
+      visualRelationships: [],
+      provenance: {},
+    } as unknown as PdfReconstruction
+
+    const extracted = structuredExtractionContextFromReconstruction({
+      reconstruction,
+      split: 'development',
+      layout: 'one-column',
+    })
+    expect(extracted.sourceLinks).toEqual([
+      expect.objectContaining({
+        id: 'image-link',
+        sourceRunIds: [],
+        sourceAssetIds: ['exact-image-asset'],
+        sourceObjectIds: ['native-image-object'],
+      }),
+    ])
+  })
+
+  it('binds an image-only link to its exact overlapping deterministic asset node', () => {
+    const input = context()
+    input.sourceLinks = [
+      {
+        id: 'image-only-link',
+        page: 1,
+        sourceRunIds: [],
+        sourceAssetIds: ['figure-asset'],
+        sourceObjectIds: ['native-figure'],
+        box: { x: 0.12, y: 0.22, width: 0.1, height: 0.1 },
+        destination: { kind: 'external', url: 'https://example.test/image' },
+      },
+    ]
+    const candidate = validProposal()
+    candidate.links = [
+      { sourceLinkId: 'image-only-link', sourceNodeId: 'figure' },
+    ]
+    const passed = verifyStructuredExtraction(input, candidate)
+    expect(passed.status).toBe('passed')
+
+    candidate.links[0]!.sourceNodeId = 'body'
+    const swapped = verifyStructuredExtraction(input, candidate)
+    expect(swapped.status).toBe('failed')
+    if (swapped.status === 'failed') {
+      expect(swapped.issues.map(({ code }) => code)).toContain('invalid-link')
+    }
+  })
+
+  it('rejects an equal-overlap image link owned by the wrong deterministic asset', () => {
+    const input = context()
+    input.sourceAssets.push({
+      ...structuredClone(input.sourceAssets[0]!),
+      id: 'decoy-asset',
+      required: false,
+      bytesSha256: '3'.repeat(64),
+      sourceObjectIds: ['native-decoy'],
+    })
+    input.sourceLinks = [
+      {
+        id: 'image-only-link',
+        page: 1,
+        sourceRunIds: [],
+        sourceAssetIds: ['figure-asset'],
+        sourceObjectIds: ['native-figure'],
+        box: { x: 0.12, y: 0.22, width: 0.1, height: 0.1 },
+        destination: { kind: 'external', url: 'https://example.test/image' },
+      },
+    ]
+    const candidate = validProposal()
+    candidate.assetIds = ['figure-asset', 'decoy-asset']
+    candidate.nodes[2]!.assetId = 'decoy-asset'
+    candidate.links = [
+      { sourceLinkId: 'image-only-link', sourceNodeId: 'figure' },
+    ]
+    const result = verifyStructuredExtraction(input, candidate)
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues.map(({ code }) => code)).toContain('invalid-link')
+    }
+  })
+
   it('materializes text and alt text from source runs rather than proposal text', () => {
     const proposal = validProposal()
     proposal.nodes[0]!.text = 'A source-backed title'
@@ -155,6 +449,9 @@ describe('source-backed structured extraction verifier', () => {
       sourceRunIds: ['table-head', 'table-value'],
     })
     const candidate = validProposal()
+    candidate.nodes = candidate.nodes.filter(
+      ({ id }) => id !== 'table-source-text',
+    )
     candidate.nodes.push({
       id: 'table',
       type: 'table',
@@ -1070,6 +1367,188 @@ describe('source-backed structured extraction verifier', () => {
       expect(result.issues.map(({ code }) => code)).toContain(
         'invalid-relationship',
       )
+    }
+  })
+
+  it('rejects the omitted right-column heading even when other obligations were selected', () => {
+    const input: StructuredExtractionContext = {
+      documentId: 'three-column-source',
+      sourceSha256,
+      split: 'development',
+      layout: 'multi-region',
+      regionTopology: {
+        regions: [
+          {
+            id: 'left',
+            page: 1,
+            order: 0,
+            role: 'heading',
+            bounds: { x: 0, y: 0, width: 0.3, height: 1 },
+          },
+          {
+            id: 'middle',
+            page: 1,
+            order: 1,
+            role: 'body',
+            bounds: { x: 0.35, y: 0, width: 0.3, height: 1 },
+          },
+          {
+            id: 'right',
+            page: 1,
+            order: 2,
+            role: 'heading',
+            bounds: { x: 0.7, y: 0, width: 0.3, height: 1 },
+          },
+        ],
+        edges: [
+          { fromRegionId: 'left', toRegionId: 'middle' },
+          { fromRegionId: 'middle', toRegionId: 'right' },
+        ],
+      },
+      sourceRuns: [
+        {
+          id: 'left-heading',
+          text: 'Column 1',
+          page: 1,
+          order: 0,
+          regionId: 'left',
+        },
+        {
+          id: 'middle-body',
+          text: 'Middle body.',
+          page: 1,
+          order: 1,
+          regionId: 'middle',
+        },
+        {
+          id: 'right-heading',
+          text: 'Column 3',
+          page: 1,
+          order: 2,
+          regionId: 'right',
+        },
+      ],
+      sourceAssets: [],
+    }
+    const result = verifyStructuredExtraction(input, {
+      schemaVersion: '1.0.0',
+      nodes: [
+        {
+          id: 'left',
+          type: 'heading',
+          level: 2,
+          sourceRunIds: ['left-heading'],
+        },
+        { id: 'middle', type: 'paragraph', sourceRunIds: ['middle-body'] },
+      ],
+    })
+    expect(result.status).toBe('failed')
+    if (result.status === 'failed') {
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'missing-source-run',
+            sourceRunId: 'right-heading',
+          }),
+        ]),
+      )
+    }
+    const restored = verifyStructuredExtraction(input, {
+      schemaVersion: '1.0.0',
+      nodes: [
+        {
+          id: 'left',
+          type: 'heading',
+          level: 2,
+          sourceRunIds: ['left-heading'],
+        },
+        { id: 'middle', type: 'paragraph', sourceRunIds: ['middle-body'] },
+        {
+          id: 'right',
+          type: 'heading',
+          level: 2,
+          sourceRunIds: ['right-heading'],
+        },
+      ],
+    })
+    expect(restored.status).toBe('passed')
+    if (restored.status === 'passed') {
+      expect(restored.output.nodes.at(-1)).toMatchObject({
+        id: 'right',
+        text: 'Column 3',
+      })
+    }
+
+    const laundered = verifyStructuredExtraction(input, {
+      schemaVersion: '1.0.0',
+      nodes: [
+        {
+          id: 'left',
+          type: 'heading',
+          level: 2,
+          sourceRunIds: ['left-heading'],
+        },
+        { id: 'middle', type: 'paragraph', sourceRunIds: ['middle-body'] },
+        {
+          id: 'right',
+          type: 'paragraph',
+          sourceRunIds: ['right-heading'],
+        },
+      ],
+    })
+    expect(laundered.status).toBe('failed')
+    if (laundered.status === 'failed') {
+      expect(laundered.issues.map(({ code }) => code)).toContain(
+        'semantic-role-mismatch',
+      )
+    }
+  })
+
+  it('requires every typed source link to materialize exactly once', () => {
+    const input: StructuredExtractionContext = {
+      documentId: 'linked-source',
+      sourceSha256,
+      split: 'development',
+      layout: 'one-column',
+      sourceRuns: [
+        { id: 'linked-run', text: 'Open source', page: 1, order: 0 },
+      ],
+      sourceAssets: [],
+      sourceLinks: [
+        {
+          id: 'source-link',
+          page: 1,
+          sourceRunIds: ['linked-run'],
+          box: { x: 0.1, y: 0.1, width: 0.2, height: 0.03 },
+          destination: { kind: 'external', url: 'https://example.test/paper' },
+        },
+      ],
+    }
+    const proposal: StructuredExtractionProposal = {
+      schemaVersion: '1.0.0',
+      nodes: [
+        { id: 'linked-node', type: 'paragraph', sourceRunIds: ['linked-run'] },
+      ],
+    }
+    const omitted = verifyStructuredExtraction(input, proposal)
+    expect(omitted.status).toBe('failed')
+    if (omitted.status === 'failed') {
+      expect(omitted.issues.map(({ code }) => code)).toContain('missing-link')
+    }
+
+    proposal.links = [
+      { sourceLinkId: 'source-link', sourceNodeId: 'linked-node' },
+    ]
+    const materialized = verifyStructuredExtraction(input, proposal)
+    expect(materialized.status).toBe('passed')
+    if (materialized.status === 'passed') {
+      expect(materialized.output.links).toEqual([
+        {
+          sourceLinkId: 'source-link',
+          sourceNodeId: 'linked-node',
+          destination: { kind: 'external', url: 'https://example.test/paper' },
+        },
+      ])
     }
   })
 })

--- a/src/research/structured-extraction.ts
+++ b/src/research/structured-extraction.ts
@@ -22,6 +22,7 @@ export const STRUCTURED_EXTRACTION_NODE_TYPES = [
   'equation',
   'footnote',
   'reference',
+  'source-fallback',
 ] as const
 
 export type StructuredExtractionNodeType =
@@ -30,6 +31,7 @@ export type StructuredExtractionNodeType =
 export const STRUCTURED_EXTRACTION_LAYOUTS = [
   'one-column',
   'two-column',
+  'multi-region',
 ] as const
 
 export type StructuredExtractionLayout =
@@ -45,10 +47,13 @@ export type StructuredSourceRun = {
   text: string
   page: number
   order: number
+  sourceSequenceIndex?: number
   /** Stable deterministic line ownership for whitespace-sensitive material. */
   lineId?: string
   /** A source run is already normalized by the deterministic extractor. */
   layout?: StructuredExtractionLayout
+  regionId?: string
+  bounds?: { x: number; y: number; width: number; height: number }
   stratum?: string
 }
 
@@ -61,7 +66,8 @@ export type StructuredSourceLine = {
 
 export type StructuredSourceAsset = {
   id: string
-  kind: 'figure' | 'diagram' | 'table' | 'equation'
+  kind: 'figure' | 'diagram' | 'table' | 'equation' | 'source-fallback'
+  required?: boolean
   page: number
   bounds: {
     x: number
@@ -72,6 +78,32 @@ export type StructuredSourceAsset = {
   bytesSha256: string
   sourceObjectIds: string[]
   captionRunIds?: string[]
+}
+
+export type StructuredRegionTopology = {
+  regions: Array<{
+    id: string
+    page: number
+    order: number
+    role: 'body' | 'heading' | 'figure' | 'table' | 'margin' | 'other'
+    bounds: { x: number; y: number; width: number; height: number }
+  }>
+  edges: Array<{ fromRegionId: string; toRegionId: string }>
+}
+
+export type StructuredSourceLink = {
+  id: string
+  page: number
+  sourceRunIds: string[]
+  /** Exact deterministic assets that own a non-text annotation anchor. */
+  sourceAssetIds?: string[]
+  /** Exact native PDF objects beneath the linked deterministic asset. */
+  sourceObjectIds?: string[]
+  box: { x: number; y: number; width: number; height: number }
+  destination:
+    | { kind: 'external'; url: string }
+    | { kind: 'internal'; targetId: string }
+    | { kind: 'unresolved'; reason: string }
 }
 
 /** Owner-local page evidence shared by every extraction arm. */
@@ -94,6 +126,9 @@ export type StructuredProvenArtifact = {
     | 'line-boundary'
     | 'note-relationship'
     | 'citation-relationship'
+    | 'cross-reference-relationship'
+    | 'visual-relationship'
+    | 'reading-order-relationship'
     | 'source-run-provenance'
   sourceRunIds: string[]
   /** Deterministic destination ownership for note/citation relationships. */
@@ -107,9 +142,11 @@ export type StructuredExtractionContext = {
   sourceSha256: string
   split: StructuredExtractionSplit
   layout: StructuredExtractionLayout
+  regionTopology?: StructuredRegionTopology
   sourceRuns: StructuredSourceRun[]
   sourceLines?: StructuredSourceLine[]
   sourceAssets: StructuredSourceAsset[]
+  sourceLinks?: StructuredSourceLink[]
   pageRenditions?: StructuredExtractionPageRendition[]
   provenArtifacts?: StructuredProvenArtifact[]
   /** These runs remain accounted for but may not enter body flow. */
@@ -153,6 +190,7 @@ export type StructuredExtractionProposal = {
   nodes: StructuredExtractionNode[]
   /** All deterministic assets that the model associates with the flow. */
   assetIds?: string[]
+  links?: Array<{ sourceLinkId: string; sourceNodeId: string }>
   /** Explicit accounting for page furniture omitted from body flow. */
   excludedBoilerplateRunIds?: string[]
   /** Optional model diagnostics are never copied to the publication graph. */
@@ -188,6 +226,12 @@ export type VerifiedStructuredExtraction = {
   assetIds: string[]
   excludedBoilerplateRunIds: string[]
   accountedSourceRunIds: string[]
+  links: Array<{
+    sourceLinkId: string
+    sourceNodeId: string
+    destination: StructuredSourceLink['destination']
+  }>
+  relationshipIds: string[]
 }
 
 export type StructuredExtractionVerificationIssueCode =
@@ -207,6 +251,14 @@ export type StructuredExtractionVerificationIssueCode =
   | 'invalid-heading-level'
   | 'invalid-table'
   | 'invalid-relationship'
+  | 'missing-source-run'
+  | 'missing-asset'
+  | 'duplicate-asset'
+  | 'missing-link'
+  | 'duplicate-link'
+  | 'invalid-link'
+  | 'semantic-role-mismatch'
+  | 'invalid-region-topology'
 
 export type StructuredExtractionVerificationIssue = {
   code: StructuredExtractionVerificationIssueCode
@@ -236,8 +288,19 @@ const sourceRunSchema = z
     text: z.string(),
     page: z.number().int().positive(),
     order: z.number().int().nonnegative(),
+    sourceSequenceIndex: z.number().int().nonnegative().optional(),
     lineId: idSchema.optional(),
     layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS).optional(),
+    regionId: idSchema.optional(),
+    bounds: z
+      .object({
+        x: z.number().finite(),
+        y: z.number().finite(),
+        width: z.number().positive(),
+        height: z.number().positive(),
+      })
+      .strict()
+      .optional(),
     stratum: z.string().min(1).optional(),
   })
   .strict()
@@ -245,7 +308,8 @@ const sourceRunSchema = z
 const sourceAssetSchema = z
   .object({
     id: idSchema,
-    kind: z.enum(['figure', 'diagram', 'table', 'equation']),
+    kind: z.enum(['figure', 'diagram', 'table', 'equation', 'source-fallback']),
+    required: z.boolean().optional(),
     page: z.number().int().positive(),
     bounds: z
       .object({
@@ -258,6 +322,59 @@ const sourceAssetSchema = z
     bytesSha256: sha256Schema,
     sourceObjectIds: z.array(idSchema),
     captionRunIds: z.array(idSchema).optional(),
+  })
+  .strict()
+
+const boundsSchema = z
+  .object({
+    x: z.number().finite(),
+    y: z.number().finite(),
+    width: z.number().positive(),
+    height: z.number().positive(),
+  })
+  .strict()
+
+const regionTopologySchema = z
+  .object({
+    regions: z.array(
+      z
+        .object({
+          id: idSchema,
+          page: z.number().int().positive(),
+          order: z.number().int().nonnegative(),
+          role: z.enum([
+            'body',
+            'heading',
+            'figure',
+            'table',
+            'margin',
+            'other',
+          ]),
+          bounds: boundsSchema,
+        })
+        .strict(),
+    ),
+    edges: z.array(
+      z.object({ fromRegionId: idSchema, toRegionId: idSchema }).strict(),
+    ),
+  })
+  .strict()
+
+const sourceLinkSchema = z
+  .object({
+    id: idSchema,
+    page: z.number().int().positive(),
+    sourceRunIds: z.array(idSchema),
+    sourceAssetIds: z.array(idSchema).optional(),
+    sourceObjectIds: z.array(idSchema).optional(),
+    box: boundsSchema,
+    destination: z.discriminatedUnion('kind', [
+      z.object({ kind: z.literal('external'), url: z.string().url() }).strict(),
+      z.object({ kind: z.literal('internal'), targetId: idSchema }).strict(),
+      z
+        .object({ kind: z.literal('unresolved'), reason: z.string().min(1) })
+        .strict(),
+    ]),
   })
   .strict()
 
@@ -294,6 +411,9 @@ const sourceArtifactSchema = z
       'line-boundary',
       'note-relationship',
       'citation-relationship',
+      'cross-reference-relationship',
+      'visual-relationship',
+      'reading-order-relationship',
       'source-run-provenance',
     ]),
     sourceRunIds: z.array(idSchema),
@@ -308,9 +428,11 @@ const contextSchema = z
     sourceSha256: sha256Schema,
     split: z.enum(STRUCTURED_EXTRACTION_SPLITS),
     layout: z.enum(STRUCTURED_EXTRACTION_LAYOUTS),
+    regionTopology: regionTopologySchema.optional(),
     sourceRuns: z.array(sourceRunSchema),
     sourceLines: z.array(sourceLineSchema).optional(),
     sourceAssets: z.array(sourceAssetSchema),
+    sourceLinks: z.array(sourceLinkSchema).optional(),
     pageRenditions: z.array(pageRenditionSchema).min(1).optional(),
     provenArtifacts: z.array(sourceArtifactSchema).optional(),
     boilerplateRunIds: z.array(idSchema).optional(),
@@ -364,10 +486,47 @@ const proposalSchema = z
     schemaVersion: z.literal(STRUCTURED_EXTRACTION_SCHEMA_VERSION).optional(),
     nodes: z.array(nodeSchema).min(1),
     assetIds: z.array(idSchema).optional(),
+    links: z
+      .array(
+        z.object({ sourceLinkId: idSchema, sourceNodeId: idSchema }).strict(),
+      )
+      .optional(),
     excludedBoilerplateRunIds: z.array(idSchema).optional(),
     diagnostics: z.array(z.string()).optional(),
   })
   .strict()
+
+function physicalRunIdentity(run: {
+  page: number
+  text: string
+  x: number
+  y: number
+  width: number
+  height: number
+  rotation: number
+  method: string
+  fontName: string
+  fontSize: number
+  sourceSequenceIndex?: number
+}) {
+  return JSON.stringify(
+    Number.isSafeInteger(run.sourceSequenceIndex)
+      ? ['source-sequence', run.page, run.sourceSequenceIndex]
+      : [
+          'source-geometry',
+          run.page,
+          run.text,
+          run.x,
+          run.y,
+          run.width,
+          run.height,
+          run.rotation,
+          run.method,
+          run.fontName,
+          run.fontSize,
+        ],
+  )
+}
 
 /**
  * Adapt the deterministic PDF reconstruction into the arm-neutral context.
@@ -392,12 +551,18 @@ export function structuredExtractionContextFromReconstruction({
   const sourceRuns: StructuredSourceRun[] = []
   const sourceLines: StructuredSourceLine[] = []
   const runIdsByKey = new Map<string, string>()
+  const regionRunCounts = new Map<string, number>()
   let order = 0
   for (const region of reconstruction.regions) {
     for (const line of region.lines) {
       const lineId = `${region.id}:${line.id}`
       const sourceRunIds: string[] = []
       for (const [runIndex, run] of line.runs.entries()) {
+        const physicalIdentity = physicalRunIdentity(run)
+        regionRunCounts.set(
+          physicalIdentity,
+          (regionRunCounts.get(physicalIdentity) ?? 0) + 1,
+        )
         const id = `r-${region.id}-${line.id}-${runIndex}`
         sourceRunIds.push(id)
         runIdsByKey.set(`${region.id}\u0000${line.id}\u0000${runIndex}`, id)
@@ -406,8 +571,18 @@ export function structuredExtractionContextFromReconstruction({
           text: run.text,
           page: run.page,
           order: order++,
+          ...(Number.isSafeInteger(run.sourceSequenceIndex)
+            ? { sourceSequenceIndex: run.sourceSequenceIndex }
+            : {}),
           lineId,
           layout,
+          regionId: region.id,
+          bounds: {
+            x: run.x,
+            y: run.y,
+            width: run.width,
+            height: run.height,
+          },
           ...(stratum ? { stratum } : {}),
         })
       }
@@ -416,6 +591,51 @@ export function structuredExtractionContextFromReconstruction({
       }
     }
   }
+  const unmatchedRegionRunCounts = new Map(regionRunCounts)
+  for (const page of [...reconstruction.pages].sort(
+    (left, right) => left.page - right.page,
+  )) {
+    for (const [runIndex, run] of page.runs.entries()) {
+      const physicalIdentity = physicalRunIdentity(run)
+      const remaining = unmatchedRegionRunCounts.get(physicalIdentity) ?? 0
+      if (remaining > 0) {
+        unmatchedRegionRunCounts.set(physicalIdentity, remaining - 1)
+        continue
+      }
+      sourceRuns.push({
+        id: `r-page-${page.page}-${runIndex}`,
+        text: run.text,
+        page: run.page,
+        order: order++,
+        ...(Number.isSafeInteger(run.sourceSequenceIndex)
+          ? { sourceSequenceIndex: run.sourceSequenceIndex }
+          : {}),
+        layout,
+        bounds: {
+          x: run.x,
+          y: run.y,
+          width: run.width,
+          height: run.height,
+        },
+        ...(stratum ? { stratum } : {}),
+      })
+    }
+  }
+  sourceRuns
+    .sort((left, right) => {
+      if (left.page !== right.page) return left.page - right.page
+      if (
+        left.sourceSequenceIndex !== undefined &&
+        right.sourceSequenceIndex !== undefined &&
+        left.sourceSequenceIndex !== right.sourceSequenceIndex
+      ) {
+        return left.sourceSequenceIndex - right.sourceSequenceIndex
+      }
+      return left.order - right.order
+    })
+    .forEach((run, sourceOrder) => {
+      run.order = sourceOrder
+    })
   const runIdsForRegion = (regionId: string) => {
     const region = reconstruction.regions.find(({ id }) => id === regionId)
     if (!region) return []
@@ -433,43 +653,170 @@ export function structuredExtractionContextFromReconstruction({
           runIdsForRegion,
         )
       : []
-  const sourceAssets: StructuredSourceAsset[] = reconstruction.assets.map(
-    (asset) => {
-      const relationship = reconstruction.visualRelationships.find(
-        ({ assetIds }) => assetIds.includes(asset.id),
-      )
-      const kind: StructuredSourceAsset['kind'] =
-        asset.kind === 'table'
+  const retainedAssets = [
+    ...reconstruction.assets,
+    ...reconstruction.pages
+      .flatMap(({ assets }) => assets ?? [])
+      .filter(
+        (asset) =>
+          asset.rendition === 'source-page-render' &&
+          !reconstruction.assets.some(({ id }) => id === asset.id),
+      ),
+  ]
+  const sourceAssets: StructuredSourceAsset[] = retainedAssets.map((asset) => {
+    const relationship = reconstruction.visualRelationships.find(
+      ({ assetIds }) => assetIds.includes(asset.id),
+    )
+    const kind: StructuredSourceAsset['kind'] =
+      asset.rendition === 'source-page-render'
+        ? 'source-fallback'
+        : asset.kind === 'table'
           ? 'table'
           : asset.kind === 'equation'
             ? 'equation'
             : relationship?.kind === 'figure'
               ? 'figure'
               : 'diagram'
-      const box = asset.sourceCropBox ?? asset.sourceBoxes[0]
-      return {
-        id: asset.id,
-        kind,
-        page: box?.page ?? 1,
-        bounds: {
-          x: box?.x ?? 0,
-          y: box?.y ?? 0,
-          width: box?.width ?? 0.001,
-          height: box?.height ?? 0.001,
-        },
-        bytesSha256: asset.sha256,
-        sourceObjectIds: [...asset.sourceObjectIds],
-        ...(relationship
-          ? { captionRunIds: runIdsForRegion(relationship.captionRegionId) }
-          : {}),
-      }
-    },
-  )
+    const box = asset.sourceCropBox ?? asset.sourceBoxes[0]
+    return {
+      id: asset.id,
+      kind,
+      page: box?.page ?? 1,
+      bounds: {
+        x: box?.x ?? 0,
+        y: box?.y ?? 0,
+        width: box?.width ?? 0.001,
+        height: box?.height ?? 0.001,
+      },
+      bytesSha256: asset.sha256,
+      sourceObjectIds: [...asset.sourceObjectIds],
+      ...(relationship
+        ? { captionRunIds: runIdsForRegion(relationship.captionRegionId) }
+        : {}),
+    }
+  })
   const boilerplateRunIds = reconstruction.regions
     .filter((region) =>
       ['header', 'footer', 'page-number'].includes(region.kind),
     )
     .flatMap(({ id }) => runIdsForRegion(id))
+  const regionTopology: StructuredRegionTopology = {
+    regions: reconstruction.regions.map((region, regionOrder) => ({
+      id: region.id,
+      page: region.page,
+      order: regionOrder,
+      role: ['heading', 'figure', 'table'].includes(region.kind)
+        ? (region.kind as 'heading' | 'figure' | 'table')
+        : ['header', 'footer', 'page-number'].includes(region.kind)
+          ? 'margin'
+          : 'body',
+      bounds: {
+        x: region.box.x,
+        y: region.box.y,
+        width: region.box.width,
+        height: region.box.height,
+      },
+    })),
+    edges: reconstruction.readingOrder.edges
+      .filter(({ status }) => status === 'accepted')
+      .map(({ from, to }) => ({ fromRegionId: from, toRegionId: to })),
+  }
+  const sourceLinks: StructuredSourceLink[] = reconstruction.pages.flatMap(
+    (page) =>
+      (page.links ?? []).map((link, linkIndex) => {
+        const box = 'box' in link && link.box ? link.box : null
+        const linkId =
+          'id' in link && typeof link.id === 'string'
+            ? link.id
+            : `link-${page.page}-${linkIndex + 1}`
+        const provenRegionIds = Object.values(reconstruction.provenance)
+          .filter(({ links }) =>
+            links.some(
+              (provenLink) =>
+                ('id' in provenLink && provenLink.id === linkId) ||
+                (!('id' in provenLink) &&
+                  !('id' in link) &&
+                  provenLink.url === link.url),
+            ),
+          )
+          .flatMap(({ regionIds }) => regionIds)
+        const sourceRunIds = [
+          ...new Set(
+            provenRegionIds.length > 0
+              ? provenRegionIds.flatMap(runIdsForRegion)
+              : sourceRuns
+                  .filter(
+                    (run) =>
+                      box !== null &&
+                      run.page === page.page &&
+                      run.bounds !== undefined &&
+                      Math.max(run.bounds.x, box.x) <
+                        Math.min(
+                          run.bounds.x + run.bounds.width,
+                          box.x + box.width,
+                        ) &&
+                      Math.max(run.bounds.y, box.y) <
+                        Math.min(
+                          run.bounds.y + run.bounds.height,
+                          box.y + box.height,
+                        ),
+                  )
+                  .map(({ id }) => id),
+          ),
+        ]
+        const destination: StructuredSourceLink['destination'] =
+          'status' in link && link.status === 'internal'
+            ? { kind: 'internal', targetId: link.destination }
+            : 'url' in link && typeof link.url === 'string'
+              ? { kind: 'external', url: link.url }
+              : {
+                  kind: 'unresolved',
+                  reason:
+                    'reason' in link && typeof link.reason === 'string'
+                      ? link.reason
+                      : 'unresolved-source-annotation',
+                }
+        const overlappingAssets = sourceAssets.filter(
+          (asset) =>
+            box !== null &&
+            asset.page === page.page &&
+            Math.max(asset.bounds.x, box.x) <
+              Math.min(
+                asset.bounds.x + asset.bounds.width,
+                box.x + box.width,
+              ) &&
+            Math.max(asset.bounds.y, box.y) <
+              Math.min(
+                asset.bounds.y + asset.bounds.height,
+                box.y + box.height,
+              ),
+        )
+        return {
+          id: linkId,
+          page: page.page,
+          sourceRunIds,
+          ...(sourceRunIds.length === 0
+            ? {
+                sourceAssetIds: overlappingAssets.map(({ id }) => id).sort(),
+                sourceObjectIds: [
+                  ...new Set(
+                    overlappingAssets.flatMap(({ sourceObjectIds }) =>
+                      sourceObjectIds,
+                    ),
+                  ),
+                ].sort(),
+              }
+            : {}),
+          box: {
+            x: box?.x ?? 0,
+            y: box?.y ?? 0,
+            width: box?.width ?? 1,
+            height: box?.height ?? 1,
+          },
+          destination,
+        }
+      }),
+  )
   const provenArtifacts: StructuredProvenArtifact[] = [
     ...reconstruction.regions.map((region) => ({
       id: region.id,
@@ -502,6 +849,31 @@ export function structuredExtractionContextFromReconstruction({
       sourceRunIds: [relationship.referenceRegionId].flatMap(runIdsForRegion),
       targetSourceRunIdGroups: relationship.targetNodeIds.map(runIdsForNode),
     })),
+    ...reconstruction.crossReferenceRelationships.map((relationship) => ({
+      id: relationship.id,
+      kind: 'cross-reference-relationship' as const,
+      sourceRunIds: runIdsForRegion(relationship.referenceRegionId),
+      targetSourceRunIdGroups: relationship.targets
+        .map(({ targetNodeId }) => runIdsForNode(targetNodeId))
+        .filter((group) => group.length > 0),
+    })),
+    ...reconstruction.visualRelationships.map((relationship) => ({
+      id: relationship.id,
+      kind: 'visual-relationship' as const,
+      sourceRunIds: [
+        ...relationship.sourceRegionIds,
+        relationship.captionRegionId,
+      ].flatMap(runIdsForRegion),
+    })),
+    ...reconstruction.readingOrder.edges
+      .filter(({ status }) => status === 'accepted')
+      .map((relationship) => ({
+        id: relationship.id,
+        kind: 'reading-order-relationship' as const,
+        sourceRunIds: [relationship.from, relationship.to].flatMap(
+          runIdsForRegion,
+        ),
+      })),
     {
       id: 'source-run-provenance',
       kind: 'source-run-provenance' as const,
@@ -513,9 +885,11 @@ export function structuredExtractionContextFromReconstruction({
     sourceSha256: reconstruction.source.sha256,
     split,
     layout,
+    ...(layout === 'multi-region' ? { regionTopology } : {}),
     sourceRuns,
     sourceLines,
     sourceAssets,
+    ...(sourceLinks.length > 0 ? { sourceLinks } : {}),
     ...(pageRenditions ? { pageRenditions } : {}),
     provenArtifacts,
     boilerplateRunIds,
@@ -638,6 +1012,10 @@ function nodeOwnedSourceRunIds(node: StructuredExtractionNode) {
         ) ?? [])
       : []),
   ]
+}
+
+function canonicalStringSet(values: readonly string[]) {
+  return JSON.stringify([...new Set(values)].sort())
 }
 
 function issue(
@@ -1229,7 +1607,13 @@ export function verifyStructuredExtraction(
   const assetsById = new Map(
     context.sourceAssets.map((asset) => [asset.id, asset]),
   )
+  const linksById = new Map(
+    (context.sourceLinks ?? []).map((link) => [link.id, link]),
+  )
   const nodesById = new Map(proposal.nodes.map((node) => [node.id, node]))
+  const regionRoleById = new Map(
+    (context.regionTopology?.regions ?? []).map(({ id, role }) => [id, role]),
+  )
   const claimed = new Set<string>()
   const boilerplate = new Set(context.boilerplateRunIds ?? [])
   const excluded = new Set(proposal.excludedBoilerplateRunIds ?? [])
@@ -1252,6 +1636,42 @@ export function verifyStructuredExtraction(
     issues.push(
       issue('invalid-output', 'Deterministic source line IDs must be unique.'),
     )
+  }
+  if (context.layout === 'multi-region' && !context.regionTopology) {
+    issues.push(
+      issue(
+        'invalid-region-topology',
+        'Multi-region extraction requires a typed region topology.',
+      ),
+    )
+  }
+  if (context.regionTopology) {
+    const regionIds = new Set(
+      context.regionTopology.regions.map(({ id }) => id),
+    )
+    const regionOrders = new Set(
+      context.regionTopology.regions.map(({ order }) => order),
+    )
+    if (
+      regionIds.size !== context.regionTopology.regions.length ||
+      regionOrders.size !== context.regionTopology.regions.length ||
+      context.regionTopology.edges.some(
+        ({ fromRegionId, toRegionId }) =>
+          fromRegionId === toRegionId ||
+          !regionIds.has(fromRegionId) ||
+          !regionIds.has(toRegionId),
+      ) ||
+      context.sourceRuns.some(
+        ({ regionId }) => regionId !== undefined && !regionIds.has(regionId),
+      )
+    ) {
+      issues.push(
+        issue(
+          'invalid-region-topology',
+          'Region IDs, orders, edges, and source-run ownership must form one closed topology.',
+        ),
+      )
+    }
   }
   const lineOwnedRunIds = new Set<string>()
   for (const line of context.sourceLines ?? []) {
@@ -1288,6 +1708,38 @@ export function verifyStructuredExtraction(
       ),
     )
   }
+  if (linksById.size !== (context.sourceLinks ?? []).length) {
+    issues.push(
+      issue('invalid-link', 'Deterministic source link IDs must be unique.'),
+    )
+  }
+  for (const sourceLink of context.sourceLinks ?? []) {
+    if (
+      new Set(sourceLink.sourceAssetIds ?? []).size !==
+        (sourceLink.sourceAssetIds ?? []).length ||
+      new Set(sourceLink.sourceObjectIds ?? []).size !==
+        (sourceLink.sourceObjectIds ?? []).length
+    ) {
+      issues.push(
+        issue(
+          'invalid-link',
+          `Deterministic source link ${sourceLink.id} has duplicate asset ownership.`,
+        ),
+      )
+    }
+    if (
+      sourceLink.sourceRunIds.length === 0 &&
+      ((sourceLink.sourceAssetIds?.length ?? 0) === 0 ||
+        (sourceLink.sourceObjectIds?.length ?? 0) === 0)
+    ) {
+      issues.push(
+        issue(
+          'invalid-link',
+          `Image-only link ${sourceLink.id} must name its exact deterministic asset and source objects.`,
+        ),
+      )
+    }
+  }
 
   if (nodesById.size !== proposal.nodes.length) {
     issues.push(issue('invalid-output', 'Node identifiers must be unique.'))
@@ -1322,6 +1774,22 @@ export function verifyStructuredExtraction(
         issue(
           'invalid-heading-level',
           'Headings require a level from 1 through 6.',
+          { nodeId: node.id },
+        ),
+      )
+    }
+    if (
+      node.type !== 'heading' &&
+      node.sourceRunIds.some(
+        (sourceRunId) =>
+          regionRoleById.get(runsById.get(sourceRunId)?.regionId ?? '') ===
+          'heading',
+      )
+    ) {
+      issues.push(
+        issue(
+          'semantic-role-mismatch',
+          `Heading-region source runs cannot be laundered into ${node.type}.`,
           { nodeId: node.id },
         ),
       )
@@ -1495,9 +1963,46 @@ export function verifyStructuredExtraction(
     }
   }
 
+  for (const sourceRun of context.sourceRuns) {
+    if (!boilerplate.has(sourceRun.id) && !claimed.has(sourceRun.id)) {
+      issues.push(
+        issue(
+          'missing-source-run',
+          `Non-boilerplate source run ${sourceRun.id} has no materialized owner or bounded source fallback.`,
+          { sourceRunId: sourceRun.id },
+        ),
+      )
+    }
+  }
+
+  const proposalAssetIds = proposal.assetIds ?? []
+  if (new Set(proposalAssetIds).size !== proposalAssetIds.length) {
+    issues.push(
+      issue('duplicate-asset', 'Materialized asset IDs must be unique.'),
+    )
+  }
+  const nodeAssetCounts = new Map<string, number>()
+  for (const node of proposal.nodes) {
+    if (!node.assetId) continue
+    nodeAssetCounts.set(
+      node.assetId,
+      (nodeAssetCounts.get(node.assetId) ?? 0) + 1,
+    )
+  }
+  for (const [assetId, count] of nodeAssetCounts) {
+    if (count > 1) {
+      issues.push(
+        issue(
+          'duplicate-asset',
+          `Deterministic asset ${assetId} has more than one materialized owner.`,
+          { assetId },
+        ),
+      )
+    }
+  }
   const assetIds = [
     ...new Set([
-      ...(proposal.assetIds ?? []),
+      ...proposalAssetIds,
       ...proposal.nodes.flatMap((node) => (node.assetId ? [node.assetId] : [])),
     ]),
   ]
@@ -1509,8 +2014,128 @@ export function verifyStructuredExtraction(
         }),
       )
   }
+  for (const asset of context.sourceAssets) {
+    if ((asset.required ?? true) && !assetIds.includes(asset.id)) {
+      issues.push(
+        issue(
+          'missing-asset',
+          `Required deterministic asset ${asset.id} has no materialized asset or bounded source fallback.`,
+          { assetId: asset.id },
+        ),
+      )
+    }
+  }
+
+  const claimedLinks = new Set<string>()
+  const materializedLinks: VerifiedStructuredExtraction['links'] = []
+  for (const proposedLink of proposal.links ?? []) {
+    const sourceLink = linksById.get(proposedLink.sourceLinkId)
+    const sourceNode = nodesById.get(proposedLink.sourceNodeId)
+    if (!sourceLink || !sourceNode) {
+      issues.push(
+        issue(
+          'invalid-link',
+          `Link ${proposedLink.sourceLinkId} must name a deterministic source link and materialized source node.`,
+          { nodeId: proposedLink.sourceNodeId },
+        ),
+      )
+      continue
+    }
+    if (claimedLinks.has(sourceLink.id)) {
+      issues.push(
+        issue(
+          'duplicate-link',
+          `Source link ${sourceLink.id} has more than one materialized owner.`,
+          { nodeId: sourceNode.id },
+        ),
+      )
+      continue
+    }
+    if (
+      sourceLink.sourceRunIds.length > 0 &&
+      !sourceLink.sourceRunIds.some((id) =>
+        nodeOwnedSourceRunIds(sourceNode).includes(id),
+      )
+    ) {
+      issues.push(
+        issue(
+          'invalid-link',
+          `Source node ${sourceNode.id} does not own the source anchor for link ${sourceLink.id}.`,
+          { nodeId: sourceNode.id },
+        ),
+      )
+      continue
+    }
+    if (sourceLink.sourceRunIds.length === 0) {
+      const anchoredAsset = sourceNode.assetId
+        ? assetsById.get(sourceNode.assetId)
+        : undefined
+      const exactAssetOwner =
+        anchoredAsset !== undefined &&
+        (sourceLink.sourceAssetIds ?? []).length === 1 &&
+        sourceLink.sourceAssetIds![0] === anchoredAsset.id &&
+        canonicalStringSet(anchoredAsset.sourceObjectIds) ===
+          canonicalStringSet(sourceLink.sourceObjectIds ?? [])
+      const overlaps =
+        anchoredAsset !== undefined &&
+        anchoredAsset.page === sourceLink.page &&
+        Math.max(anchoredAsset.bounds.x, sourceLink.box.x) <
+          Math.min(
+            anchoredAsset.bounds.x + anchoredAsset.bounds.width,
+            sourceLink.box.x + sourceLink.box.width,
+          ) &&
+        Math.max(anchoredAsset.bounds.y, sourceLink.box.y) <
+          Math.min(
+            anchoredAsset.bounds.y + anchoredAsset.bounds.height,
+            sourceLink.box.y + sourceLink.box.height,
+          )
+      if (!exactAssetOwner || !overlaps) {
+        issues.push(
+          issue(
+            'invalid-link',
+            `Image-only link ${sourceLink.id} must be owned by the exact overlapping deterministic asset node.`,
+            { nodeId: sourceNode.id },
+          ),
+        )
+        continue
+      }
+    }
+    if (sourceLink.destination.kind === 'external') {
+      const protocol = new URL(sourceLink.destination.url).protocol
+      if (!['http:', 'https:', 'mailto:'].includes(protocol)) {
+        issues.push(
+          issue(
+            'invalid-link',
+            `Source link ${sourceLink.id} has an unsafe external destination.`,
+            { nodeId: sourceNode.id },
+          ),
+        )
+        continue
+      }
+    }
+    claimedLinks.add(sourceLink.id)
+    materializedLinks.push({
+      sourceLinkId: sourceLink.id,
+      sourceNodeId: sourceNode.id,
+      destination: structuredClone(sourceLink.destination),
+    })
+  }
+  for (const sourceLink of context.sourceLinks ?? []) {
+    if (!claimedLinks.has(sourceLink.id)) {
+      issues.push(
+        issue(
+          'missing-link',
+          `Deterministic source link ${sourceLink.id} has no materialized link or unresolved source-preserved fallback.`,
+        ),
+      )
+    }
+  }
   const accountedSourceRunIds = [...new Set([...claimed, ...excluded])].sort()
   if (issues.length > 0) return { status: 'failed', output: null, issues }
+  const relationshipIds = (context.provenArtifacts ?? [])
+    .filter(({ kind }) => kind.endsWith('-relationship'))
+    .map(({ id }) => id)
+    .sort()
   return {
     status: 'passed',
     issues: [],
@@ -1522,6 +2147,10 @@ export function verifyStructuredExtraction(
       assetIds: assetIds.sort(),
       excludedBoilerplateRunIds: [...excluded].sort(),
       accountedSourceRunIds,
+      links: materializedLinks.sort((left, right) =>
+        left.sourceLinkId.localeCompare(right.sourceLinkId),
+      ),
+      relationshipIds,
     },
   }
 }
@@ -1556,6 +2185,17 @@ export function modelInputForStructuredExtraction(
     sourceSha256: context.sourceSha256,
     split: context.split,
     layout: context.layout,
+    ...(context.regionTopology
+      ? {
+          regionTopology: {
+            regions: context.regionTopology.regions.map((region) => ({
+              ...region,
+              bounds: { ...region.bounds },
+            })),
+            edges: context.regionTopology.edges.map((edge) => ({ ...edge })),
+          },
+        }
+      : {}),
     sourceRuns: context.sourceRuns.map((run) => ({ ...run })),
     ...(context.sourceLines
       ? {
@@ -1573,6 +2213,22 @@ export function modelInputForStructuredExtraction(
         ? { captionRunIds: [...asset.captionRunIds] }
         : {}),
     })),
+    ...(context.sourceLinks
+      ? {
+          sourceLinks: context.sourceLinks.map((link) => ({
+            ...link,
+            sourceRunIds: [...link.sourceRunIds],
+            ...(link.sourceAssetIds
+              ? { sourceAssetIds: [...link.sourceAssetIds] }
+              : {}),
+            ...(link.sourceObjectIds
+              ? { sourceObjectIds: [...link.sourceObjectIds] }
+              : {}),
+            box: { ...link.box },
+            destination: { ...link.destination },
+          })),
+        }
+      : {}),
     ...(context.pageRenditions
       ? {
           pageRenditions: context.pageRenditions.map((rendition) => ({


### PR DESCRIPTION
## What changed

- Adds the provider-neutral PdfEvidenceBundle and SourceEvidenceGraph contracts for mandatory deterministic PDF evidence plus authenticated MinerU evidence.
- Adds the sealed owner-local MinerU 3.4.4 runner and manifest verifier with pinned runtime, backend, model, config, cache, source and artifact identities under bounded storage and process contracts.
- Adds source conservation, typed links and destinations, multi-column topology, provider-neutral candidate resolution, grounded STRUCT verification, and all 19 expected-observation payload commitments consumed by the merged #203 evaluator contracts.
- Adds the owner-local Codex app-server reconciliation transport and receipt boundary. It accepts only bounded source-backed candidate evidence and can select candidate IDs or abstain; it cannot invent text, geometry, assets or destinations.
- Uses one canonical code-unit order for MinerU runtime-tree preflight and sealed-tree inventories, with a regression for `bin` versus `CACHEDIR.TAG` ordering.
- Gates the two live namespace probes on the exact user+network namespace command capability. Unsupported hosted kernels skip with an explicit reason, while production remains fail-closed with no fallback and the trusted VM still executes the live probes.
- Updates the existing Struct Typeset skill with executable owner-local runner, reconciliation, evidence and validation contracts.

## Scope and current hold

This draft publishes the independently reviewed parser/provider and contract slice for #198, plus the narrow sealed-runner repairs exposed by the bounded provider pilot. Current exact head: `9af5035772859a7126d355ca6446fa3dcf52eb0f`.

Issue completion remains held. The bounded owner-local provider/parser pilot completed for born-digital, scan/OCR, figure-heavy, table/formula-heavy, and a separate malformed negative. It authenticates parser/provider graphs and all 19 source-observation commitments only; this PR does not claim reconstruction or product success.

Still intentionally out of scope:

- #200 grounded materialization implementation
- actual downloadable EPUB, renderer and final comparator evidence
- calibrated judge or side-by-side review UX
- frozen 20-document evaluation
- deployment or merge

The merged #203 evaluator contract is consumed without changing its effective main-branch content. Refs #198; this draft does not close it.

## Validation

- Current-head focused parser/provider/contract suites: 182/182 passed.
- Current-head `npx tsc --noEmit`: passed.
- Current-head `npm run build:staging`: passed; Astro reported 0 errors and 0 warnings, 28 existing hints, and 132 pages built.
- Current-head full repository suite: 3,624/3,624 passed, 4 skipped; association audit: 5/5 passed. The trusted VM executed both live isolation probes.
- Current-head diff/whitespace and high-signal secret scans: passed.
- Exact-head GitHub evidence is running. The earlier hosted-kernel failure was limited to unsupported user/network namespace creation in two live test probes; the production command and fail-closed behavior were not weakened.
- Retained pilot packet: `/private/tmp/erniesg-issue198-pilot-b3fcfc7.phEQk1/packet/pilot-packet.json`, SHA-256 `046f13dd821691a8d6c10bfda39b4367c692631f28311518438fa3afabf060f0`. It contains four current-schema success cases and one malformed negative, with each graph, contract, and all 19 payload hashes reopened.
- The provider execution head was `b3fcfc7bff993573bdf0e48848c045ec9dbc8601`. The publication head adds only `src/research/mineru-owner-local-runner.test.ts`; an explicit non-relabelling rebind receipt records that test-only diff at `/private/tmp/erniesg-issue198-pilot-b3fcfc7.phEQk1/packet/publication-head-rebind.json`, SHA-256 `b14077f097495969e29bd05b0e718348fa4aaf007543dab06b9d0c0b9afb3bf7`.
- Real public synthetic owner-local Codex app-server receipt remains bound to the unchanged contract: `/private/tmp/erniesg-issue198-real-codex-receipt.json`, SHA-256 `bc067d38608f1735a3d7aed85075c1d7d2823b0f6a3e6c6a0bf9ddb2dba8e0af`. It contains no hosted PDF or API key and is not a product pilot.

No private PDF, hosted upload, model re-download, deployment or final corpus run was performed for publication.
