### PR TITLE
Move reconstruction hash consumers to app-owned helper

### DIFF
--- a/src/research/grounded-struct-materializer.test.ts
+++ b/src/research/grounded-struct-materializer.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { path as epubCheckJarPath } from 'epubcheck-static'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import {
   hashTraceValue,
   type ProviderReceiptBinding,

--- a/src/research/reconstruction-attempt-trace.test.ts
+++ b/src/research/reconstruction-attempt-trace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import {
   RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
   canonicalTraceJson,

--- a/src/research/reconstruction-attempt-trace.ts
+++ b/src/research/reconstruction-attempt-trace.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import type { StructBox } from '@erniesg/struct/schema'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 
 /**
  * Closed, content-addressed evidence for one source-PDF reconstruction attempt.

--- a/src/research/reconstruction-materialization.test.ts
+++ b/src/research/reconstruction-materialization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { structDigest } from '@erniesg/struct/ids'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import type { StructDocument } from '@erniesg/struct/schema'
 import {
   GROUNDED_STRUCT_MATERIALIZATION_SCHEMA_VERSION,

--- a/src/research/reconstruction-refinement.test.ts
+++ b/src/research/reconstruction-refinement.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import {
   RECONSTRUCTION_ATTEMPT_TRACE_SCHEMA_VERSION,
   createReconstructionAttemptTrace,

--- a/src/research/reconstruction-refinement.ts
+++ b/src/research/reconstruction-refinement.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import {
   RECONSTRUCTION_ATTEMPT_DEFAULT_BUDGET,
   canonicalTraceJson,

--- a/src/research/source-epub-comparator.test.ts
+++ b/src/research/source-epub-comparator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sha256HexSync } from '../struct/sha256'
+import { sha256HexSync } from './sha256-sync'
 import {
   DETERMINISTIC_CHECK_IDS,
   encodeCanonicalObservationPayload,


### PR DESCRIPTION
## Summary

- replace the seven remaining `src/research` imports of the canonical private STRUCT SHA helper with the existing app-owned `sha256-sync` helper
- keep `@erniesg/struct` exports intentionally limited; do not publish the private SHA implementation as package API
- preserve all serialized bytes, hashes, receipts, XHTML, EPUB, asset, and table goldens

References #208. This draft is stacked on #215 and does not publish, merge, deploy, remove shims, or change package metadata.

## Exact-head checkpoint

```text
repo=erniesg/erniesg
issue=208
branch=codex/issue-208-struct-hash-consumers
base_sha=407146d0691876e598c99e32d07d3ba7a61e02bb
exact_head=c15e9bea80c4a27793b54e43a331e2c0b950eeef
clean=true
model=gpt-5.6-luna
reasoning_effort=medium implementation; high independent review
changed_seam=seven import-only substitutions from ../struct/sha256 to app-owned ./sha256-sync
focused_tests=52 passed; 1 intentional EPUBCheck environment skip; direct 30-vector app/canonical SHA parity including Unicode/surrogates and padding boundaries
full_suite_result=struct build, package parity/golden tests, Astro build, Python discovery, diff and secret gates passed
environment_refusals=EPUBCheck case requires its external runtime and remains intentionally skipped
product_gates=zero remaining src/research canonical SHA imports; no package, lockfile, canonical source, policy, manifest, or tools changes
caveats=stacked draft; exact-head GitHub Linux checks pending
next_action=require exact-head checks, then audit remaining non-package tool/shim consumers; no merge or publication under current authority
```

Independent adversarial review approved exact head `c15e9bea80c4a27793b54e43a331e2c0b950eeef`.