### PR TITLE
fix(struct): restore package codec security parity

### DIFF
--- a/packages/struct/src/codec/primitives.ts
+++ b/packages/struct/src/codec/primitives.ts
@@ -6,6 +6,8 @@ const CREDENTIAL_SHAPED_ID = [
   /^(?:AKIA|ASIA)[A-Z0-9]{12,}$/u,
   /^bearer[.:-][A-Za-z0-9._:-]{8,}$/iu,
   /^eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}$/u,
+  /^(?:-----)?BEGIN[.:-]?(?:(?:RSA|EC|OPENSSH)[.:-]?)?PRIVATE[.:-]?KEY/iu,
+  /^xox[baprs]-[A-Za-z0-9._:-]{8,}$/iu,
   /^(?:gh[pousr]|github_pat)_/iu,
 ] as const
 export const SAFE_ID = {

--- a/packages/struct/src/model-consultation-receipt.ts
+++ b/packages/struct/src/model-consultation-receipt.ts
@@ -1,5 +1,11 @@
 import { sha256HexSync } from './sha256.js'
-import { dataEntries, fail, finiteNumber } from './codec/primitives.js'
+import {
+  array,
+  copyRecord,
+  dataEntries,
+  fail,
+  finiteNumber,
+} from './codec/primitives.js'
 
 export const MODEL_CONSULTATION_SCHEMA_VERSION = '1.0.0' as const
 export const MODEL_FALLBACK_SCHEMA_VERSION = MODEL_CONSULTATION_SCHEMA_VERSION
@@ -89,6 +95,8 @@ const SAFE_ID = {
   },
 }
 const MAX_RECEIPT_HISTORY_ITEMS = 100_000
