### PR TITLE
Resolve STRUCT digest through package in evidence tool

### DIFF
--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -27,6 +27,8 @@ import { createCanvas, loadImage } from '@napi-rs/canvas'
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs'
 import { structDigest } from '@erniesg/struct/ids'
 
+export const sourceOutputStructDigest = structDigest
+
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const DEFAULT_DOCUMENT = resolve(
   REPOSITORY_ROOT,
@@ -349,7 +351,6 @@ async function createFixtureStructDocument({
   fileName,
   page,
   asset,
-  structDigest,
 }) {
   const figureAsset = await cropFixtureFigure(asset)
   const sourceEvidence = evidence(
@@ -642,7 +643,7 @@ async function createFixtureStructDocument({
     },
   }
   const { receipt, ...withoutReceipt } = document
-  receipt.generatedSha256 = structDigest({
+  receipt.generatedSha256 = sourceOutputStructDigest({
     ...withoutReceipt,
     conservation: receipt.conservation,
     assets: document.assets.map(({ bytes: _bytes, ...asset }) => asset),
@@ -762,6 +763,16 @@ async function renderRendition({
   }
 }
 
+export async function loadViteModules(loadModule) {
+  const [checkpoints, pdf, struct, targets] = await Promise.all([
+    loadModule('/src/research/source-output-checkpoints.ts'),
+    loadModule('/src/research/pdf.ts'),
+    loadModule('/src/research/epub.ts'),
+    loadModule('/src/research/targets.ts'),
+  ])
+  return { checkpoints, pdf, struct, targets }
+}
+
 async function createViteModules() {
   const vite = await createServer({
     appType: 'custom',
@@ -770,13 +781,10 @@ async function createViteModules() {
     server: { middlewareMode: true, watch: null },
   })
   try {
-    const [checkpoints, pdf, struct, targets] = await Promise.all([
-      vite.ssrLoadModule('/src/research/source-output-checkpoints.ts'),
-      vite.ssrLoadModule('/src/research/pdf.ts'),
-      vite.ssrLoadModule('/src/research/epub.ts'),
-      vite.ssrLoadModule('/src/research/targets.ts'),
-    ])
-    return { vite, checkpoints, pdf, struct, targets }
+    const modules = await loadViteModules((specifier) =>
+      vite.ssrLoadModule(specifier),
+    )
+    return { vite, ...modules }
   } catch (error) {
     await vite.close()
     throw error
@@ -872,7 +880,6 @@ async function run(options) {
           fileName: basename(options.document),
           page: checkpoints[0].page,
           asset: sourceAsset,
-          structDigest,
         })
       : null
     const document = await loadStructDocument(options.struct, fallback)

--- a/tools/srt-source-output-evidence.mjs
+++ b/tools/srt-source-output-evidence.mjs
@@ -25,6 +25,7 @@ import { chromium } from '@playwright/test'
 import { strFromU8, unzipSync } from 'fflate'
 import { createCanvas, loadImage } from '@napi-rs/canvas'
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs'
+import { structDigest } from '@erniesg/struct/ids'
 
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const DEFAULT_DOCUMENT = resolve(
@@ -769,14 +770,13 @@ async function createViteModules() {
     server: { middlewareMode: true, watch: null },
   })
   try {
-    const [checkpoints, pdf, struct, targets, structIds] = await Promise.all([
+    const [checkpoints, pdf, struct, targets] = await Promise.all([
       vite.ssrLoadModule('/src/research/source-output-checkpoints.ts'),
       vite.ssrLoadModule('/src/research/pdf.ts'),
       vite.ssrLoadModule('/src/research/epub.ts'),
       vite.ssrLoadModule('/src/research/targets.ts'),
-      vite.ssrLoadModule('/src/struct/ids.ts'),
     ])
-    return { vite, checkpoints, pdf, struct, targets, structIds }
+    return { vite, checkpoints, pdf, struct, targets }
   } catch (error) {
     await vite.close()
     throw error
@@ -872,7 +872,7 @@ async function run(options) {
           fileName: basename(options.document),
           page: checkpoints[0].page,
           asset: sourceAsset,
-          structDigest: modules.structIds.structDigest,
+          structDigest,
         })
       : null
     const document = await loadStructDocument(options.struct, fallback)

--- a/tools/srt-source-output-evidence.test.mjs
+++ b/tools/srt-source-output-evidence.test.mjs
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
+import { structDigest as packageStructDigest } from '@erniesg/struct/ids'
 import { renditionSourceForCheckpoint } from './srt-source-output-evidence.mjs'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
@@ -49,6 +50,16 @@ function privateFixture() {
 }
 
 describe('source/output evidence privacy boundary', () => {
+  it('resolves STRUCT digest from the reviewed package export', async () => {
+    const source = readFileSync(tool, 'utf8')
+
+    expect(source).toContain("from '@erniesg/struct/ids'")
+    expect(source).not.toContain("'/src/struct/ids.ts'")
+    expect(packageStructDigest({ B: 1, a: 2 })).toBe(
+      '812e5e7fb7bb816dc477e91a136430192eadcf83ff303881298146e106ae0161',
+    )
+  })
+
   it.each([
     'marker-to-body',
     'citation-to-entry',

--- a/tools/srt-source-output-evidence.test.mjs
+++ b/tools/srt-source-output-evidence.test.mjs
@@ -11,7 +11,11 @@ import { basename, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import { structDigest as packageStructDigest } from '@erniesg/struct/ids'
-import { renditionSourceForCheckpoint } from './srt-source-output-evidence.mjs'
+import {
+  loadViteModules,
+  renditionSourceForCheckpoint,
+  sourceOutputStructDigest,
+} from './srt-source-output-evidence.mjs'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
 const tool = fileURLToPath(
@@ -50,14 +54,32 @@ function privateFixture() {
 }
 
 describe('source/output evidence privacy boundary', () => {
-  it('resolves STRUCT digest from the reviewed package export', async () => {
-    const source = readFileSync(tool, 'utf8')
-
-    expect(source).toContain("from '@erniesg/struct/ids'")
-    expect(source).not.toContain("'/src/struct/ids.ts'")
-    expect(packageStructDigest({ B: 1, a: 2 })).toBe(
+  it('uses the reviewed package export for fixture digest construction', () => {
+    expect(sourceOutputStructDigest).toBe(packageStructDigest)
+    expect(sourceOutputStructDigest({ B: 1, a: 2 })).toBe(
       '812e5e7fb7bb816dc477e91a136430192eadcf83ff303881298146e106ae0161',
     )
+  })
+
+  it('loads only the evidence tool Vite module graph', async () => {
+    const requested = []
+    const modules = await loadViteModules(async (specifier) => {
+      requested.push(specifier)
+      return { specifier }
+    })
+
+    expect(requested).toEqual([
+      '/src/research/source-output-checkpoints.ts',
+      '/src/research/pdf.ts',
+      '/src/research/epub.ts',
+      '/src/research/targets.ts',
+    ])
+    expect(modules).toEqual({
+      checkpoints: { specifier: requested[0] },
+      pdf: { specifier: requested[1] },
+      struct: { specifier: requested[2] },
+      targets: { specifier: requested[3] },
+    })
   })
 
   it.each([


### PR DESCRIPTION
## Summary

- replace the final evidence-tool Vite load of `/src/struct/ids.ts` with the reviewed `@erniesg/struct/ids` export
- expose and behaviorally test the exact package digest seam used by fixture generation
- preserve the four-module Vite graph, error cleanup, CLI outputs, evidence bytes, and manifest hashes

References #208. This draft is stacked on #216 and does not publish, merge, deploy, or remove compatibility shims.

## Exact-head checkpoint

```text
repo=erniesg/erniesg
issue=208
branch=codex/issue-208-struct-evidence-tool-consumer
base_sha=c15e9bea80c4a27793b54e43a331e2c0b950eeef
exact_head=ae05e138ac080b42ff2730fc0fe407b049bb82fb
clean=true
model=gpt-5.6-luna
reasoning_effort=medium implementation; two high independent review passes
changed_seam=evidence fixture digest resolves from package export; Vite graph contains only four research modules
focused_tests=8 tool tests; 39 package tests; struct build; executable digest identity and ordered module-graph contracts
full_suite_result=two real CLI runs produced identical 20-file trees and identical manifest SHA-256; package suite 39/39
product_gates=no canonical/package/manifest/lock/research/policy change; exact two-file scope; Vite cleanup preserved
caveats=stacked draft; exact-head GitHub checks pending
next_action=require exact-head checks, then run consolidated external-tarball/frozen-golden migration audit; no merge or publication under current authority
```

Fresh independent review approved `ae05e138ac080b42ff2730fc0fe407b049bb82fb`.