### PR TITLE
Add app-owned STRUCT publication conversion

### DIFF
--- a/src/publication/adapter-registry.ts
+++ b/src/publication/adapter-registry.ts
@@ -5,6 +5,7 @@ import {
 } from './source-adapter'
 import { astroPublicationAdapter } from './adapters/astro'
 import { payloadLexicalSourceAdapter } from './adapters/payload-lexical'
+import { structPublicationAdapter } from './struct-adapter'
 
 export type PublicationBundle = PublicationSourceResult
 
@@ -55,4 +56,5 @@ export function createDefaultPublicationAdapterRegistry() {
   return new PublicationAdapterRegistry()
     .register(astroPublicationAdapter)
     .register(payloadLexicalSourceAdapter)
+    .register(structPublicationAdapter)
 }

--- a/src/publication/source-adapter.ts
+++ b/src/publication/source-adapter.ts
@@ -64,7 +64,7 @@ export type PublicationContractReceipt = z.infer<
   typeof publicationContractReceiptSchema
 >
 
-function safeSourceId(value: string) {
+export function isSafePublicationSourceId(value: string) {
   let decoded = value
   try {
     decoded = decodeURIComponent(value)
@@ -90,7 +90,7 @@ const safeSourceIdSchema = z
   .min(1)
   .max(2_048)
   .refine(
-    safeSourceId,
+    isSafePublicationSourceId,
     'Source ids cannot contain local paths or secret material',
   )
 

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -384,6 +384,137 @@ describe('STRUCT publication adapter', () => {
     expect(adaptStructDocument(input).graph).toEqual(result.graph)
   })
 
+  it('maps the #212 mixed asset and caption endpoint shape without fallback assets or unresolved diagnostics', () => {
+    const input = document([
+      block({
+        id: 'figure',
+        kind: 'figure',
+        text: 'Figure source',
+        label: 'A figure',
+        order: 0,
+      }),
+      block({
+        id: 'figure-caption',
+        kind: 'caption',
+        text: 'Figure caption',
+        order: 1,
+      }),
+    ])
+    input.relationships = [
+      {
+        id: 'figure-relation',
+        kind: 'figure',
+        from: 'figure',
+        to: ['figure-asset', 'figure-caption'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    const figure = result.graph.nodes.find((node) => node.id === 'figure')
+    const caption = result.graph.nodes.find(
+      (node) => node.id === 'figure-caption',
+    )
+
+    expect(figure).toMatchObject({
+      type: 'figure',
+      assetIds: ['figure-asset'],
+      captionId: 'figure-caption',
+    })
+    expect(caption).toMatchObject({
+      type: 'caption',
+      parentId: 'figure',
+      text: 'Figure caption',
+    })
+    expect(result.diagnostics.map(({ code }) => code)).not.toContain(
+      'unresolved-relationship-target',
+    )
+  })
+
+  it.each([
+    {
+      kind: 'table' as const,
+      parent: block({
+        id: 'table',
+        kind: 'table',
+        text: 'Table source',
+        order: 0,
+        table: {
+          rows: 1,
+          columns: 1,
+          semantic: 'verified',
+          cells: [
+            {
+              id: 'table-cell',
+              text: 'Cell',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+          ],
+        },
+      }),
+    },
+    {
+      kind: 'equation' as const,
+      parent: block({
+        id: 'equation',
+        kind: 'equation',
+        text: 'x = y',
+        order: 0,
+      }),
+    },
+  ])(
+    'maps the #212 mixed asset and caption endpoint shape for $kind',
+    ({ kind, parent }) => {
+      const captionId = `${kind}-caption`
+      const input = document([
+        parent,
+        block({
+          id: captionId,
+          kind: 'caption',
+          text: `${kind} caption`,
+          order: 1,
+        }),
+      ])
+      input.relationships = [
+        {
+          id: `${kind}-relation`,
+          kind,
+          from: kind,
+          to: ['figure-asset', captionId],
+          status: 'matched',
+          confidence: 1,
+          evidence,
+        },
+      ]
+
+      const result = adaptStructDocument(input)
+
+      expect(result.graph.nodes.find((node) => node.id === kind)).toMatchObject(
+        {
+          type: kind,
+          captionId,
+        },
+      )
+      expect(
+        result.graph.nodes.find((node) => node.id === captionId),
+      ).toMatchObject({
+        type: 'caption',
+        parentId: kind,
+      })
+      expect(result.diagnostics.map(({ code }) => code)).not.toContain(
+        'unresolved-relationship-target',
+      )
+    },
+  )
+
   it('preserves unresolved/source-preserved meaning through deterministic diagnostics and excludes recovery/page/provider data', async () => {
     const input = document([
       block({

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -452,6 +452,9 @@ describe('STRUCT publication adapter', () => {
     ).toMatchObject({ inlineRuns: [{ start: 0, end: 10 }] })
     expect(result.diagnostics.map(({ code }) => code)).toEqual([
       'struct-source',
+      'unresolved-relationship-target',
+      'unresolved-relationship-target',
+      'unresolved-relationship-target',
       'unresolved-cross-reference',
       'source-preserved-table',
       'source-preserved-equation',
@@ -614,5 +617,281 @@ describe('STRUCT publication adapter', () => {
       type: 'paragraph',
       inlineRuns: [{ start: 0, end: 1, semanticRole: 'affiliation-marker' }],
     })
+  })
+
+  it('diagnoses inline references to omitted blocks without throwing the graph schema', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'A',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 1,
+            relationshipId: 'omitted-rel',
+            targetIds: ['empty'],
+            semanticRole: 'affiliation-marker',
+          },
+        ],
+      }),
+      block({ id: 'empty', kind: 'heading', text: '', order: 1 }),
+    ])
+    input.relationships = [
+      {
+        id: 'omitted-rel',
+        kind: 'cross-reference',
+        from: 'paragraph',
+        to: ['empty'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    expect(() => publicationGraphSchema.parse(result.graph)).not.toThrow()
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unresolved-relationship-target' }),
+    )
+  })
+
+  it('assigns stable occurrence relationship ids for repeated valid inline references', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'A B',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 1,
+            relationshipId: 'shared-rel',
+            targetIds: ['target'],
+            semanticRole: 'cross-reference',
+          },
+          {
+            start: 2,
+            end: 3,
+            relationshipId: 'shared-rel',
+            targetIds: ['target'],
+            semanticRole: 'cross-reference',
+          },
+        ],
+      }),
+      block({ id: 'target', kind: 'paragraph', text: 'Target', order: 1 }),
+    ])
+    input.relationships = [
+      {
+        id: 'shared-rel',
+        kind: 'cross-reference',
+        from: 'paragraph',
+        to: ['target'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const paragraph = graph.nodes.find((node) => node.id === 'paragraph')
+    const runs =
+      paragraph && 'inlineRuns' in paragraph ? paragraph.inlineRuns : undefined
+
+    expect(runs?.map((run) => run.relationshipId)).toEqual([
+      'shared-rel',
+      'shared-rel-occurrence-2',
+    ])
+    expect(runs?.every((run) => run.targetIds?.[0] === 'target')).toBe(true)
+  })
+
+  it('keeps repeated note occurrences reciprocal with stable backlink ids', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: '1 2',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 1,
+            relationshipId: 'note-rel',
+            targetIds: ['note'],
+            semanticRole: 'note-reference',
+          },
+          {
+            start: 2,
+            end: 3,
+            relationshipId: 'note-rel',
+            targetIds: ['note'],
+            semanticRole: 'note-reference',
+          },
+        ],
+      }),
+      block({ id: 'note', kind: 'footnote', text: 'Note', order: 1 }),
+    ])
+    input.relationships = [
+      {
+        id: 'note-rel',
+        kind: 'footnote',
+        from: 'paragraph',
+        to: ['note'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const note = graph.nodes.find((node) => node.id === 'note')
+
+    expect(note).toMatchObject({
+      type: 'note',
+      backlinkIds: ['note-rel', 'note-rel-occurrence-2'],
+    })
+  })
+
+  it('diagnoses matched non-inline relationships with missing endpoints', () => {
+    const input = document([
+      block({ id: 'paragraph', kind: 'paragraph', text: 'A', order: 0 }),
+    ])
+    input.relationships = [
+      {
+        id: 'reading-order-rel',
+        kind: 'reading-order',
+        from: 'paragraph',
+        to: ['missing-target'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    expect(() => publicationGraphSchema.parse(result.graph)).not.toThrow()
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unresolved-relationship-target' }),
+    )
+  })
+
+  it('preserves and diagnoses generic inline relationships whose status is unresolved', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'A',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 1,
+            relationshipId: 'affiliation-rel',
+            targetIds: ['target'],
+            semanticRole: 'affiliation-marker',
+          },
+        ],
+      }),
+      block({ id: 'target', kind: 'paragraph', text: 'Target', order: 1 }),
+    ])
+    input.relationships = [
+      {
+        id: 'affiliation-rel',
+        kind: 'cross-reference',
+        from: 'paragraph',
+        to: ['target'],
+        status: 'unresolved',
+        confidence: 0.2,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const paragraph = graph.nodes.find((node) => node.id === 'paragraph')
+    const run =
+      paragraph && 'inlineRuns' in paragraph
+        ? paragraph.inlineRuns?.[0]
+        : undefined
+
+    expect(run).toMatchObject({
+      relationshipId: 'affiliation-rel',
+      targetIds: ['target'],
+      semanticRole: 'affiliation-marker',
+    })
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unresolved-relationship-status' }),
+    )
+  })
+
+  it('diagnoses sparse table row compaction rather than silently changing row meaning', () => {
+    const input = document([
+      block({
+        id: 'table',
+        kind: 'table',
+        text: 'A',
+        order: 0,
+        table: {
+          rows: 3,
+          columns: 1,
+          semantic: 'verified',
+          cells: [
+            {
+              id: 'cell',
+              text: 'A',
+              row: 2,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+          ],
+        },
+      }),
+    ])
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const table = graph.nodes.find((node) => node.id === 'table')
+
+    expect(table).toMatchObject({
+      type: 'table',
+      rows: [{ cells: [{ text: 'A' }] }],
+    })
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'lossy-table-geometry' }),
+    )
+  })
+
+  it('diagnoses fragment links targeting omitted blocks and removes the dangling href', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'A',
+        order: 0,
+        inline: [{ start: 0, end: 1, href: '#empty' }],
+      }),
+      block({ id: 'empty', kind: 'heading', text: '', order: 1 }),
+    ])
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const paragraph = graph.nodes.find((node) => node.id === 'paragraph')
+    const run =
+      paragraph && 'inlineRuns' in paragraph
+        ? paragraph.inlineRuns?.[0]
+        : undefined
+
+    expect(run).not.toHaveProperty('href')
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unresolved-link' }),
+    )
   })
 })

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -182,6 +182,8 @@ describe('STRUCT publication adapter', () => {
   it.each([
     '/private/exports/customer-manuscript.pdf',
     'submission?credential=do-not-return.pdf',
+    'private%2Fexports%2Fcustomer-manuscript.pdf',
+    'private%5Cexports%5Ccustomer-manuscript.pdf',
   ])(
     'uses a deterministic safe source id for unsafe file names (%s)',
     async (fileName) => {

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -466,4 +466,153 @@ describe('STRUCT publication adapter', () => {
       sourceId: 'fixture.pdf',
     })
   })
+
+  it('omits table-cell inline annotations with an explicit lossy diagnostic', () => {
+    const input = document([
+      block({
+        id: 'table',
+        kind: 'table',
+        text: 'A',
+        order: 0,
+        table: {
+          rows: 1,
+          columns: 1,
+          semantic: 'verified',
+          cells: [
+            {
+              id: 'cell',
+              text: 'A',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [{ start: 0, end: 1, bold: true }],
+              evidence,
+            },
+          ],
+        },
+      }),
+    ])
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+
+    expect(graph.nodes[0]).toMatchObject({
+      type: 'table',
+      rows: [{ cells: [{ text: 'A' }] }],
+    })
+    expect(graph.nodes[0]).not.toHaveProperty('rows.0.cells.0.inlineRuns')
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'lossy-table-inline' }),
+    )
+  })
+
+  it('diagnoses and omits figure assets whose bytes are unavailable', () => {
+    const input = document([
+      block({
+        id: 'figure',
+        kind: 'figure',
+        text: 'Figure source',
+        label: 'A figure',
+        order: 0,
+        fallbackAssetIds: ['figure-asset'],
+      }),
+    ])
+    input.assets = input.assets.map((asset) => ({
+      ...asset,
+      bytes: undefined,
+    }))
+
+    const result = adaptStructDocument(input)
+    const figure = result.graph.nodes.find((node) => node.id === 'figure')
+
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'asset-bytes-unavailable' }),
+    )
+    expect(result.assetBundle.descriptor.assets).toEqual([])
+    expect(figure).toMatchObject({ type: 'figure', assetIds: [] })
+  })
+
+  it.each([
+    [
+      'block',
+      (input: StructDocument) => {
+        input.blocks.push(
+          block({ id: 'duplicate', kind: 'heading', text: 'Second', order: 1 }),
+        )
+      },
+    ],
+    [
+      'relationship',
+      (input: StructDocument) => {
+        input.relationships.push({
+          ...input.relationships[0]!,
+          id: 'duplicate',
+        })
+        input.relationships[0]!.id = 'duplicate'
+      },
+    ],
+    [
+      'asset',
+      (input: StructDocument) => {
+        input.assets.push({ ...input.assets[0]!, id: 'duplicate' })
+        input.assets[0]!.id = 'duplicate'
+      },
+    ],
+  ])(
+    'rejects duplicate source %s ids with a deterministic adapter error',
+    (kind, mutate) => {
+      const input = document([
+        block({ id: 'duplicate', kind: 'paragraph', text: 'First', order: 0 }),
+      ])
+      mutate(input)
+
+      expect(() => adaptStructDocument(input)).toThrow(
+        `STRUCT_DUPLICATE_${kind.toUpperCase()}_ID:duplicate`,
+      )
+    },
+  )
+
+  it('diagnoses matched relationships whose inline targets are missing', () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'A',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 1,
+            relationshipId: 'matched-rel',
+            targetIds: ['missing-target'],
+            semanticRole: 'affiliation-marker',
+          },
+        ],
+      }),
+    ])
+    input.relationships = [
+      {
+        id: 'matched-rel',
+        kind: 'cross-reference',
+        from: 'paragraph',
+        to: ['missing-target'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+    ]
+
+    const result = adaptStructDocument(input)
+    const paragraph = result.graph.nodes.find((node) => node.id === 'paragraph')
+
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'unresolved-relationship-target' }),
+    )
+    expect(paragraph).toMatchObject({
+      type: 'paragraph',
+      inlineRuns: [{ start: 0, end: 1, semanticRole: 'affiliation-marker' }],
+    })
+  })
 })

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -1,0 +1,469 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import type {
+  StructDocument,
+  StructBlock,
+} from '../../packages/struct/src/types'
+import { publicationGraphSchema } from './schema'
+import { adaptStructDocument } from './struct-adapter'
+
+const bytes = new Uint8Array([1, 2, 3])
+const assetSha256 = createHash('sha256').update(bytes).digest('hex')
+
+const evidence = {
+  confidence: 1,
+  pages: [1],
+  boxes: [],
+  sourceIds: ['source-node'],
+}
+
+function block(
+  value: Partial<StructBlock> &
+    Pick<StructBlock, 'id' | 'kind' | 'text' | 'order'>,
+): StructBlock {
+  return {
+    page: 1,
+    column: 'single',
+    inline: [],
+    evidence,
+    ...value,
+  }
+}
+
+function document(blocks: StructBlock[]): StructDocument {
+  return {
+    schemaVersion: '0.2.0',
+    documentId: 'struct-fixture',
+    source: {
+      format: 'pdf',
+      fileName: 'fixture.pdf',
+      sha256: 'a'.repeat(64),
+      byteLength: 3,
+      pageCount: 1,
+      localOnly: true,
+    },
+    metadata: {
+      title: 'STRUCT fixture',
+      subtitle: 'Semantic source',
+      authors: ['Ada Example'],
+      abstract: 'An adapter fixture.',
+      language: 'en',
+      baseDirection: 'ltr',
+    },
+    blocks,
+    assets: [
+      {
+        id: 'figure-asset',
+        kind: 'figure',
+        href: 'assets/figure.png',
+        mediaType: 'image/png',
+        sha256: assetSha256,
+        width: 10,
+        height: 20,
+        bytes,
+        sourceObjectIds: ['provider-object-must-not-leak'],
+        evidence,
+        fallback: 'asset',
+      },
+    ],
+    relationships: [
+      {
+        id: 'caption-rel',
+        kind: 'caption',
+        from: 'figure',
+        to: ['figure-caption'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+      {
+        id: 'note-rel',
+        kind: 'footnote',
+        from: 'paragraph',
+        to: ['note'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+      {
+        id: 'citation-rel',
+        kind: 'citation',
+        from: 'paragraph',
+        to: ['reference'],
+        status: 'matched',
+        confidence: 1,
+        evidence,
+      },
+      {
+        id: 'unresolved-rel',
+        kind: 'cross-reference',
+        from: 'paragraph',
+        to: ['missing-target'],
+        status: 'unresolved',
+        confidence: 0.2,
+        evidence,
+      },
+    ],
+    pages: [
+      {
+        page: 1,
+        width: 600,
+        height: 800,
+        rotation: 0,
+        blocks: blocks.map(({ id }) => id),
+        columns: [
+          {
+            id: 'column-1',
+            side: 'single',
+            blockIds: blocks.map(({ id }) => id),
+          },
+        ],
+      },
+    ],
+    diagnostics: [
+      {
+        id: 'source-diagnostic',
+        severity: 'warning',
+        category: 'source',
+        title: 'Source-preserved content',
+        message: 'The source contains content that was not fully resolved.',
+        pages: [1],
+        sourceIds: ['source-node'],
+      },
+    ],
+    recovery: {
+      status: 'review-required',
+      title: 'Review',
+      summary: 'Recovery details must stay outside PublicationGraph.',
+      issues: [],
+    },
+    receipt: {
+      schemaVersion: '0.2.0',
+      documentId: 'struct-fixture',
+      sourceSha256: 'a'.repeat(64),
+      blockCount: blocks.length,
+      assetCount: 1,
+      relationshipCount: 4,
+      diagnosticCount: 1,
+      textCharacterCount: blocks.reduce(
+        (sum, item) => sum + item.text.length,
+        0,
+      ),
+      conservation: {
+        sourceNodeCount: blocks.length,
+        accountedSourceNodeCount: blocks.length,
+        sourceRegionCount: 0,
+        accountedSourceRegionCount: 0,
+        sourceAnnotationCount: 0,
+        accountedSourceAnnotationCount: 0,
+        sourceAssetCount: 1,
+        accountedSourceAssetCount: 1,
+        sourceRelationshipCount: 4,
+        accountedSourceRelationshipCount: 4,
+        sourceDiagnosticCount: 1,
+        accountedSourceDiagnosticCount: 1,
+        sourceTextCharacterCount: blocks.reduce(
+          (sum, item) => sum + item.text.length,
+          0,
+        ),
+        structBlockCount: blocks.length,
+        structAssetCount: 1,
+        structRelationshipCount: 4,
+        structDiagnosticCount: 1,
+        structTextCharacterCount: blocks.reduce(
+          (sum, item) => sum + item.text.length,
+          0,
+        ),
+      },
+      generatedSha256: 'b'.repeat(64),
+    },
+  }
+}
+
+describe('STRUCT publication adapter', () => {
+  it('maps semantic blocks, lists, notes, backlinks, tables, equations, figures, and stable ids', async () => {
+    const input = document([
+      block({
+        id: 'heading',
+        kind: 'heading',
+        text: 'Heading',
+        order: 0,
+        attributes: { level: 2 },
+      }),
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'See 1 and [ref].',
+        order: 1,
+        inline: [
+          {
+            start: 4,
+            end: 5,
+            relationshipId: 'note-rel',
+            targetIds: ['note'],
+            semanticRole: 'note-reference',
+          },
+          {
+            start: 10,
+            end: 15,
+            relationshipId: 'citation-rel',
+            targetIds: ['reference'],
+            semanticRole: 'citation',
+          },
+        ],
+      }),
+      block({
+        id: 'item-a',
+        kind: 'list-item',
+        text: 'First',
+        order: 2,
+        attributes: { listLevel: 0, listOrdered: true },
+      }),
+      block({
+        id: 'item-b',
+        kind: 'list-item',
+        text: 'Second',
+        order: 3,
+        attributes: { listLevel: 0, listOrdered: true },
+      }),
+      block({
+        id: 'table',
+        kind: 'table',
+        text: 'A B',
+        order: 4,
+        table: {
+          rows: 1,
+          columns: 2,
+          semantic: 'verified',
+          cells: [
+            {
+              id: 'cell-a',
+              text: 'A',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 2,
+              headerScope: 'column',
+              inline: [],
+              evidence,
+            },
+            {
+              id: 'cell-b',
+              text: 'B',
+              row: 0,
+              column: 1,
+              rowSpan: 2,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+          ],
+        },
+      }),
+      block({
+        id: 'equation',
+        kind: 'equation',
+        text: 'x^2 = 1',
+        order: 5,
+        attributes: { equationFormat: 'latex' },
+      }),
+      block({
+        id: 'figure',
+        kind: 'figure',
+        text: 'Figure source',
+        label: 'A figure',
+        order: 6,
+        fallbackAssetIds: ['figure-asset'],
+      }),
+      block({
+        id: 'figure-caption',
+        kind: 'caption',
+        text: 'Figure caption',
+        order: 7,
+      }),
+      block({
+        id: 'note',
+        kind: 'footnote',
+        text: 'Footnote body',
+        label: '1',
+        order: 8,
+      }),
+      block({
+        id: 'reference',
+        kind: 'paragraph',
+        text: 'Bibliography entry',
+        order: 9,
+      }),
+      block({ id: 'furniture', kind: 'furniture', text: 'Page 1', order: 10 }),
+      block({
+        id: 'unknown',
+        kind: 'unknown',
+        text: 'Unknown structure',
+        order: 11,
+      }),
+    ])
+
+    const result = adaptStructDocument(input)
+    const graph = publicationGraphSchema.parse(result.graph)
+    const byId = new Map(graph.nodes.map((node) => [node.id, node]))
+
+    expect(graph.nodes.map((node) => node.id)).toEqual([
+      'heading',
+      'paragraph',
+      'item-a-list',
+      'item-a',
+      'item-b',
+      'table',
+      'equation',
+      'figure',
+      'figure-caption',
+      'note',
+      'reference',
+    ])
+    expect(byId.get('heading')).toMatchObject({ type: 'heading', level: 2 })
+    expect(byId.get('item-a')).toMatchObject({
+      type: 'list-item',
+      parentListId: 'item-a-list',
+    })
+    expect(byId.get('item-b')).toMatchObject({
+      type: 'list-item',
+      parentListId: 'item-a-list',
+    })
+    expect(byId.get('note')).toMatchObject({
+      type: 'note',
+      noteKind: 'footnote',
+      backlinkIds: ['note-rel'],
+    })
+    expect(byId.get('paragraph')).toMatchObject({
+      inlineRuns: expect.arrayContaining([
+        expect.objectContaining({
+          semanticRole: 'cross-reference',
+          targetIds: ['note'],
+          href: '#note',
+          relationshipId: 'note-rel',
+        }),
+        expect.objectContaining({
+          semanticRole: 'citation',
+          targetIds: ['reference'],
+          relationshipId: 'citation-rel',
+        }),
+      ]),
+    })
+    expect(byId.get('table')).toMatchObject({
+      type: 'table',
+      rows: [
+        {
+          cells: [
+            { text: 'A', rowSpan: 1, columnSpan: 2 },
+            { text: 'B', rowSpan: 2, columnSpan: 1 },
+          ],
+        },
+      ],
+    })
+    expect(byId.get('equation')).toMatchObject({
+      type: 'equation',
+      source: 'x^2 = 1',
+      format: 'latex',
+    })
+    expect(byId.get('figure')).toMatchObject({
+      type: 'figure',
+      title: 'A figure',
+      assetIds: ['figure-asset'],
+      captionId: 'figure-caption',
+      sourceText: 'Figure source',
+    })
+    expect(result.assetBundle.descriptor.assets.map(({ id }) => id)).toEqual([
+      'figure-asset',
+    ])
+    expect(
+      await result.assetBundle.resolveBytes(
+        result.assetBundle.descriptor.assets[0]!,
+      ),
+    ).toEqual(bytes)
+    expect(adaptStructDocument(input).graph).toEqual(result.graph)
+  })
+
+  it('preserves unresolved/source-preserved meaning through deterministic diagnostics and excludes recovery/page/provider data', async () => {
+    const input = document([
+      block({
+        id: 'paragraph',
+        kind: 'paragraph',
+        text: 'Unresolved target',
+        order: 0,
+        inline: [
+          {
+            start: 0,
+            end: 10,
+            relationshipId: 'unresolved-rel',
+            targetIds: ['missing-target'],
+            semanticRole: 'cross-reference',
+          },
+        ],
+      }),
+      block({
+        id: 'table',
+        kind: 'table',
+        text: 'Source table',
+        order: 1,
+        table: {
+          rows: 1,
+          columns: 1,
+          semantic: 'source-preserved',
+          cells: [
+            {
+              id: 'cell',
+              text: 'Source cell',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+          ],
+        },
+      }),
+      block({
+        id: 'equation',
+        kind: 'equation',
+        text: 'unresolved equation',
+        order: 2,
+        attributes: { equationFormat: 'plain-text', sourcePreserved: true },
+      }),
+      block({
+        id: 'furniture',
+        kind: 'furniture',
+        text: 'Furniture',
+        order: 3,
+      }),
+    ])
+    const result = adaptStructDocument(input)
+    const serialized = JSON.stringify(result.graph)
+
+    expect(result.graph.nodes.map((node) => node.id)).toEqual([
+      'paragraph',
+      'table',
+      'equation',
+    ])
+    expect(
+      result.graph.nodes.find((node) => node.id === 'paragraph'),
+    ).toMatchObject({ inlineRuns: [{ start: 0, end: 10 }] })
+    expect(result.diagnostics.map(({ code }) => code)).toEqual([
+      'struct-source',
+      'unresolved-cross-reference',
+      'source-preserved-table',
+      'source-preserved-equation',
+      'unsupported-furniture',
+    ])
+    expect(serialized).not.toContain('review-required')
+    expect(serialized).not.toContain('provider-object-must-not-leak')
+    expect(serialized).not.toContain('pageCount')
+    expect(result.provenance).toMatchObject({
+      adapterId: 'struct-document',
+      sourceType: 'pdf',
+      sourceId: 'fixture.pdf',
+    })
+  })
+})

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -894,4 +894,139 @@ describe('STRUCT publication adapter', () => {
       expect.objectContaining({ code: 'unresolved-link' }),
     )
   })
+
+  it('diagnoses invalid metadata dates without leaking a publication schema error', () => {
+    const input = document([
+      block({ id: 'paragraph', kind: 'paragraph', text: 'A', order: 0 }),
+    ])
+    input.relationships = []
+    input.metadata.publicationDate = '2024-99-99'
+    input.metadata.updated = '2024-02-30'
+    input.metadata.artifactModifiedAt = '2024-99-99T00:00:00+00:00'
+
+    const result = adaptStructDocument(input)
+
+    expect(result.graph.metadata).not.toHaveProperty('created')
+    expect(result.graph.metadata).not.toHaveProperty('modified')
+    expect(result.graph.metadata).not.toHaveProperty('artifactModifiedAt')
+    expect(
+      result.diagnostics
+        .map(({ code }) => code)
+        .filter((code) => code.startsWith('invalid-')),
+    ).toEqual([
+      'invalid-publication-date',
+      'invalid-updated-date',
+      'invalid-artifact-modified-at',
+    ])
+    expect(() => publicationGraphSchema.parse(result.graph)).not.toThrow()
+  })
+
+  it('rejects duplicate table-cell source ids before publication schema parsing', () => {
+    const input = document([
+      block({
+        id: 'table',
+        kind: 'table',
+        text: 'A B',
+        order: 0,
+        table: {
+          rows: 1,
+          columns: 2,
+          semantic: 'verified',
+          cells: [
+            {
+              id: 'duplicate-cell',
+              text: 'A',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+            {
+              id: 'duplicate-cell',
+              text: 'B',
+              row: 0,
+              column: 1,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence,
+            },
+          ],
+        },
+      }),
+    ])
+
+    expect(() => adaptStructDocument(input)).toThrow(
+      'STRUCT_DUPLICATE_TABLE_CELL_ID:duplicate-cell',
+    )
+  })
+
+  it('bounds unexpected publication schema failures behind a STRUCT adapter error', () => {
+    const input = document([
+      block({ id: 'paragraph', kind: 'paragraph', text: 'A', order: 0 }),
+    ])
+    input.relationships = []
+    input.metadata.authors = ['']
+
+    expect(() => adaptStructDocument(input)).toThrow(
+      'STRUCT_PUBLICATION_SCHEMA_INVALID:',
+    )
+  })
+
+  it.each([
+    ['reverse caption relationship', 'caption', 'figure'],
+    ['caption attached to a paragraph', 'paragraph', 'caption'],
+  ])(
+    'diagnoses %s without a raw schema error or semantic mislink',
+    (_label, fromId, toId) => {
+      const input = document([
+        block({
+          id: 'figure',
+          kind: 'figure',
+          text: 'Figure source',
+          label: 'A figure',
+          order: 0,
+        }),
+        block({
+          id: 'paragraph',
+          kind: 'paragraph',
+          text: 'Paragraph',
+          order: 1,
+        }),
+        block({
+          id: 'caption',
+          kind: 'caption',
+          text: 'Caption',
+          order: 2,
+        }),
+      ])
+      input.relationships = [
+        {
+          id: 'invalid-caption-rel',
+          kind: 'caption',
+          from: fromId,
+          to: [toId],
+          status: 'matched',
+          confidence: 1,
+          evidence,
+        },
+      ]
+
+      const result = adaptStructDocument(input)
+      const figure = result.graph.nodes.find((node) => node.id === 'figure')
+
+      expect(result.graph.nodes.some((node) => node.id === 'caption')).toBe(
+        false,
+      )
+      expect(figure).not.toHaveProperty('captionId')
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({ code: 'invalid-caption-relationship' }),
+      )
+      expect(() => publicationGraphSchema.parse(result.graph)).not.toThrow()
+    },
+  )
 })

--- a/src/publication/struct-adapter.test.ts
+++ b/src/publication/struct-adapter.test.ts
@@ -1,11 +1,9 @@
 import { createHash } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
-import type {
-  StructDocument,
-  StructBlock,
-} from '../../packages/struct/src/types'
+import type { StructDocument, StructBlock } from '@erniesg/struct/schema'
+import { PublicationAdapterRegistry } from './adapter-registry'
 import { publicationGraphSchema } from './schema'
-import { adaptStructDocument } from './struct-adapter'
+import { adaptStructDocument, structPublicationAdapter } from './struct-adapter'
 
 const bytes = new Uint8Array([1, 2, 3])
 const assetSha256 = createHash('sha256').update(bytes).digest('hex')
@@ -181,6 +179,31 @@ function document(blocks: StructBlock[]): StructDocument {
 }
 
 describe('STRUCT publication adapter', () => {
+  it.each([
+    '/private/exports/customer-manuscript.pdf',
+    'submission?credential=do-not-return.pdf',
+  ])(
+    'uses a deterministic safe source id for unsafe file names (%s)',
+    async (fileName) => {
+      const input = document([
+        block({ id: 'paragraph', kind: 'paragraph', text: 'Body', order: 0 }),
+      ])
+      input.source.fileName = fileName
+      input.relationships = []
+      const expectedSourceId = `struct-${input.source.sha256.slice(0, 16)}`
+
+      const direct = adaptStructDocument(input)
+      expect(direct.provenance.sourceId).toBe(expectedSourceId)
+      expect(JSON.stringify(direct)).not.toContain(fileName)
+
+      const registry = new PublicationAdapterRegistry().register(
+        structPublicationAdapter,
+      )
+      const resolved = await registry.resolve('struct-document', input)
+      expect(resolved.provenance.sourceId).toBe(expectedSourceId)
+    },
+  )
+
   it('maps semantic blocks, lists, notes, backlinks, tables, equations, figures, and stable ids', async () => {
     const input = document([
       block({

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -1,0 +1,932 @@
+import { createAssetBundle, type AssetDescriptor } from './asset-bundle'
+import {
+  PUBLICATION_GRAPH_VERSION,
+  publicationGraphSchema,
+  type PublicationInlineRun,
+  type PublicationNode,
+} from './schema'
+import {
+  PUBLICATION_SOURCE_ADAPTER_VERSION,
+  type AdapterDiagnostic,
+  type PublicationSourceAdapter,
+  type PublicationSourceResult,
+} from './source-adapter'
+import type {
+  StructBlock,
+  StructDocument,
+  StructInline,
+  StructRelationship,
+  StructTableCell,
+} from '../../packages/struct/src/types'
+
+export const STRUCT_PUBLICATION_ADAPTER_ID = 'struct-document' as const
+export const STRUCT_PUBLICATION_MAPPING_VERSION = '1.0.0' as const
+
+type Severity = AdapterDiagnostic['severity']
+
+function safeId(value: string, fallback: string) {
+  const normalized = value.replace(/[^A-Za-z0-9._:-]+/g, '-')
+  if (!normalized) return fallback
+  return /^[A-Za-z0-9]/.test(normalized) ? normalized : `id-${normalized}`
+}
+
+function uniqueId(value: string, used: Set<string>) {
+  const base = safeId(value, 'node')
+  let candidate = base
+  let suffix = 2
+  while (used.has(candidate)) candidate = `${base}-${suffix++}`
+  used.add(candidate)
+  return candidate
+}
+
+function localeFor(document: StructDocument) {
+  const candidate = document.metadata.language ?? 'en'
+  try {
+    return Intl.getCanonicalLocales(candidate)[0] ?? 'en'
+  } catch {
+    return 'en'
+  }
+}
+
+function dateOnly(value: string | undefined) {
+  if (!value) return undefined
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined
+}
+
+function dateTime(value: string | undefined) {
+  if (!value) return undefined
+  return /^\d{4}-\d{2}-\d{2}T/.test(value) ? value : undefined
+}
+
+function direction(
+  value: StructDocument['metadata']['baseDirection'],
+): 'ltr' | 'rtl' | 'auto' {
+  return value === 'ltr' || value === 'rtl' ? value : 'auto'
+}
+
+function basename(value: string) {
+  const withoutQuery = value.split(/[?#]/, 1)[0] ?? ''
+  const part = withoutQuery.split(/[\\/]/).at(-1)
+  return part && /^[^\u0000-\u001f\u007f/\\]+$/.test(part) ? part : undefined
+}
+
+function isExternalHref(value: string) {
+  try {
+    const url = new URL(value)
+    return (
+      ['http:', 'https:', 'mailto:'].includes(url.protocol) &&
+      !url.username &&
+      !url.password
+    )
+  } catch {
+    return false
+  }
+}
+
+function inlineStyle(
+  inline: StructInline,
+): Omit<PublicationInlineRun, 'start' | 'end'> {
+  return {
+    ...(inline.bold ? { bold: true } : {}),
+    ...(inline.italic ? { italic: true } : {}),
+    ...(inline.verticalAlign ? { verticalAlign: inline.verticalAlign } : {}),
+    ...(inline.compactMathAtom ? { compactMathAtom: true } : {}),
+  }
+}
+
+function relationshipStatusIsResolved(
+  relationship: StructRelationship | undefined,
+) {
+  return relationship?.status === 'matched'
+}
+
+function sourceType(
+  document: StructDocument,
+): 'astro' | 'payload' | 'docx' | 'pdf' | 'research-paper' {
+  if (document.source.format === 'pdf') return 'pdf'
+  if (document.source.format === 'docx') return 'docx'
+  return 'research-paper'
+}
+
+/**
+ * Convert the source-neutral STRUCT document into the app-owned publication
+ * graph.  Page geometry, recovery state, model receipts, and provider
+ * evidence are deliberately read only for diagnostics and never projected.
+ */
+export function adaptStructDocument(
+  document: StructDocument,
+): PublicationSourceResult {
+  const diagnostics: AdapterDiagnostic[] = []
+  const sourceId =
+    basename(document.source.fileName) ??
+    `struct-${document.source.sha256.slice(0, 16)}`
+  const addDiagnostic = (
+    severity: Severity,
+    code: string,
+    message: string,
+    nodeId?: string,
+  ) => {
+    diagnostics.push({
+      severity,
+      code,
+      message,
+      sourceId,
+      ...(nodeId ? { nodeId } : {}),
+    })
+  }
+
+  for (const diagnostic of document.diagnostics) {
+    addDiagnostic(
+      diagnostic.severity,
+      `struct-${diagnostic.category}`,
+      `${diagnostic.title}: ${diagnostic.message}`,
+    )
+  }
+
+  const locale = localeFor(document)
+  const directionValue = direction(document.metadata.baseDirection)
+  const graphId = uniqueId(
+    document.documentId ?? `struct-${document.source.sha256.slice(0, 16)}`,
+    new Set(),
+  )
+  const editionId = uniqueId(`${graphId}-${locale}`, new Set())
+  const orderedBlocks = document.blocks
+    .map((block, index) => ({ block, index }))
+    .sort(
+      (left, right) =>
+        left.block.order - right.block.order || left.index - right.index,
+    )
+
+  const usedNodeIds = new Set<string>()
+  const nodeIds = new Map<string, string>()
+  for (const { block } of orderedBlocks)
+    nodeIds.set(block.id, uniqueId(block.id, usedNodeIds))
+  const nonGraphBlockIds = new Set(
+    document.blocks
+      .filter((block) => block.kind === 'furniture' || block.kind === 'unknown')
+      .map((block) => block.id),
+  )
+  const relationshipIds = new Map<string, string>()
+  for (const relationship of document.relationships) {
+    relationshipIds.set(relationship.id, uniqueId(relationship.id, usedNodeIds))
+  }
+  const relationships = new Map(
+    document.relationships.map((relationship) => [
+      relationship.id,
+      relationship,
+    ]),
+  )
+  const mappedNode = (id: string) =>
+    nonGraphBlockIds.has(id) ? undefined : nodeIds.get(id)
+  const mappedRelationship = (id: string) => relationshipIds.get(id)
+
+  for (const relationship of document.relationships) {
+    if (relationship.status === 'matched') continue
+    const appearsInline = document.blocks.some((block) =>
+      block.inline.some((inline) => inline.relationshipId === relationship.id),
+    )
+    if (appearsInline || relationship.kind === 'caption') continue
+    const prefix =
+      relationship.status === 'source-preserved'
+        ? 'source-preserved'
+        : 'unresolved'
+    addDiagnostic(
+      'warning',
+      `${prefix}-${relationship.kind}`,
+      `Relationship ${relationship.id} (${relationship.kind}) was ${relationship.status} and was not projected as a link.`,
+      relationship.from,
+    )
+  }
+
+  const captionParent = new Map<string, string>()
+  for (const relationship of document.relationships) {
+    if (relationship.kind !== 'caption' || !relationship.to[0]) continue
+    if (relationship.status === 'matched') {
+      const fromBlock = document.blocks.find(
+        (block) => block.id === relationship.from,
+      )
+      if (fromBlock?.kind === 'caption')
+        captionParent.set(relationship.from, relationship.to[0])
+      else captionParent.set(relationship.to[0], relationship.from)
+    } else {
+      addDiagnostic(
+        'warning',
+        'unresolved-caption',
+        `Caption relationship ${relationship.id} was ${relationship.status} and was not linked.`,
+      )
+    }
+  }
+
+  const mapInline = (
+    text: string,
+    source: StructInline[],
+    ownerId: string,
+  ): PublicationInlineRun[] => {
+    const result: PublicationInlineRun[] = []
+    for (const inline of source) {
+      if (
+        inline.start < 0 ||
+        inline.end <= inline.start ||
+        inline.end > text.length
+      ) {
+        addDiagnostic(
+          'warning',
+          'lossy-inline-range',
+          `Inline range ${inline.start}:${inline.end} was outside ${ownerId} and was omitted.`,
+          ownerId,
+        )
+        continue
+      }
+      const relationship = inline.relationshipId
+        ? relationships.get(inline.relationshipId)
+        : undefined
+      const targets = inline.targetIds ?? []
+      const mappedTargets = targets
+        .map(mappedNode)
+        .filter((target): target is string => Boolean(target))
+      const hasMissingTarget = mappedTargets.length !== targets.length
+      const resolved = relationship
+        ? relationshipStatusIsResolved(relationship)
+        : !hasMissingTarget
+      const base = {
+        start: inline.start,
+        end: inline.end,
+        ...inlineStyle(inline),
+      }
+
+      if (inline.semanticRole === 'note-reference') {
+        const noteTarget = mappedTargets.find((target) => {
+          const block = document.blocks.find(
+            (candidate) => mappedNode(candidate.id) === target,
+          )
+          return block?.kind === 'footnote' || block?.kind === 'endnote'
+        })
+        if (
+          resolved &&
+          !hasMissingTarget &&
+          noteTarget &&
+          (relationship?.kind === 'footnote' ||
+            relationship?.kind === 'endnote')
+        ) {
+          result.push({
+            ...base,
+            href: `#${noteTarget}`,
+            relationshipId:
+              mappedRelationship(inline.relationshipId ?? '') ??
+              safeId(
+                inline.relationshipId ?? `${ownerId}-note`,
+                `${ownerId}-note`,
+              ),
+            semanticRole: 'cross-reference',
+            targetIds: [noteTarget],
+          })
+        } else {
+          addDiagnostic(
+            'warning',
+            'unresolved-note-reference',
+            `Note reference in ${ownerId} was source-preserved without a destination.`,
+            ownerId,
+          )
+          result.push(base)
+        }
+        continue
+      }
+
+      if (
+        (inline.semanticRole === 'citation' ||
+          inline.semanticRole === 'cross-reference') &&
+        (!resolved || hasMissingTarget || !mappedTargets.length)
+      ) {
+        addDiagnostic(
+          'warning',
+          'unresolved-cross-reference',
+          `The ${inline.semanticRole} in ${ownerId} was source-preserved without an unverified destination.`,
+          ownerId,
+        )
+        result.push(base)
+        continue
+      }
+
+      const href = inline.href
+        ? inline.href.startsWith('#')
+          ? mappedNode(inline.href.slice(1))
+            ? `#${mappedNode(inline.href.slice(1))}`
+            : undefined
+          : isExternalHref(inline.href)
+            ? inline.href
+            : undefined
+        : undefined
+      if (inline.href && !href)
+        addDiagnostic(
+          'warning',
+          'unresolved-link',
+          `Link in ${ownerId} was source-preserved without an unsafe or unresolved destination.`,
+          ownerId,
+        )
+      result.push({
+        ...base,
+        ...(href ? { href } : {}),
+        ...(inline.annotationId
+          ? {
+              annotationId: safeId(
+                inline.annotationId,
+                `${ownerId}-annotation`,
+              ),
+            }
+          : {}),
+        ...(inline.relationshipId && (resolved || href)
+          ? { relationshipId: mappedRelationship(inline.relationshipId) }
+          : {}),
+        ...(inline.semanticRole ? { semanticRole: inline.semanticRole } : {}),
+        ...(mappedTargets.length && resolved
+          ? { targetIds: mappedTargets }
+          : {}),
+      })
+    }
+    return result
+  }
+
+  const common = (block: StructBlock) => ({
+    id: nodeIds.get(block.id)!,
+    locale,
+    direction: directionValue,
+    requirement: 'required' as const,
+    importance:
+      block.kind === 'caption' ||
+      block.kind === 'footnote' ||
+      block.kind === 'endnote'
+        ? ('supporting' as const)
+        : ('essential' as const),
+    provenance: {
+      adapterId: STRUCT_PUBLICATION_ADAPTER_ID,
+      sourceId,
+      sourceRevision: document.source.sha256,
+      evidence: [],
+    },
+    accessibility: { decorative: false },
+    variants: [],
+    permittedTransformationIds: [],
+    edition: { editionId },
+  })
+
+  const captionIdFor = (block: StructBlock) => {
+    const relationship = document.relationships.find(
+      (candidate) =>
+        candidate.kind === 'caption' && candidate.from === block.id,
+    )
+    if (!relationship || relationship.status !== 'matched') return undefined
+    const target = mappedNode(relationship.to[0] ?? '')
+    if (!target) return undefined
+    return document.blocks.find(
+      (candidate) => candidate.id === relationship.to[0],
+    )?.kind === 'caption'
+      ? target
+      : undefined
+  }
+
+  const mapTableCell = (
+    cell: StructTableCell,
+    ownerId: string,
+    cellId: string,
+  ) => ({
+    ...(cell.id ? { id: cellId } : {}),
+    text: cell.text,
+    headerScope:
+      cell.headerScope === 'column' || cell.headerScope === 'row'
+        ? cell.headerScope
+        : null,
+    columnSpan: cell.columnSpan,
+    rowSpan: cell.rowSpan,
+    ...(cell.headerScope === 'colgroup' || cell.headerScope === 'rowgroup'
+      ? (addDiagnostic(
+          'warning',
+          'lossy-table-header-scope',
+          `Table cell ${cell.id} used unsupported ${cell.headerScope} scope; it was projected to an unscoped cell.`,
+          ownerId,
+        ),
+        {})
+      : {}),
+    ...(cell.inline.length
+      ? { inlineRuns: mapInline(cell.text, cell.inline, ownerId) }
+      : {}),
+  })
+
+  const mapBlock = (block: StructBlock): PublicationNode | undefined => {
+    const base = common(block)
+    const inlineRuns = block.inline.length
+      ? mapInline(block.text, block.inline, block.id)
+      : undefined
+    switch (block.kind) {
+      case 'heading':
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-heading',
+            `Heading ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        return {
+          ...base,
+          type: 'heading',
+          level:
+            typeof block.attributes?.level === 'number'
+              ? Math.min(6, Math.max(1, Math.trunc(block.attributes.level)))
+              : 1,
+          text: block.text,
+          ...(inlineRuns ? { inlineRuns } : {}),
+        }
+      case 'paragraph':
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-paragraph',
+            `Paragraph ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        if (block.attributes?.bibliographyEntry === true)
+          return {
+            ...base,
+            type: 'reference',
+            targetIds: [],
+            text: block.text,
+            ...(inlineRuns ? { inlineRuns } : {}),
+          }
+        return {
+          ...base,
+          type: 'paragraph',
+          text: block.text,
+          ...(inlineRuns ? { inlineRuns } : {}),
+        }
+      case 'quote':
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-quote',
+            `Quote ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        return {
+          ...base,
+          type: 'quote',
+          text: block.text,
+          ...(typeof block.attributes?.attribution === 'string'
+            ? { attribution: block.attributes.attribution }
+            : {}),
+          ...(inlineRuns ? { inlineRuns } : {}),
+        }
+      case 'code':
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-code',
+            `Code block ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        return {
+          ...base,
+          type: 'code',
+          code: block.text,
+          ...(typeof block.attributes?.language === 'string'
+            ? { language: block.attributes.language }
+            : {}),
+        }
+      case 'figure': {
+        const title = block.label || block.text
+        if (!title) {
+          addDiagnostic(
+            'error',
+            'unsupported-figure',
+            `Figure ${block.id} had no title and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        const relatedAssetIds = document.relationships
+          .filter(
+            (relationship) =>
+              relationship.from === block.id &&
+              relationship.kind === 'figure' &&
+              relationship.status === 'matched',
+          )
+          .flatMap((relationship) => relationship.to)
+        const sourceAssetIds = block.fallbackAssetIds?.length
+          ? block.fallbackAssetIds
+          : relatedAssetIds
+        const assetIds = sourceAssetIds
+          .map((id) => assetIdsMap.get(id))
+          .filter((id): id is string => Boolean(id))
+        if (sourceAssetIds.length > assetIds.length)
+          addDiagnostic(
+            'warning',
+            'unresolved-asset',
+            `Figure ${block.id} referenced an unavailable asset; its source text was retained.`,
+            block.id,
+          )
+        return {
+          ...base,
+          type: 'figure',
+          title,
+          ...(block.text ? { sourceText: block.text } : {}),
+          ...(inlineRuns ? { inlineRuns } : {}),
+          assetIds,
+          ...(captionIdFor(block) ? { captionId: captionIdFor(block) } : {}),
+        }
+      }
+      case 'caption': {
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-caption',
+            `Caption ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        const parent = captionParent.get(block.id)
+        const parentId = parent ? mappedNode(parent) : undefined
+        if (!parentId) {
+          addDiagnostic(
+            'warning',
+            'unsupported-caption',
+            `Caption ${block.id} had no verified owning node and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        return {
+          ...base,
+          type: 'caption',
+          parentId,
+          text: block.text,
+          ...(inlineRuns ? { inlineRuns } : {}),
+        }
+      }
+      case 'table': {
+        if (!block.table) {
+          addDiagnostic(
+            'warning',
+            'unsupported-table',
+            `Table ${block.id} had no cell grid and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        if (block.table.semantic !== 'verified')
+          addDiagnostic(
+            'warning',
+            `source-preserved-table`,
+            `Table ${block.id} was ${block.table.semantic}; its text and spans were retained without promoting its semantics.`,
+            block.id,
+          )
+        const cellIds = new Map<string, string>()
+        block.table.cells.forEach((cell, index) =>
+          cellIds.set(
+            cell.id,
+            uniqueId(
+              `${nodeIds.get(block.id)}-cell-${cell.id || index + 1}`,
+              usedNodeIds,
+            ),
+          ),
+        )
+        const rows = Array.from({ length: block.table.rows }, () => ({
+          cells: [] as ReturnType<typeof mapTableCell>[],
+        }))
+        for (const cell of [...block.table.cells].sort(
+          (left, right) => left.row - right.row || left.column - right.column,
+        )) {
+          const row = rows[cell.row]
+          if (!row) {
+            addDiagnostic(
+              'warning',
+              'lossy-table-cell',
+              `Table cell ${cell.id} was outside the declared row count and was omitted.`,
+              block.id,
+            )
+            continue
+          }
+          row.cells.push(mapTableCell(cell, block.id, cellIds.get(cell.id)!))
+        }
+        const validRows = rows.filter((row) => row.cells.length)
+        if (!validRows.length) return undefined
+        return {
+          ...base,
+          type: 'table',
+          rows: validRows,
+          ...(captionIdFor(block) ? { captionId: captionIdFor(block) } : {}),
+        }
+      }
+      case 'equation': {
+        const format = block.attributes?.equationFormat
+        const equationFormat =
+          format === 'mathml' || format === 'latex' || format === 'plain-text'
+            ? format
+            : 'plain-text'
+        if (block.attributes?.equationFormat && format !== equationFormat)
+          addDiagnostic(
+            'warning',
+            'lossy-equation-format',
+            `Equation ${block.id} used an unsupported format and was retained as plain text.`,
+            block.id,
+          )
+        if (block.attributes?.sourcePreserved === true)
+          addDiagnostic(
+            'warning',
+            'source-preserved-equation',
+            `Equation ${block.id} was source-preserved; no unverified transcription was introduced.`,
+            block.id,
+          )
+        if (!block.text) {
+          addDiagnostic(
+            'error',
+            'unsupported-equation',
+            `Equation ${block.id} had no source text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        return {
+          ...base,
+          type: 'equation',
+          source: block.text,
+          format: equationFormat,
+          ...(block.label ? { label: block.label } : {}),
+          ...(captionIdFor(block) ? { captionId: captionIdFor(block) } : {}),
+        }
+      }
+      case 'footnote':
+      case 'endnote': {
+        if (!block.text) {
+          addDiagnostic(
+            'warning',
+            'unsupported-note',
+            `Note ${block.id} had no text and was omitted.`,
+            block.id,
+          )
+          return undefined
+        }
+        const backlinks = document.relationships
+          .filter(
+            (relationship) =>
+              (relationship.kind === 'footnote' ||
+                relationship.kind === 'endnote') &&
+              relationship.status === 'matched' &&
+              relationship.to.includes(block.id) &&
+              document.blocks.some(
+                (candidate) =>
+                  candidate.text.length > 0 &&
+                  candidate.inline.some(
+                    (inline) =>
+                      inline.relationshipId === relationship.id &&
+                      inline.semanticRole === 'note-reference' &&
+                      inline.targetIds?.includes(block.id) &&
+                      inline.start >= 0 &&
+                      inline.end > inline.start &&
+                      inline.end <= candidate.text.length,
+                  ),
+              ),
+          )
+          .map((relationship) => mappedRelationship(relationship.id))
+          .filter((id): id is string => Boolean(id))
+          .filter((id, index, all) => all.indexOf(id) === index)
+        return {
+          ...base,
+          type: 'note',
+          noteKind: block.kind === 'endnote' ? 'endnote' : 'footnote',
+          label: block.label || block.id,
+          backlinkIds: backlinks,
+          text: block.text,
+          ...(inlineRuns ? { inlineRuns } : {}),
+        }
+      }
+      default:
+        addDiagnostic(
+          'warning',
+          block.kind === 'furniture'
+            ? 'unsupported-furniture'
+            : 'unsupported-block',
+          `STRUCT block ${block.id} (${block.kind}) was not flattened into PublicationGraph.`,
+          block.id,
+        )
+        return undefined
+    }
+  }
+
+  const assetIdsMap = new Map<string, string>()
+  const assetDescriptors: AssetDescriptor[] = []
+  const assetBytes = new Map<string, Uint8Array>()
+  const assetHashes = new Map<string, string>()
+  for (const asset of document.assets) {
+    const prior = assetHashes.get(asset.sha256)
+    if (prior) {
+      assetIdsMap.set(asset.id, prior)
+      addDiagnostic(
+        'warning',
+        'duplicate-asset-content',
+        `Asset ${asset.id} shared content with ${prior}; the bundle uses one stable descriptor.`,
+        asset.id,
+      )
+      continue
+    }
+    const id = uniqueId(asset.id, usedNodeIds)
+    assetIdsMap.set(asset.id, id)
+    assetHashes.set(asset.sha256, id)
+    assetDescriptors.push({
+      id,
+      sha256: asset.sha256,
+      byteLength: asset.bytes?.byteLength ?? 0,
+      mediaType: asset.mediaType,
+      ...(basename(asset.href) ? { fileName: basename(asset.href) } : {}),
+      ...(asset.width > 0 ? { width: asset.width } : {}),
+      ...(asset.height > 0 ? { height: asset.height } : {}),
+    })
+    if (asset.bytes) assetBytes.set(id, new Uint8Array(asset.bytes))
+    else if (assetDescriptors.at(-1)!.byteLength > 0)
+      addDiagnostic(
+        'warning',
+        'asset-bytes-unavailable',
+        `Asset ${asset.id} has no local bytes; resolution remains explicitly unavailable.`,
+        asset.id,
+      )
+  }
+
+  const nodes: PublicationNode[] = []
+  const listGroups = new Map<
+    string,
+    {
+      id: string
+      level: number
+      ordered: boolean
+      start?: number
+      itemIds: string[]
+      firstIndex: number
+      parentItemId?: string
+    }
+  >()
+  const listStack: Array<{
+    level: number
+    group: {
+      id: string
+      level: number
+      ordered: boolean
+      start?: number
+      itemIds: string[]
+      firstIndex: number
+      parentItemId?: string
+    }
+  }> = []
+  for (const { block, index } of orderedBlocks) {
+    if (block.kind === 'list-item') {
+      if (!block.text) {
+        addDiagnostic(
+          'warning',
+          'unsupported-list-item',
+          `List item ${block.id} had no text and was omitted.`,
+          block.id,
+        )
+        continue
+      }
+      const level =
+        typeof block.attributes?.listLevel === 'number'
+          ? Math.max(0, Math.trunc(block.attributes.listLevel))
+          : 0
+      const ordered = block.attributes?.listOrdered === true
+      while (listStack.at(-1) && listStack.at(-1)!.level > level)
+        listStack.pop()
+      let group =
+        listStack.at(-1)?.level === level &&
+        listStack.at(-1)?.group.ordered === ordered
+          ? listStack.at(-1)!.group
+          : undefined
+      if (!group) {
+        group = {
+          id: uniqueId(`${nodeIds.get(block.id)}-list`, usedNodeIds),
+          level,
+          ordered,
+          ...(ordered && typeof block.attributes?.listOrdinal === 'number'
+            ? { start: Math.max(0, Math.trunc(block.attributes.listOrdinal)) }
+            : {}),
+          itemIds: [],
+          firstIndex: index,
+          ...(listStack.at(-1)
+            ? { parentItemId: listStack.at(-1)!.group.itemIds.at(-1) }
+            : {}),
+        }
+        listGroups.set(`${level}:${ordered}:${index}`, group)
+        listStack.push({ level, group })
+        nodes.push({
+          ...common(block),
+          id: group.id,
+          type: 'list',
+          ordered,
+          itemIds: [],
+          ...(group.start !== undefined ? { start: group.start } : {}),
+        })
+      }
+      group.itemIds.push(nodeIds.get(block.id)!)
+      const listInlineRuns = inlineRunsFor(block, mapInline)
+      nodes.push({
+        ...common(block),
+        type: 'list-item',
+        parentListId: group.id,
+        childListIds: [],
+        text: block.text,
+        ...(listInlineRuns ? { inlineRuns: listInlineRuns } : {}),
+      })
+      continue
+    }
+    listStack.length = 0
+    const mapped = mapBlock(block)
+    if (mapped) nodes.push(mapped)
+  }
+  for (const group of listGroups.values()) {
+    const list = nodes.find((node) => node.id === group.id)
+    if (list?.type === 'list') list.itemIds = group.itemIds
+  }
+  for (const group of listGroups.values()) {
+    if (!group.parentItemId) continue
+    const parent = nodes.find((node) => node.id === group.parentItemId)
+    if (parent?.type === 'list-item') parent.childListIds.push(group.id)
+  }
+
+  if (!nodes.length) throw new Error('STRUCT_NO_PUBLICATION_NODES')
+  const graph = publicationGraphSchema.parse({
+    version: PUBLICATION_GRAPH_VERSION,
+    id: graphId,
+    metadata: {
+      title: document.metadata.title || sourceId,
+      ...(document.metadata.subtitle
+        ? { subtitle: document.metadata.subtitle }
+        : {}),
+      contributors: document.metadata.authors,
+      ...(document.metadata.abstract
+        ? { abstract: document.metadata.abstract }
+        : {}),
+      sourceDocumentVersion: document.schemaVersion,
+      ...(dateOnly(document.metadata.publicationDate)
+        ? { created: dateOnly(document.metadata.publicationDate) }
+        : {}),
+      ...(dateOnly(document.metadata.updated)
+        ? { modified: dateOnly(document.metadata.updated) }
+        : {}),
+      ...(dateTime(document.metadata.artifactModifiedAt)
+        ? { artifactModifiedAt: dateTime(document.metadata.artifactModifiedAt) }
+        : {}),
+      defaultLocale: locale,
+      defaultDirection: directionValue,
+      keywords: [],
+    },
+    edition: { id: editionId, locale, direction: directionValue },
+    nodes,
+  })
+  return {
+    graph,
+    assetBundle: createAssetBundle(
+      { version: '1.0.0', assets: assetDescriptors },
+      async (descriptor) => {
+        const bytesForAsset = assetBytes.get(descriptor.id)
+        if (!bytesForAsset)
+          throw new Error(`STRUCT_ASSET_BYTES_UNAVAILABLE:${descriptor.id}`)
+        return new Uint8Array(bytesForAsset)
+      },
+    ),
+    diagnostics,
+    provenance: {
+      adapterId: STRUCT_PUBLICATION_ADAPTER_ID,
+      adapterVersion: PUBLICATION_SOURCE_ADAPTER_VERSION,
+      sourceType: sourceType(document),
+      sourceId,
+      sourceRevision: document.source.sha256,
+      mappingVersion: STRUCT_PUBLICATION_MAPPING_VERSION,
+    },
+  }
+}
+
+function inlineRunsFor(
+  block: StructBlock,
+  mapInline: (
+    text: string,
+    source: StructInline[],
+    ownerId: string,
+  ) => PublicationInlineRun[],
+) {
+  return block.inline.length
+    ? mapInline(block.text, block.inline, block.id)
+    : undefined
+}
+
+export const structPublicationAdapter: PublicationSourceAdapter<StructDocument> =
+  {
+    id: STRUCT_PUBLICATION_ADAPTER_ID,
+    version: PUBLICATION_SOURCE_ADAPTER_VERSION,
+    adapt: adaptStructDocument,
+  }
+
+export const structDocumentToPublicationSourceResult = adaptStructDocument

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -287,20 +287,56 @@ export function adaptStructDocument(
   const captionIdsByParent = new Map<string, string>()
   const captionParentsByCaption = new Map<string, string>()
   const graphBlockIds = new Set(baseGraphBlockIds)
-  for (const relationship of document.relationships) {
-    if (relationship.kind !== 'caption' || relationship.status !== 'matched')
-      continue
+  const knownAssetIds = new Set(document.assets.map((asset) => asset.id))
+  const captionEndpointsFor = (relationship: StructRelationship) => {
     const fromBlock = blocksById.get(relationship.from)
-    const toBlock =
-      relationship.to.length === 1
-        ? blocksById.get(relationship.to[0]!)
-        : undefined
-    if (!fromBlock || !toBlock) continue
-    const endpoints =
-      captionParentKinds.has(fromBlock.kind) && toBlock.kind === 'caption'
+    if (!fromBlock) return undefined
+    if (relationship.kind === 'caption') {
+      const toBlock =
+        relationship.to.length === 1
+          ? blocksById.get(relationship.to[0]!)
+          : undefined
+      return captionParentKinds.has(fromBlock.kind) &&
+        toBlock?.kind === 'caption'
         ? { captionId: toBlock.id, parentId: fromBlock.id }
         : undefined
+    }
+    if (
+      !['figure', 'table', 'equation'].includes(relationship.kind) ||
+      fromBlock.kind !== relationship.kind
+    )
+      return undefined
+    const captionTargets = relationship.to.filter(
+      (target) => blocksById.get(target)?.kind === 'caption',
+    )
+    const relatedAssets = relationship.to.filter((target) =>
+      knownAssetIds.has(target),
+    )
+    return captionTargets.length === 1 &&
+      relatedAssets.length > 0 &&
+      relationship.to.length === relatedAssets.length + 1
+      ? { captionId: captionTargets[0]!, parentId: fromBlock.id }
+      : undefined
+  }
+  for (const relationship of document.relationships) {
+    if (relationship.status !== 'matched') continue
+    const endpoints = captionEndpointsFor(relationship)
     if (!endpoints) {
+      if (
+        relationship.kind === 'caption' &&
+        (!blocksById.has(relationship.from) ||
+          relationship.to.length !== 1 ||
+          !blocksById.has(relationship.to[0]!))
+      )
+        continue
+      const mentionsCaption = relationship.to.some(
+        (target) => blocksById.get(target)?.kind === 'caption',
+      )
+      const isTypedCaptionRelation =
+        ['figure', 'table', 'equation'].includes(relationship.kind) &&
+        blocksById.get(relationship.from)?.kind === relationship.kind &&
+        mentionsCaption
+      if (relationship.kind !== 'caption' && !isTypedCaptionRelation) continue
       addDiagnostic(
         'warning',
         'invalid-caption-relationship',
@@ -379,11 +415,10 @@ export function adaptStructDocument(
 
   const captionParent = new Map<string, string>()
   for (const relationship of document.relationships) {
-    if (relationship.kind !== 'caption') continue
     if (relationship.status === 'matched') {
       const endpoints = captionLinks.get(relationship.id)
       if (endpoints) captionParent.set(endpoints.captionId, endpoints.parentId)
-    } else {
+    } else if (relationship.kind === 'caption') {
       addDiagnostic(
         'warning',
         'unresolved-caption',
@@ -756,7 +791,9 @@ export function adaptStructDocument(
               relationship.kind === 'figure' &&
               relationship.status === 'matched',
           )
-          .flatMap((relationship) => relationship.to)
+          .flatMap((relationship) =>
+            relationship.to.filter((target) => knownAssetIds.has(target)),
+          )
         const sourceAssetIds = block.fallbackAssetIds?.length
           ? block.fallbackAssetIds
           : relatedAssetIds
@@ -1055,9 +1092,11 @@ export function adaptStructDocument(
     const toAvailable =
       relationship.to.length > 0 &&
       relationship.to.every((target) =>
-        relationship.kind === 'figure'
-          ? assetIdsMap.has(target)
-          : Boolean(mappedNode(target)),
+        captionLinks.get(relationship.id)?.captionId === target
+          ? Boolean(mappedNode(target))
+          : relationship.kind === 'figure' || captionLinks.has(relationship.id)
+            ? assetIdsMap.has(target)
+            : Boolean(mappedNode(target)),
       )
     if (
       (!fromAvailable || !toAvailable) &&

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -7,9 +7,11 @@ import {
 } from './schema'
 import {
   PUBLICATION_SOURCE_ADAPTER_VERSION,
+  isSafePublicationSourceId,
   type AdapterDiagnostic,
   type PublicationSourceAdapter,
   type PublicationSourceResult,
+  validatePublicationSourceResult,
 } from './source-adapter'
 import type {
   StructBlock,
@@ -17,7 +19,7 @@ import type {
   StructInline,
   StructRelationship,
   StructTableCell,
-} from '../../packages/struct/src/types'
+} from '@erniesg/struct/schema'
 
 export const STRUCT_PUBLICATION_ADAPTER_ID = 'struct-document' as const
 export const STRUCT_PUBLICATION_MAPPING_VERSION = '1.0.0' as const
@@ -120,6 +122,18 @@ function basename(value: string) {
   return part && /^[^\u0000-\u001f\u007f/\\]+$/.test(part) ? part : undefined
 }
 
+function sourceIdFor(document: StructDocument) {
+  const fallback = `struct-${document.source.sha256.slice(0, 16)}`
+  const fileName = document.source.fileName
+  const candidate = basename(fileName)
+  return candidate &&
+    !/[\\/]/.test(fileName) &&
+    isSafePublicationSourceId(fileName) &&
+    isSafePublicationSourceId(candidate)
+    ? candidate
+    : fallback
+}
+
 function isExternalHref(value: string) {
   try {
     const url = new URL(value)
@@ -167,9 +181,7 @@ export function adaptStructDocument(
   document: StructDocument,
 ): PublicationSourceResult {
   const diagnostics: AdapterDiagnostic[] = []
-  const sourceId =
-    basename(document.source.fileName) ??
-    `struct-${document.source.sha256.slice(0, 16)}`
+  const sourceId = sourceIdFor(document)
   const addDiagnostic = (
     severity: Severity,
     code: string,
@@ -1254,7 +1266,7 @@ export function adaptStructDocument(
     edition: { id: editionId, locale, direction: directionValue },
     nodes,
   })
-  return {
+  return validatePublicationSourceResult({
     graph,
     assetBundle: createAssetBundle(
       { version: '1.0.0', assets: assetDescriptors },
@@ -1274,7 +1286,7 @@ export function adaptStructDocument(
       sourceRevision: document.source.sha256,
       mappingVersion: STRUCT_PUBLICATION_MAPPING_VERSION,
     },
-  }
+  })
 }
 
 function inlineRunsFor(

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -61,12 +61,51 @@ function localeFor(document: StructDocument) {
 
 function dateOnly(value: string | undefined) {
   if (!value) return undefined
-  return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return undefined
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const daysInMonth = [
+    31,
+    year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ]
+  return month >= 1 && day >= 1 && day <= (daysInMonth[month - 1] ?? 0)
+    ? value
+    : undefined
 }
 
 function dateTime(value: string | undefined) {
   if (!value) return undefined
-  return /^\d{4}-\d{2}-\d{2}T/.test(value) ? value : undefined
+  const match =
+    /^(\d{4}-\d{2}-\d{2})T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})$/.exec(
+      value,
+    )
+  if (!match || !dateOnly(match[1]) || !Number.isFinite(Date.parse(value)))
+    return undefined
+  const offset = /([+-])(\d{2}):?(\d{2})$/.exec(value)
+  if (offset && (Number(offset[2]) > 23 || Number(offset[3]) > 59))
+    return undefined
+  return value
+}
+
+function parsePublicationGraph(value: unknown) {
+  const parsed = publicationGraphSchema.safeParse(value)
+  if (parsed.success) return parsed.data
+  const details = parsed.error.issues
+    .map((issue) => `${issue.path.join('.') || 'graph'}:${issue.message}`)
+    .join(';')
+  throw new Error(`STRUCT_PUBLICATION_SCHEMA_INVALID:${details}`)
 }
 
 function direction(
@@ -239,30 +278,57 @@ export function adaptStructDocument(
       })
       .map((block) => block.id),
   )
+  const blocksById = new Map(document.blocks.map((block) => [block.id, block]))
+  const captionParentKinds = new Set(['figure', 'table', 'equation', 'media'])
+  const captionLinks = new Map<
+    string,
+    { captionId: string; parentId: string }
+  >()
+  const captionIdsByParent = new Map<string, string>()
+  const captionParentsByCaption = new Map<string, string>()
   const graphBlockIds = new Set(baseGraphBlockIds)
   for (const relationship of document.relationships) {
     if (relationship.kind !== 'caption' || relationship.status !== 'matched')
       continue
-    const fromBlock = document.blocks.find(
-      (block) => block.id === relationship.from,
-    )
-    const captionId =
-      fromBlock?.kind === 'caption'
-        ? relationship.from
-        : relationship.to.find(
-            (target) =>
-              document.blocks.find((block) => block.id === target)?.kind ===
-              'caption',
-          )
-    if (
-      !captionId ||
-      !document.blocks.find((block) => block.id === captionId)?.text
-    )
+    const fromBlock = blocksById.get(relationship.from)
+    const toBlock =
+      relationship.to.length === 1
+        ? blocksById.get(relationship.to[0]!)
+        : undefined
+    if (!fromBlock || !toBlock) continue
+    const endpoints =
+      captionParentKinds.has(fromBlock.kind) && toBlock.kind === 'caption'
+        ? { captionId: toBlock.id, parentId: fromBlock.id }
+        : undefined
+    if (!endpoints) {
+      addDiagnostic(
+        'warning',
+        'invalid-caption-relationship',
+        `Caption relationship ${relationship.id} did not connect one caption to one figure, table, equation, or media node and was omitted.`,
+        relationship.from,
+      )
       continue
-    const parentId =
-      captionId === relationship.from ? relationship.to[0] : relationship.from
-    if (parentId && baseGraphBlockIds.has(parentId))
-      graphBlockIds.add(captionId)
+    }
+    if (
+      captionIdsByParent.has(endpoints.parentId) ||
+      captionParentsByCaption.has(endpoints.captionId)
+    ) {
+      addDiagnostic(
+        'warning',
+        'invalid-caption-relationship',
+        `Caption relationship ${relationship.id} would create an ambiguous caption owner and was omitted.`,
+        relationship.from,
+      )
+      continue
+    }
+    captionLinks.set(relationship.id, endpoints)
+    captionIdsByParent.set(endpoints.parentId, endpoints.captionId)
+    captionParentsByCaption.set(endpoints.captionId, endpoints.parentId)
+    if (
+      baseGraphBlockIds.has(endpoints.parentId) &&
+      blocksById.get(endpoints.captionId)?.text
+    )
+      graphBlockIds.add(endpoints.captionId)
   }
   const mappedNode = (id: string) =>
     nonGraphBlockIds.has(id) || !graphBlockIds.has(id)
@@ -313,14 +379,10 @@ export function adaptStructDocument(
 
   const captionParent = new Map<string, string>()
   for (const relationship of document.relationships) {
-    if (relationship.kind !== 'caption' || !relationship.to[0]) continue
+    if (relationship.kind !== 'caption') continue
     if (relationship.status === 'matched') {
-      const fromBlock = document.blocks.find(
-        (block) => block.id === relationship.from,
-      )
-      if (fromBlock?.kind === 'caption')
-        captionParent.set(relationship.from, relationship.to[0])
-      else captionParent.set(relationship.to[0], relationship.from)
+      const endpoints = captionLinks.get(relationship.id)
+      if (endpoints) captionParent.set(endpoints.captionId, endpoints.parentId)
     } else {
       addDiagnostic(
         'warning',
@@ -552,18 +614,8 @@ export function adaptStructDocument(
   })
 
   const captionIdFor = (block: StructBlock) => {
-    const relationship = document.relationships.find(
-      (candidate) =>
-        candidate.kind === 'caption' && candidate.from === block.id,
-    )
-    if (!relationship || relationship.status !== 'matched') return undefined
-    const target = mappedNode(relationship.to[0] ?? '')
-    if (!target) return undefined
-    return document.blocks.find(
-      (candidate) => candidate.id === relationship.to[0],
-    )?.kind === 'caption'
-      ? target
-      : undefined
+    const captionId = captionIdsByParent.get(block.id)
+    return captionId ? mappedNode(captionId) : undefined
   }
 
   const mapTableCell = (
@@ -775,15 +827,19 @@ export function adaptStructDocument(
             block.id,
           )
         const cellIds = new Map<string, string>()
-        block.table.cells.forEach((cell, index) =>
+        const sourceCellIds = new Set<string>()
+        for (const [index, cell] of block.table.cells.entries()) {
+          if (sourceCellIds.has(cell.id))
+            throw new Error(`STRUCT_DUPLICATE_TABLE_CELL_ID:${cell.id}`)
+          sourceCellIds.add(cell.id)
           cellIds.set(
             cell.id,
             uniqueId(
               `${nodeIds.get(block.id)}-cell-${cell.id || index + 1}`,
               usedNodeIds,
             ),
-          ),
-        )
+          )
+        }
         const rows = Array.from({ length: block.table.rows }, () => ({
           cells: [] as ReturnType<typeof mapTableCell>[],
         }))
@@ -1115,7 +1171,28 @@ export function adaptStructDocument(
   }
 
   if (!nodes.length) throw new Error('STRUCT_NO_PUBLICATION_NODES')
-  const graph = publicationGraphSchema.parse({
+  const created = dateOnly(document.metadata.publicationDate)
+  if (document.metadata.publicationDate && !created)
+    addDiagnostic(
+      'warning',
+      'invalid-publication-date',
+      `Publication date ${document.metadata.publicationDate} was not a valid calendar date and was omitted.`,
+    )
+  const modified = dateOnly(document.metadata.updated)
+  if (document.metadata.updated && !modified)
+    addDiagnostic(
+      'warning',
+      'invalid-updated-date',
+      `Updated date ${document.metadata.updated} was not a valid calendar date and was omitted.`,
+    )
+  const artifactModifiedAt = dateTime(document.metadata.artifactModifiedAt)
+  if (document.metadata.artifactModifiedAt && !artifactModifiedAt)
+    addDiagnostic(
+      'warning',
+      'invalid-artifact-modified-at',
+      `Artifact modified timestamp ${document.metadata.artifactModifiedAt} was not a valid offset datetime and was omitted.`,
+    )
+  const graph = parsePublicationGraph({
     version: PUBLICATION_GRAPH_VERSION,
     id: graphId,
     metadata: {
@@ -1128,15 +1205,9 @@ export function adaptStructDocument(
         ? { abstract: document.metadata.abstract }
         : {}),
       sourceDocumentVersion: document.schemaVersion,
-      ...(dateOnly(document.metadata.publicationDate)
-        ? { created: dateOnly(document.metadata.publicationDate) }
-        : {}),
-      ...(dateOnly(document.metadata.updated)
-        ? { modified: dateOnly(document.metadata.updated) }
-        : {}),
-      ...(dateTime(document.metadata.artifactModifiedAt)
-        ? { artifactModifiedAt: dateTime(document.metadata.artifactModifiedAt) }
-        : {}),
+      ...(created ? { created } : {}),
+      ...(modified ? { modified } : {}),
+      ...(artifactModifiedAt ? { artifactModifiedAt } : {}),
       defaultLocale: locale,
       defaultDirection: directionValue,
       keywords: [],

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -39,6 +39,17 @@ function uniqueId(value: string, used: Set<string>) {
   return candidate
 }
 
+function assertUniqueSourceIds(
+  kind: 'BLOCK' | 'RELATIONSHIP' | 'ASSET',
+  ids: string[],
+) {
+  const seen = new Set<string>()
+  for (const id of ids) {
+    if (seen.has(id)) throw new Error(`STRUCT_DUPLICATE_${kind}_ID:${id}`)
+    seen.add(id)
+  }
+}
+
 function localeFor(document: StructDocument) {
   const candidate = document.metadata.language ?? 'en'
   try {
@@ -134,6 +145,19 @@ export function adaptStructDocument(
       ...(nodeId ? { nodeId } : {}),
     })
   }
+
+  assertUniqueSourceIds(
+    'BLOCK',
+    document.blocks.map((block) => block.id),
+  )
+  assertUniqueSourceIds(
+    'RELATIONSHIP',
+    document.relationships.map((relationship) => relationship.id),
+  )
+  assertUniqueSourceIds(
+    'ASSET',
+    document.assets.map((asset) => asset.id),
+  )
 
   for (const diagnostic of document.diagnostics) {
     addDiagnostic(
@@ -245,9 +269,53 @@ export function adaptStructDocument(
         .map(mappedNode)
         .filter((target): target is string => Boolean(target))
       const hasMissingTarget = mappedTargets.length !== targets.length
+      const hasMissingRelationship = Boolean(
+        inline.relationshipId && !relationship,
+      )
+      const relationshipHasMissingTarget = Boolean(
+        relationship &&
+        (relationship.to.length === 0 ||
+          relationship.to.some((target) => !mappedNode(target))),
+      )
+      const hasUnavailableMatchedTarget = Boolean(
+        relationship?.status === 'matched' &&
+        (hasMissingTarget ||
+          targets.length === 0 ||
+          relationshipHasMissingTarget),
+      )
+      if (hasMissingRelationship)
+        addDiagnostic(
+          'warning',
+          'unresolved-relationship',
+          `Inline relationship ${inline.relationshipId} in ${ownerId} had no matching source relationship.`,
+          ownerId,
+        )
+      const hasRoleSpecificTargetDiagnostic =
+        inline.semanticRole === 'citation' ||
+        inline.semanticRole === 'cross-reference' ||
+        inline.semanticRole === 'note-reference'
+      if (
+        hasMissingTarget &&
+        !hasRoleSpecificTargetDiagnostic &&
+        !hasUnavailableMatchedTarget
+      )
+        addDiagnostic(
+          'warning',
+          'unresolved-relationship-target',
+          `Inline target in ${ownerId} was unavailable and was source-preserved without a destination.`,
+          ownerId,
+        )
+      if (hasUnavailableMatchedTarget)
+        addDiagnostic(
+          'warning',
+          'unresolved-relationship-target',
+          `Matched relationship ${inline.relationshipId} in ${ownerId} had an unavailable target.`,
+          ownerId,
+        )
       const resolved = relationship
-        ? relationshipStatusIsResolved(relationship)
-        : !hasMissingTarget
+        ? relationshipStatusIsResolved(relationship) &&
+          !hasUnavailableMatchedTarget
+        : !hasMissingTarget && !hasMissingRelationship
       const base = {
         start: inline.start,
         end: inline.end,
@@ -334,7 +402,7 @@ export function adaptStructDocument(
               ),
             }
           : {}),
-        ...(inline.relationshipId && (resolved || href)
+        ...(inline.relationshipId && resolved
           ? { relationshipId: mappedRelationship(inline.relationshipId) }
           : {}),
         ...(inline.semanticRole ? { semanticRole: inline.semanticRole } : {}),
@@ -407,7 +475,13 @@ export function adaptStructDocument(
         {})
       : {}),
     ...(cell.inline.length
-      ? { inlineRuns: mapInline(cell.text, cell.inline, ownerId) }
+      ? (addDiagnostic(
+          'warning',
+          'lossy-table-inline',
+          `Table cell ${cell.id} contained inline annotations that are not supported by the publication table-cell schema; annotations were omitted.`,
+          ownerId,
+        ),
+        {})
       : {}),
   })
 
@@ -724,6 +798,15 @@ export function adaptStructDocument(
   const assetBytes = new Map<string, Uint8Array>()
   const assetHashes = new Map<string, string>()
   for (const asset of document.assets) {
+    if (!asset.bytes) {
+      addDiagnostic(
+        'warning',
+        'asset-bytes-unavailable',
+        `Asset ${asset.id} has no local bytes and was omitted from the publication asset bundle.`,
+        asset.id,
+      )
+      continue
+    }
     const prior = assetHashes.get(asset.sha256)
     if (prior) {
       assetIdsMap.set(asset.id, prior)
@@ -747,14 +830,7 @@ export function adaptStructDocument(
       ...(asset.width > 0 ? { width: asset.width } : {}),
       ...(asset.height > 0 ? { height: asset.height } : {}),
     })
-    if (asset.bytes) assetBytes.set(id, new Uint8Array(asset.bytes))
-    else if (assetDescriptors.at(-1)!.byteLength > 0)
-      addDiagnostic(
-        'warning',
-        'asset-bytes-unavailable',
-        `Asset ${asset.id} has no local bytes; resolution remains explicitly unavailable.`,
-        asset.id,
-      )
+    assetBytes.set(id, new Uint8Array(asset.bytes))
   }
 
   const nodes: PublicationNode[] = []

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -200,9 +200,98 @@ export function adaptStructDocument(
       relationship,
     ]),
   )
+  const baseGraphBlockIds = new Set(
+    document.blocks
+      .filter((block) => {
+        if (
+          block.kind === 'furniture' ||
+          block.kind === 'unknown' ||
+          block.kind === 'caption'
+        )
+          return false
+        if (
+          [
+            'heading',
+            'paragraph',
+            'quote',
+            'code',
+            'equation',
+            'footnote',
+            'endnote',
+            'list-item',
+          ].includes(block.kind)
+        )
+          return Boolean(block.text)
+        if (block.kind === 'figure') return Boolean(block.label || block.text)
+        if (block.kind === 'table')
+          return Boolean(
+            block.table &&
+            block.table.rows > 0 &&
+            block.table.cells.some(
+              (cell) =>
+                cell.row >= 0 &&
+                cell.row < block.table!.rows &&
+                cell.column >= 0 &&
+                cell.column < block.table!.columns,
+            ),
+          )
+        return false
+      })
+      .map((block) => block.id),
+  )
+  const graphBlockIds = new Set(baseGraphBlockIds)
+  for (const relationship of document.relationships) {
+    if (relationship.kind !== 'caption' || relationship.status !== 'matched')
+      continue
+    const fromBlock = document.blocks.find(
+      (block) => block.id === relationship.from,
+    )
+    const captionId =
+      fromBlock?.kind === 'caption'
+        ? relationship.from
+        : relationship.to.find(
+            (target) =>
+              document.blocks.find((block) => block.id === target)?.kind ===
+              'caption',
+          )
+    if (
+      !captionId ||
+      !document.blocks.find((block) => block.id === captionId)?.text
+    )
+      continue
+    const parentId =
+      captionId === relationship.from ? relationship.to[0] : relationship.from
+    if (parentId && baseGraphBlockIds.has(parentId))
+      graphBlockIds.add(captionId)
+  }
   const mappedNode = (id: string) =>
-    nonGraphBlockIds.has(id) ? undefined : nodeIds.get(id)
+    nonGraphBlockIds.has(id) || !graphBlockIds.has(id)
+      ? undefined
+      : nodeIds.get(id)
   const mappedRelationship = (id: string) => relationshipIds.get(id)
+  const inlineRelationshipIds = new Map<StructInline, string>()
+  const occurrenceCounts = new Map<string, number>()
+  for (const { block } of orderedBlocks) {
+    if (!graphBlockIds.has(block.id)) continue
+    for (const inline of block.inline) {
+      const sourceRelationshipId = inline.relationshipId
+      const relationship = sourceRelationshipId
+        ? relationships.get(sourceRelationshipId)
+        : undefined
+      const mapped = sourceRelationshipId
+        ? mappedRelationship(sourceRelationshipId)
+        : undefined
+      if (!sourceRelationshipId || !relationship || !mapped) continue
+      const count = (occurrenceCounts.get(sourceRelationshipId) ?? 0) + 1
+      occurrenceCounts.set(sourceRelationshipId, count)
+      inlineRelationshipIds.set(
+        inline,
+        count === 1
+          ? mapped
+          : uniqueId(`${mapped}-occurrence-${count}`, usedNodeIds),
+      )
+    }
+  }
 
   for (const relationship of document.relationships) {
     if (relationship.status === 'matched') continue
@@ -312,6 +401,26 @@ export function adaptStructDocument(
           `Matched relationship ${inline.relationshipId} in ${ownerId} had an unavailable target.`,
           ownerId,
         )
+      const preservesGenericRelationship = Boolean(
+        relationship &&
+        !hasMissingTarget &&
+        !hasUnavailableMatchedTarget &&
+        mappedTargets.length,
+      )
+      if (
+        relationship &&
+        relationship.status !== 'matched' &&
+        preservesGenericRelationship &&
+        inline.semanticRole !== 'citation' &&
+        inline.semanticRole !== 'cross-reference' &&
+        inline.semanticRole !== 'note-reference'
+      )
+        addDiagnostic(
+          'warning',
+          'unresolved-relationship-status',
+          `Inline relationship ${inline.relationshipId} in ${ownerId} was ${relationship.status}; its safe source targets were preserved.`,
+          ownerId,
+        )
       const resolved = relationship
         ? relationshipStatusIsResolved(relationship) &&
           !hasUnavailableMatchedTarget
@@ -340,6 +449,7 @@ export function adaptStructDocument(
             ...base,
             href: `#${noteTarget}`,
             relationshipId:
+              inlineRelationshipIds.get(inline) ??
               mappedRelationship(inline.relationshipId ?? '') ??
               safeId(
                 inline.relationshipId ?? `${ownerId}-note`,
@@ -402,11 +512,15 @@ export function adaptStructDocument(
               ),
             }
           : {}),
-        ...(inline.relationshipId && resolved
-          ? { relationshipId: mappedRelationship(inline.relationshipId) }
+        ...(inline.relationshipId && (resolved || preservesGenericRelationship)
+          ? {
+              relationshipId:
+                inlineRelationshipIds.get(inline) ??
+                mappedRelationship(inline.relationshipId),
+            }
           : {}),
         ...(inline.semanticRole ? { semanticRole: inline.semanticRole } : {}),
-        ...(mappedTargets.length && resolved
+        ...(mappedTargets.length && (resolved || preservesGenericRelationship)
           ? { targetIds: mappedTargets }
           : {}),
       })
@@ -677,17 +791,43 @@ export function adaptStructDocument(
           (left, right) => left.row - right.row || left.column - right.column,
         )) {
           const row = rows[cell.row]
-          if (!row) {
+          if (
+            !row ||
+            cell.column < 0 ||
+            cell.column >= block.table.columns ||
+            cell.rowSpan < 1 ||
+            cell.columnSpan < 1
+          ) {
             addDiagnostic(
               'warning',
               'lossy-table-cell',
-              `Table cell ${cell.id} was outside the declared row count and was omitted.`,
+              `Table cell ${cell.id} was outside the declared table geometry and was omitted.`,
               block.id,
             )
             continue
           }
+          if (
+            cell.row + cell.rowSpan > block.table.rows ||
+            cell.column + cell.columnSpan > block.table.columns
+          )
+            addDiagnostic(
+              'warning',
+              'lossy-table-geometry',
+              `Table cell ${cell.id} exceeded the declared table geometry; its source span was retained.`,
+              block.id,
+            )
           row.cells.push(mapTableCell(cell, block.id, cellIds.get(cell.id)!))
         }
+        const emptyRows = rows
+          .map((row, index) => (row.cells.length ? undefined : index))
+          .filter((index): index is number => index !== undefined)
+        if (emptyRows.length)
+          addDiagnostic(
+            'warning',
+            'lossy-table-geometry',
+            `Table ${block.id} omitted empty source rows ${emptyRows.join(', ')} when projecting the strict publication table schema.`,
+            block.id,
+          )
         const validRows = rows.filter((row) => row.cells.length)
         if (!validRows.length) return undefined
         return {
@@ -767,7 +907,24 @@ export function adaptStructDocument(
                   ),
               ),
           )
-          .map((relationship) => mappedRelationship(relationship.id))
+          .flatMap((relationship) => {
+            const occurrences = document.blocks.flatMap((candidate) =>
+              candidate.inline
+                .filter(
+                  (inline) =>
+                    inline.relationshipId === relationship.id &&
+                    inline.semanticRole === 'note-reference' &&
+                    inline.targetIds?.includes(block.id) &&
+                    inline.start >= 0 &&
+                    inline.end > inline.start &&
+                    inline.end <= candidate.text.length,
+                )
+                .map((inline) => inlineRelationshipIds.get(inline)),
+            )
+            return occurrences.length
+              ? occurrences
+              : [mappedRelationship(relationship.id)]
+          })
           .filter((id): id is string => Boolean(id))
           .filter((id, index, all) => all.indexOf(id) === index)
         return {
@@ -831,6 +988,31 @@ export function adaptStructDocument(
       ...(asset.height > 0 ? { height: asset.height } : {}),
     })
     assetBytes.set(id, new Uint8Array(asset.bytes))
+  }
+
+  for (const relationship of document.relationships) {
+    if (relationship.status !== 'matched') continue
+    const appearsInline = document.blocks.some((block) =>
+      block.inline.some((inline) => inline.relationshipId === relationship.id),
+    )
+    const fromAvailable = Boolean(mappedNode(relationship.from))
+    const toAvailable =
+      relationship.to.length > 0 &&
+      relationship.to.every((target) =>
+        relationship.kind === 'figure'
+          ? assetIdsMap.has(target)
+          : Boolean(mappedNode(target)),
+      )
+    if (
+      (!fromAvailable || !toAvailable) &&
+      !(appearsInline && fromAvailable && !toAvailable)
+    )
+      addDiagnostic(
+        'warning',
+        'unresolved-relationship-target',
+        `Matched relationship ${relationship.id} (${relationship.kind}) had an unavailable endpoint and was not projected as a link.`,
+        relationship.from,
+      )
   }
 
   const nodes: PublicationNode[] = []

--- a/src/publication/struct-adapter.ts
+++ b/src/publication/struct-adapter.ts
@@ -122,12 +122,20 @@ function basename(value: string) {
   return part && /^[^\u0000-\u001f\u007f/\\]+$/.test(part) ? part : undefined
 }
 
+function containsPathSeparator(value: string) {
+  try {
+    return /[\\/]/.test(decodeURIComponent(value))
+  } catch {
+    return true
+  }
+}
+
 function sourceIdFor(document: StructDocument) {
   const fallback = `struct-${document.source.sha256.slice(0, 16)}`
   const fileName = document.source.fileName
   const candidate = basename(fileName)
   return candidate &&
-    !/[\\/]/.test(fileName) &&
+    !containsPathSeparator(fileName) &&
     isSafePublicationSourceId(fileName) &&
     isSafePublicationSourceId(candidate)
     ? candidate

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
+      "@erniesg/struct/schema": ["./packages/struct/src/schema.ts"],
       "@/*": ["./src/*"]
     },
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- add an app-owned `StructDocument` to `PublicationGraph` conversion boundary
- map supported semantic nodes, relationships, and assets while emitting explicit diagnostics for lossy or unsupported content
- keep page geometry, recovery state, furniture, model receipts, provider policy, and package internals out of `PublicationGraph`
- register the adapter in the app-owned publication adapter registry

Refs #207 and #124. This stacked draft does not close either issue and does not publish `@erniesg/struct`.

## Exact-head checkpoint

```text
repo=erniesg/erniesg
issue=207
branch=codex/issue-207-struct-publication-adapter
base_sha=a05deb3621497f95fdbd14330cda3d7e565d481a
exact_head=7727ba50038b07537085a83ba5ca535f12eb5f69
clean=true
model=gpt-5.6-luna implementation + repeated independent adversarial review
reasoning_effort=high
changed_seam=app-owned StructDocument-to-PublicationGraph conversion and diagnostics
changed_files=src/publication/struct-adapter.ts; src/publication/struct-adapter.test.ts; src/publication/adapter-registry.ts
focused_tests=20 adapter + 224 publication + 16 package parity/export/codec/golden; TypeScript, Prettier, Astro check, 132-page build, diff and secret checks
full_suite_result=awaiting exact-head GitHub Linux CI
environment_refusals=full local suite lacks pinned Playwright Chromium and has a known parent-worktree-name package-boundary false positive; no focused failure waived
product_gates=unsupported/lossy mappings are deterministic diagnostics or bounded STRUCT adapter errors; IDs/references/tables/assets/captions remain schema-valid; excluded recovery/geometry/furniture/receipt/provider state never enters PublicationGraph
integration_gates=final independent APPROVE; package parity/hash/export contract green; app registry explicitly owns the conversion
caveats=stacked on #212; compatibility shims remain; no merge, npm publication, repository creation, deployment, or live consumer migration
next_action=require exact-head Linux CI, then migrate consumer families only under #208 ordering; no live publication
```

## Validation

- focused adapter tests
- publication suite
- package/hash compatibility suite
- Astro check and build
- strict TypeScript and Prettier
- diff and secret checks