+const MAX_CANONICAL_DEPTH = 128
+const MAX_CANONICAL_NODES = 100_000
 const forbiddenKeys = new Set([
   'text',
   'content',
@@ -260,34 +268,51 @@ function forbidden(value: unknown): string | null {
 export function copyCanonicalJson(
   value: unknown,
   path: string,
-  active = new WeakSet<object>(),
+  state: { active: WeakSet<object>; nodes: number } = {
+    active: new WeakSet<object>(),
+    nodes: 0,
+  },
   depth = 0,
 ): unknown {
-  if (depth > 128)
+  if (depth > MAX_CANONICAL_DEPTH)
     fail('MODEL_RECEIPT', path, 'canonical JSON nesting is too deep')
+  state.nodes += 1
+  if (state.nodes > MAX_CANONICAL_NODES)
+    fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
   if (value === null || typeof value === 'string' || typeof value === 'boolean')
     return value
   if (typeof value === 'number') return finiteNumber(value, path)
-  if (!value || typeof value !== 'object')
+  if (typeof value !== 'object')
     fail('TYPE', path, 'model receipt must contain canonical JSON values')
-  if (active.has(value))
+  if (state.active.has(value))
     fail('MODEL_RECEIPT', path, 'cycles are not permitted in model receipts')
-  active.add(value)
+  state.active.add(value)
   try {
-    if (Array.isArray(value))
-      return value.map((entry, index) =>
-        copyCanonicalJson(entry, `${path}[${index}]`, active, depth + 1),
+    let isArray = false
+    try {
+      isArray = Array.isArray(value)
+    } catch {
+      fail(
+        'MODEL_RECEIPT',
+        path,
+        'model receipt object cannot be inspected safely',
       )
-    return Object.fromEntries(
-      dataEntries(value, path)
-        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-        .map(([key, entry]) => [
-          key,
-          copyCanonicalJson(entry, `${path}.${key}`, active, depth + 1),
-        ]),
+    }
+    if (isArray)
+      return array(value, path).map((entry, index) =>
+        copyCanonicalJson(entry, `${path}[${index}]`, state, depth + 1),
+      )
+    const entries = dataEntries(value, path).sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    )
+    return copyRecord(
+      entries.map(([key, entry]) => [
+        key,
+        copyCanonicalJson(entry, `${path}.${key}`, state, depth + 1),
+      ]),
     )
   } finally {
-    active.delete(value)
+    state.active.delete(value)
   }
 }
 function validChoice(value: unknown): value is ModelFallbackChoice {

--- a/packages/struct/test/model-receipt.test.ts
+++ b/packages/struct/test/model-receipt.test.ts
@@ -3,12 +3,22 @@ import {
   buildStructEpub,
   decodeStructDocument,
   encodeStructDocument,
+  StructCodecError,
   structDigest,
   type ModelFallbackReceipt,
   validateModelConsultationReceipt,
 } from '../src/index'
-import { hash } from '../src/model-consultation-receipt'
-import { characterizationDocument } from './characterization-fixtures'
+import {
+  copyCanonicalJson,
+  hash,
+  SAFE_ID as packageReceiptSafeId,
+} from '../src/model-consultation-receipt'
+import { SAFE_ID as packageDocumentSafeId } from '../src/codec/primitives'
+import { SAFE_ID as canonicalSafeId } from '../../../src/struct/model-consultation-receipt'
+import {
+  characterizationDocument,
+  resealDocument,
+} from './characterization-fixtures'
 
 function sealedDocument() {
   const document = characterizationDocument('0.2.0') as any
@@ -170,6 +180,64 @@ function refreshGeneratedDigest(document: any) {
 }
 
 describe('generic STRUCT model consultation receipt', () => {
+  it('contains hostile array inspection and enforces canonical resource bounds', () => {
+    const hostile: unknown[] = []
+    let getterExecuted = false
+    Object.defineProperty(hostile, 'map', {
+      enumerable: true,
+      get() {
+        getterExecuted = true
+        throw new Error('HOSTILE_MAP_GETTER_EXECUTED')
+      },
+    })
+    expect(() =>
+      copyCanonicalJson(hostile, '$.receipt.modelConsultations'),
+    ).toThrow(StructCodecError)
+    expect(getterExecuted).toBe(false)
+
+    const revoked = Proxy.revocable([], {})
+    revoked.revoke()
+    expect(() =>
+      copyCanonicalJson(revoked.proxy, '$.receipt.modelConsultations'),
+    ).toThrow(StructCodecError)
+
+    let atDepthLimit: unknown = null
+    for (let depth = 0; depth < 128; depth += 1) atDepthLimit = [atDepthLimit]
+    expect(() => copyCanonicalJson(atDepthLimit, '$')).not.toThrow()
+    expect(() => copyCanonicalJson([atDepthLimit], '$')).toThrow(
+      /nesting is too deep/,
+    )
+
+    const overNodeLimit = Array.from({ length: 100_000 }, () => null)
+    expect(() => copyCanonicalJson(overNodeLimit, '$')).toThrow(/node bound/)
+  })
+
+  it.each([
+    ['OpenAI', 'sk-proj-FAKEFAKEFAKE'],
+    ['AWS', 'AKIAFAKEFAKEFAKE'],
+    ['bearer', 'bearer-FAKEFAKEFAKE'],
+    ['JWT', 'eyJFAKE.payloadFAKE.signatureFAKE'],
+    ['encoded private key', 'BEGIN-RSA-PRIVATE-KEY'],
+    ['Slack', 'xoxb-FAKEFAKEFAKE'],
+    ['GitHub', 'github_pat_FAKEFAKEFAKE'],
+  ])(
+    'keeps package and canonical credential-shaped ID denial in parity (%s)',
+    (_label, credentialShapedId) => {
+      expect(canonicalSafeId.test(credentialShapedId)).toBe(false)
+      expect(packageReceiptSafeId.test(credentialShapedId)).toBe(false)
+      expect(packageDocumentSafeId.test(credentialShapedId)).toBe(false)
+
+      const document = characterizationDocument('0.2.0') as any
+      document.blocks[0].id = credentialShapedId
+      document.pages[0].blocks = [credentialShapedId]
+      document.pages[0].columns[0].blockIds = [credentialShapedId]
+      resealDocument(document)
+      expect(() => decodeStructDocument(document)).toThrow(
+        /STRUCT_CODEC_IDENTIFIER/,
+      )
+    },
+  )
+
   it('round-trips a valid closed receipt without policy symbols', () => {
     const document = sealedDocument()
     expect(

--- a/packages/struct/test/parity.test.ts
+++ b/packages/struct/test/parity.test.ts
@@ -62,7 +62,7 @@ const MAPPINGS: readonly Mapping[] = [
     canonicalSha256:
       '136fc31c551768d0bfb998ff3db7ff0e0667911811686ae5efad9a376812ccd1',
     packageSha256:
-      'b276d35ddd215ce81e5cd06679342adea4e24ceb2175299c4abdfb565735a156',
+      '707ced139e00b4d80aae27d52d7f4fb3ef6e604296be874677643715047287c5',
   },
   {
     packagePath: 'codec/structure.ts',
@@ -119,7 +119,7 @@ const MAPPINGS: readonly Mapping[] = [
     canonicalSha256:
       'f5bb7c8638ff23b75d2cc8f284e687b9d9799fd703c6784717731a4faf38d778',
     packageSha256:
-      'fec7f837a6a1806de8a48e11a02f631913500615df3884724c03eb1583d808b6',
+      'c98da5d50eaee762fe01c4f1ad326d20d55f3b5d8d14041696866d6f21d66bc6',
   },
   {
     packagePath: 'reading-order.ts',


### PR DESCRIPTION
## Summary

Restores security parity between the packaged `@erniesg/struct` codec and the
canonical compatibility codec after the final whole-stack review found two
blocking extraction regressions.

- snapshots model-receipt arrays through descriptor-safe codec primitives;
- contains hostile accessors/proxies as `StructCodecError` without executing an
  attacker-controlled `map` property;
- restores the canonical depth-128 and 100,000-node resource bounds;
- aligns package `SAFE_ID` denial with encoded-private-key and Slack token
  signatures already rejected by canonical STRUCT.

This is a focused package-only repair stacked on draft PR #217. It references
#124, #206, and #208; it does not close an epic or authorize npm publication,
repository creation, deployment, or merge.

## Exact-head evidence

- Base: `ae05e138ac080b42ff2730fc0fe407b049bb82fb`
- Head: `57aea3dd9751fa553c7ddaef1b2b510979460c20`
- Package build: passed
- Package suite: 47/47
- Canonical hostile-input/model-boundary suite: 118/118
- App suite: 3,858 passed, 5 skipped; one environment refusal at missing Java
  for EPUBCheck after pinned Chromium was provisioned
- Astro: 0 errors; 132 pages built
- Clean packed-tarball install: passed; SHA-256
  `94b893585a6fe7e7c8a561b91fc35c1d3df7c0facce9adf289b266a2a1c4507f`
- Root plus all six public subpaths resolve; private subpaths remain rejected
- Valid receipt/JSON/XHTML/EPUB/asset/table golden hashes remain unchanged
- Staged secret scan, formatting, and diff check: passed

The strongest-model whole-stack re-review approves this exact head and the
complete PR #209–#217 stack plus this repair. Exact-head GitHub CI remains
required before merge-ready status.

## Authority boundary

Draft/review only. No merge, package publication, repository creation,
deployment, or destructive cleanup is included.
