### PR TITLE
test(struct): enforce package import boundary

### DIFF
--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -307,14 +307,17 @@ describe('STRUCT package artifact boundary', () => {
     }
   })
 
-  it('does not treat AMD dependency lookalikes as edges for allowed modules', async () => {
+  it('rejects compiler-recognized AMD directives in every module mode', async () => {
     const cases = [
       { module: 'ESNext', moduleResolution: 'Bundler' },
       { module: 'CommonJS', moduleResolution: 'Node10' },
+      { module: 'System', moduleResolution: 'Node10' },
+      { module: 'None', moduleResolution: 'Node10' },
     ]
     for (const compilerOptions of cases) {
       const fixture = await makeFixture(
         '/// <amd-dependency path="evil" />\n' +
+          '/// <amd-dependency path="second" />\n' +
           'export const value = true\n' +
           '/// <amd-dependency path="late" />\n',
         {
@@ -330,6 +333,44 @@ describe('STRUCT package artifact boundary', () => {
           }),
         },
       )
+      try {
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        expect(
+          diagnostics.filter(({ code }) => code === 'invalid-amd-dependency'),
+        ).toHaveLength(1)
+        expect(diagnostics).toEqual([
+          expect.objectContaining({
+            code: 'invalid-amd-dependency',
+            importer: 'src/index.ts',
+            offset: 0,
+          }),
+        ])
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('ignores AMD directive lookalikes that TypeScript does not recognize', async () => {
+    const sources = [
+      '//// <amd-dependency path="four-slash" />\nexport const value = true\n',
+      'export const value = true\n/// <amd-dependency path="post-code" />\n',
+      '/// <amd-dependency name=\'path="decoy"\' data-path="decoy" />\nexport const value = true\n',
+    ]
+    for (const source of sources) {
+      const fixture = await makeFixture(source, {
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+          },
+          include: ['src/**/*.ts'],
+        }),
+      })
       try {
         await expect(auditPackageImportBoundary(fixture)).resolves.toEqual([])
       } finally {
@@ -359,6 +400,14 @@ describe('STRUCT package artifact boundary', () => {
         declaration: 'evil.TAR.GZ',
       },
       { name: 'bare tar archive', declaration: 'evil.tar' },
+      { name: 'dot-prefixed local directory', declaration: '.hidden' },
+      {
+        name: 'dot-prefixed nested local directory',
+        declaration: '.config/pkg',
+      },
+      { name: 'multi-dot local directory', declaration: '.../evil' },
+      { name: 'nested local directory', declaration: 'dir/sub/local' },
+      { name: 'raw scoped local directory', declaration: '@scope/pkg' },
       { name: 'file protocol', declaration: 'file:../evil' },
       { name: 'link protocol', declaration: 'link:../evil' },
       { name: 'workspace protocol', declaration: 'workspace:*' },
@@ -371,6 +420,37 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'semver range', declaration: '^1.2.3', portable: true },
       { name: 'semver tilde', declaration: '~1.2.3', portable: true },
       { name: 'npm alias', declaration: 'npm:evil@^1.2.3', portable: true },
+      {
+        name: 'npm scoped alias',
+        declaration: 'npm:@scope/pkg@^1.2.3',
+        portable: true,
+      },
+      { name: 'GitHub shorthand', declaration: 'user/repo', portable: true },
+      {
+        name: 'GitHub shorthand tgz repository',
+        declaration: 'user/repo.tgz',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand tar.gz repository',
+        declaration: 'user/repo.tar.gz',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand tar repository',
+        declaration: 'user/repo.tar',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand archive fragment',
+        declaration: 'user/repo.tgz#main',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand semver fragment',
+        declaration: 'user/repo#semver:^1.2.3',
+        portable: true,
+      },
       {
         name: 'HTTPS archive',
         declaration: 'https://example.com/evil.tgz',

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -138,15 +138,10 @@ describe('STRUCT package artifact boundary', () => {
         specifier: 'vitest',
       },
       {
-        name: 'undeclared AMD dependency directive',
+        name: 'AMD module compiler option',
         source:
           '/// <amd-dependency path="evil" />\nexport const value = true\n',
         extra: {
-          'node_modules/evil/package.json': JSON.stringify({
-            name: 'evil',
-            types: 'index.d.ts',
-          }),
-          'node_modules/evil/index.d.ts': 'export {}\n',
           'tsconfig.json': JSON.stringify({
             compilerOptions: {
               target: 'ES2022',
@@ -159,8 +154,9 @@ describe('STRUCT package artifact boundary', () => {
             include: ['src/**/*.ts'],
           }),
         },
-        expected: 'undeclared-runtime-dependency',
-        specifier: 'evil',
+        expected: 'compiler-option-not-allowed',
+        importer: 'tsconfig.json',
+        specifier: 'module',
       },
       ...['constructor', 'toString', 'hasOwnProperty'].map((name) => ({
         name: `inherited dependency name: ${name}`,
@@ -265,54 +261,80 @@ describe('STRUCT package artifact boundary', () => {
     }
   })
 
-  it('pairs AMD dependency paths with ordered public edges and exact offsets', async () => {
+  it('rejects AMD and UMD options without lexically parsing directive text', async () => {
+    const cases = [
+      { name: 'AMD', module: 'AMD' },
+      { name: 'UMD', module: 'UMD' },
+    ]
     const source =
-      '// ordinary comment mentions evil\n' +
-      '/// <amd-dependency path="evil" name="first" />\n' +
-      "/// <amd-dependency   name='second'   path = 'evil'   />\n" +
-      '/// <amd-dependency path = "" name="empty" />\n' +
-      '/// <amd-dependency path="evil" />\n' +
-      'export const value = true\n'
-    const fixture = await makeFixture(source, {
-      'node_modules/evil/package.json': JSON.stringify({
-        name: 'evil',
-        types: 'index.d.ts',
-      }),
-      'node_modules/evil/index.d.ts': 'export {}\n',
-      'tsconfig.json': JSON.stringify({
-        compilerOptions: {
-          target: 'ES2022',
-          module: 'AMD',
-          moduleResolution: 'Node10',
-          strict: true,
-          skipLibCheck: true,
-          rootDir: 'src',
-        },
-        include: ['src/**/*.ts'],
-      }),
-    })
-    try {
-      const diagnostics = await auditPackageImportBoundary(fixture)
-      const undeclared = diagnostics.filter(
-        ({ code, specifier }) =>
-          code === 'undeclared-runtime-dependency' && specifier === 'evil',
-      )
-      const firstDirective = source.indexOf('path="evil"')
-      const secondDirective = source.indexOf("path = 'evil'")
-      const thirdDirective = source.lastIndexOf('path="evil"')
-      expect(undeclared.map(({ offset }) => offset)).toEqual([
-        source.indexOf('evil', firstDirective),
-        source.indexOf('evil', secondDirective),
-        source.indexOf('evil', thirdDirective),
-      ])
+      '/// <amd-dependency name=\'path="evil"\' data-path="evil" />\n' +
+      'export const value = true\n' +
+      '//// <amd-dependency path="late" />\n' +
+      'text = "<amd-dependency path=\\"ignored\\" />"\n' +
+      '/// <amd-dependency path="post-code" />\n'
 
-      const empty = diagnostics.find(({ specifier }) => specifier === '')
-      expect(empty).toMatchObject({
-        code: 'unresolved-module',
-        offset: source.indexOf('path = ""') + 'path = "'.length,
+    for (const testCase of cases) {
+      const fixture = await makeFixture(source, {
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: testCase.module,
+            moduleResolution: 'Node10',
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+          },
+          include: ['src/**/*.ts'],
+        }),
       })
-    } finally {
-      await rm(fixture, { recursive: true, force: true })
+      try {
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            code: 'compiler-option-not-allowed',
+            importer: 'tsconfig.json',
+            offset: 0,
+            specifier: 'module',
+          }),
+        )
+        expect(
+          diagnostics.filter(({ code }) => code === 'invalid-amd-dependency'),
+          testCase.name,
+        ).toEqual([])
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('does not treat AMD dependency lookalikes as edges for allowed modules', async () => {
+    const cases = [
+      { module: 'ESNext', moduleResolution: 'Bundler' },
+      { module: 'CommonJS', moduleResolution: 'Node10' },
+    ]
+    for (const compilerOptions of cases) {
+      const fixture = await makeFixture(
+        '/// <amd-dependency path="evil" />\n' +
+          'export const value = true\n' +
+          '/// <amd-dependency path="late" />\n',
+        {
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              ...compilerOptions,
+              strict: true,
+              skipLibCheck: true,
+              rootDir: 'src',
+            },
+            include: ['src/**/*.ts'],
+          }),
+        },
+      )
+      try {
+        await expect(auditPackageImportBoundary(fixture)).resolves.toEqual([])
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
     }
   })
 
@@ -329,6 +351,14 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'Windows drive-relative parent', declaration: 'C:../evil' },
       { name: 'Windows drive-relative archive', declaration: 'Z:package.tgz' },
       { name: 'Windows UNC path', declaration: '\\\\server\\share\\evil' },
+      { name: 'bare tgz archive', declaration: 'evil.tgz' },
+      { name: 'bare tgz archive is case-insensitive', declaration: 'evil.TGZ' },
+      { name: 'bare tar.gz archive', declaration: 'evil.tar.gz' },
+      {
+        name: 'bare tar.gz archive is case-insensitive',
+        declaration: 'evil.TAR.GZ',
+      },
+      { name: 'bare tar archive', declaration: 'evil.tar' },
       { name: 'file protocol', declaration: 'file:../evil' },
       { name: 'link protocol', declaration: 'link:../evil' },
       { name: 'workspace protocol', declaration: 'workspace:*' },

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -1,8 +1,19 @@
-import { readFile, readdir } from 'node:fs/promises'
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
 import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { auditPackageImportBoundary } from './package-import-boundary.js'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -83,4 +94,301 @@ describe('STRUCT package artifact boundary', () => {
       ),
     ).toBe(false)
   })
+
+  it('reports exact graph-boundary diagnostics for red fixtures', async () => {
+    const cases = [
+      {
+        name: 'relative import escaping source',
+        source: "import '../app.js'\n",
+        extra: { 'app.ts': 'export const app = true\n' },
+        expected: 'relative-outside-source',
+        specifier: '../app.js',
+      },
+      {
+        name: 'resolution indirection',
+        source: "import '@app/secret.js'\n",
+        extra: {
+          'app/secret.ts': 'export const secret = true\n',
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'ESNext',
+              moduleResolution: 'Bundler',
+              rootDir: 'src',
+              baseUrl: '.',
+              paths: { '@app/*': ['app/*'] },
+            },
+            include: ['src/**/*.ts'],
+          }),
+        },
+        expected: 'resolution-indirection-not-allowed',
+        importer: 'tsconfig.json',
+      },
+      {
+        name: 'undeclared dependency',
+        source: "import 'vitest'\n",
+        extra: {
+          'node_modules/vitest/package.json': JSON.stringify({
+            name: 'vitest',
+            types: 'index.d.ts',
+          }),
+          'node_modules/vitest/index.d.ts': 'export {}\n',
+        },
+        expected: 'undeclared-runtime-dependency',
+        specifier: 'vitest',
+      },
+      {
+        name: 'unresolved dependency',
+        source: "import 'missing-runtime'\n",
+        expected: 'unresolved-module',
+        specifier: 'missing-runtime',
+      },
+      {
+        name: 'unsafe dependency subpath',
+        source: "import 'fflate/../fast-xml-parser'\n",
+        expected: 'unsafe-module-specifier',
+        specifier: 'fflate/../fast-xml-parser',
+      },
+      {
+        name: 'encoded dependency traversal',
+        source: "import 'fflate%2e%2fsecret'\n",
+        expected: 'unsafe-module-specifier',
+        specifier: 'fflate%2e%2fsecret',
+      },
+      {
+        name: 'backslash dependency traversal',
+        source: "import 'fflate\\\\secret'\n",
+        expected: 'unsafe-module-specifier',
+        specifier: 'fflate\\secret',
+      },
+      {
+        name: 'reference directive',
+        source: '/// <reference path="../app.ts" />\nexport const value = 1\n',
+        extra: { 'app.ts': 'export const app = true\n' },
+        expected: 'reference-directive-not-allowed',
+        specifier: '../app.ts',
+      },
+      {
+        name: 'source symlink',
+        source: 'export const value = 1\n',
+        symlink: true,
+        expected: 'source-symlink-not-allowed',
+        importer: 'src/link.ts',
+      },
+    ]
+
+    for (const testCase of cases) {
+      const fixture = await makeFixture(testCase.source, testCase.extra)
+      try {
+        if (testCase.symlink) {
+          await symlink(
+            join(fixture, 'src/index.ts'),
+            join(fixture, 'src/link.ts'),
+          )
+        }
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        const matching = diagnostics.find(
+          ({ code }) => code === testCase.expected,
+        )
+        expect(matching, testCase.name).toBeDefined()
+        expect(matching).toMatchObject({
+          importer: testCase.importer ?? 'src/index.ts',
+          ...(testCase.specifier ? { specifier: testCase.specifier } : {}),
+        })
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('reports exact lexical policy diagnostics for unsupported capabilities', async () => {
+    const cases = [
+      {
+        source: "export const value = import('./local.js')\n",
+        expected: 'dynamic-import-not-allowed',
+      },
+      {
+        source: "export const value = require('x')\n",
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source: "export const value = require.resolve('x')\n",
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source:
+          'const require = () => undefined\nexport const value = require()\n',
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source:
+          'declare const name: string\nexport const value = import(name)\n',
+        expected: 'dynamic-import-not-allowed',
+      },
+      {
+        source: "import value = require('x')\n",
+        expected: 'import-equals-not-allowed',
+      },
+      {
+        source: 'export const value = eval("1")\n',
+        expected: 'runtime-codegen-not-allowed',
+      },
+      {
+        source: 'export const value = Function("return 1")\n',
+        expected: 'runtime-codegen-not-allowed',
+      },
+      {
+        source: "import { readFile } from 'node:module'\n",
+        expected: 'loader-module-not-allowed',
+      },
+      {
+        source:
+          'const { process: proc } = globalThis\nexport const value = proc\n',
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source: 'const req = global.process\nexport const value = req\n',
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source:
+          "const req = process.getBuiltinModule('module').Module.createRequire(import.meta.url)\nexport const value = req\n",
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source:
+          "const { Module } = process.getBuiltinModule('module')\nexport const value = Module\n",
+        expected: 'reserved-capability-not-allowed',
+      },
+      {
+        source:
+          "const { default: proc } = await import('node:process')\nexport const value = proc\n",
+        expected: 'dynamic-import-not-allowed',
+      },
+      {
+        source:
+          "const proc = await import('node:process' as const)\nexport const value = proc\n",
+        expected: 'dynamic-import-not-allowed',
+      },
+      {
+        source:
+          '// require eval Function globalThis\nconst value = "process module"\n',
+        expected: undefined,
+      },
+    ]
+
+    for (const testCase of cases) {
+      const fixture = await makeFixture(testCase.source)
+      try {
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        if (testCase.expected) {
+          expect(
+            diagnostics.map(({ code }) => code),
+            testCase.source,
+          ).toContain(testCase.expected)
+        } else {
+          expect(diagnostics).toEqual([])
+        }
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('accepts the current source tree', async () => {
+    expect(await auditPackageImportBoundary(root)).toEqual([])
+  })
+
+  it('compiles and packs from a package-only temporary copy', async () => {
+    const fixture = await mkdtemp(join(tmpdir(), 'struct-package-only-'))
+    try {
+      await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
+      await cp(join(root, 'package.json'), join(fixture, 'package.json'))
+      await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
+      await symlink(
+        join(root, '../../node_modules'),
+        join(fixture, 'node_modules'),
+      )
+
+      execFileSync(
+        process.execPath,
+        [
+          join(root, '../../node_modules/typescript/bin/tsc'),
+          '-p',
+          join(fixture, 'tsconfig.json'),
+        ],
+        { cwd: fixture, stdio: 'pipe' },
+      )
+      const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>
+        path.slice(fixture.length + 1),
+      )
+      expect(distPaths).toEqual(
+        expect.arrayContaining([
+          'dist/index.js',
+          'dist/core.js',
+          'dist/schema.js',
+          'dist/ids.js',
+          'dist/recovery.js',
+          'dist/renderers/xhtml.js',
+          'dist/renderers/epub.js',
+        ]),
+      )
+      const pack = JSON.parse(
+        execFileSync(
+          'npm',
+          ['pack', '--dry-run', '--ignore-scripts', '--json'],
+          {
+            cwd: fixture,
+            encoding: 'utf8',
+          },
+        ),
+      )[0] as { files?: Array<{ path: string }> }
+      const packedPaths = pack.files?.map(({ path }) => path) ?? []
+      expect(packedPaths).toContain('package.json')
+      expect(
+        packedPaths.every(
+          (path) => path === 'package.json' || path.startsWith('dist/'),
+        ),
+      ).toBe(true)
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
+  })
 })
+
+type FixtureExtra = Record<string, string | undefined>
+
+async function makeFixture(source: string, extra: FixtureExtra = {}) {
+  const fixture = await mkdtemp(join(tmpdir(), 'struct-boundary-'))
+  await mkdir(join(fixture, 'src'), { recursive: true })
+  await writeFile(join(fixture, 'src/index.ts'), source)
+  await writeFile(
+    join(fixture, 'package.json'),
+    JSON.stringify({
+      name: 'fixture',
+      version: '1.0.0',
+      dependencies: { fflate: '^0.8.3', 'fast-xml-parser': '^5.10.1' },
+    }),
+  )
+  await writeFile(
+    join(fixture, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+        strict: true,
+        skipLibCheck: true,
+        rootDir: 'src',
+      },
+      include: ['src/**/*.ts'],
+    }),
+  )
+  for (const [path, contents] of Object.entries(extra)) {
+    if (contents === undefined) continue
+    const destination = join(fixture, path)
+    await mkdir(dirname(destination), { recursive: true })
+    await writeFile(destination, contents)
+  }
+  return fixture
+}

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -424,6 +424,16 @@ describe('STRUCT package artifact boundary', () => {
           '// ordinary comment mentioning jsxRuntime automatic\nexport const value = true\n',
         jsx: 'react-jsx',
       },
+      {
+        name: 'line comment with pragma text',
+        source: '// @jsxRuntime automatic\nexport const value = true\n',
+        jsx: 'react-jsx',
+      },
+      {
+        name: 'block comment with pragma text',
+        source: '/* @jsxImportSource evil */\nexport const value = true\n',
+        jsx: 'react-jsx',
+      },
     ]
 
     const missing: string[] = []

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -431,8 +431,29 @@ describe('STRUCT package artifact boundary', () => {
       },
       {
         name: 'block comment with pragma text',
-        source: '/* @jsxImportSource evil */\nexport const value = true\n',
+        source: '/* @jsxImportSource evil */\nexport const value = <div />\n',
         jsx: 'react-jsx',
+        pragma: '@jsxImportSource',
+      },
+      {
+        name: 'block automatic runtime override',
+        source: '/* @jsxRuntime automatic */\nexport const value = <div />\n',
+        jsx: 'react',
+        pragma: '@jsxRuntime',
+      },
+      {
+        name: 'lowercase block import source pragma',
+        source: '/* @jsximportsource evil */\nexport const value = <div />\n',
+        jsx: 'react-jsx',
+        pragma: '@jsxImportSource',
+        marker: '@jsximportsource',
+      },
+      {
+        name: 'uppercase block runtime pragma',
+        source: '/* @JSXRUNTIME automatic */\nexport const value = <div />\n',
+        jsx: 'react',
+        pragma: '@jsxRuntime',
+        marker: '@JSXRUNTIME',
       },
     ]
 
@@ -481,7 +502,9 @@ describe('STRUCT package artifact boundary', () => {
           } else {
             expect(matching).toMatchObject({
               importer: 'src/index.tsx',
-              offset: testCase.source.indexOf(testCase.pragma),
+              offset: testCase.source.indexOf(
+                testCase.marker ?? testCase.pragma,
+              ),
               message: `${testCase.pragma} is not part of the package source dialect`,
             })
           }

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
@@ -96,7 +96,7 @@ describe('STRUCT package artifact boundary', () => {
   })
 
   it('reports exact graph-boundary diagnostics for red fixtures', async () => {
-    const cases = [
+    const cases: GraphBoundaryCase[] = [
       {
         name: 'relative import escaping source',
         source: "import '../app.js'\n",
@@ -286,9 +286,17 @@ describe('STRUCT package artifact boundary', () => {
   })
 
   it('rejects compiler-selected local declaration closure outside src', async () => {
-    const fixture = await makeFixture('export const value = true\n', {
-      '../ambient/index.d.ts': 'declare const ambient: unique symbol\n',
-      'tsconfig.json': JSON.stringify({
+    const fixture = await makeFixture('export const value = true\n')
+    const ambientName = `ambient-${basename(fixture)}`
+    const ambientPath = join(fixture, '..', ambientName)
+    await mkdir(ambientPath, { recursive: true })
+    await writeFile(
+      join(ambientPath, 'index.d.ts'),
+      'declare const ambient: unique symbol\n',
+    )
+    await writeFile(
+      join(fixture, 'tsconfig.json'),
+      JSON.stringify({
         compilerOptions: {
           target: 'ES2022',
           module: 'ESNext',
@@ -296,57 +304,101 @@ describe('STRUCT package artifact boundary', () => {
           strict: true,
           skipLibCheck: true,
           rootDir: 'src',
-          types: ['../ambient'],
+          types: [`../${ambientName}`],
         },
         include: ['src/**/*.ts'],
       }),
-    })
+    )
     try {
       expect(
         (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
       ).toContain('source-closure-outside-source')
     } finally {
       await rm(fixture, { recursive: true, force: true })
-      await rm(join(fixture, '..', 'ambient'), {
-        recursive: true,
-        force: true,
-      })
+      await rm(ambientPath, { recursive: true, force: true })
     }
   })
 
   it('classifies the implicit JSX runtime module edge', async () => {
-    const fixture = await makeFixture(
-      'export const value = <div />\n',
+    const cases = [
       {
-        'node_modules/evil/package.json': JSON.stringify({
-          name: 'evil',
-          types: 'jsx-runtime.d.ts',
-        }),
-        'node_modules/evil/jsx-runtime.d.ts':
-          'export function jsx(): unknown\n',
-        'tsconfig.json': JSON.stringify({
-          compilerOptions: {
-            target: 'ES2022',
-            module: 'ESNext',
-            moduleResolution: 'Bundler',
-            jsx: 'react-jsx',
-            jsxImportSource: 'evil',
-            strict: true,
-            skipLibCheck: true,
-            rootDir: 'src',
-          },
-          include: ['src/**/*.tsx'],
-        }),
+        name: 'configured JSX import source',
+        source: 'export const value = <div />\n',
+        packageName: 'evil',
+        jsx: 'react-jsx',
+        runtimeFile: 'jsx-runtime.d.ts',
+        runtime: 'evil/jsx-runtime',
       },
-      'src/index.tsx',
-    )
-    try {
-      expect(
-        (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
-      ).toContain('undeclared-runtime-dependency')
-    } finally {
-      await rm(fixture, { recursive: true, force: true })
+      {
+        name: 'default React JSX runtime',
+        source: 'export const value = <div />\n',
+        packageName: 'react',
+        jsx: 'react-jsx',
+        runtimeFile: 'jsx-runtime.d.ts',
+        runtime: 'react/jsx-runtime',
+      },
+      {
+        name: 'default React JSX dev runtime',
+        source: 'export const value = <div />\n',
+        packageName: 'react',
+        jsx: 'react-jsxdev',
+        runtimeFile: 'jsx-dev-runtime.d.ts',
+        runtime: 'react/jsx-dev-runtime',
+      },
+      {
+        name: 'source JSX import pragma',
+        source: '/** @jsxImportSource evil */\nexport const value = <div />\n',
+        packageName: 'evil',
+        jsx: 'react-jsx',
+        runtimeFile: 'jsx-runtime.d.ts',
+        runtime: 'evil/jsx-runtime',
+      },
+    ]
+
+    const missing: string[] = []
+    for (const testCase of cases) {
+      const fixture = await makeFixture(
+        testCase.source,
+        {
+          [`node_modules/${testCase.packageName}/package.json`]: JSON.stringify(
+            {
+              name: testCase.packageName,
+              types: testCase.runtimeFile,
+            },
+          ),
+          [`node_modules/${testCase.packageName}/${testCase.runtimeFile}`]:
+            'export function jsx(): unknown\n',
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'ESNext',
+              moduleResolution: 'Bundler',
+              jsx: testCase.jsx,
+              ...(testCase.packageName === 'evil' &&
+              !testCase.source.includes('@jsxImportSource')
+                ? { jsxImportSource: 'evil' }
+                : {}),
+              strict: true,
+              skipLibCheck: true,
+              rootDir: 'src',
+            },
+            include: ['src/**/*.tsx'],
+          }),
+        },
+        'src/index.tsx',
+      )
+      try {
+        const matching = (await auditPackageImportBoundary(fixture)).find(
+          ({ code, specifier }) =>
+            code === 'undeclared-runtime-dependency' &&
+            specifier === testCase.runtime,
+        )
+        if (!matching) missing.push(testCase.name)
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
     }
+    expect(missing).toEqual([])
   })
 
   it('reports exact lexical policy diagnostics for unsupported capabilities', async () => {
@@ -505,6 +557,16 @@ describe('STRUCT package artifact boundary', () => {
 })
 
 type FixtureExtra = Record<string, string | undefined>
+
+type GraphBoundaryCase = {
+  name: string
+  source: string
+  extra?: FixtureExtra
+  expected: string
+  symlink?: boolean
+  importer?: string
+  specifier?: string
+}
 
 async function makeFixture(
   source: string,

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -455,6 +455,20 @@ describe('STRUCT package artifact boundary', () => {
         pragma: '@jsxRuntime',
         marker: '@JSXRUNTIME',
       },
+      {
+        name: 'unknown prefix before import source token',
+        source:
+          '/* @notAThing @jsxImportSource evil */\nexport const value = <div />\n',
+        jsx: 'react-jsx',
+        allowRuntimeEdge: true,
+      },
+      {
+        name: 'unknown prefix before runtime token',
+        source:
+          '/* @notAThing @jsxRuntime automatic */\nexport const value = <div />\n',
+        jsx: 'react',
+        allowRuntimeEdge: true,
+      },
     ]
 
     const missing: string[] = []
@@ -508,7 +522,10 @@ describe('STRUCT package artifact boundary', () => {
               message: `${testCase.pragma} is not part of the package source dialect`,
             })
           }
-        } else if (diagnostics.length > 0) {
+        } else if (
+          diagnostics.some(({ code }) => code === 'jsx-pragma-not-allowed') ||
+          (!testCase.allowRuntimeEdge && diagnostics.length > 0)
+        ) {
           missing.push(testCase.name)
         }
       } finally {

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -442,6 +442,42 @@ describe('STRUCT package artifact boundary', () => {
         declaration: 'user/%ZZ',
       },
       {
+        name: 'hosted shorthand with invalid UTF-8 byte',
+        declaration: 'user/%FF',
+      },
+      {
+        name: 'hosted shorthand with overlong UTF-8 sequence',
+        declaration: 'user/%C0%AF',
+      },
+      {
+        name: 'hosted shorthand with surrogate UTF-8 sequence',
+        declaration: 'user/%ED%A0%80',
+      },
+      {
+        name: 'hosted shorthand with invalid fragment UTF-8 byte',
+        declaration: 'user/repo#foo%FF',
+      },
+      {
+        name: 'hosted shorthand with overlong four-byte sequence',
+        declaration: 'user/%F0%80%80%AF',
+      },
+      {
+        name: 'hosted shorthand with truncated three-byte sequence',
+        declaration: 'user/%E2%82',
+      },
+      {
+        name: 'hosted shorthand with truncated four-byte sequence',
+        declaration: 'user/%F0%9F%92',
+      },
+      {
+        name: 'hosted shorthand with invalid continuation byte',
+        declaration: 'user/%E2%28%A1',
+      },
+      {
+        name: 'hosted shorthand with out-of-range UTF-8 sequence',
+        declaration: 'user/%F4%90%80%80',
+      },
+      {
         name: 'slash value with non-protocol colon',
         declaration: 'user/repo:tag',
       },
@@ -503,6 +539,16 @@ describe('STRUCT package artifact boundary', () => {
       {
         name: 'GitHub shorthand slash escape',
         declaration: 'user/repo%2F',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand encoded repository dot',
+        declaration: 'user/repo%2e',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand encoded owner dot',
+        declaration: 'user%2e/repo',
         portable: true,
       },
       {

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -150,6 +150,32 @@ describe('STRUCT package artifact boundary', () => {
         specifier: 'fflate/../fast-xml-parser',
       },
       {
+        name: 'dot dependency subpath',
+        source: "import 'fflate/./index'\n",
+        extra: {
+          'node_modules/fflate/package.json': JSON.stringify({
+            name: 'fflate',
+            types: 'index.d.ts',
+          }),
+          'node_modules/fflate/index.d.ts': 'export {}\n',
+        },
+        expected: 'unsafe-module-specifier',
+        specifier: 'fflate/./index',
+      },
+      {
+        name: 'dot package root subpath',
+        source: "import 'fflate/.'\n",
+        extra: {
+          'node_modules/fflate/package.json': JSON.stringify({
+            name: 'fflate',
+            types: 'index.d.ts',
+          }),
+          'node_modules/fflate/index.d.ts': 'export {}\n',
+        },
+        expected: 'unsafe-module-specifier',
+        specifier: 'fflate/.',
+      },
+      {
         name: 'encoded dependency traversal',
         source: "import 'fflate%2e%2fsecret'\n",
         expected: 'unsafe-module-specifier',

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -137,6 +137,19 @@ describe('STRUCT package artifact boundary', () => {
         expected: 'undeclared-runtime-dependency',
         specifier: 'vitest',
       },
+      ...['constructor', 'toString', 'hasOwnProperty'].map((name) => ({
+        name: `inherited dependency name: ${name}`,
+        source: `import '${name}'\n`,
+        extra: {
+          [`node_modules/${name}/package.json`]: JSON.stringify({
+            name,
+            types: 'index.d.ts',
+          }),
+          [`node_modules/${name}/index.d.ts`]: 'export {}\n',
+        },
+        expected: 'undeclared-runtime-dependency',
+        specifier: name,
+      })),
       {
         name: 'unresolved dependency',
         source: "import 'missing-runtime'\n",
@@ -224,6 +237,115 @@ describe('STRUCT package artifact boundary', () => {
       } finally {
         await rm(fixture, { recursive: true, force: true })
       }
+    }
+  })
+
+  it('rejects every parsed root outside the canonical source set', async () => {
+    const cases = [
+      { name: 'mts', path: 'src/extra.mts', compilerOptions: {} },
+      { name: 'cts', path: 'src/extra.cts', compilerOptions: {} },
+      {
+        name: 'javascript with allowJs',
+        path: 'src/extra.js',
+        compilerOptions: { allowJs: true },
+      },
+      {
+        name: 'json with resolveJsonModule',
+        path: 'src/extra.json',
+        compilerOptions: { resolveJsonModule: true },
+      },
+    ]
+
+    for (const testCase of cases) {
+      const fixture = await makeFixture('export const value = true\n', {
+        [testCase.path]: testCase.path.endsWith('.json')
+          ? '{"value":true}\n'
+          : 'export const extra = true\n',
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+            ...testCase.compilerOptions,
+          },
+          files: ['src/index.ts', testCase.path],
+        }),
+      })
+      try {
+        expect(
+          (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
+          testCase.name,
+        ).toContain('configured-source-set-mismatch')
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('rejects compiler-selected local declaration closure outside src', async () => {
+    const fixture = await makeFixture('export const value = true\n', {
+      '../ambient/index.d.ts': 'declare const ambient: unique symbol\n',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          strict: true,
+          skipLibCheck: true,
+          rootDir: 'src',
+          types: ['../ambient'],
+        },
+        include: ['src/**/*.ts'],
+      }),
+    })
+    try {
+      expect(
+        (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
+      ).toContain('source-closure-outside-source')
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+      await rm(join(fixture, '..', 'ambient'), {
+        recursive: true,
+        force: true,
+      })
+    }
+  })
+
+  it('classifies the implicit JSX runtime module edge', async () => {
+    const fixture = await makeFixture(
+      'export const value = <div />\n',
+      {
+        'node_modules/evil/package.json': JSON.stringify({
+          name: 'evil',
+          types: 'jsx-runtime.d.ts',
+        }),
+        'node_modules/evil/jsx-runtime.d.ts':
+          'export function jsx(): unknown\n',
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            jsx: 'react-jsx',
+            jsxImportSource: 'evil',
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+          },
+          include: ['src/**/*.tsx'],
+        }),
+      },
+      'src/index.tsx',
+    )
+    try {
+      expect(
+        (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
+      ).toContain('undeclared-runtime-dependency')
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
     }
   })
 
@@ -384,10 +506,14 @@ describe('STRUCT package artifact boundary', () => {
 
 type FixtureExtra = Record<string, string | undefined>
 
-async function makeFixture(source: string, extra: FixtureExtra = {}) {
+async function makeFixture(
+  source: string,
+  extra: FixtureExtra = {},
+  sourcePath = 'src/index.ts',
+) {
   const fixture = await mkdtemp(join(tmpdir(), 'struct-boundary-'))
   await mkdir(join(fixture, 'src'), { recursive: true })
-  await writeFile(join(fixture, 'src/index.ts'), source)
+  await writeFile(join(fixture, sourcePath), source)
   await writeFile(
     join(fixture, 'package.json'),
     JSON.stringify({

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -384,6 +384,7 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'parent path', declaration: '../evil' },
       { name: 'current path', declaration: './evil' },
       { name: 'npm local path', declaration: '~/evil' },
+      { name: 'npm local backslash path', declaration: '~\\evil' },
       { name: 'npm local archive', declaration: '~/evil.tgz' },
       { name: 'POSIX absolute path', declaration: '/tmp/evil' },
       { name: 'Windows drive path', declaration: 'C:\\evil' },
@@ -408,6 +409,58 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'multi-dot local directory', declaration: '.../evil' },
       { name: 'nested local directory', declaration: 'dir/sub/local' },
       { name: 'raw scoped local directory', declaration: '@scope/pkg' },
+      {
+        name: 'hosted shorthand with version suffix',
+        declaration: 'user/repo@1.2.3',
+      },
+      {
+        name: 'hosted shorthand with tag suffix',
+        declaration: 'foo/bar@latest',
+      },
+      {
+        name: 'hosted shorthand with whitespace',
+        declaration: 'user/repo name',
+      },
+      {
+        name: 'hosted shorthand with tab whitespace',
+        declaration: 'user/repo\tname',
+      },
+      {
+        name: 'hosted shorthand with control character',
+        declaration: 'user/repo\u0000name',
+      },
+      {
+        name: 'hosted shorthand with user at-sign',
+        declaration: 'user@name/repo',
+      },
+      {
+        name: 'hosted shorthand with invalid repository escape',
+        declaration: 'user/repo%ZZ',
+      },
+      {
+        name: 'hosted shorthand with invalid user escape',
+        declaration: 'user/%ZZ',
+      },
+      {
+        name: 'slash value with non-protocol colon',
+        declaration: 'user/repo:tag',
+      },
+      {
+        name: 'multisegment shorthand with semver fragment',
+        declaration: 'dir/sub/local#semver:^1.2.3',
+      },
+      {
+        name: 'multisegment shorthand with path fragment',
+        declaration: 'user/repo/extra#path:packages/a',
+      },
+      {
+        name: 'scoped multisegment shorthand with semver fragment',
+        declaration: '@scope/pkg/path#semver:^1.2.3',
+      },
+      {
+        name: 'hosted shorthand with invalid fragment escape',
+        declaration: 'user/repo#main%ZZ',
+      },
       { name: 'file protocol', declaration: 'file:../evil' },
       { name: 'link protocol', declaration: 'link:../evil' },
       { name: 'workspace protocol', declaration: 'workspace:*' },
@@ -419,6 +472,12 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'exact semver', declaration: '1.2.3', portable: true },
       { name: 'semver range', declaration: '^1.2.3', portable: true },
       { name: 'semver tilde', declaration: '~1.2.3', portable: true },
+      { name: 'bare tilde registry tag', declaration: '~', portable: true },
+      {
+        name: 'named tilde registry tag',
+        declaration: '~latest',
+        portable: true,
+      },
       { name: 'npm alias', declaration: 'npm:evil@^1.2.3', portable: true },
       {
         name: 'npm scoped alias',
@@ -426,6 +485,26 @@ describe('STRUCT package artifact boundary', () => {
         portable: true,
       },
       { name: 'GitHub shorthand', declaration: 'user/repo', portable: true },
+      {
+        name: 'GitHub shorthand empty fragment',
+        declaration: 'user/repo#',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand space escape',
+        declaration: 'user/repo%20',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand letter escape',
+        declaration: 'user/repo%72',
+        portable: true,
+      },
+      {
+        name: 'GitHub shorthand slash escape',
+        declaration: 'user/repo%2F',
+        portable: true,
+      },
       {
         name: 'GitHub shorthand tgz repository',
         declaration: 'user/repo.tgz',
@@ -459,6 +538,31 @@ describe('STRUCT package artifact boundary', () => {
       {
         name: 'HTTPS git repository',
         declaration: 'git+https://github.com/example/evil.git',
+        portable: true,
+      },
+      {
+        name: 'GitHub protocol repository',
+        declaration: 'github:user/repo',
+        portable: true,
+      },
+      {
+        name: 'GitLab protocol repository',
+        declaration: 'gitlab:user/repo',
+        portable: true,
+      },
+      {
+        name: 'Bitbucket protocol repository',
+        declaration: 'bitbucket:user/repo',
+        portable: true,
+      },
+      {
+        name: 'git+ssh repository',
+        declaration: 'git+ssh://git@github.com/example/evil.git',
+        portable: true,
+      },
+      {
+        name: 'SCP git repository',
+        declaration: 'git@github.com:example/evil.git',
         portable: true,
       },
     ]

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -265,13 +265,69 @@ describe('STRUCT package artifact boundary', () => {
     }
   })
 
+  it('pairs AMD dependency paths with ordered public edges and exact offsets', async () => {
+    const source =
+      '// ordinary comment mentions evil\n' +
+      '/// <amd-dependency path="evil" name="first" />\n' +
+      "/// <amd-dependency   name='second'   path = 'evil'   />\n" +
+      '/// <amd-dependency path = "" name="empty" />\n' +
+      '/// <amd-dependency path="evil" />\n' +
+      'export const value = true\n'
+    const fixture = await makeFixture(source, {
+      'node_modules/evil/package.json': JSON.stringify({
+        name: 'evil',
+        types: 'index.d.ts',
+      }),
+      'node_modules/evil/index.d.ts': 'export {}\n',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'AMD',
+          moduleResolution: 'Node10',
+          strict: true,
+          skipLibCheck: true,
+          rootDir: 'src',
+        },
+        include: ['src/**/*.ts'],
+      }),
+    })
+    try {
+      const diagnostics = await auditPackageImportBoundary(fixture)
+      const undeclared = diagnostics.filter(
+        ({ code, specifier }) =>
+          code === 'undeclared-runtime-dependency' && specifier === 'evil',
+      )
+      const firstDirective = source.indexOf('path="evil"')
+      const secondDirective = source.indexOf("path = 'evil'")
+      const thirdDirective = source.lastIndexOf('path="evil"')
+      expect(undeclared.map(({ offset }) => offset)).toEqual([
+        source.indexOf('evil', firstDirective),
+        source.indexOf('evil', secondDirective),
+        source.indexOf('evil', thirdDirective),
+      ])
+
+      const empty = diagnostics.find(({ specifier }) => specifier === '')
+      expect(empty).toMatchObject({
+        code: 'unresolved-module',
+        offset: source.indexOf('path = ""') + 'path = "'.length,
+      })
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
+  })
+
   it('rejects non-portable dependency declarations while retaining portable forms', async () => {
     const cases = [
       { name: 'parent path', declaration: '../evil' },
       { name: 'current path', declaration: './evil' },
+      { name: 'npm local path', declaration: '~/evil' },
+      { name: 'npm local archive', declaration: '~/evil.tgz' },
       { name: 'POSIX absolute path', declaration: '/tmp/evil' },
       { name: 'Windows drive path', declaration: 'C:\\evil' },
       { name: 'Windows drive slash path', declaration: 'C:/evil' },
+      { name: 'Windows drive-relative path', declaration: 'C:evil' },
+      { name: 'Windows drive-relative parent', declaration: 'C:../evil' },
+      { name: 'Windows drive-relative archive', declaration: 'Z:package.tgz' },
       { name: 'Windows UNC path', declaration: '\\\\server\\share\\evil' },
       { name: 'file protocol', declaration: 'file:../evil' },
       { name: 'link protocol', declaration: 'link:../evil' },
@@ -283,6 +339,7 @@ describe('STRUCT package artifact boundary', () => {
       { name: 'object declaration', declaration: { path: 'evil' } },
       { name: 'exact semver', declaration: '1.2.3', portable: true },
       { name: 'semver range', declaration: '^1.2.3', portable: true },
+      { name: 'semver tilde', declaration: '~1.2.3', portable: true },
       { name: 'npm alias', declaration: 'npm:evil@^1.2.3', portable: true },
       {
         name: 'HTTPS archive',

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -641,7 +641,7 @@ describe('STRUCT package artifact boundary', () => {
         await rm(fixture, { recursive: true, force: true })
       }
     }
-  })
+  }, 15_000)
 
   it('rejects every parsed root outside the canonical source set', async () => {
     const cases = [
@@ -715,10 +715,61 @@ describe('STRUCT package artifact boundary', () => {
     try {
       expect(
         (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
-      ).toContain('source-closure-outside-source')
+      ).toEqual(
+        expect.arrayContaining([
+          'compiler-option-not-allowed',
+          'source-closure-outside-source',
+        ]),
+      )
     } finally {
       await rm(fixture, { recursive: true, force: true })
       await rm(ambientPath, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects compiler-clean source that depends on an ambient @types package', async () => {
+    const fixture = await makeFixture(
+      'export const value: true = ambientEvil\n',
+      {
+        'node_modules/@types/evil/index.d.ts':
+          'declare const ambientEvil: true\n',
+      },
+    )
+    try {
+      expect(
+        (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
+      ).toContain('compiler-diagnostic')
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects explicit ambient type selection without an exact dependency policy', async () => {
+    const fixture = await makeFixture(
+      'export const value: true = ambientEvil\n',
+      {
+        'node_modules/@types/evil/index.d.ts':
+          'declare const ambientEvil: true\n',
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+            types: ['evil'],
+          },
+          include: ['src/**/*.ts'],
+        }),
+      },
+    )
+    try {
+      expect(
+        (await auditPackageImportBoundary(fixture)).map(({ code }) => code),
+      ).toContain('compiler-option-not-allowed')
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
     }
   })
 
@@ -1095,11 +1146,24 @@ describe('STRUCT package artifact boundary', () => {
       await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
       await cp(join(root, 'package.json'), join(fixture, 'package.json'))
       await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
+      await mkdir(join(fixture, 'empty-types'))
       await symlink(
         join(root, '../../node_modules'),
         join(fixture, 'node_modules'),
       )
 
+      execFileSync(
+        process.execPath,
+        [
+          join(root, '../../node_modules/typescript/bin/tsc'),
+          '-p',
+          join(fixture, 'tsconfig.json'),
+          '--noEmit',
+          '--typeRoots',
+          join(fixture, 'empty-types'),
+        ],
+        { cwd: fixture, stdio: 'pipe' },
+      )
       execFileSync(
         process.execPath,
         [

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -137,6 +137,31 @@ describe('STRUCT package artifact boundary', () => {
         expected: 'undeclared-runtime-dependency',
         specifier: 'vitest',
       },
+      {
+        name: 'undeclared AMD dependency directive',
+        source:
+          '/// <amd-dependency path="evil" />\nexport const value = true\n',
+        extra: {
+          'node_modules/evil/package.json': JSON.stringify({
+            name: 'evil',
+            types: 'index.d.ts',
+          }),
+          'node_modules/evil/index.d.ts': 'export {}\n',
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'AMD',
+              moduleResolution: 'Node10',
+              strict: true,
+              skipLibCheck: true,
+              rootDir: 'src',
+            },
+            include: ['src/**/*.ts'],
+          }),
+        },
+        expected: 'undeclared-runtime-dependency',
+        specifier: 'evil',
+      },
       ...['constructor', 'toString', 'hasOwnProperty'].map((name) => ({
         name: `inherited dependency name: ${name}`,
         source: `import '${name}'\n`,
@@ -234,6 +259,67 @@ describe('STRUCT package artifact boundary', () => {
           importer: testCase.importer ?? 'src/index.ts',
           ...(testCase.specifier ? { specifier: testCase.specifier } : {}),
         })
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+  })
+
+  it('rejects non-portable dependency declarations while retaining portable forms', async () => {
+    const cases = [
+      { name: 'parent path', declaration: '../evil' },
+      { name: 'current path', declaration: './evil' },
+      { name: 'POSIX absolute path', declaration: '/tmp/evil' },
+      { name: 'Windows drive path', declaration: 'C:\\evil' },
+      { name: 'Windows drive slash path', declaration: 'C:/evil' },
+      { name: 'Windows UNC path', declaration: '\\\\server\\share\\evil' },
+      { name: 'file protocol', declaration: 'file:../evil' },
+      { name: 'link protocol', declaration: 'link:../evil' },
+      { name: 'workspace protocol', declaration: 'workspace:*' },
+      { name: 'git file protocol', declaration: 'git+file:///tmp/evil' },
+      { name: 'empty declaration', declaration: '' },
+      { name: 'whitespace declaration', declaration: '   ' },
+      { name: 'null declaration', declaration: null },
+      { name: 'object declaration', declaration: { path: 'evil' } },
+      { name: 'exact semver', declaration: '1.2.3', portable: true },
+      { name: 'semver range', declaration: '^1.2.3', portable: true },
+      { name: 'npm alias', declaration: 'npm:evil@^1.2.3', portable: true },
+      {
+        name: 'HTTPS archive',
+        declaration: 'https://example.com/evil.tgz',
+        portable: true,
+      },
+      {
+        name: 'HTTPS git repository',
+        declaration: 'git+https://github.com/example/evil.git',
+        portable: true,
+      },
+    ]
+
+    for (const testCase of cases) {
+      const fixture = await makeFixture("import 'evil'\n", {
+        'package.json': JSON.stringify({
+          name: 'fixture',
+          version: '1.0.0',
+          dependencies: { evil: testCase.declaration },
+        }),
+        'node_modules/evil/package.json': JSON.stringify({
+          name: 'evil',
+          types: 'index.d.ts',
+        }),
+        'node_modules/evil/index.d.ts': 'export {}\n',
+      })
+      try {
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        const matching = diagnostics.filter(
+          ({ code, specifier }) =>
+            code === 'non-portable-dependency' && specifier === 'evil',
+        )
+        if (testCase.portable) {
+          expect(matching, testCase.name).toEqual([])
+        } else {
+          expect(matching, testCase.name).toHaveLength(1)
+        }
       } finally {
         await rm(fixture, { recursive: true, force: true })
       }
@@ -469,6 +555,22 @@ describe('STRUCT package artifact boundary', () => {
         jsx: 'react',
         allowRuntimeEdge: true,
       },
+      ...[
+        { name: 'CRLF', lineBreak: '\r\n' },
+        { name: 'LF', lineBreak: '\n' },
+        { name: 'bare CR', lineBreak: '\r' },
+        { name: 'line separator', lineBreak: '\u2028' },
+        { name: 'paragraph separator', lineBreak: '\u2029' },
+      ].map(({ name, lineBreak }) => {
+        const marker = '@jSxImPoRtSoUrCe'
+        return {
+          name: `pragma after ${name}`,
+          source: `/* @notAThing${lineBreak}${marker} evil */\nexport const value = <div />\n`,
+          jsx: 'react-jsx',
+          pragma: '@jsxImportSource',
+          marker,
+        }
+      }),
     ]
 
     const missing: string[] = []

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -345,14 +345,6 @@ describe('STRUCT package artifact boundary', () => {
         runtimeFile: 'jsx-dev-runtime.d.ts',
         runtime: 'react/jsx-dev-runtime',
       },
-      {
-        name: 'source JSX import pragma',
-        source: '/** @jsxImportSource evil */\nexport const value = <div />\n',
-        packageName: 'evil',
-        jsx: 'react-jsx',
-        runtimeFile: 'jsx-runtime.d.ts',
-        runtime: 'evil/jsx-runtime',
-      },
     ]
 
     const missing: string[] = []
@@ -399,6 +391,135 @@ describe('STRUCT package artifact boundary', () => {
       }
     }
     expect(missing).toEqual([])
+  })
+
+  it('rejects unsupported source JSX pragmas with exact diagnostics', async () => {
+    const cases = [
+      {
+        name: 'automatic runtime override',
+        source: '/** @jsxRuntime automatic */\nexport const value = <div />\n',
+        jsx: 'react',
+        pragma: '@jsxRuntime',
+      },
+      {
+        name: 'classic runtime override',
+        source: '/** @jsxRuntime classic */\nexport const value = <div />\n',
+        jsx: 'react-jsx',
+        pragma: '@jsxRuntime',
+      },
+      {
+        name: 'source import override',
+        source: '/** @jsxImportSource evil */\nexport const value = <div />\n',
+        jsx: 'react-jsx',
+        pragma: '@jsxImportSource',
+      },
+      {
+        name: 'pragma-looking string',
+        source: 'const value = "@jsxRuntime automatic"\nexport { value }\n',
+        jsx: 'react-jsx',
+      },
+      {
+        name: 'ordinary comment',
+        source:
+          '// ordinary comment mentioning jsxRuntime automatic\nexport const value = true\n',
+        jsx: 'react-jsx',
+      },
+    ]
+
+    const missing: string[] = []
+    for (const testCase of cases) {
+      const fixture = await makeFixture(
+        testCase.source,
+        {
+          'node_modules/react/package.json': JSON.stringify({
+            name: 'react',
+            types: 'jsx-runtime.d.ts',
+          }),
+          'node_modules/react/jsx-runtime.d.ts':
+            'export function jsx(): unknown\n',
+          'node_modules/evil/package.json': JSON.stringify({
+            name: 'evil',
+            types: 'jsx-runtime.d.ts',
+          }),
+          'node_modules/evil/jsx-runtime.d.ts':
+            'export function jsx(): unknown\n',
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'ESNext',
+              moduleResolution: 'Bundler',
+              jsx: testCase.jsx,
+              strict: true,
+              skipLibCheck: true,
+              rootDir: 'src',
+            },
+            include: ['src/**/*.tsx'],
+          }),
+        },
+        'src/index.tsx',
+      )
+      try {
+        const diagnostics = await auditPackageImportBoundary(fixture)
+        if (testCase.pragma) {
+          const matching = diagnostics.find(
+            ({ code, specifier }) =>
+              code === 'jsx-pragma-not-allowed' &&
+              specifier === testCase.pragma,
+          )
+          if (!matching) {
+            missing.push(testCase.name)
+          } else {
+            expect(matching).toMatchObject({
+              importer: 'src/index.tsx',
+              offset: testCase.source.indexOf(testCase.pragma),
+              message: `${testCase.pragma} is not part of the package source dialect`,
+            })
+          }
+        } else if (diagnostics.length > 0) {
+          missing.push(testCase.name)
+        }
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
+      }
+    }
+    expect(missing).toEqual([])
+  })
+
+  it('rejects compiler helper imports as an unsupported dialect option', async () => {
+    const fixture = await makeFixture(
+      'export async function value() { await Promise.resolve() }\n',
+      {
+        'node_modules/tslib/package.json': JSON.stringify({
+          name: 'tslib',
+          types: 'index.d.ts',
+        }),
+        'node_modules/tslib/index.d.ts':
+          'export declare const __awaiter: unknown\n',
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2015',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            importHelpers: true,
+            strict: true,
+            skipLibCheck: true,
+            rootDir: 'src',
+          },
+          include: ['src/**/*.ts'],
+        }),
+      },
+    )
+    try {
+      expect(await auditPackageImportBoundary(fixture)).toContainEqual(
+        expect.objectContaining({
+          code: 'compiler-option-not-allowed',
+          importer: 'tsconfig.json',
+          specifier: 'importHelpers',
+        }),
+      )
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
   })
 
   it('reports exact lexical policy diagnostics for unsupported capabilities', async () => {

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -1,5 +1,5 @@
 import { lstat, readFile, readdir } from 'node:fs/promises'
-import { dirname, extname, relative, resolve } from 'node:path'
+import { extname, relative, resolve } from 'node:path'
 import * as ts from 'typescript'
 
 export type ImportBoundaryViolation = {
@@ -167,8 +167,8 @@ export async function auditPackageImportBoundary(
     const sourcePath = resolve(sourceFile.fileName)
     if (!sourceFiles.has(sourcePath)) {
       if (
-        !isExternalLibraryPath(sourcePath) &&
-        !isDefaultLibraryPath(sourcePath, parsed.options)
+        !program.isSourceFileFromExternalLibrary(sourceFile) &&
+        !program.isSourceFileDefaultLibrary(sourceFile)
       ) {
         violations.push(
           violation(
@@ -539,21 +539,6 @@ function checkModuleSpecifier(
   }
 }
 
-function isExternalLibraryPath(fileName: string) {
-  return /(?:^|\/)node_modules\//u.test(normalizePath(fileName))
-}
-
-function isDefaultLibraryPath(fileName: string, options: ts.CompilerOptions) {
-  const normalized = normalizePath(fileName)
-  const defaultLibDirectory = normalizePath(
-    dirname(ts.getDefaultLibFilePath(options)),
-  )
-  return (
-    normalized.startsWith(`${defaultLibDirectory}/`) &&
-    /\/lib\.[^/]+\.d\.ts$/u.test(normalized)
-  )
-}
-
 function normalizePath(fileName: string) {
   return fileName.replaceAll('\\', '/')
 }
@@ -563,12 +548,21 @@ function jsxRuntimeSpecifier(
   options: ts.CompilerOptions,
 ) {
   if (
-    !options.jsxImportSource ||
-    (options.jsx !== ts.JsxEmit.ReactJSX &&
-      options.jsx !== ts.JsxEmit.ReactJSXDev)
+    options.jsx !== ts.JsxEmit.ReactJSX &&
+    options.jsx !== ts.JsxEmit.ReactJSXDev
   ) {
     return undefined
   }
+  const pragma = (
+    sourceFile as ts.SourceFile & {
+      pragmas?: ReadonlyMap<
+        string,
+        { arguments?: { factory?: string | undefined } }
+      >
+    }
+  ).pragmas?.get('jsximportsource')
+  const importSource =
+    pragma?.arguments?.factory ?? options.jsxImportSource ?? 'react'
   let offset: number | undefined
   const visit = (node: ts.Node) => {
     if (
@@ -586,7 +580,7 @@ function jsxRuntimeSpecifier(
     ? undefined
     : {
         offset,
-        specifier: `${options.jsxImportSource}/${
+        specifier: `${importSource}/${
           options.jsx === ts.JsxEmit.ReactJSXDev
             ? 'jsx-dev-runtime'
             : 'jsx-runtime'
@@ -663,21 +657,26 @@ function violation(
   resolvedTarget?: string,
   specifier?: string,
 ): ImportBoundaryViolation {
+  const normalizedImporter = normalizePath(importer)
   return {
     code,
-    importer: importer.startsWith('/')
-      ? displayPath(packageRoot, importer)
-      : importer,
+    importer: isAbsolutePath(normalizedImporter)
+      ? displayPath(packageRoot, normalizedImporter)
+      : normalizedImporter,
     offset,
     ...(specifier === undefined ? {} : { specifier }),
-    ...(resolvedTarget === undefined ? {} : { resolvedTarget }),
+    ...(resolvedTarget === undefined
+      ? {}
+      : { resolvedTarget: normalizePath(resolvedTarget) }),
     message,
   }
 }
 
 function displayPath(packageRoot: string, fileName: string) {
   return (
-    normalizePath(relative(packageRoot, fileName)) || normalizePath(fileName)
+    normalizePath(
+      relative(normalizePath(packageRoot), normalizePath(fileName)),
+    ) || normalizePath(fileName)
   )
 }
 
@@ -718,6 +717,10 @@ function isAbsoluteModuleSpecifier(specifier: string) {
     normalized.startsWith('//') ||
     /^[A-Za-z]:\//u.test(normalized)
   )
+}
+
+function isAbsolutePath(fileName: string) {
+  return isAbsoluteModuleSpecifier(fileName)
 }
 
 function isLoaderSpecifier(specifier: string) {

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -677,11 +677,13 @@ function collectJsxPragmaViolations(
   for (const comment of ts.getLeadingCommentRanges(sourceFile.text, 0) ?? []) {
     if (comment.kind !== ts.SyntaxKind.MultiLineCommentTrivia) continue
     const text = sourceFile.text.slice(comment.pos, comment.end)
-    if (!text.startsWith('/**')) continue
-    const match = /@(jsxRuntime|jsxImportSource)\b/u.exec(text)
+    const match = /@(jsxRuntime|jsxImportSource)\b/iu.exec(text)
     if (!match || match.index === undefined) continue
     found = true
-    const specifier = `@${match[1]}`
+    const specifier =
+      match[1].toLowerCase() === 'jsxruntime'
+        ? '@jsxRuntime'
+        : '@jsxImportSource'
     violations.push(
       violation(
         packageRoot,

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -353,6 +353,21 @@ function collectStaticEdges(
   }
   visit(sourceFile)
 
+  for (const dependency of sourceFile.amdDependencies) {
+    const offset = sourceFile.text.indexOf(dependency.path)
+    checkModuleSpecifier(
+      dependency.path,
+      offset < 0 ? sourceFile.getStart(sourceFile) : offset,
+      importer,
+      packageRoot,
+      sourceFiles,
+      dependencies,
+      options,
+      cache,
+      violations,
+    )
+  }
+
   const runtime = skipJsxRuntime
     ? undefined
     : jsxRuntimeSpecifier(sourceFile, options)
@@ -472,10 +487,7 @@ function checkModuleSpecifier(
     Object.prototype.hasOwnProperty.call(dependencies, packageName)
   ) {
     const declaration = dependencies[packageName]
-    if (
-      typeof declaration === 'string' &&
-      /^(?:file|link|workspace):/iu.test(declaration)
-    ) {
+    if (isNonPortableDependencyDeclaration(declaration)) {
       violations.push(
         violation(
           packageRoot,
@@ -558,6 +570,17 @@ function checkModuleSpecifier(
       ),
     )
   }
+}
+
+function isNonPortableDependencyDeclaration(declaration: unknown) {
+  if (typeof declaration !== 'string') return true
+  const trimmed = declaration.trim()
+  if (trimmed.length === 0 || trimmed !== declaration) return true
+  return (
+    /^(?:file|link|workspace|git\+file):/iu.test(trimmed) ||
+    /^(?:\.\.?[\\/]|[\\/]|[A-Za-z]:[\\/])/u.test(trimmed) ||
+    trimmed.includes('\\')
+  )
 }
 
 function normalizePath(fileName: string) {
@@ -678,7 +701,7 @@ function collectJsxPragmaViolations(
     if (comment.kind !== ts.SyntaxKind.MultiLineCommentTrivia) continue
     const text = sourceFile.text.slice(comment.pos, comment.end)
     let lineStart = 0
-    for (const line of text.split(/\r?\n/u)) {
+    for (const line of text.split(/\r\n|[\r\n\u2028\u2029]/u)) {
       const at = line.indexOf('@')
       if (at >= 0) {
         const match = /^@(\S+)/u.exec(line.slice(at))

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -580,7 +580,7 @@ function isNonPortableDependencyDeclaration(declaration: unknown) {
   if (trimmed.length === 0 || trimmed !== declaration) return true
   if (
     /^(?:file|link|workspace|git\+file):/iu.test(trimmed) ||
-    /^~(?:[\\/]|$)/u.test(trimmed) ||
+    /^~[\\/]/u.test(trimmed) ||
     /^[A-Za-z]:/u.test(trimmed) ||
     /^(?:\.\.?[\\/]|[\\/])/u.test(trimmed) ||
     trimmed.includes('\\')
@@ -591,26 +591,30 @@ function isNonPortableDependencyDeclaration(declaration: unknown) {
 }
 
 function isLocalDependencyDeclaration(value: string) {
-  if (isPortableHostedShorthand(value)) return false
-  return (
-    value.startsWith('.') ||
-    (!value.includes(':') && value.includes('/')) ||
-    (!value.includes(':') && /\.(?:tgz|tar\.gz|tar)(?:#.*)?$/iu.test(value))
-  )
-}
-
-function isPortableHostedShorthand(value: string) {
-  if (
-    value.startsWith('.') ||
-    value.startsWith('@') ||
-    value.includes('\\') ||
-    value.includes(':')
-  ) {
+  if (isPortableHostedShorthand(value) || isPortableRemoteDeclaration(value)) {
     return false
   }
   const fragmentOffset = value.indexOf('#')
   const repository = fragmentOffset < 0 ? value : value.slice(0, fragmentOffset)
-  if (fragmentOffset >= 0 && value.length === fragmentOffset + 1) {
+  return (
+    repository.startsWith('.') ||
+    repository.includes('/') ||
+    /\.(?:tgz|tar\.gz|tar)(?:#.*)?$/iu.test(value)
+  )
+}
+
+function isPortableHostedShorthand(value: string) {
+  const fragmentOffset = value.indexOf('#')
+  const repository = fragmentOffset < 0 ? value : value.slice(0, fragmentOffset)
+  if (
+    repository.startsWith('.') ||
+    repository.startsWith('@') ||
+    repository.includes('@') ||
+    repository.includes('\\') ||
+    repository.includes(':') ||
+    /[\s\p{Cc}]/u.test(repository) ||
+    /%(?![0-9a-f]{2})/iu.test(value)
+  ) {
     return false
   }
   const segments = repository.split('/')
@@ -619,6 +623,15 @@ function isPortableHostedShorthand(value: string) {
     segments.every(
       (segment) => segment.length > 0 && segment !== '.' && segment !== '..',
     )
+  )
+}
+
+function isPortableRemoteDeclaration(value: string) {
+  return (
+    /^(?:https?|git|ssh):/iu.test(value) ||
+    /^git\+(?:https|ssh):/iu.test(value) ||
+    /^(?:github|gitlab|bitbucket|npm):/iu.test(value) ||
+    /^[^/\s:@]+@[^/\s:]+:[^\s]+$/u.test(value)
   )
 }
 

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -675,7 +675,9 @@ function collectJsxPragmaViolations(
 ) {
   let found = false
   for (const comment of ts.getLeadingCommentRanges(sourceFile.text, 0) ?? []) {
+    if (comment.kind !== ts.SyntaxKind.MultiLineCommentTrivia) continue
     const text = sourceFile.text.slice(comment.pos, comment.end)
+    if (!text.startsWith('/**')) continue
     const match = /@(jsxRuntime|jsxImportSource)\b/u.exec(text)
     if (!match || match.index === undefined) continue
     found = true

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -353,19 +353,35 @@ function collectStaticEdges(
   }
   visit(sourceFile)
 
-  for (const dependency of sourceFile.amdDependencies) {
-    const offset = sourceFile.text.indexOf(dependency.path)
-    checkModuleSpecifier(
-      dependency.path,
-      offset < 0 ? sourceFile.getStart(sourceFile) : offset,
-      importer,
-      packageRoot,
-      sourceFiles,
-      dependencies,
-      options,
-      cache,
-      violations,
-    )
+  if (sourceFile.amdDependencies.length > 0) {
+    const paths = amdDependencyPathOffsets(sourceFile)
+    if (!paths) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          sourceFile.getStart(sourceFile),
+          'invalid-amd-dependency',
+          'AMD dependency directives could not be paired with compiler metadata',
+        ),
+      )
+    } else {
+      for (let index = 0; index < sourceFile.amdDependencies.length; index++) {
+        const dependency = sourceFile.amdDependencies[index]
+        const path = paths[index]
+        checkModuleSpecifier(
+          dependency.path,
+          path.offset,
+          importer,
+          packageRoot,
+          sourceFiles,
+          dependencies,
+          options,
+          cache,
+          violations,
+        )
+      }
+    }
   }
 
   const runtime = skipJsxRuntime
@@ -384,6 +400,34 @@ function collectStaticEdges(
       violations,
     )
   }
+}
+
+function amdDependencyPathOffsets(sourceFile: ts.SourceFile) {
+  const paths: Array<{ path: string; offset: number }> = []
+  let lineStart = 0
+  for (const line of sourceFile.text.split(/\r\n|[\r\n\u2028\u2029]/u)) {
+    const directive = /^\/\/\/\s*<amd-dependency\b.*\/>\s*$/u.exec(line)
+    if (directive) {
+      const attributes = /\bpath\s*=\s*(["'])(.*?)\1/u.exec(line)
+      if (!attributes) return undefined
+      const attributeOffset = line.indexOf(attributes[0])
+      const quoteOffset = attributes[0].indexOf(attributes[1])
+      paths.push({
+        path: attributes[2],
+        offset: lineStart + attributeOffset + quoteOffset + 1,
+      })
+    }
+    lineStart += line.length
+    if (lineStart < sourceFile.text.length) {
+      lineStart += sourceFile.text.startsWith('\r\n', lineStart) ? 2 : 1
+    }
+  }
+  return paths.length === sourceFile.amdDependencies.length &&
+    paths.every(
+      ({ path }, index) => path === sourceFile.amdDependencies[index].path,
+    )
+    ? paths
+    : undefined
 }
 
 function checkModuleSpecifier(
@@ -578,7 +622,9 @@ function isNonPortableDependencyDeclaration(declaration: unknown) {
   if (trimmed.length === 0 || trimmed !== declaration) return true
   return (
     /^(?:file|link|workspace|git\+file):/iu.test(trimmed) ||
-    /^(?:\.\.?[\\/]|[\\/]|[A-Za-z]:[\\/])/u.test(trimmed) ||
+    /^~(?:[\\/]|$)/u.test(trimmed) ||
+    /^[A-Za-z]:/u.test(trimmed) ||
+    /^(?:\.\.?[\\/]|[\\/])/u.test(trimmed) ||
     trimmed.includes('\\')
   )
 }

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -677,24 +677,36 @@ function collectJsxPragmaViolations(
   for (const comment of ts.getLeadingCommentRanges(sourceFile.text, 0) ?? []) {
     if (comment.kind !== ts.SyntaxKind.MultiLineCommentTrivia) continue
     const text = sourceFile.text.slice(comment.pos, comment.end)
-    const match = /@(jsxRuntime|jsxImportSource)\b/iu.exec(text)
-    if (!match || match.index === undefined) continue
-    found = true
-    const specifier =
-      match[1].toLowerCase() === 'jsxruntime'
-        ? '@jsxRuntime'
-        : '@jsxImportSource'
-    violations.push(
-      violation(
-        packageRoot,
-        importer,
-        comment.pos + match.index,
-        'jsx-pragma-not-allowed',
-        `${specifier} is not part of the package source dialect`,
-        undefined,
-        specifier,
-      ),
-    )
+    let lineStart = 0
+    for (const line of text.split(/\r?\n/u)) {
+      const at = line.indexOf('@')
+      if (at >= 0) {
+        const match = /^@(\S+)/u.exec(line.slice(at))
+        if (match) {
+          const name = match[1].toLowerCase()
+          if (name === 'jsxruntime' || name === 'jsximportsource') {
+            found = true
+            const specifier =
+              name === 'jsxruntime' ? '@jsxRuntime' : '@jsxImportSource'
+            violations.push(
+              violation(
+                packageRoot,
+                importer,
+                comment.pos + lineStart + at,
+                'jsx-pragma-not-allowed',
+                `${specifier} is not part of the package source dialect`,
+                undefined,
+                specifier,
+              ),
+            )
+          }
+        }
+      }
+      lineStart += line.length
+      if (lineStart < text.length) {
+        lineStart += text.startsWith('\r\n', lineStart) ? 2 : 1
+      }
+    }
   }
   return found
 }

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -30,7 +30,7 @@ const forbiddenResolutionOptions = new Set([
   'typeRoots',
 ])
 
-const forbiddenDialectOptions = new Set(['importHelpers'])
+const forbiddenDialectOptions = new Set(['importHelpers', 'types'])
 const forbiddenModuleKinds = new Set([ts.ModuleKind.AMD, ts.ModuleKind.UMD])
 
 export async function auditPackageImportBoundary(
@@ -187,15 +187,40 @@ export async function auditPackageImportBoundary(
     await readFile(resolve(packagePath, 'package.json'), 'utf8'),
   ) as { dependencies?: Record<string, unknown> }
   const dependencies = packageManifest.dependencies ?? {}
+  // The package boundary is closed over source files and explicitly declared
+  // runtime dependencies.  Do not let the repository's ambient @types tree
+  // widen that graph (or make the result depend on a host checkout).
+  const isolatedOptions: ts.CompilerOptions = {
+    ...parsed.options,
+    noEmit: true,
+  }
+  if (!Object.prototype.hasOwnProperty.call(rawCompilerOptions, 'types')) {
+    isolatedOptions.typeRoots = []
+    isolatedOptions.types = []
+  }
   const program = ts.createProgram({
     rootNames: [...sourceFiles],
-    options: parsed.options,
+    options: isolatedOptions,
   })
+  for (const diagnostic of ts.getPreEmitDiagnostics(program)) {
+    const diagnosticPath = diagnostic.file?.fileName
+      ? resolve(diagnostic.file.fileName)
+      : configPath
+    violations.push(
+      violation(
+        packagePath,
+        diagnostic.file ? displayPath(packagePath, diagnosticPath) : configPath,
+        diagnostic.start ?? 0,
+        'compiler-diagnostic',
+        flattenMessage(diagnostic.messageText),
+      ),
+    )
+  }
   const resolutionCache = ts.createModuleResolutionCache(
     packagePath,
     (fileName) =>
       ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase(),
-    parsed.options,
+    isolatedOptions,
   )
 
   for (const sourceFile of program.getSourceFiles()) {
@@ -251,7 +276,7 @@ export async function auditPackageImportBoundary(
       packagePath,
       sourceFiles,
       dependencies,
-      parsed.options,
+      isolatedOptions,
       resolutionCache,
       violations,
       collectDialectViolations(syntax, importer, packagePath, violations),

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -30,6 +30,8 @@ const forbiddenResolutionOptions = new Set([
   'typeRoots',
 ])
 
+const forbiddenDialectOptions = new Set(['importHelpers'])
+
 export async function auditPackageImportBoundary(
   packageRoot: string,
 ): Promise<readonly ImportBoundaryViolation[]> {
@@ -77,6 +79,22 @@ export async function auditPackageImportBoundary(
           0,
           'resolution-indirection-not-allowed',
           `compiler option ${option} is not permitted`,
+        ),
+      )
+    }
+  }
+  for (const option of forbiddenDialectOptions) {
+    const parsedOption = parsedOptionValue(option, parsed.options)
+    if (option in rawCompilerOptions || parsedOption !== undefined) {
+      violations.push(
+        violation(
+          packagePath,
+          configPath,
+          0,
+          'compiler-option-not-allowed',
+          `compiler option ${option} is not permitted by the package dialect`,
+          undefined,
+          option,
         ),
       )
     }
@@ -219,8 +237,8 @@ export async function auditPackageImportBoundary(
       parsed.options,
       resolutionCache,
       violations,
+      collectDialectViolations(syntax, importer, packagePath, violations),
     )
-    collectDialectViolations(syntax, importer, packagePath, violations)
   }
 
   return sortViolations(violations)
@@ -296,6 +314,7 @@ function collectStaticEdges(
   options: ts.CompilerOptions,
   cache: ts.ModuleResolutionCache,
   violations: ImportBoundaryViolation[],
+  skipJsxRuntime = false,
 ) {
   const check = (node: ts.Node, literal: ts.StringLiteralLike) => {
     checkModuleSpecifier(
@@ -334,7 +353,9 @@ function collectStaticEdges(
   }
   visit(sourceFile)
 
-  const runtime = jsxRuntimeSpecifier(sourceFile, options)
+  const runtime = skipJsxRuntime
+    ? undefined
+    : jsxRuntimeSpecifier(sourceFile, options)
   if (runtime) {
     checkModuleSpecifier(
       runtime.specifier,
@@ -553,16 +574,7 @@ function jsxRuntimeSpecifier(
   ) {
     return undefined
   }
-  const pragma = (
-    sourceFile as ts.SourceFile & {
-      pragmas?: ReadonlyMap<
-        string,
-        { arguments?: { factory?: string | undefined } }
-      >
-    }
-  ).pragmas?.get('jsximportsource')
-  const importSource =
-    pragma?.arguments?.factory ?? options.jsxImportSource ?? 'react'
+  const importSource = options.jsxImportSource ?? 'react'
   let offset: number | undefined
   const visit = (node: ts.Node) => {
     if (
@@ -594,6 +606,12 @@ function collectDialectViolations(
   packageRoot: string,
   violations: ImportBoundaryViolation[],
 ) {
+  const hasUnsupportedJsxPragma = collectJsxPragmaViolations(
+    sourceFile,
+    importer,
+    packageRoot,
+    violations,
+  )
   const visit = (node: ts.Node) => {
     if (ts.isImportEqualsDeclaration(node)) {
       violations.push(
@@ -646,6 +664,35 @@ function collectDialectViolations(
     ts.forEachChild(node, visit)
   }
   visit(sourceFile)
+  return hasUnsupportedJsxPragma
+}
+
+function collectJsxPragmaViolations(
+  sourceFile: ts.SourceFile,
+  importer: string,
+  packageRoot: string,
+  violations: ImportBoundaryViolation[],
+) {
+  let found = false
+  for (const comment of ts.getLeadingCommentRanges(sourceFile.text, 0) ?? []) {
+    const text = sourceFile.text.slice(comment.pos, comment.end)
+    const match = /@(jsxRuntime|jsxImportSource)\b/u.exec(text)
+    if (!match || match.index === undefined) continue
+    found = true
+    const specifier = `@${match[1]}`
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        comment.pos + match.index,
+        'jsx-pragma-not-allowed',
+        `${specifier} is not part of the package source dialect`,
+        undefined,
+        specifier,
+      ),
+    )
+  }
+  return found
 }
 
 function violation(

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -1,5 +1,5 @@
 import { lstat, readFile, readdir } from 'node:fs/promises'
-import { extname, relative, resolve } from 'node:path'
+import { dirname, extname, relative, resolve } from 'node:path'
 import * as ts from 'typescript'
 
 export type ImportBoundaryViolation = {
@@ -134,9 +134,7 @@ export async function auditPackageImportBoundary(
     )
   }
   const configuredFiles = new Set(
-    parsed.fileNames
-      .filter((fileName) => /\.(?:tsx?)$/iu.test(fileName))
-      .map((fileName) => resolve(fileName)),
+    parsed.fileNames.map((fileName) => resolve(fileName)),
   )
   if (!sameSet(configuredFiles, sourceFiles)) {
     violations.push(
@@ -169,8 +167,8 @@ export async function auditPackageImportBoundary(
     const sourcePath = resolve(sourceFile.fileName)
     if (!sourceFiles.has(sourcePath)) {
       if (
-        !sourceFile.isDeclarationFile &&
-        !sourcePath.includes('/node_modules/')
+        !isExternalLibraryPath(sourcePath) &&
+        !isDefaultLibraryPath(sourcePath, parsed.options)
       ) {
         violations.push(
           violation(
@@ -300,180 +298,17 @@ function collectStaticEdges(
   violations: ImportBoundaryViolation[],
 ) {
   const check = (node: ts.Node, literal: ts.StringLiteralLike) => {
-    const specifier = literal.text
-    const offset = literal.getStart(sourceFile)
-    if (
-      specifier.includes('%') ||
-      specifier.includes('\\') ||
-      specifier.includes('\0')
-    ) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'unsafe-module-specifier',
-          'module specifier contains an encoded or platform escape',
-          undefined,
-          specifier,
-        ),
-      )
-      return
-    }
-    if (specifier.startsWith('/') || /^[A-Za-z]:[\\/]/u.test(specifier)) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'unsafe-module-specifier',
-          'absolute module specifiers are not part of the package dialect',
-          undefined,
-          specifier,
-        ),
-      )
-      return
-    }
-    if (isLoaderSpecifier(specifier)) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'loader-module-not-allowed',
-          'module loader and process modules are outside the package dialect',
-          undefined,
-          specifier,
-        ),
-      )
-      return
-    }
-    if (specifier.startsWith('node:')) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'node-builtin-not-allowed',
-          'Node builtin modules are not part of the package source dialect',
-          undefined,
-          specifier,
-        ),
-      )
-      return
-    }
-    const relativeImport =
-      specifier === '.' ||
-      specifier === '..' ||
-      specifier.startsWith('./') ||
-      specifier.startsWith('../')
-    const packageName = barePackageName(specifier)
-    if (
-      !relativeImport &&
-      packageName &&
-      /(?:^|\/)(?:\.|\.\.)(?:\/|$)/u.test(specifier)
-    ) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'unsafe-module-specifier',
-          'dependency subpaths may not contain traversal segments',
-          undefined,
-          specifier,
-        ),
-      )
-      return
-    }
-    if (!relativeImport && packageName && packageName in dependencies) {
-      const declaration = dependencies[packageName]
-      if (
-        typeof declaration === 'string' &&
-        /^(?:file|link|workspace):/iu.test(declaration)
-      ) {
-        violations.push(
-          violation(
-            packageRoot,
-            importer,
-            offset,
-            'non-portable-dependency',
-            'runtime dependencies may not point into the repository',
-            undefined,
-            specifier,
-          ),
-        )
-        return
-      }
-      const resolved = ts.resolveModuleName(
-        specifier,
-        resolve(packageRoot, importer),
-        options,
-        ts.sys,
-        cache,
-      ).resolvedModule
-      if (!resolved || !resolved.isExternalLibraryImport) {
-        violations.push(
-          violation(
-            packageRoot,
-            importer,
-            offset,
-            'unresolved-module',
-            'declared dependency does not resolve as an external library',
-            resolved?.resolvedFileName,
-            specifier,
-          ),
-        )
-      }
-      return
-    }
-    const resolved = ts.resolveModuleName(
-      specifier,
-      resolve(packageRoot, importer),
+    checkModuleSpecifier(
+      literal.text,
+      literal.getStart(sourceFile),
+      importer,
+      packageRoot,
+      sourceFiles,
+      dependencies,
       options,
-      ts.sys,
       cache,
-    ).resolvedModule
-    const resolvedTarget = resolved?.resolvedFileName
-      ? resolve(resolved.resolvedFileName)
-      : undefined
-    if (!resolvedTarget) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'unresolved-module',
-          'module specifier does not resolve',
-          undefined,
-          specifier,
-        ),
-      )
-    } else if (relativeImport && !sourceFiles.has(resolvedTarget)) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'relative-outside-source',
-          'relative module resolves outside the canonical source set',
-          resolvedTarget,
-          specifier,
-        ),
-      )
-    } else if (!relativeImport) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          offset,
-          'undeclared-runtime-dependency',
-          'bare module is not an exact declared runtime dependency',
-          resolvedTarget,
-          specifier,
-        ),
-      )
-    }
+      violations,
+    )
   }
 
   const visit = (node: ts.Node) => {
@@ -498,6 +333,265 @@ function collectStaticEdges(
     ts.forEachChild(node, visit)
   }
   visit(sourceFile)
+
+  const runtime = jsxRuntimeSpecifier(sourceFile, options)
+  if (runtime) {
+    checkModuleSpecifier(
+      runtime.specifier,
+      runtime.offset,
+      importer,
+      packageRoot,
+      sourceFiles,
+      dependencies,
+      options,
+      cache,
+      violations,
+    )
+  }
+}
+
+function checkModuleSpecifier(
+  specifier: string,
+  offset: number,
+  importer: string,
+  packageRoot: string,
+  sourceFiles: Set<string>,
+  dependencies: Record<string, unknown>,
+  options: ts.CompilerOptions,
+  cache: ts.ModuleResolutionCache,
+  violations: ImportBoundaryViolation[],
+) {
+  if (
+    specifier.includes('%') ||
+    specifier.includes('\\') ||
+    specifier.includes('\0')
+  ) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'unsafe-module-specifier',
+        'module specifier contains an encoded or platform escape',
+        undefined,
+        specifier,
+      ),
+    )
+    return
+  }
+  if (isAbsoluteModuleSpecifier(specifier)) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'unsafe-module-specifier',
+        'absolute module specifiers are not part of the package dialect',
+        undefined,
+        specifier,
+      ),
+    )
+    return
+  }
+  if (isLoaderSpecifier(specifier)) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'loader-module-not-allowed',
+        'module loader and process modules are outside the package dialect',
+        undefined,
+        specifier,
+      ),
+    )
+    return
+  }
+  if (specifier.startsWith('node:')) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'node-builtin-not-allowed',
+        'Node builtin modules are not part of the package source dialect',
+        undefined,
+        specifier,
+      ),
+    )
+    return
+  }
+  const relativeImport =
+    specifier === '.' ||
+    specifier === '..' ||
+    specifier.startsWith('./') ||
+    specifier.startsWith('../')
+  const packageName = barePackageName(specifier)
+  if (
+    !relativeImport &&
+    packageName &&
+    /(?:^|\/)(?:\.|\.\.)(?:\/|$)/u.test(specifier)
+  ) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'unsafe-module-specifier',
+        'dependency subpaths may not contain traversal segments',
+        undefined,
+        specifier,
+      ),
+    )
+    return
+  }
+  if (
+    !relativeImport &&
+    packageName &&
+    Object.prototype.hasOwnProperty.call(dependencies, packageName)
+  ) {
+    const declaration = dependencies[packageName]
+    if (
+      typeof declaration === 'string' &&
+      /^(?:file|link|workspace):/iu.test(declaration)
+    ) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'non-portable-dependency',
+          'runtime dependencies may not point into the repository',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    const resolved = ts.resolveModuleName(
+      specifier,
+      resolve(packageRoot, importer),
+      options,
+      ts.sys,
+      cache,
+    ).resolvedModule
+    if (!resolved || !resolved.isExternalLibraryImport) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'unresolved-module',
+          'declared dependency does not resolve as an external library',
+          resolved?.resolvedFileName,
+          specifier,
+        ),
+      )
+    }
+    return
+  }
+  const resolved = ts.resolveModuleName(
+    specifier,
+    resolve(packageRoot, importer),
+    options,
+    ts.sys,
+    cache,
+  ).resolvedModule
+  const resolvedTarget = resolved?.resolvedFileName
+    ? resolve(resolved.resolvedFileName)
+    : undefined
+  if (!resolvedTarget) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'unresolved-module',
+        'module specifier does not resolve',
+        undefined,
+        specifier,
+      ),
+    )
+  } else if (relativeImport && !sourceFiles.has(resolvedTarget)) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'relative-outside-source',
+        'relative module resolves outside the canonical source set',
+        resolvedTarget,
+        specifier,
+      ),
+    )
+  } else if (!relativeImport) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        offset,
+        'undeclared-runtime-dependency',
+        'bare module is not an exact declared runtime dependency',
+        resolvedTarget,
+        specifier,
+      ),
+    )
+  }
+}
+
+function isExternalLibraryPath(fileName: string) {
+  return /(?:^|\/)node_modules\//u.test(normalizePath(fileName))
+}
+
+function isDefaultLibraryPath(fileName: string, options: ts.CompilerOptions) {
+  const normalized = normalizePath(fileName)
+  const defaultLibDirectory = normalizePath(
+    dirname(ts.getDefaultLibFilePath(options)),
+  )
+  return (
+    normalized.startsWith(`${defaultLibDirectory}/`) &&
+    /\/lib\.[^/]+\.d\.ts$/u.test(normalized)
+  )
+}
+
+function normalizePath(fileName: string) {
+  return fileName.replaceAll('\\', '/')
+}
+
+function jsxRuntimeSpecifier(
+  sourceFile: ts.SourceFile,
+  options: ts.CompilerOptions,
+) {
+  if (
+    !options.jsxImportSource ||
+    (options.jsx !== ts.JsxEmit.ReactJSX &&
+      options.jsx !== ts.JsxEmit.ReactJSXDev)
+  ) {
+    return undefined
+  }
+  let offset: number | undefined
+  const visit = (node: ts.Node) => {
+    if (
+      offset === undefined &&
+      (ts.isJsxElement(node) ||
+        ts.isJsxSelfClosingElement(node) ||
+        ts.isJsxFragment(node))
+    ) {
+      offset = node.getStart(sourceFile)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return offset === undefined
+    ? undefined
+    : {
+        offset,
+        specifier: `${options.jsxImportSource}/${
+          options.jsx === ts.JsxEmit.ReactJSXDev
+            ? 'jsx-dev-runtime'
+            : 'jsx-runtime'
+        }`,
+      }
 }
 
 function collectDialectViolations(
@@ -582,7 +676,9 @@ function violation(
 }
 
 function displayPath(packageRoot: string, fileName: string) {
-  return relative(packageRoot, fileName).split('/').join('/') || fileName
+  return (
+    normalizePath(relative(packageRoot, fileName)) || normalizePath(fileName)
+  )
 }
 
 function sortViolations(violations: ImportBoundaryViolation[]) {
@@ -609,14 +705,19 @@ function parsedOptionValue(option: string, options: ts.CompilerOptions) {
 }
 
 function barePackageName(specifier: string) {
-  if (
-    specifier.startsWith('.') ||
-    specifier.startsWith('/') ||
-    /^[A-Za-z]:[\\/]/u.test(specifier)
-  )
+  if (specifier.startsWith('.') || isAbsoluteModuleSpecifier(specifier))
     return undefined
   const parts = specifier.split('/')
   return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+function isAbsoluteModuleSpecifier(specifier: string) {
+  const normalized = normalizePath(specifier)
+  return (
+    normalized.startsWith('/') ||
+    normalized.startsWith('//') ||
+    /^[A-Za-z]:\//u.test(normalized)
+  )
 }
 
 function isLoaderSpecifier(specifier: string) {

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -578,13 +578,47 @@ function isNonPortableDependencyDeclaration(declaration: unknown) {
   if (typeof declaration !== 'string') return true
   const trimmed = declaration.trim()
   if (trimmed.length === 0 || trimmed !== declaration) return true
-  return (
+  if (
     /^(?:file|link|workspace|git\+file):/iu.test(trimmed) ||
     /^~(?:[\\/]|$)/u.test(trimmed) ||
     /^[A-Za-z]:/u.test(trimmed) ||
     /^(?:\.\.?[\\/]|[\\/])/u.test(trimmed) ||
-    trimmed.includes('\\') ||
-    (!trimmed.includes(':') && /\.(?:tgz|tar\.gz|tar)$/iu.test(trimmed))
+    trimmed.includes('\\')
+  ) {
+    return true
+  }
+  return isLocalDependencyDeclaration(trimmed)
+}
+
+function isLocalDependencyDeclaration(value: string) {
+  if (isPortableHostedShorthand(value)) return false
+  return (
+    value.startsWith('.') ||
+    (!value.includes(':') && value.includes('/')) ||
+    (!value.includes(':') && /\.(?:tgz|tar\.gz|tar)(?:#.*)?$/iu.test(value))
+  )
+}
+
+function isPortableHostedShorthand(value: string) {
+  if (
+    value.startsWith('.') ||
+    value.startsWith('@') ||
+    value.includes('\\') ||
+    value.includes(':')
+  ) {
+    return false
+  }
+  const fragmentOffset = value.indexOf('#')
+  const repository = fragmentOffset < 0 ? value : value.slice(0, fragmentOffset)
+  if (fragmentOffset >= 0 && value.length === fragmentOffset + 1) {
+    return false
+  }
+  const segments = repository.split('/')
+  return (
+    segments.length === 2 &&
+    segments.every(
+      (segment) => segment.length > 0 && segment !== '.' && segment !== '..',
+    )
   )
 }
 
@@ -634,6 +668,17 @@ function collectDialectViolations(
   packageRoot: string,
   violations: ImportBoundaryViolation[],
 ) {
+  if (sourceFile.amdDependencies.length > 0) {
+    violations.push(
+      violation(
+        packageRoot,
+        importer,
+        0,
+        'invalid-amd-dependency',
+        'AMD dependency directives are not part of the package source dialect',
+      ),
+    )
+  }
   const hasUnsupportedJsxPragma = collectJsxPragmaViolations(
     sourceFile,
     importer,

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -613,7 +613,7 @@ function isPortableHostedShorthand(value: string) {
     repository.includes('\\') ||
     repository.includes(':') ||
     /[\s\p{Cc}]/u.test(repository) ||
-    /%(?![0-9a-f]{2})/iu.test(value)
+    !hasValidPercentDecoding(value)
   ) {
     return false
   }
@@ -624,6 +624,15 @@ function isPortableHostedShorthand(value: string) {
       (segment) => segment.length > 0 && segment !== '.' && segment !== '..',
     )
   )
+}
+
+function hasValidPercentDecoding(value: string) {
+  try {
+    decodeURIComponent(value)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function isPortableRemoteDeclaration(value: string) {

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -1,0 +1,635 @@
+import { lstat, readFile, readdir } from 'node:fs/promises'
+import { extname, relative, resolve } from 'node:path'
+import * as ts from 'typescript'
+
+export type ImportBoundaryViolation = {
+  code: string
+  importer: string
+  offset: number
+  specifier?: string
+  resolvedTarget?: string
+  message: string
+}
+
+const reservedCapabilities = new Set([
+  'createRequire',
+  'getBuiltinModule',
+  'global',
+  'globalThis',
+  'eval',
+  'Function',
+  'module',
+  'process',
+  'require',
+])
+
+const forbiddenResolutionOptions = new Set([
+  'baseUrl',
+  'paths',
+  'rootDirs',
+  'typeRoots',
+])
+
+export async function auditPackageImportBoundary(
+  packageRoot: string,
+): Promise<readonly ImportBoundaryViolation[]> {
+  const packagePath = resolve(packageRoot)
+  const sourceRoot = resolve(packagePath, 'src')
+  const violations: ImportBoundaryViolation[] = []
+  const sourceFiles = new Set<string>()
+
+  await enumerateSources(sourceRoot, packagePath, sourceFiles, violations)
+
+  const configPath = resolve(packagePath, 'tsconfig.json')
+  const configRead = ts.readConfigFile(configPath, ts.sys.readFile)
+  if (configRead.error) {
+    violations.push(
+      violation(
+        packagePath,
+        packagePath,
+        0,
+        'invalid-tsconfig',
+        flattenMessage(configRead.error.messageText),
+      ),
+    )
+    return sortViolations(violations)
+  }
+
+  const config = configRead.config as {
+    compilerOptions?: Record<string, unknown>
+    references?: unknown
+  }
+  const rawCompilerOptions = config.compilerOptions ?? {}
+  const parsed = ts.parseJsonConfigFileContent(
+    configRead.config,
+    ts.sys,
+    packagePath,
+    undefined,
+    configPath,
+  )
+  for (const option of forbiddenResolutionOptions) {
+    const parsedOption = parsedOptionValue(option, parsed.options)
+    if (option in rawCompilerOptions || parsedOption !== undefined) {
+      violations.push(
+        violation(
+          packagePath,
+          configPath,
+          0,
+          'resolution-indirection-not-allowed',
+          `compiler option ${option} is not permitted`,
+        ),
+      )
+    }
+  }
+  if ('extends' in config) {
+    violations.push(
+      violation(
+        packagePath,
+        configPath,
+        0,
+        'resolution-indirection-not-allowed',
+        'tsconfig extends is not permitted',
+      ),
+    )
+  }
+  if (config.references !== undefined) {
+    violations.push(
+      violation(
+        packagePath,
+        configPath,
+        0,
+        'resolution-indirection-not-allowed',
+        'project references are not permitted',
+      ),
+    )
+  }
+
+  if (parsed.errors.length > 0) {
+    for (const diagnostic of parsed.errors) {
+      violations.push(
+        violation(
+          packagePath,
+          configPath,
+          0,
+          'invalid-tsconfig',
+          flattenMessage(diagnostic.messageText),
+        ),
+      )
+    }
+  }
+
+  const configuredRoot = parsed.options.rootDir
+    ? resolve(parsed.options.rootDir)
+    : undefined
+  if (configuredRoot !== sourceRoot) {
+    violations.push(
+      violation(
+        packagePath,
+        configPath,
+        0,
+        'root-dir-not-source',
+        'rootDir must resolve exactly to src',
+        configuredRoot,
+      ),
+    )
+  }
+  const configuredFiles = new Set(
+    parsed.fileNames
+      .filter((fileName) => /\.(?:tsx?)$/iu.test(fileName))
+      .map((fileName) => resolve(fileName)),
+  )
+  if (!sameSet(configuredFiles, sourceFiles)) {
+    violations.push(
+      violation(
+        packagePath,
+        configPath,
+        0,
+        'configured-source-set-mismatch',
+        'tsconfig root files must equal the canonical source set',
+      ),
+    )
+  }
+
+  const packageManifest = JSON.parse(
+    await readFile(resolve(packagePath, 'package.json'), 'utf8'),
+  ) as { dependencies?: Record<string, unknown> }
+  const dependencies = packageManifest.dependencies ?? {}
+  const program = ts.createProgram({
+    rootNames: [...sourceFiles],
+    options: parsed.options,
+  })
+  const resolutionCache = ts.createModuleResolutionCache(
+    packagePath,
+    (fileName) =>
+      ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase(),
+    parsed.options,
+  )
+
+  for (const sourceFile of program.getSourceFiles()) {
+    const sourcePath = resolve(sourceFile.fileName)
+    if (!sourceFiles.has(sourcePath)) {
+      if (
+        !sourceFile.isDeclarationFile &&
+        !sourcePath.includes('/node_modules/')
+      ) {
+        violations.push(
+          violation(
+            packagePath,
+            sourcePath,
+            0,
+            'source-closure-outside-source',
+            'compiler source closure leaves the package source set',
+            sourcePath,
+          ),
+        )
+      }
+      continue
+    }
+    const source = await readFile(sourcePath, 'utf8')
+    const syntax = ts.createSourceFile(
+      sourcePath,
+      source,
+      parsed.options.target ?? ts.ScriptTarget.Latest,
+      true,
+    )
+    const importer = displayPath(packagePath, sourcePath)
+    const preprocessed = ts.preProcessFile(source, true, true)
+    for (const reference of [
+      ...preprocessed.referencedFiles,
+      ...preprocessed.typeReferenceDirectives,
+      ...preprocessed.libReferenceDirectives,
+    ]) {
+      violations.push(
+        violation(
+          packagePath,
+          importer,
+          reference.pos,
+          'reference-directive-not-allowed',
+          reference.fileName,
+          undefined,
+          reference.fileName,
+        ),
+      )
+    }
+
+    collectStaticEdges(
+      syntax,
+      importer,
+      packagePath,
+      sourceFiles,
+      dependencies,
+      parsed.options,
+      resolutionCache,
+      violations,
+    )
+    collectDialectViolations(syntax, importer, packagePath, violations)
+  }
+
+  return sortViolations(violations)
+}
+
+async function enumerateSources(
+  sourceRoot: string,
+  packageRoot: string,
+  sourceFiles: Set<string>,
+  violations: ImportBoundaryViolation[],
+) {
+  let rootStat
+  try {
+    rootStat = await lstat(sourceRoot)
+  } catch {
+    violations.push(
+      violation(
+        packageRoot,
+        sourceRoot,
+        0,
+        'source-root-missing',
+        'src is missing',
+      ),
+    )
+    return
+  }
+  if (rootStat.isSymbolicLink()) {
+    violations.push(
+      violation(
+        packageRoot,
+        sourceRoot,
+        0,
+        'source-symlink-not-allowed',
+        'source root may not be a symbolic link',
+      ),
+    )
+    return
+  }
+
+  async function visit(directory: string) {
+    const entries = (await readdir(directory, { withFileTypes: true })).sort(
+      (a, b) => compareLexical(a.name, b.name),
+    )
+    for (const entry of entries) {
+      const child = resolve(directory, entry.name)
+      const childStat = await lstat(child)
+      if (childStat.isSymbolicLink()) {
+        violations.push(
+          violation(
+            packageRoot,
+            child,
+            0,
+            'source-symlink-not-allowed',
+            'source files and directories may not be symbolic links',
+          ),
+        )
+      } else if (childStat.isDirectory()) {
+        await visit(child)
+      } else if (childStat.isFile() && /\.(?:ts|tsx)$/iu.test(extname(child))) {
+        sourceFiles.add(child)
+      }
+    }
+  }
+  await visit(sourceRoot)
+}
+
+function collectStaticEdges(
+  sourceFile: ts.SourceFile,
+  importer: string,
+  packageRoot: string,
+  sourceFiles: Set<string>,
+  dependencies: Record<string, unknown>,
+  options: ts.CompilerOptions,
+  cache: ts.ModuleResolutionCache,
+  violations: ImportBoundaryViolation[],
+) {
+  const check = (node: ts.Node, literal: ts.StringLiteralLike) => {
+    const specifier = literal.text
+    const offset = literal.getStart(sourceFile)
+    if (
+      specifier.includes('%') ||
+      specifier.includes('\\') ||
+      specifier.includes('\0')
+    ) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'unsafe-module-specifier',
+          'module specifier contains an encoded or platform escape',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    if (specifier.startsWith('/') || /^[A-Za-z]:[\\/]/u.test(specifier)) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'unsafe-module-specifier',
+          'absolute module specifiers are not part of the package dialect',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    if (isLoaderSpecifier(specifier)) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'loader-module-not-allowed',
+          'module loader and process modules are outside the package dialect',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    if (specifier.startsWith('node:')) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'node-builtin-not-allowed',
+          'Node builtin modules are not part of the package source dialect',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    const relativeImport =
+      specifier === '.' ||
+      specifier === '..' ||
+      specifier.startsWith('./') ||
+      specifier.startsWith('../')
+    const packageName = barePackageName(specifier)
+    if (
+      !relativeImport &&
+      packageName &&
+      /(?:^|\/)\.\.(?:\/|$)/u.test(specifier)
+    ) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'unsafe-module-specifier',
+          'dependency subpaths may not contain traversal segments',
+          undefined,
+          specifier,
+        ),
+      )
+      return
+    }
+    if (!relativeImport && packageName && packageName in dependencies) {
+      const declaration = dependencies[packageName]
+      if (
+        typeof declaration === 'string' &&
+        /^(?:file|link|workspace):/iu.test(declaration)
+      ) {
+        violations.push(
+          violation(
+            packageRoot,
+            importer,
+            offset,
+            'non-portable-dependency',
+            'runtime dependencies may not point into the repository',
+            undefined,
+            specifier,
+          ),
+        )
+        return
+      }
+      const resolved = ts.resolveModuleName(
+        specifier,
+        resolve(packageRoot, importer),
+        options,
+        ts.sys,
+        cache,
+      ).resolvedModule
+      if (!resolved || !resolved.isExternalLibraryImport) {
+        violations.push(
+          violation(
+            packageRoot,
+            importer,
+            offset,
+            'unresolved-module',
+            'declared dependency does not resolve as an external library',
+            resolved?.resolvedFileName,
+            specifier,
+          ),
+        )
+      }
+      return
+    }
+    const resolved = ts.resolveModuleName(
+      specifier,
+      resolve(packageRoot, importer),
+      options,
+      ts.sys,
+      cache,
+    ).resolvedModule
+    const resolvedTarget = resolved?.resolvedFileName
+      ? resolve(resolved.resolvedFileName)
+      : undefined
+    if (!resolvedTarget) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'unresolved-module',
+          'module specifier does not resolve',
+          undefined,
+          specifier,
+        ),
+      )
+    } else if (relativeImport && !sourceFiles.has(resolvedTarget)) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'relative-outside-source',
+          'relative module resolves outside the canonical source set',
+          resolvedTarget,
+          specifier,
+        ),
+      )
+    } else if (!relativeImport) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          offset,
+          'undeclared-runtime-dependency',
+          'bare module is not an exact declared runtime dependency',
+          resolvedTarget,
+          specifier,
+        ),
+      )
+    }
+  }
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      check(node, node.moduleSpecifier)
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      check(node, node.moduleSpecifier)
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      check(node, node.argument.literal)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function collectDialectViolations(
+  sourceFile: ts.SourceFile,
+  importer: string,
+  packageRoot: string,
+  violations: ImportBoundaryViolation[],
+) {
+  const visit = (node: ts.Node) => {
+    if (ts.isImportEqualsDeclaration(node)) {
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          node.getStart(sourceFile),
+          'import-equals-not-allowed',
+          'ImportEquals is not part of the package source dialect',
+        ),
+      )
+      return
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      const argument = node.arguments[0]
+      const specifier =
+        argument && ts.isStringLiteral(argument) ? argument.text : undefined
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          node.getStart(sourceFile),
+          'dynamic-import-not-allowed',
+          'dynamic import is not part of the package source dialect',
+          undefined,
+          specifier,
+        ),
+      )
+    }
+    if (ts.isIdentifier(node) && reservedCapabilities.has(node.text)) {
+      const code =
+        node.text === 'eval' || node.text === 'Function'
+          ? 'runtime-codegen-not-allowed'
+          : 'reserved-capability-not-allowed'
+      violations.push(
+        violation(
+          packageRoot,
+          importer,
+          node.getStart(sourceFile),
+          code,
+          `${node.text} is reserved by the package source dialect`,
+          undefined,
+          node.text,
+        ),
+      )
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function violation(
+  packageRoot: string,
+  importer: string,
+  offset: number,
+  code: string,
+  message: string,
+  resolvedTarget?: string,
+  specifier?: string,
+): ImportBoundaryViolation {
+  return {
+    code,
+    importer: importer.startsWith('/')
+      ? displayPath(packageRoot, importer)
+      : importer,
+    offset,
+    ...(specifier === undefined ? {} : { specifier }),
+    ...(resolvedTarget === undefined ? {} : { resolvedTarget }),
+    message,
+  }
+}
+
+function displayPath(packageRoot: string, fileName: string) {
+  return relative(packageRoot, fileName).split('/').join('/') || fileName
+}
+
+function sortViolations(violations: ImportBoundaryViolation[]) {
+  return violations.sort(
+    (a, b) =>
+      compareLexical(a.importer, b.importer) ||
+      a.offset - b.offset ||
+      compareLexical(a.code, b.code),
+  )
+}
+
+function compareLexical(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function sameSet(left: Set<string>, right: Set<string>) {
+  return (
+    left.size === right.size && [...left].every((value) => right.has(value))
+  )
+}
+
+function parsedOptionValue(option: string, options: ts.CompilerOptions) {
+  return (options as ts.CompilerOptions & Record<string, unknown>)[option]
+}
+
+function barePackageName(specifier: string) {
+  if (
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/u.test(specifier)
+  )
+    return undefined
+  const parts = specifier.split('/')
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+function isLoaderSpecifier(specifier: string) {
+  return (
+    specifier === 'module' ||
+    specifier === 'process' ||
+    specifier === 'node:module' ||
+    specifier === 'node:process'
+  )
+}
+
+function flattenMessage(message: string | ts.DiagnosticMessageChain): string {
+  return typeof message === 'string'
+    ? message
+    : ts.flattenDiagnosticMessageText(message, ' ')
+}

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -371,7 +371,7 @@ function collectStaticEdges(
     if (
       !relativeImport &&
       packageName &&
-      /(?:^|\/)\.\.(?:\/|$)/u.test(specifier)
+      /(?:^|\/)(?:\.|\.\.)(?:\/|$)/u.test(specifier)
     ) {
       violations.push(
         violation(

--- a/packages/struct/test/package-import-boundary.ts
+++ b/packages/struct/test/package-import-boundary.ts
@@ -31,6 +31,7 @@ const forbiddenResolutionOptions = new Set([
 ])
 
 const forbiddenDialectOptions = new Set(['importHelpers'])
+const forbiddenModuleKinds = new Set([ts.ModuleKind.AMD, ts.ModuleKind.UMD])
 
 export async function auditPackageImportBoundary(
   packageRoot: string,
@@ -98,6 +99,22 @@ export async function auditPackageImportBoundary(
         ),
       )
     }
+  }
+  if (
+    parsed.options.module !== undefined &&
+    forbiddenModuleKinds.has(parsed.options.module)
+  ) {
+    violations.push(
+      violation(
+        packagePath,
+        configPath,
+        0,
+        'compiler-option-not-allowed',
+        'compiler option module is not permitted by the package dialect',
+        undefined,
+        'module',
+      ),
+    )
   }
   if ('extends' in config) {
     violations.push(
@@ -353,37 +370,6 @@ function collectStaticEdges(
   }
   visit(sourceFile)
 
-  if (sourceFile.amdDependencies.length > 0) {
-    const paths = amdDependencyPathOffsets(sourceFile)
-    if (!paths) {
-      violations.push(
-        violation(
-          packageRoot,
-          importer,
-          sourceFile.getStart(sourceFile),
-          'invalid-amd-dependency',
-          'AMD dependency directives could not be paired with compiler metadata',
-        ),
-      )
-    } else {
-      for (let index = 0; index < sourceFile.amdDependencies.length; index++) {
-        const dependency = sourceFile.amdDependencies[index]
-        const path = paths[index]
-        checkModuleSpecifier(
-          dependency.path,
-          path.offset,
-          importer,
-          packageRoot,
-          sourceFiles,
-          dependencies,
-          options,
-          cache,
-          violations,
-        )
-      }
-    }
-  }
-
   const runtime = skipJsxRuntime
     ? undefined
     : jsxRuntimeSpecifier(sourceFile, options)
@@ -400,34 +386,6 @@ function collectStaticEdges(
       violations,
     )
   }
-}
-
-function amdDependencyPathOffsets(sourceFile: ts.SourceFile) {
-  const paths: Array<{ path: string; offset: number }> = []
-  let lineStart = 0
-  for (const line of sourceFile.text.split(/\r\n|[\r\n\u2028\u2029]/u)) {
-    const directive = /^\/\/\/\s*<amd-dependency\b.*\/>\s*$/u.exec(line)
-    if (directive) {
-      const attributes = /\bpath\s*=\s*(["'])(.*?)\1/u.exec(line)
-      if (!attributes) return undefined
-      const attributeOffset = line.indexOf(attributes[0])
-      const quoteOffset = attributes[0].indexOf(attributes[1])
-      paths.push({
-        path: attributes[2],
-        offset: lineStart + attributeOffset + quoteOffset + 1,
-      })
-    }
-    lineStart += line.length
-    if (lineStart < sourceFile.text.length) {
-      lineStart += sourceFile.text.startsWith('\r\n', lineStart) ? 2 : 1
-    }
-  }
-  return paths.length === sourceFile.amdDependencies.length &&
-    paths.every(
-      ({ path }, index) => path === sourceFile.amdDependencies[index].path,
-    )
-    ? paths
-    : undefined
 }
 
 function checkModuleSpecifier(
@@ -625,7 +583,8 @@ function isNonPortableDependencyDeclaration(declaration: unknown) {
     /^~(?:[\\/]|$)/u.test(trimmed) ||
     /^[A-Za-z]:/u.test(trimmed) ||
     /^(?:\.\.?[\\/]|[\\/])/u.test(trimmed) ||
-    trimmed.includes('\\')
+    trimmed.includes('\\') ||
+    (!trimmed.includes(':') && /\.(?:tgz|tar\.gz|tar)$/iu.test(trimmed))
   )
 }
 


### PR DESCRIPTION
Refs #206 and #124.

## What changed

Adds the package import-boundary audit and its adversarial contract tests. The
audit proves the Struct package graph stays inside its source set plus exact,
portable declared dependencies and uses only public TypeScript APIs.

The final repair closes automatic and explicit ambient `@types/*` leakage:
explicit `compilerOptions.types` is refused, ambient discovery is disabled for
the audit/package-only proof, and hidden ambient reliance becomes a stable
compiler diagnostic.

## Frozen boundary

The cumulative base-to-head diff is exactly:

- `packages/struct/test/package-import-boundary.ts`
- `packages/struct/test/package-boundary.test.ts`

Runtime source, metadata, exports, schema, lockfile, app code, frozen JSON/
receipt/XHTML/EPUB/asset/table hashes and all seven public export contracts are
unchanged.

## Exact-head evidence

- accepted parent: `57aea3dd9751fa553c7ddaef1b2b510979460c20`;
- exact head: `ebb6a5262af39602293297140158d104d9bf8260`;
- independent scoped and strongest immutable reviews: APPROVE;
- coordinator: 9 files / 62 package tests pass, including build/prepack;
- isolated empty-ambient no-emit, mutation replay, 16-way deterministic audit,
  77-entry pack, physical tarball install, and runtime/type imports for all
  seven exports pass;
- diff/scope/frozen-object/format/secret/clean checks pass.

This is a stacked draft on #218. Merge remains blocked by predecessor
integration/restack and the trusted evidence-publisher dependency tracked in
`erniesg/rucksack#562`.

No npm publication, repository creation, deployment, workflow activation,
secret/billing change, merge or destructive cleanup is included.
