### PR TITLE
test(struct): make package conformance standalone

### DIFF
--- a/packages/struct/package-lock.json
+++ b/packages/struct/package-lock.json
@@ -1,0 +1,1369 @@
+{
+  "name": "@erniesg/struct",
+  "version": "0.1.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@erniesg/struct",
+      "version": "0.1.0-rc.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.10.1",
+        "fflate": "^0.8.3"
+      },
+      "devDependencies": {
+        "typescript": "5.7.2",
+        "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
+      "integrity": "sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.2",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.2.tgz",
+      "integrity": "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.2.tgz",
+      "integrity": "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    }
+  }
+}

--- a/packages/struct/package.json
+++ b/packages/struct/package.json
@@ -44,11 +44,17 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run test --maxWorkers=1",
+    "ci": "npm run build && npm test",
+    "test": "vitest run --config vitest.config.ts --maxWorkers=1",
+    "test:consumer": "node test/consumer/standalone-tarball.mjs",
     "prepack": "npm run build"
   },
   "dependencies": {
     "fast-xml-parser": "^5.10.1",
     "fflate": "^0.8.3"
+  },
+  "devDependencies": {
+    "typescript": "5.7.2",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/struct/test/consumer/standalone-tarball.mjs
+++ b/packages/struct/test/consumer/standalone-tarball.mjs
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const packageManifest = JSON.parse(
+  await readFile(join(packageRoot, "package.json"), "utf8"),
+);
+const consumerRoot = await mkdtemp(join(tmpdir(), "struct-consumer-"));
+let tarballPath;
+
+try {
+  const packed = JSON.parse(
+    execFileSync("npm", ["pack", "--json"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+    }),
+  )[0];
+  tarballPath = join(packageRoot, packed.filename);
+  assert.equal(packed.name, "@erniesg/struct");
+  assert.equal(packed.version, "0.1.0-rc.0");
+
+  execFileSync("npm", ["init", "--yes"], {
+    cwd: consumerRoot,
+    stdio: "ignore",
+  });
+  execFileSync(
+    "npm",
+    ["install", "--ignore-scripts", "--no-package-lock", tarballPath],
+    { cwd: consumerRoot, stdio: "inherit" },
+  );
+
+  const installedRoot = join(
+    consumerRoot,
+    "node_modules",
+    "@erniesg",
+    "struct",
+  );
+  const installedManifest = JSON.parse(
+    await readFile(join(installedRoot, "package.json"), "utf8"),
+  );
+  assert.deepEqual(Object.keys(installedManifest.exports), [
+    ".",
+    "./core",
+    "./schema",
+    "./ids",
+    "./recovery",
+    "./renderers/xhtml",
+    "./renderers/epub",
+  ]);
+
+  const declarationPaths = Object.values(installedManifest.exports).flatMap(
+    (entry) => [entry.types],
+  );
+  for (const declarationPath of declarationPaths) {
+    await stat(join(installedRoot, declarationPath));
+  }
+
+  const root = await import("@erniesg/struct");
+  const core = await import("@erniesg/struct/core");
+  const schema = await import("@erniesg/struct/schema");
+  const ids = await import("@erniesg/struct/ids");
+  const recovery = await import("@erniesg/struct/recovery");
+  const xhtml = await import("@erniesg/struct/renderers/xhtml");
+  const epub = await import("@erniesg/struct/renderers/epub");
+
+  assert.equal(schema.STRUCT_SCHEMA_VERSION, "0.2.0");
+  assert.match(ids.structId("consumer", "sample"), /^struct-consumer-/u);
+  assert.equal(
+    recovery.recoverySummary({ ready: true, diagnostics: [] }).status,
+    "ready",
+  );
+
+  const document = consumerDocument(root.structDigest);
+  const encoded = root.encodeStructDocument(document);
+  const decoded = root.decodeStructDocument(encoded);
+  assert.deepEqual(decoded, document);
+  assert.equal(
+    core.pageLayoutsFromBlocks(
+      [{ page: 1, width: 600, height: 800, rotation: 0 }],
+      decoded.blocks,
+    )[0].blocks[0],
+    "consumer-block",
+  );
+  assert.match(xhtml.renderPublicationXhtml(decoded), /Consumer/u);
+  const exportResult = await epub.buildStructEpub(decoded);
+  assert.equal(exportResult.mediaType, "application/epub+zip");
+  assert.ok(exportResult.bytes.byteLength > 0);
+
+  await assert.rejects(
+    import("@erniesg/struct/src/index.js"),
+    (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
+  );
+  await assert.rejects(
+    import("@erniesg/struct/package.json"),
+    (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
+  );
+
+  console.log(
+    JSON.stringify({
+      tarball: packed.filename,
+      exports: Object.keys(installedManifest.exports),
+      declarations: declarationPaths.length,
+      privatePathRefusals: 2,
+    }),
+  );
+} finally {
+  if (tarballPath) await rm(tarballPath, { force: true });
+  await rm(consumerRoot, { recursive: true, force: true });
+}
+
+function consumerDocument(structDigest) {
+  const sourceSha256 = "b".repeat(64);
+  const document = {
+    schemaVersion: "0.2.0",
+    documentId: "consumer-document",
+    source: {
+      format: "unknown",
+      fileName: "consumer.struct",
+      sha256: sourceSha256,
+      byteLength: 13,
+      pageCount: 1,
+      localOnly: true,
+    },
+    metadata: {
+      title: "Consumer",
+      subtitle: "",
+      authors: ["Fixture Author"],
+      abstract: "",
+      updated: "2026-08-20",
+    },
+    blocks: [
+      {
+        id: "consumer-block",
+        kind: "paragraph",
+        text: "Consumer text",
+        page: 1,
+        order: 0,
+        column: "single",
+        inline: [],
+        evidence: {
+          confidence: 1,
+          pages: [1],
+          boxes: [],
+          sourceIds: ["source-node"],
+        },
+      },
+    ],
+    assets: [],
+    relationships: [],
+    pages: [
+      {
+        page: 1,
+        width: 600,
+        height: 800,
+        rotation: 0,
+        blocks: ["consumer-block"],
+        columns: [
+          {
+            id: "consumer-column",
+            side: "single",
+            blockIds: ["consumer-block"],
+          },
+        ],
+      },
+    ],
+    diagnostics: [],
+    recovery: {
+      status: "ready",
+      title: "Ready",
+      summary: "Ready",
+      issues: [],
+    },
+    receipt: {
+      schemaVersion: "0.2.0",
+      documentId: "consumer-document",
+      sourceSha256,
+      blockCount: 1,
+      assetCount: 0,
+      relationshipCount: 0,
+      diagnosticCount: 0,
+      textCharacterCount: 13,
+      conservation: {
+        sourceNodeCount: 1,
+        accountedSourceNodeCount: 1,
+        sourceRegionCount: 0,
+        accountedSourceRegionCount: 0,
+        sourceAnnotationCount: 0,
+        accountedSourceAnnotationCount: 0,
+        sourceAssetCount: 0,
+        accountedSourceAssetCount: 0,
+        sourceRelationshipCount: 0,
+        accountedSourceRelationshipCount: 0,
+        sourceDiagnosticCount: 0,
+        accountedSourceDiagnosticCount: 0,
+        sourceTextCharacterCount: 13,
+        structBlockCount: 1,
+        structAssetCount: 0,
+        structRelationshipCount: 0,
+        structDiagnosticCount: 0,
+        structTextCharacterCount: 13,
+      },
+      generatedSha256: "",
+    },
+  };
+  const { receipt, ...withoutReceipt } = document;
+  receipt.generatedSha256 = structDigest({
+    ...withoutReceipt,
+    conservation: receipt.conservation,
+    assets: [],
+  });
+  return document;
+}

--- a/packages/struct/test/consumer/standalone-tarball.mjs
+++ b/packages/struct/test/consumer/standalone-tarball.mjs
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const packageManifest = JSON.parse(
@@ -61,7 +61,11 @@ try {
 
   const probePath = join(consumerRoot, "installed-consumer.mjs");
   await writeFile(probePath, consumerProbeSource(), "utf8");
-  const probe = await import(probePath);
+  assert.equal(
+    pathToFileURL(String.raw`C:\Users\struct\installed-consumer.mjs`).protocol,
+    "file:",
+  );
+  const probe = await import(pathToFileURL(probePath).href);
   const { root, core, schema, ids, recovery, xhtml, epub } = probe;
 
   assert.equal(schema.STRUCT_SCHEMA_VERSION, "0.2.0");

--- a/packages/struct/test/consumer/standalone-tarball.mjs
+++ b/packages/struct/test/consumer/standalone-tarball.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -59,13 +59,10 @@ try {
     await stat(join(installedRoot, declarationPath));
   }
 
-  const root = await import("@erniesg/struct");
-  const core = await import("@erniesg/struct/core");
-  const schema = await import("@erniesg/struct/schema");
-  const ids = await import("@erniesg/struct/ids");
-  const recovery = await import("@erniesg/struct/recovery");
-  const xhtml = await import("@erniesg/struct/renderers/xhtml");
-  const epub = await import("@erniesg/struct/renderers/epub");
+  const probePath = join(consumerRoot, "installed-consumer.mjs");
+  await writeFile(probePath, consumerProbeSource(), "utf8");
+  const probe = await import(probePath);
+  const { root, core, schema, ids, recovery, xhtml, epub } = probe;
 
   assert.equal(schema.STRUCT_SCHEMA_VERSION, "0.2.0");
   assert.match(ids.structId("consumer", "sample"), /^struct-consumer-/u);
@@ -90,15 +87,6 @@ try {
   assert.equal(exportResult.mediaType, "application/epub+zip");
   assert.ok(exportResult.bytes.byteLength > 0);
 
-  await assert.rejects(
-    import("@erniesg/struct/src/index.js"),
-    (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
-  );
-  await assert.rejects(
-    import("@erniesg/struct/package.json"),
-    (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
-  );
-
   console.log(
     JSON.stringify({
       tarball: packed.filename,
@@ -110,6 +98,52 @@ try {
 } finally {
   if (tarballPath) await rm(tarballPath, { force: true });
   await rm(consumerRoot, { recursive: true, force: true });
+}
+
+function consumerProbeSource() {
+  return `
+import assert from "node:assert/strict";
+
+const publicSpecifiers = [
+  "@erniesg/struct",
+  "@erniesg/struct/core",
+  "@erniesg/struct/schema",
+  "@erniesg/struct/ids",
+  "@erniesg/struct/recovery",
+  "@erniesg/struct/renderers/xhtml",
+  "@erniesg/struct/renderers/epub",
+];
+const installedRootUrl = new URL(
+  ".",
+  await import.meta.resolve("@erniesg/struct"),
+);
+const publicResolvedUrls = await Promise.all(
+  publicSpecifiers.map((specifier) => import.meta.resolve(specifier)),
+);
+for (const resolvedUrl of publicResolvedUrls) {
+  assert.ok(
+    resolvedUrl.startsWith(installedRootUrl.href),
+    resolvedUrl + " must resolve below " + installedRootUrl.href,
+  );
+}
+
+export const root = await import("@erniesg/struct");
+export const core = await import("@erniesg/struct/core");
+export const schema = await import("@erniesg/struct/schema");
+export const ids = await import("@erniesg/struct/ids");
+export const recovery = await import("@erniesg/struct/recovery");
+export const xhtml = await import("@erniesg/struct/renderers/xhtml");
+export const epub = await import("@erniesg/struct/renderers/epub");
+
+await assert.rejects(
+  import("@erniesg/struct/src/index.js"),
+  (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
+);
+await assert.rejects(
+  import("@erniesg/struct/package.json"),
+  (error) => error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
+);
+`;
 }
 
 function consumerDocument(structDigest) {

--- a/packages/struct/test/contracts/model-receipt.ts
+++ b/packages/struct/test/contracts/model-receipt.ts
@@ -1,0 +1,16 @@
+export type SafeIdDenialCase = readonly [
+  label: string,
+  value: string,
+  expected: false,
+];
+
+/** Intentionally fake credential-shaped values used only as denial fixtures. */
+export const SAFE_ID_DENIAL_CASES: readonly SafeIdDenialCase[] = [
+  ["OpenAI", "sk-proj-FAKEFAKEFAKE", false],
+  ["AWS", "AKIAFAKEFAKEFAKE", false],
+  ["bearer", "bearer-FAKEFAKEFAKE", false],
+  ["JWT", "eyJFAKE.payloadFAKE.signatureFAKE", false],
+  ["encoded private key", "BEGIN-RSA-PRIVATE-KEY", false],
+  ["Slack", "xoxb-FAKEFAKEFAKE", false],
+  ["GitHub", "github_pat_FAKEFAKEFAKE", false],
+] as const;

--- a/packages/struct/test/contracts/source-parity.ts
+++ b/packages/struct/test/contracts/source-parity.ts
@@ -1,0 +1,145 @@
+export type SourceParityEntry = {
+  readonly packagePath: string;
+  readonly rule: string;
+  readonly packageSha256: string;
+};
+
+/**
+ * Immutable package-local source contract. The package tree is the only
+ * source read by the conformance test; canonical app paths are retained only
+ * as reviewed exclusions in the historical manifest contract.
+ */
+export const PARITY_SCHEMA_VERSION = 1 as const;
+
+export const PARITY_ENTRIES: readonly SourceParityEntry[] = [
+  {
+    packagePath: "codec/bytes.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "04549a3f84594453ec90c319ad3b013ac479a99a1861c70344bc5b0cdc80b805",
+  },
+  {
+    packagePath: "codec/index.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "c6e4d730dc782a400a833f79a14f672944e23d0cffd1ac38243b2ae2995eacac",
+  },
+  {
+    packagePath: "codec/invariants.ts",
+    rule: "generic-model-invariants",
+    packageSha256:
+      "1d317a67ecbfa7eda8c9c820524f5449a7aa806ac9228141112c81750ba3c5f2",
+  },
+  {
+    packagePath: "codec/parsers.ts",
+    rule: "generic-model-parser",
+    packageSha256:
+      "620f330d7f5c73342c82a0eb9cff5f4b18a6b5797a2e160a4881757ec91fae33",
+  },
+  {
+    packagePath: "codec/primitives.ts",
+    rule: "safe-id-primitives",
+    packageSha256:
+      "707ced139e00b4d80aae27d52d7f4fb3ef6e604296be874677643715047287c5",
+  },
+  {
+    packagePath: "codec/structure.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "1241ab23eb0da2cd85f7e0ac198b442a4cc0246d75f67603d2980cbe4387fe3e",
+  },
+  {
+    packagePath: "core.ts",
+    rule: "codec-facade",
+    packageSha256:
+      "5ea085ff0a109434009af112ccb987501ae178549589018749b422840bfb32d2",
+  },
+  {
+    packagePath: "epub.ts",
+    rule: "generic-model-epub",
+    packageSha256:
+      "4be79a389054a86b084660f64890966dc290a575a078120bab7d969208d5a429",
+  },
+  {
+    packagePath: "ids.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "556f86b46550760719984d392266f551e1b3a73b8dc25854f59f5e925e684202",
+  },
+  {
+    packagePath: "index.ts",
+    rule: "root-facade",
+    packageSha256:
+      "c16a9ebc3250fb4bb62c364e079cfc05ea3a77563df301954215695d5efb42fd",
+  },
+  {
+    packagePath: "model-consultation-receipt.ts",
+    rule: "generic-receipt",
+    packageSha256:
+      "c98da5d50eaee762fe01c4f1ad326d20d55f3b5d8d14041696866d6f21d66bc6",
+  },
+  {
+    packagePath: "reading-order.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "7c496f3d4bb72f2810e8f9a3ef8a3cc04d359d85158a8148d6ce03bad81cd1d9",
+  },
+  {
+    packagePath: "recovery.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "ac2ab6b8f674008c09a69aad84766c922e767e500e82011c1042656bde754c79",
+  },
+  {
+    packagePath: "renderers/epub.ts",
+    rule: "renderer-epub-facade",
+    packageSha256:
+      "77dfd2ce81a50ef6e5bcee424b04add78b979fa5f626fd504b8f8abaff535452",
+  },
+  {
+    packagePath: "renderers/xhtml.ts",
+    rule: "renderer-xhtml-facade",
+    packageSha256:
+      "6907f349531561be4247374af910145a132d0c240bde6e26a4a78d7f32b680d5",
+  },
+  {
+    packagePath: "schema.ts",
+    rule: "package-only-schema",
+    packageSha256:
+      "b3835d149b5f8dc96c0ccac7d9c2604799a57ebdb2e82f64f7d994741d2d4471",
+  },
+  {
+    packagePath: "sha256.ts",
+    rule: "byte-identical",
+    packageSha256:
+      "7c240348df2f60ec53ee870346ab4d1ac2dfff16b8a32b1464b7b875c1c749f4",
+  },
+  {
+    packagePath: "types.ts",
+    rule: "generic-model-types",
+    packageSha256:
+      "9aaf1e51c0167dd3445db491fdd5e36f5ac120d63a033e147e84d223c8195083",
+  },
+  {
+    packagePath: "xhtml.ts",
+    rule: "esm-imports",
+    packageSha256:
+      "4014eb7be096e01508287c33060a64fb2a5abb66040f00bb36ed8677ca4692a3",
+  },
+] as const;
+
+export const EXCLUDED_CANONICAL: Readonly<Record<string, string>> = {
+  "codec/model.ts":
+    "PDF-coupled model receipt codec is forbidden from the package",
+  "codec.test.ts":
+    "canonical codec suite is app-coupled; package characterization suite is maintained locally",
+  "epub-integrity.test.ts":
+    "canonical EPUB suite is app-coupled; package characterization suite is maintained locally",
+  "from-reconstruction.ts":
+    "historical compatibility shim for the app-owned extractor adapter is outside package core",
+  "struct.test.ts":
+    "canonical integration suite imports app/PDF providers; package characterization suites are maintained locally",
+} as const;
+
+export const PARITY_MANIFEST_SHA256 =
+  "9a141b01808d04f22c40f001b495825dba7fc129e2997db9ad5406a8a43fc714";

--- a/packages/struct/test/model-receipt.test.ts
+++ b/packages/struct/test/model-receipt.test.ts
@@ -14,11 +14,11 @@ import {
   SAFE_ID as packageReceiptSafeId,
 } from '../src/model-consultation-receipt'
 import { SAFE_ID as packageDocumentSafeId } from '../src/codec/primitives'
-import { SAFE_ID as canonicalSafeId } from '../../../src/struct/model-consultation-receipt'
 import {
   characterizationDocument,
   resealDocument,
 } from './characterization-fixtures'
+import { SAFE_ID_DENIAL_CASES } from './contracts/model-receipt.js'
 
 function sealedDocument() {
   const document = characterizationDocument('0.2.0') as any
@@ -212,20 +212,11 @@ describe('generic STRUCT model consultation receipt', () => {
     expect(() => copyCanonicalJson(overNodeLimit, '$')).toThrow(/node bound/)
   })
 
-  it.each([
-    ['OpenAI', 'sk-proj-FAKEFAKEFAKE'],
-    ['AWS', 'AKIAFAKEFAKEFAKE'],
-    ['bearer', 'bearer-FAKEFAKEFAKE'],
-    ['JWT', 'eyJFAKE.payloadFAKE.signatureFAKE'],
-    ['encoded private key', 'BEGIN-RSA-PRIVATE-KEY'],
-    ['Slack', 'xoxb-FAKEFAKEFAKE'],
-    ['GitHub', 'github_pat_FAKEFAKEFAKE'],
-  ])(
-    'keeps package and canonical credential-shaped ID denial in parity (%s)',
-    (_label, credentialShapedId) => {
-      expect(canonicalSafeId.test(credentialShapedId)).toBe(false)
-      expect(packageReceiptSafeId.test(credentialShapedId)).toBe(false)
-      expect(packageDocumentSafeId.test(credentialShapedId)).toBe(false)
+  it.each(SAFE_ID_DENIAL_CASES)(
+    'denies frozen credential-shaped IDs in every package SAFE_ID contract (%s)',
+    (_label, credentialShapedId, expected) => {
+      expect(packageReceiptSafeId.test(credentialShapedId)).toBe(expected)
+      expect(packageDocumentSafeId.test(credentialShapedId)).toBe(expected)
 
       const document = characterizationDocument('0.2.0') as any
       document.blocks[0].id = credentialShapedId

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -9,9 +9,9 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, join, sep } from 'node:path'
 import { tmpdir } from 'node:os'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { auditPackageImportBoundary } from './package-import-boundary.js'
 
@@ -29,6 +29,20 @@ async function filesUnder(path: string): Promise<string[]> {
 }
 
 describe('STRUCT package artifact boundary', () => {
+  it('resolves the Vitest root when the package path contains spaces', async () => {
+    const fixture = await mkdtemp(join(tmpdir(), 'struct package config-'))
+    const configPath = join(fixture, 'vitest.config.ts')
+    try {
+      await cp(join(root, 'vitest.config.ts'), configPath)
+      const configModule = (await import(
+        `${pathToFileURL(configPath).href}?space-path-regression`
+      )) as { default: { root?: string } }
+      expect(configModule.default.root).toBe(`${fixture}${sep}`)
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
+  })
+
   it('publishes only built files and contains no private consumer contracts', async () => {
     const manifest = JSON.parse(
       await readFile(join(root, 'package.json'), 'utf8'),

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -95,10 +95,30 @@ async function resolvePackageRootFromEntry(name: string): Promise<PackageRoot> {
 }
 
 async function resolveDeclaredPackageRoot(name: string): Promise<PackageRoot> {
-  if (name === 'fast-xml-parser') {
-    return resolvePackageRootFromEntry(name)
+  try {
+    return await resolvePackageRootFromManifest(name)
+  } catch (error) {
+    if (
+      (error as NodeJS.ErrnoException).code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+    ) {
+      throw new Error(
+        `could not resolve ${name}/package.json from the package-boundary test: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error },
+      )
+    }
+    try {
+      return await resolvePackageRootFromEntry(name)
+    } catch (entryError) {
+      throw new Error(
+        `could not resolve the package root for ${name} after its package.json export was blocked: ${
+          entryError instanceof Error ? entryError.message : String(entryError)
+        }`,
+        { cause: entryError },
+      )
+    }
   }
-  return resolvePackageRootFromManifest(name)
 }
 
 async function resolveTypeScriptPackage(): Promise<
@@ -114,14 +134,140 @@ async function resolveTypeScriptPackage(): Promise<
   return { ...(await resolvePackageRootFromManifest('typescript')), compiler }
 }
 
-async function linkPackageRoot(fixture: string, packageRoot: PackageRoot) {
-  const destination = join(
-    fixture,
-    'node_modules',
-    ...packageRoot.name.split('/'),
-  )
+async function linkPackageRoot(nodeModules: string, packageRoot: PackageRoot) {
+  const destination = join(nodeModules, ...packageRoot.name.split('/'))
   await mkdir(dirname(destination), { recursive: true })
   await symlink(packageRoot.root, destination, directoryLinkType)
+}
+
+type PackageOnlyLayout = 'package-local' | 'root-hoisted' | 'pnpm-virtual-store'
+
+async function packageVersion(packageRoot: PackageRoot): Promise<string> {
+  const manifest = JSON.parse(
+    await readFile(join(packageRoot.root, 'package.json'), 'utf8'),
+  ) as { version?: unknown }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(
+      `resolved package has no usable version: ${packageRoot.root}`,
+    )
+  }
+  return manifest.version
+}
+
+async function resolvePackageOnlyDependencies(): Promise<PackageRoot[]> {
+  const manifest = JSON.parse(
+    await readFile(join(root, 'package.json'), 'utf8'),
+  ) as { dependencies?: Record<string, string> }
+  const dependencyNames = Object.keys(manifest.dependencies ?? {})
+  return Promise.all(dependencyNames.map(resolveDeclaredPackageRoot))
+}
+
+async function stagePackageOnlyLayout(
+  fixture: string,
+  dependencies: PackageRoot[],
+  typeScript: PackageRoot & { compiler: string },
+  layout: PackageOnlyLayout,
+): Promise<string> {
+  const packages = [...dependencies, typeScript]
+  if (layout === 'package-local') {
+    const nodeModules = join(fixture, 'node_modules')
+    await mkdir(nodeModules)
+    for (const packageRoot of packages) {
+      await linkPackageRoot(nodeModules, packageRoot)
+    }
+    return typeScript.compiler
+  }
+
+  if (layout === 'root-hoisted') {
+    const hoistedNodeModules = join(fixture, 'root-hoisted-node_modules')
+    await mkdir(hoistedNodeModules)
+    for (const packageRoot of packages) {
+      await linkPackageRoot(hoistedNodeModules, packageRoot)
+    }
+    await symlink(
+      hoistedNodeModules,
+      join(fixture, 'node_modules'),
+      directoryLinkType,
+    )
+    return typeScript.compiler
+  }
+
+  const nodeModules = join(fixture, 'node_modules')
+  const virtualStore = join(nodeModules, '.pnpm')
+  await mkdir(virtualStore, { recursive: true })
+  let compiler = typeScript.compiler
+  for (const packageRoot of packages) {
+    const version = await packageVersion(packageRoot)
+    const storePackage = join(
+      virtualStore,
+      `${packageRoot.name.replaceAll('/', '+')}@${version}`,
+      'node_modules',
+    )
+    const virtualPackageRoot = join(
+      storePackage,
+      ...packageRoot.name.split('/'),
+    )
+    await mkdir(dirname(virtualPackageRoot), { recursive: true })
+    await symlink(packageRoot.root, virtualPackageRoot, directoryLinkType)
+    await linkPackageRoot(nodeModules, {
+      ...packageRoot,
+      root: virtualPackageRoot,
+    })
+    if (packageRoot.name === 'typescript') {
+      compiler = join(virtualPackageRoot, 'bin', 'tsc')
+      const compilerStat = await stat(compiler)
+      if (!compilerStat.isFile()) {
+        throw new Error(
+          `staged TypeScript compiler is not a regular file: ${compiler}`,
+        )
+      }
+    }
+  }
+  return compiler
+}
+
+async function assertPackageOnlyFixture(
+  fixture: string,
+  compiler: string,
+): Promise<void> {
+  const emptyTypes = join(fixture, 'empty-types')
+  const tsconfig = join(fixture, 'tsconfig.json')
+  execFileSync(
+    process.execPath,
+    [compiler, '-p', tsconfig, '--noEmit', '--typeRoots', emptyTypes],
+    { cwd: fixture, stdio: 'pipe' },
+  )
+  execFileSync(process.execPath, [compiler, '-p', tsconfig], {
+    cwd: fixture,
+    stdio: 'pipe',
+  })
+  const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>
+    path.slice(fixture.length + 1),
+  )
+  expect(distPaths).toEqual(
+    expect.arrayContaining([
+      'dist/index.js',
+      'dist/core.js',
+      'dist/schema.js',
+      'dist/ids.js',
+      'dist/recovery.js',
+      'dist/renderers/xhtml.js',
+      'dist/renderers/epub.js',
+    ]),
+  )
+  const pack = JSON.parse(
+    execFileSync('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], {
+      cwd: fixture,
+      encoding: 'utf8',
+    }),
+  )[0] as { files?: Array<{ path: string }> }
+  const packedPaths = pack.files?.map(({ path }) => path) ?? []
+  expect(packedPaths).toContain('package.json')
+  expect(
+    packedPaths.every(
+      (path) => path === 'package.json' || path.startsWith('dist/'),
+    ),
+  ).toBe(true)
 }
 
 async function filesUnder(path: string): Promise<string[]> {
@@ -1321,76 +1467,30 @@ describe('STRUCT package artifact boundary', () => {
     }
   })
 
-  it('compiles and packs from a package-only temporary copy', async () => {
-    const fixture = await mkdtemp(join(tmpdir(), 'struct-package-only-'))
-    try {
-      const typeScript = await resolveTypeScriptPackage()
-      await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
-      await cp(join(root, 'package.json'), join(fixture, 'package.json'))
-      await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
-      await mkdir(join(fixture, 'empty-types'))
-      await mkdir(join(fixture, 'node_modules'))
-      for (const dependency of Object.keys(
-        JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
-          .dependencies,
-      )) {
-        await linkPackageRoot(
+  it('compiles and packs from package-local, root-hoisted, and PNPM layouts', async () => {
+    const dependencies = await resolvePackageOnlyDependencies()
+    const typeScript = await resolveTypeScriptPackage()
+    for (const layout of [
+      'package-local',
+      'root-hoisted',
+      'pnpm-virtual-store',
+    ] as const) {
+      const fixture = await mkdtemp(join(tmpdir(), `struct-package-${layout}-`))
+      try {
+        await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
+        await cp(join(root, 'package.json'), join(fixture, 'package.json'))
+        await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
+        await mkdir(join(fixture, 'empty-types'))
+        const compiler = await stagePackageOnlyLayout(
           fixture,
-          await resolveDeclaredPackageRoot(dependency),
+          dependencies,
+          typeScript,
+          layout,
         )
+        await assertPackageOnlyFixture(fixture, compiler)
+      } finally {
+        await rm(fixture, { recursive: true, force: true })
       }
-      await linkPackageRoot(fixture, typeScript)
-
-      execFileSync(
-        process.execPath,
-        [
-          typeScript.compiler,
-          '-p',
-          join(fixture, 'tsconfig.json'),
-          '--noEmit',
-          '--typeRoots',
-          join(fixture, 'empty-types'),
-        ],
-        { cwd: fixture, stdio: 'pipe' },
-      )
-      execFileSync(
-        process.execPath,
-        [typeScript.compiler, '-p', join(fixture, 'tsconfig.json')],
-        { cwd: fixture, stdio: 'pipe' },
-      )
-      const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>
-        path.slice(fixture.length + 1),
-      )
-      expect(distPaths).toEqual(
-        expect.arrayContaining([
-          'dist/index.js',
-          'dist/core.js',
-          'dist/schema.js',
-          'dist/ids.js',
-          'dist/recovery.js',
-          'dist/renderers/xhtml.js',
-          'dist/renderers/epub.js',
-        ]),
-      )
-      const pack = JSON.parse(
-        execFileSync(
-          'npm',
-          ['pack', '--dry-run', '--ignore-scripts', '--json'],
-          {
-            cwd: fixture,
-            encoding: 'utf8',
-          },
-        ),
-      )[0] as { files?: Array<{ path: string }> }
-      const packedPaths = pack.files?.map(({ path }) => path) ?? []
-      expect(packedPaths).toContain('package.json')
-      expect(
-        packedPaths.every(
-          (path) => path === 'package.json' || path.startsWith('dist/'),
-        ),
-      ).toBe(true)
-    } finally {
-      await rm(fixture, { recursive: true, force: true })
     }
   })
 })

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -20,7 +20,90 @@ import { auditPackageImportBoundary } from './package-import-boundary.js'
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const require = createRequire(import.meta.url)
 
-async function resolveTypeScriptCompiler(): Promise<string> {
+type PackageRoot = {
+  name: string
+  root: string
+}
+
+const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+async function validatePackageRoot(
+  name: string,
+  packageRoot: string,
+  manifestPath: string,
+): Promise<PackageRoot> {
+  const rootStat = await stat(packageRoot)
+  if (!rootStat.isDirectory()) {
+    throw new Error(`resolved package root is not a directory: ${packageRoot}`)
+  }
+  const manifestStat = await stat(manifestPath)
+  if (!manifestStat.isFile()) {
+    throw new Error(
+      `resolved package manifest is not a regular file: ${manifestPath}`,
+    )
+  }
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+    name?: unknown
+  }
+  if (manifest.name !== name) {
+    throw new Error(
+      `resolved package manifest identity mismatch: expected ${name}, got ${String(manifest.name)}`,
+    )
+  }
+  return { name, root: packageRoot }
+}
+
+async function resolvePackageRootFromManifest(
+  name: string,
+): Promise<PackageRoot> {
+  const manifestPath = require.resolve(`${name}/package.json`)
+  return validatePackageRoot(name, dirname(manifestPath), manifestPath)
+}
+
+async function resolvePackageRootFromEntry(name: string): Promise<PackageRoot> {
+  const entry = require.resolve(name)
+  const entryStat = await stat(entry)
+  if (!entryStat.isFile()) {
+    throw new Error(`resolved package entry is not a regular file: ${entry}`)
+  }
+
+  let candidate = dirname(entry)
+  for (let depth = 0; depth < 8; depth += 1) {
+    const manifestPath = join(candidate, 'package.json')
+    try {
+      const manifestStat = await stat(manifestPath)
+      if (manifestStat.isFile()) {
+        const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+          name?: unknown
+        }
+        if (manifest.name === name) {
+          return validatePackageRoot(name, candidate, manifestPath)
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
+    }
+    const parent = dirname(candidate)
+    if (parent === candidate) break
+    candidate = parent
+  }
+  throw new Error(
+    `could not find bounded package root for ${name} from ${entry}`,
+  )
+}
+
+async function resolveDeclaredPackageRoot(name: string): Promise<PackageRoot> {
+  if (name === 'fast-xml-parser') {
+    return resolvePackageRootFromEntry(name)
+  }
+  return resolvePackageRootFromManifest(name)
+}
+
+async function resolveTypeScriptPackage(): Promise<
+  PackageRoot & { compiler: string }
+> {
   const compiler = require.resolve('typescript/bin/tsc')
   const compilerStat = await stat(compiler)
   if (!compilerStat.isFile()) {
@@ -28,7 +111,17 @@ async function resolveTypeScriptCompiler(): Promise<string> {
       `resolved TypeScript compiler is not a regular file: ${compiler}`,
     )
   }
-  return compiler
+  return { ...(await resolvePackageRootFromManifest('typescript')), compiler }
+}
+
+async function linkPackageRoot(fixture: string, packageRoot: PackageRoot) {
+  const destination = join(
+    fixture,
+    'node_modules',
+    ...packageRoot.name.split('/'),
+  )
+  await mkdir(dirname(destination), { recursive: true })
+  await symlink(packageRoot.root, destination, directoryLinkType)
 }
 
 async function filesUnder(path: string): Promise<string[]> {
@@ -1168,23 +1261,90 @@ describe('STRUCT package artifact boundary', () => {
     expect(await auditPackageImportBoundary(root)).toEqual([])
   })
 
-  it('compiles and packs from a package-only temporary copy', async () => {
-    const fixture = await mkdtemp(join(tmpdir(), 'struct-package-only-'))
+  it('reproduces the PNPM dirname^3 dependency omission', async () => {
+    const fixture = await mkdtemp(join(tmpdir(), 'struct-package-pnpm-red-'))
     try {
-      const typeScriptCompiler = await resolveTypeScriptCompiler()
+      const typeScript = await resolveTypeScriptPackage()
       await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
       await cp(join(root, 'package.json'), join(fixture, 'package.json'))
       await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
       await mkdir(join(fixture, 'empty-types'))
-      await symlink(
-        dirname(dirname(dirname(typeScriptCompiler))),
-        join(fixture, 'node_modules'),
+
+      const pnpmNodeModules = join(
+        fixture,
+        'node_modules-store',
+        '.pnpm',
+        `typescript@${
+          JSON.parse(
+            await readFile(join(typeScript.root, 'package.json'), 'utf8'),
+          ).version
+        }`,
+        'node_modules',
       )
+      const innerTypeScript = join(pnpmNodeModules, 'typescript')
+      await mkdir(pnpmNodeModules, { recursive: true })
+      await symlink(typeScript.root, innerTypeScript, directoryLinkType)
+      await symlink(
+        pnpmNodeModules,
+        join(fixture, 'node_modules'),
+        directoryLinkType,
+      )
+
+      const dirnameThreeNodeModules = dirname(
+        dirname(dirname(join(innerTypeScript, 'bin', 'tsc'))),
+      )
+      expect(dirnameThreeNodeModules).toBe(pnpmNodeModules)
+
+      let compilerOutput = ''
+      try {
+        execFileSync(
+          process.execPath,
+          [
+            join(innerTypeScript, 'bin', 'tsc'),
+            '-p',
+            join(fixture, 'tsconfig.json'),
+            '--noEmit',
+            '--typeRoots',
+            join(fixture, 'empty-types'),
+          ],
+          { cwd: fixture, encoding: 'utf8', stdio: 'pipe' },
+        )
+      } catch (error) {
+        const compilerError = error as { stdout?: string; stderr?: string }
+        compilerOutput = `${compilerError.stdout ?? ''}\n${compilerError.stderr ?? ''}`
+      }
+      expect(compilerOutput).toContain('TS2307')
+      expect(compilerOutput).toContain("Cannot find module 'fflate'")
+      expect(compilerOutput).toContain("Cannot find module 'fast-xml-parser'")
+    } finally {
+      await rm(fixture, { recursive: true, force: true })
+    }
+  })
+
+  it('compiles and packs from a package-only temporary copy', async () => {
+    const fixture = await mkdtemp(join(tmpdir(), 'struct-package-only-'))
+    try {
+      const typeScript = await resolveTypeScriptPackage()
+      await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
+      await cp(join(root, 'package.json'), join(fixture, 'package.json'))
+      await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
+      await mkdir(join(fixture, 'empty-types'))
+      await mkdir(join(fixture, 'node_modules'))
+      for (const dependency of Object.keys(
+        JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+          .dependencies,
+      )) {
+        await linkPackageRoot(
+          fixture,
+          await resolveDeclaredPackageRoot(dependency),
+        )
+      }
+      await linkPackageRoot(fixture, typeScript)
 
       execFileSync(
         process.execPath,
         [
-          typeScriptCompiler,
+          typeScript.compiler,
           '-p',
           join(fixture, 'tsconfig.json'),
           '--noEmit',
@@ -1195,7 +1355,7 @@ describe('STRUCT package artifact boundary', () => {
       )
       execFileSync(
         process.execPath,
-        [typeScriptCompiler, '-p', join(fixture, 'tsconfig.json')],
+        [typeScript.compiler, '-p', join(fixture, 'tsconfig.json')],
         { cwd: fixture, stdio: 'pipe' },
       )
       const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -1148,14 +1148,14 @@ describe('STRUCT package artifact boundary', () => {
       await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
       await mkdir(join(fixture, 'empty-types'))
       await symlink(
-        join(root, '../../node_modules'),
+        join(root, 'node_modules'),
         join(fixture, 'node_modules'),
       )
 
       execFileSync(
         process.execPath,
         [
-          join(root, '../../node_modules/typescript/bin/tsc'),
+          join(root, 'node_modules/typescript/bin/tsc'),
           '-p',
           join(fixture, 'tsconfig.json'),
           '--noEmit',
@@ -1167,7 +1167,7 @@ describe('STRUCT package artifact boundary', () => {
       execFileSync(
         process.execPath,
         [
-          join(root, '../../node_modules/typescript/bin/tsc'),
+          join(root, 'node_modules/typescript/bin/tsc'),
           '-p',
           join(fixture, 'tsconfig.json'),
         ],

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -35,6 +35,22 @@ function fixtureRelativePath(fixture: string, pathValue: string): string {
   return normalizeFixtureRelativePath(relative(fixture, pathValue))
 }
 
+const allowedModelReceiptPaths = new Set([
+  'src/model-consultation-receipt.ts',
+  'dist/model-consultation-receipt.js',
+  'dist/model-consultation-receipt.d.ts',
+  'dist/model-consultation-receipt.js.map',
+  'dist/model-consultation-receipt.d.ts.map',
+])
+
+function isAllowedModelReceiptPath(pathValue: string): boolean {
+  const normalized = normalizeFixtureRelativePath(pathValue)
+  return (
+    allowedModelReceiptPaths.has(normalized) &&
+    basename(normalized).startsWith('model-consultation-receipt.')
+  )
+}
+
 async function validatePackageRoot(
   name: string,
   packageRoot: string,
@@ -170,6 +186,31 @@ async function stagedTypeScriptCompiler(nodeModules: string): Promise<string> {
 
 type PackageOnlyLayout = 'package-local' | 'root-hoisted' | 'pnpm-virtual-store'
 
+type StagedPackageOnlyFixture = {
+  packageRoot: string
+  nodeModules: string
+  compiler: string
+}
+
+function packageOnlyRootForLayout(
+  fixture: string,
+  layout: PackageOnlyLayout,
+): string {
+  return layout === 'root-hoisted'
+    ? join(fixture, 'workspace', 'packages', 'struct')
+    : fixture
+}
+
+async function pathExists(pathValue: string): Promise<boolean> {
+  try {
+    await stat(pathValue)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
 async function packageVersion(packageRoot: PackageRoot): Promise<string> {
   const manifest = JSON.parse(
     await readFile(join(packageRoot.root, 'package.json'), 'utf8'),
@@ -195,7 +236,7 @@ async function stagePackageOnlyLayout(
   dependencies: PackageRoot[],
   typeScript: PackageRoot & { compiler: string },
   layout: PackageOnlyLayout,
-): Promise<string> {
+): Promise<StagedPackageOnlyFixture> {
   const packages = [...dependencies, typeScript]
   if (layout === 'package-local') {
     const nodeModules = join(fixture, 'node_modules')
@@ -203,24 +244,29 @@ async function stagePackageOnlyLayout(
     for (const packageRoot of packages) {
       await copyPackageRoot(nodeModules, packageRoot)
     }
-    return stagedTypeScriptCompiler(nodeModules)
+    return {
+      packageRoot: fixture,
+      nodeModules,
+      compiler: await stagedTypeScriptCompiler(nodeModules),
+    }
   }
 
   if (layout === 'root-hoisted') {
-    const hoistedNodeModules = join(fixture, 'root-hoisted-node_modules')
+    const packageRoot = packageOnlyRootForLayout(fixture, layout)
+    const hoistedNodeModules = join(fixture, 'workspace', 'node_modules')
     await mkdir(hoistedNodeModules)
     for (const packageRoot of packages) {
       await copyPackageRoot(hoistedNodeModules, packageRoot)
     }
-    await symlink(
-      hoistedNodeModules,
-      join(fixture, 'node_modules'),
-      directoryLinkType,
-    )
-    return stagedTypeScriptCompiler(hoistedNodeModules)
+    return {
+      packageRoot,
+      nodeModules: hoistedNodeModules,
+      compiler: await stagedTypeScriptCompiler(hoistedNodeModules),
+    }
   }
 
-  const nodeModules = join(fixture, 'node_modules')
+  const packageRoot = packageOnlyRootForLayout(fixture, layout)
+  const nodeModules = join(packageRoot, 'node_modules')
   const virtualStore = join(nodeModules, '.pnpm')
   await mkdir(virtualStore, { recursive: true })
   let compiler = typeScript.compiler
@@ -250,26 +296,26 @@ async function stagePackageOnlyLayout(
       }
     }
   }
-  return compiler
+  return { packageRoot, nodeModules, compiler }
 }
 
 async function assertPackageOnlyFixture(
-  fixture: string,
-  compiler: string,
+  fixture: StagedPackageOnlyFixture,
 ): Promise<void> {
-  const emptyTypes = join(fixture, 'empty-types')
-  const tsconfig = join(fixture, 'tsconfig.json')
+  const { packageRoot, compiler } = fixture
+  const emptyTypes = join(packageRoot, 'empty-types')
+  const tsconfig = join(packageRoot, 'tsconfig.json')
   execFileSync(
     process.execPath,
     [compiler, '-p', tsconfig, '--noEmit', '--typeRoots', emptyTypes],
-    { cwd: fixture, stdio: 'pipe' },
+    { cwd: packageRoot, stdio: 'pipe' },
   )
   execFileSync(process.execPath, [compiler, '-p', tsconfig], {
-    cwd: fixture,
+    cwd: packageRoot,
     stdio: 'pipe',
   })
-  const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>
-    fixtureRelativePath(fixture, path),
+  const distPaths = (await filesUnder(join(packageRoot, 'dist'))).map((path) =>
+    fixtureRelativePath(packageRoot, path),
   )
   expect(distPaths).toEqual(
     expect.arrayContaining([
@@ -284,7 +330,7 @@ async function assertPackageOnlyFixture(
   )
   const pack = JSON.parse(
     execFileSync('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], {
-      cwd: fixture,
+      cwd: packageRoot,
       encoding: 'utf8',
     }),
   )[0] as { files?: Array<{ path: string }> }
@@ -298,9 +344,9 @@ async function assertPackageOnlyFixture(
 }
 
 async function assertNoHostDependencyLeakage(
-  fixture: string,
-  compiler: string,
+  fixture: StagedPackageOnlyFixture,
 ): Promise<void> {
+  const { packageRoot, nodeModules, compiler } = fixture
   const hostOnlyEntry = require.resolve('vitest')
   const hostOnlyStat = await stat(hostOnlyEntry)
   if (!hostOnlyStat.isFile()) {
@@ -309,7 +355,7 @@ async function assertNoHostDependencyLeakage(
     )
   }
 
-  const dependencyRoot = join(fixture, 'node_modules', 'fflate')
+  const dependencyRoot = join(nodeModules, 'fflate')
   const dependencyManifest = JSON.parse(
     await readFile(join(dependencyRoot, 'package.json'), 'utf8'),
   ) as { types?: unknown }
@@ -338,14 +384,14 @@ async function assertNoHostDependencyLeakage(
       [
         compiler,
         '-p',
-        join(fixture, 'tsconfig.json'),
+        join(packageRoot, 'tsconfig.json'),
         '--noEmit',
         '--typeRoots',
-        join(fixture, 'empty-types'),
+        join(packageRoot, 'empty-types'),
         '--skipLibCheck',
         'false',
       ],
-      { cwd: fixture, encoding: 'utf8', stdio: 'pipe' },
+      { cwd: packageRoot, encoding: 'utf8', stdio: 'pipe' },
     )
   } catch (error) {
     const compilerError = error as { stdout?: string; stderr?: string }
@@ -382,6 +428,14 @@ describe('STRUCT package artifact boundary', () => {
   })
 
   it('publishes only built files and contains no private consumer contracts', async () => {
+    expect(
+      isAllowedModelReceiptPath(String.raw`src\model-consultation-receipt.ts`),
+    ).toBe(true)
+    expect(
+      isAllowedModelReceiptPath(
+        String.raw`dist\model-consultation-receipt.d.ts.map`,
+      ),
+    ).toBe(true)
     const manifest = JSON.parse(
       await readFile(join(root, 'package.json'), 'utf8'),
     ) as {
@@ -405,11 +459,13 @@ describe('STRUCT package artifact boundary', () => {
     const forbidden =
       /(?:reconstruction|publication|astro|pdf|provider|model|bookworld)/iu
     expect(
-      sourceFiles.some(
-        (path) =>
-          forbidden.test(path) &&
-          !path.endsWith('/model-consultation-receipt.ts'),
-      ),
+      sourceFiles.some((path) => {
+        const relativePath = fixtureRelativePath(root, path)
+        return (
+          forbidden.test(relativePath) &&
+          !isAllowedModelReceiptPath(relativePath)
+        )
+      }),
     ).toBe(false)
 
     const pack = JSON.parse(
@@ -437,12 +493,7 @@ describe('STRUCT package artifact boundary', () => {
     ).toBe(true)
     expect(
       packedPaths.some(
-        (path) =>
-          forbidden.test(path) &&
-          !path.endsWith('/model-consultation-receipt.js') &&
-          !path.endsWith('/model-consultation-receipt.d.ts') &&
-          !path.endsWith('/model-consultation-receipt.js.map') &&
-          !path.endsWith('/model-consultation-receipt.d.ts.map'),
+        (path) => forbidden.test(path) && !isAllowedModelReceiptPath(path),
       ),
     ).toBe(false)
   })
@@ -1565,18 +1616,31 @@ describe('STRUCT package artifact boundary', () => {
     ] as const) {
       const fixture = await mkdtemp(join(tmpdir(), `struct-package-${layout}-`))
       try {
-        await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
-        await cp(join(root, 'package.json'), join(fixture, 'package.json'))
-        await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
-        await mkdir(join(fixture, 'empty-types'))
-        const compiler = await stagePackageOnlyLayout(
+        const packageRoot = packageOnlyRootForLayout(fixture, layout)
+        await mkdir(packageRoot, { recursive: true })
+        await cp(join(root, 'src'), join(packageRoot, 'src'), {
+          recursive: true,
+        })
+        await cp(join(root, 'package.json'), join(packageRoot, 'package.json'))
+        await cp(
+          join(root, 'tsconfig.json'),
+          join(packageRoot, 'tsconfig.json'),
+        )
+        await mkdir(join(packageRoot, 'empty-types'))
+        const stagedFixture = await stagePackageOnlyLayout(
           fixture,
           dependencies,
           typeScript,
           layout,
         )
-        await assertPackageOnlyFixture(fixture, compiler)
-        await assertNoHostDependencyLeakage(fixture, compiler)
+        expect(stagedFixture.packageRoot).toBe(packageRoot)
+        if (layout === 'root-hoisted') {
+          expect(await pathExists(join(packageRoot, 'node_modules'))).toBe(
+            false,
+          )
+        }
+        await assertPackageOnlyFixture(stagedFixture)
+        await assertNoHostDependencyLeakage(stagedFixture)
       } finally {
         await rm(fixture, { recursive: true, force: true })
       }

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -134,10 +134,30 @@ async function resolveTypeScriptPackage(): Promise<
   return { ...(await resolvePackageRootFromManifest('typescript')), compiler }
 }
 
+async function copyPackageRoot(nodeModules: string, packageRoot: PackageRoot) {
+  const destination = join(nodeModules, ...packageRoot.name.split('/'))
+  await mkdir(dirname(destination), { recursive: true })
+  await cp(packageRoot.root, destination, {
+    recursive: true,
+    dereference: true,
+  })
+}
+
 async function linkPackageRoot(nodeModules: string, packageRoot: PackageRoot) {
   const destination = join(nodeModules, ...packageRoot.name.split('/'))
   await mkdir(dirname(destination), { recursive: true })
   await symlink(packageRoot.root, destination, directoryLinkType)
+}
+
+async function stagedTypeScriptCompiler(nodeModules: string): Promise<string> {
+  const compiler = join(nodeModules, 'typescript', 'bin', 'tsc')
+  const compilerStat = await stat(compiler)
+  if (!compilerStat.isFile()) {
+    throw new Error(
+      `staged TypeScript compiler is not a regular file: ${compiler}`,
+    )
+  }
+  return compiler
 }
 
 type PackageOnlyLayout = 'package-local' | 'root-hoisted' | 'pnpm-virtual-store'
@@ -173,23 +193,23 @@ async function stagePackageOnlyLayout(
     const nodeModules = join(fixture, 'node_modules')
     await mkdir(nodeModules)
     for (const packageRoot of packages) {
-      await linkPackageRoot(nodeModules, packageRoot)
+      await copyPackageRoot(nodeModules, packageRoot)
     }
-    return typeScript.compiler
+    return stagedTypeScriptCompiler(nodeModules)
   }
 
   if (layout === 'root-hoisted') {
     const hoistedNodeModules = join(fixture, 'root-hoisted-node_modules')
     await mkdir(hoistedNodeModules)
     for (const packageRoot of packages) {
-      await linkPackageRoot(hoistedNodeModules, packageRoot)
+      await copyPackageRoot(hoistedNodeModules, packageRoot)
     }
     await symlink(
       hoistedNodeModules,
       join(fixture, 'node_modules'),
       directoryLinkType,
     )
-    return typeScript.compiler
+    return stagedTypeScriptCompiler(hoistedNodeModules)
   }
 
   const nodeModules = join(fixture, 'node_modules')
@@ -207,8 +227,7 @@ async function stagePackageOnlyLayout(
       storePackage,
       ...packageRoot.name.split('/'),
     )
-    await mkdir(dirname(virtualPackageRoot), { recursive: true })
-    await symlink(packageRoot.root, virtualPackageRoot, directoryLinkType)
+    await copyPackageRoot(storePackage, packageRoot)
     await linkPackageRoot(nodeModules, {
       ...packageRoot,
       root: virtualPackageRoot,
@@ -268,6 +287,64 @@ async function assertPackageOnlyFixture(
       (path) => path === 'package.json' || path.startsWith('dist/'),
     ),
   ).toBe(true)
+}
+
+async function assertNoHostDependencyLeakage(
+  fixture: string,
+  compiler: string,
+): Promise<void> {
+  const hostOnlyEntry = require.resolve('vitest')
+  const hostOnlyStat = await stat(hostOnlyEntry)
+  if (!hostOnlyStat.isFile()) {
+    throw new Error(
+      `host-only probe package is not a regular file: ${hostOnlyEntry}`,
+    )
+  }
+
+  const dependencyRoot = join(fixture, 'node_modules', 'fflate')
+  const dependencyManifest = JSON.parse(
+    await readFile(join(dependencyRoot, 'package.json'), 'utf8'),
+  ) as { types?: unknown }
+  if (typeof dependencyManifest.types !== 'string') {
+    throw new Error(
+      `staged fflate package has no declaration entry: ${dependencyRoot}`,
+    )
+  }
+  const declarationPath = join(dependencyRoot, dependencyManifest.types)
+  const declarationPaths = (await filesUnder(dependencyRoot)).filter((path) =>
+    /\.d\.[cm]?ts$/u.test(path),
+  )
+  expect(declarationPaths).toContain(declarationPath)
+  for (const path of declarationPaths) {
+    const declaration = await readFile(path, 'utf8')
+    await writeFile(
+      path,
+      `${declaration}\nimport type * as HostOnlyPackage from 'vitest'\n`,
+    )
+  }
+
+  let compilerOutput = ''
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        compiler,
+        '-p',
+        join(fixture, 'tsconfig.json'),
+        '--noEmit',
+        '--typeRoots',
+        join(fixture, 'empty-types'),
+        '--skipLibCheck',
+        'false',
+      ],
+      { cwd: fixture, encoding: 'utf8', stdio: 'pipe' },
+    )
+  } catch (error) {
+    const compilerError = error as { stdout?: string; stderr?: string }
+    compilerOutput = `${compilerError.stdout ?? ''}\n${compilerError.stderr ?? ''}`
+  }
+  expect(compilerOutput).toContain('TS2307')
+  expect(compilerOutput).toContain("Cannot find module 'vitest'")
 }
 
 async function filesUnder(path: string): Promise<string[]> {
@@ -1488,11 +1565,12 @@ describe('STRUCT package artifact boundary', () => {
           layout,
         )
         await assertPackageOnlyFixture(fixture, compiler)
+        await assertNoHostDependencyLeakage(fixture, compiler)
       } finally {
         await rm(fixture, { recursive: true, force: true })
       }
     }
-  })
+  }, 60_000)
 })
 
 type FixtureExtra = Record<string, string | undefined>

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
-import { basename, dirname, join, sep } from 'node:path'
+import { basename, dirname, join, relative, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
@@ -26,6 +26,14 @@ type PackageRoot = {
 }
 
 const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+function normalizeFixtureRelativePath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
+function fixtureRelativePath(fixture: string, pathValue: string): string {
+  return normalizeFixtureRelativePath(relative(fixture, pathValue))
+}
 
 async function validatePackageRoot(
   name: string,
@@ -261,7 +269,7 @@ async function assertPackageOnlyFixture(
     stdio: 'pipe',
   })
   const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>
-    path.slice(fixture.length + 1),
+    fixtureRelativePath(fixture, path),
   )
   expect(distPaths).toEqual(
     expect.arrayContaining([
@@ -1544,7 +1552,10 @@ describe('STRUCT package artifact boundary', () => {
     }
   })
 
-  it('compiles and packs from package-local, root-hoisted, and PNPM layouts', async () => {
+  it('compiles, packs, and normalizes Windows-shaped paths across layouts', async () => {
+    expect(
+      normalizeFixtureRelativePath(String.raw`dist\renderers\epub.js`),
+    ).toBe('dist/renderers/epub.js')
     const dependencies = await resolvePackageOnlyDependencies()
     const typeScript = await resolveTypeScriptPackage()
     for (const layout of [

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -401,6 +401,64 @@ async function assertNoHostDependencyLeakage(
   expect(compilerOutput).toContain("Cannot find module 'vitest'")
 }
 
+async function assertVitestIsHermeticFromPoisonedArchive(): Promise<void> {
+  const fixture = await mkdtemp(join(tmpdir(), 'struct-vitest-hermetic-'))
+  const archiveRoot = join(fixture, 'archive')
+  const packageRoot = join(archiveRoot, 'packages', 'struct')
+  const testRoot = join(packageRoot, 'test')
+  const vitestPackageRoot = dirname(require.resolve('vitest'))
+  const vitestEntry = join(vitestPackageRoot, 'dist', 'index.js')
+  const configPath = join(packageRoot, 'vitest.config.mjs')
+  const testPath = join(testRoot, 'hermetic.test.ts')
+  try {
+    await mkdir(testRoot, { recursive: true })
+    await writeFile(
+      join(archiveRoot, 'tsconfig.json'),
+      JSON.stringify({ extends: 'astro/tsconfigs/strict' }),
+    )
+    await writeFile(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@fixture/struct', type: 'module' }),
+    )
+    await cp(
+      join(root, 'test', 'tsconfig.json'),
+      join(testRoot, 'tsconfig.json'),
+    )
+    await writeFile(
+      configPath,
+      `export default { root: ${JSON.stringify(packageRoot)} }\n`,
+    )
+    await writeFile(
+      testPath,
+      [
+        `import { expect, it } from ${JSON.stringify(vitestEntry)}`,
+        "it('collects and transforms from the package fixture', () => { expect(true).toBe(true) })",
+      ].join('\n'),
+    )
+
+    const { NODE_PATH: _nodePath, ...hermeticEnv } = process.env
+    execFileSync(
+      process.execPath,
+      [
+        join(vitestPackageRoot, 'vitest.mjs'),
+        'run',
+        '--config',
+        configPath,
+        '--maxWorkers=1',
+        'test/hermetic.test.ts',
+      ],
+      {
+        cwd: packageRoot,
+        env: hermeticEnv,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      },
+    )
+  } finally {
+    await rm(fixture, { recursive: true, force: true })
+  }
+}
+
 async function filesUnder(path: string): Promise<string[]> {
   const entries = await readdir(path, { withFileTypes: true })
   const nested = await Promise.all(
@@ -1607,6 +1665,7 @@ describe('STRUCT package artifact boundary', () => {
     expect(
       normalizeFixtureRelativePath(String.raw`dist\renderers\epub.js`),
     ).toBe('dist/renderers/epub.js')
+    await assertVitestIsHermeticFromPoisonedArchive()
     const dependencies = await resolvePackageOnlyDependencies()
     const typeScript = await resolveTypeScriptPackage()
     for (const layout of [

--- a/packages/struct/test/package-boundary.test.ts
+++ b/packages/struct/test/package-boundary.test.ts
@@ -6,9 +6,11 @@ import {
   readdir,
   rm,
   symlink,
+  stat,
   writeFile,
 } from 'node:fs/promises'
 import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { basename, dirname, join, sep } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -16,6 +18,18 @@ import { describe, expect, it } from 'vitest'
 import { auditPackageImportBoundary } from './package-import-boundary.js'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const require = createRequire(import.meta.url)
+
+async function resolveTypeScriptCompiler(): Promise<string> {
+  const compiler = require.resolve('typescript/bin/tsc')
+  const compilerStat = await stat(compiler)
+  if (!compilerStat.isFile()) {
+    throw new Error(
+      `resolved TypeScript compiler is not a regular file: ${compiler}`,
+    )
+  }
+  return compiler
+}
 
 async function filesUnder(path: string): Promise<string[]> {
   const entries = await readdir(path, { withFileTypes: true })
@@ -1157,19 +1171,20 @@ describe('STRUCT package artifact boundary', () => {
   it('compiles and packs from a package-only temporary copy', async () => {
     const fixture = await mkdtemp(join(tmpdir(), 'struct-package-only-'))
     try {
+      const typeScriptCompiler = await resolveTypeScriptCompiler()
       await cp(join(root, 'src'), join(fixture, 'src'), { recursive: true })
       await cp(join(root, 'package.json'), join(fixture, 'package.json'))
       await cp(join(root, 'tsconfig.json'), join(fixture, 'tsconfig.json'))
       await mkdir(join(fixture, 'empty-types'))
       await symlink(
-        join(root, 'node_modules'),
+        dirname(dirname(dirname(typeScriptCompiler))),
         join(fixture, 'node_modules'),
       )
 
       execFileSync(
         process.execPath,
         [
-          join(root, 'node_modules/typescript/bin/tsc'),
+          typeScriptCompiler,
           '-p',
           join(fixture, 'tsconfig.json'),
           '--noEmit',
@@ -1180,11 +1195,7 @@ describe('STRUCT package artifact boundary', () => {
       )
       execFileSync(
         process.execPath,
-        [
-          join(root, 'node_modules/typescript/bin/tsc'),
-          '-p',
-          join(fixture, 'tsconfig.json'),
-        ],
+        [typeScriptCompiler, '-p', join(fixture, 'tsconfig.json')],
         { cwd: fixture, stdio: 'pipe' },
       )
       const distPaths = (await filesUnder(join(fixture, 'dist'))).map((path) =>

--- a/packages/struct/test/parity.test.ts
+++ b/packages/struct/test/parity.test.ts
@@ -3,211 +3,15 @@ import { readFile, readdir } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import {
+  EXCLUDED_CANONICAL,
+  PARITY_ENTRIES,
+  PARITY_MANIFEST_SHA256,
+  PARITY_SCHEMA_VERSION,
+} from './contracts/source-parity.js'
 import manifest from './parity-manifest.json'
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
-const canonicalRoot = join(packageRoot, '..', '..', 'src', 'struct')
-
-type Mapping = {
-  packagePath: string
-  canonicalPath: string | null
-  rule: string
-  canonicalSha256?: string
-  packageSha256: string
-}
-
-// This is deliberately code-owned. The JSON file is an auditable inventory,
-// not an authorization mechanism for adding an arbitrary transform.
-const MAPPINGS: readonly Mapping[] = [
-  {
-    packagePath: 'codec/bytes.ts',
-    canonicalPath: 'codec/bytes.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      'af31507b6cdd1c738d8aebb5d09bfe7382a18c2c68abae5f927e31685b09746f',
-    packageSha256:
-      '04549a3f84594453ec90c319ad3b013ac479a99a1861c70344bc5b0cdc80b805',
-  },
-  {
-    packagePath: 'codec/index.ts',
-    canonicalPath: 'codec/index.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      '3b6ad32b7a16b0250f6d370821d2e18bebb10aa7f65d5787d8ec2d28b2d3d1ac',
-    packageSha256:
-      'c6e4d730dc782a400a833f79a14f672944e23d0cffd1ac38243b2ae2995eacac',
-  },
-  {
-    packagePath: 'codec/invariants.ts',
-    canonicalPath: 'codec/invariants.ts',
-    rule: 'generic-model-invariants',
-    canonicalSha256:
-      'ca6c3c6ea8cda1f887cfa155c2497bd75558e25fa375c4dd31c35182918a9ded',
-    packageSha256:
-      '1d317a67ecbfa7eda8c9c820524f5449a7aa806ac9228141112c81750ba3c5f2',
-  },
-  {
-    packagePath: 'codec/parsers.ts',
-    canonicalPath: 'codec/parsers.ts',
-    rule: 'generic-model-parser',
-    canonicalSha256:
-      'a74555d7a139974babda0bf84c3587c77f7e791aaca7942b5a3a811e0f230c89',
-    packageSha256:
-      '620f330d7f5c73342c82a0eb9cff5f4b18a6b5797a2e160a4881757ec91fae33',
-  },
-  {
-    packagePath: 'codec/primitives.ts',
-    canonicalPath: 'codec/primitives.ts',
-    rule: 'safe-id-primitives',
-    canonicalSha256:
-      '136fc31c551768d0bfb998ff3db7ff0e0667911811686ae5efad9a376812ccd1',
-    packageSha256:
-      '707ced139e00b4d80aae27d52d7f4fb3ef6e604296be874677643715047287c5',
-  },
-  {
-    packagePath: 'codec/structure.ts',
-    canonicalPath: 'codec/structure.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      'f621c90887c13bd56ed8961b4c5a880868eecd8fccb422215c482ba76060f743',
-    packageSha256:
-      '1241ab23eb0da2cd85f7e0ac198b442a4cc0246d75f67603d2980cbe4387fe3e',
-  },
-  {
-    packagePath: 'core.ts',
-    canonicalPath: 'codec.ts',
-    rule: 'codec-facade',
-    canonicalSha256:
-      '6bc47d8f02d4471814e0cd830b02c1724cc7e56c4ce227bd5bed261f672aa399',
-    packageSha256:
-      '5ea085ff0a109434009af112ccb987501ae178549589018749b422840bfb32d2',
-  },
-  {
-    packagePath: 'epub.ts',
-    canonicalPath: 'epub.ts',
-    rule: 'generic-model-epub',
-    canonicalSha256:
-      'a0601458f4b4735b57436eef844c23217095d94966dae77f88ccd55f6bebcd38',
-    packageSha256:
-      '4be79a389054a86b084660f64890966dc290a575a078120bab7d969208d5a429',
-  },
-  {
-    packagePath: 'ids.ts',
-    canonicalPath: 'ids.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      'fefc2d2408acd7fc9c28167dc505af0933d153d73a58d16f5c14dcaa9a11b2d2',
-    packageSha256:
-      '556f86b46550760719984d392266f551e1b3a73b8dc25854f59f5e925e684202',
-  },
-  {
-    packagePath: 'index.ts',
-    canonicalPath: 'index.ts',
-    rule: 'root-facade',
-    canonicalSha256:
-      '99efc666348ed3fcda3efe816b681988bd073e4de3bac0029187f2f1f760af55',
-    packageSha256:
-      'c16a9ebc3250fb4bb62c364e079cfc05ea3a77563df301954215695d5efb42fd',
-  },
-  {
-    // The package and canonical generic receipt codecs share the closed wire
-    // contract but use their tree-local codec primitives; the rule below
-    // checks policy-free source and binds both reviewed literal hashes.
-    packagePath: 'model-consultation-receipt.ts',
-    canonicalPath: 'model-consultation-receipt.ts',
-    rule: 'generic-receipt',
-    canonicalSha256:
-      'f5bb7c8638ff23b75d2cc8f284e687b9d9799fd703c6784717731a4faf38d778',
-    packageSha256:
-      'c98da5d50eaee762fe01c4f1ad326d20d55f3b5d8d14041696866d6f21d66bc6',
-  },
-  {
-    packagePath: 'reading-order.ts',
-    canonicalPath: 'reading-order.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      '72f87055322257fb2c9491f3ec1d6ea1540bdfe3447923df140aa16bbfa488ba',
-    packageSha256:
-      '7c496f3d4bb72f2810e8f9a3ef8a3cc04d359d85158a8148d6ce03bad81cd1d9',
-  },
-  {
-    packagePath: 'recovery.ts',
-    canonicalPath: 'recovery.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      '6e7cc1c0603d358bb8cd026538743690ebb5db0932d40bfc89945ea62f9e1b1c',
-    packageSha256:
-      'ac2ab6b8f674008c09a69aad84766c922e767e500e82011c1042656bde754c79',
-  },
-  {
-    packagePath: 'renderers/epub.ts',
-    canonicalPath: 'epub.ts',
-    rule: 'renderer-epub-facade',
-    canonicalSha256:
-      'a0601458f4b4735b57436eef844c23217095d94966dae77f88ccd55f6bebcd38',
-    packageSha256:
-      '77dfd2ce81a50ef6e5bcee424b04add78b979fa5f626fd504b8f8abaff535452',
-  },
-  {
-    packagePath: 'renderers/xhtml.ts',
-    canonicalPath: 'xhtml.ts',
-    rule: 'renderer-xhtml-facade',
-    canonicalSha256:
-      '32fec45ad003755cfaeb61411ea241803937d174effb2ed0c36d0e876ed22e2f',
-    packageSha256:
-      '6907f349531561be4247374af910145a132d0c240bde6e26a4a78d7f32b680d5',
-  },
-  {
-    packagePath: 'schema.ts',
-    canonicalPath: null,
-    rule: 'package-only-schema',
-    packageSha256:
-      'b3835d149b5f8dc96c0ccac7d9c2604799a57ebdb2e82f64f7d994741d2d4471',
-  },
-  {
-    packagePath: 'sha256.ts',
-    canonicalPath: 'sha256.ts',
-    rule: 'byte-identical',
-    canonicalSha256:
-      '7c240348df2f60ec53ee870346ab4d1ac2dfff16b8a32b1464b7b875c1c749f4',
-    packageSha256:
-      '7c240348df2f60ec53ee870346ab4d1ac2dfff16b8a32b1464b7b875c1c749f4',
-  },
-  {
-    packagePath: 'types.ts',
-    canonicalPath: 'types.ts',
-    rule: 'generic-model-types',
-    canonicalSha256:
-      '01478f8f0277565d70bfdf9acdc07e97db796d03cb5b3db8d2aaeddbd1434df0',
-    packageSha256:
-      '9aaf1e51c0167dd3445db491fdd5e36f5ac120d63a033e147e84d223c8195083',
-  },
-  {
-    packagePath: 'xhtml.ts',
-    canonicalPath: 'xhtml.ts',
-    rule: 'esm-imports',
-    canonicalSha256:
-      '32fec45ad003755cfaeb61411ea241803937d174effb2ed0c36d0e876ed22e2f',
-    packageSha256:
-      '4014eb7be096e01508287c33060a64fb2a5abb66040f00bb36ed8677ca4692a3',
-  },
-]
-
-const EXCLUDED_CANONICAL: Readonly<Record<string, string>> = {
-  'codec/model.ts':
-    'PDF-coupled model receipt codec is forbidden from the package',
-  'codec.test.ts':
-    'canonical codec suite is app-coupled; package characterization suite is maintained locally',
-  'epub-integrity.test.ts':
-    'canonical EPUB suite is app-coupled; package characterization suite is maintained locally',
-  'from-reconstruction.ts':
-    'historical compatibility shim for the app-owned extractor adapter is outside package core',
-  'struct.test.ts':
-    'canonical integration suite imports app/PDF providers; package characterization suites are maintained locally',
-}
-
-const MANIFEST_SHA256 =
-  '9a141b01808d04f22c40f001b495825dba7fc129e2997db9ad5406a8a43fc714'
 
 async function sourceFiles(root: string, base = root): Promise<string[]> {
   const entries = await readdir(root, { withFileTypes: true })
@@ -225,60 +29,31 @@ function sha256(bytes: Buffer) {
   return createHash('sha256').update(bytes).digest('hex')
 }
 
-function normalizeEsmImports(source: string) {
-  return source.replace(
-    /((?:from\s+|import\(\s*)['"])(\.\.?\/[^'"]+?)\.js(['"])/g,
-    '$1$2$3',
-  )
-}
-
-describe('STRUCT package/canonical parity', () => {
-  it('uses a code-owned, hash-bound inventory for both source trees', async () => {
+describe('STRUCT package source conformance', () => {
+  it('uses a code-owned, hash-bound inventory for package sources', async () => {
     const packageSources = await sourceFiles(join(packageRoot, 'src'))
-    const canonicalSources = await sourceFiles(canonicalRoot)
-    const expectedPackageSources = MAPPINGS.map(
+    const expectedPackageSources = PARITY_ENTRIES.map(
       ({ packagePath }) => packagePath,
     ).sort()
-    const expectedCanonicalSources = [
-      ...MAPPINGS.flatMap(({ canonicalPath }) =>
-        canonicalPath === null ? [] : [canonicalPath],
-      ),
-      ...Object.keys(EXCLUDED_CANONICAL),
-    ]
-      .filter((path, index, paths) => paths.indexOf(path) === index)
-      .sort()
     expect(packageSources).toEqual(expectedPackageSources)
-    expect(canonicalSources).toEqual(expectedCanonicalSources)
 
-    expect(manifest.schemaVersion).toBe(1)
+    expect(manifest.schemaVersion).toBe(PARITY_SCHEMA_VERSION)
     expect(manifest.entries).toEqual(
       Object.fromEntries(
-        MAPPINGS.map(({ packagePath, rule }) => [packagePath, rule]),
+        PARITY_ENTRIES.map(({ packagePath, rule }) => [packagePath, rule]),
       ),
     )
     expect(manifest.excludedCanonical).toEqual(EXCLUDED_CANONICAL)
     const manifestBytes = await readFile(
       join(packageRoot, 'test', 'parity-manifest.json'),
     )
-    expect(sha256(manifestBytes)).toBe(MANIFEST_SHA256)
+    expect(sha256(manifestBytes)).toBe(PARITY_MANIFEST_SHA256)
 
-    for (const mapping of MAPPINGS) {
+    for (const mapping of PARITY_ENTRIES) {
       const packageBytes = await readFile(
         join(packageRoot, 'src', mapping.packagePath),
       )
       expect(sha256(packageBytes)).toBe(mapping.packageSha256)
-      if (mapping.canonicalPath === null) continue
-      const canonicalBytes = await readFile(
-        join(canonicalRoot, mapping.canonicalPath),
-      )
-      expect(sha256(canonicalBytes)).toBe(mapping.canonicalSha256)
-      if (mapping.rule === 'byte-identical') {
-        expect(packageBytes).toEqual(canonicalBytes)
-      } else if (mapping.rule === 'esm-imports') {
-        expect(normalizeEsmImports(packageBytes.toString('utf8'))).toBe(
-          normalizeEsmImports(canonicalBytes.toString('utf8')),
-        )
-      }
       const packageSource = packageBytes.toString('utf8')
       if (mapping.rule === 'generic-receipt') {
         expect(packageSource).not.toMatch(

--- a/packages/struct/test/parity.test.ts
+++ b/packages/struct/test/parity.test.ts
@@ -13,13 +13,19 @@ import manifest from './parity-manifest.json'
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
+function normalizeParityPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
 async function sourceFiles(root: string, base = root): Promise<string[]> {
   const entries = await readdir(root, { withFileTypes: true })
   const nested = await Promise.all(
     entries.map(async (entry) => {
       const path = join(root, entry.name)
       if (entry.isDirectory()) return sourceFiles(path, base)
-      return entry.name.endsWith('.ts') ? [relative(base, path)] : []
+      return entry.name.endsWith('.ts')
+        ? [normalizeParityPath(relative(base, path))]
+        : []
     }),
   )
   return nested.flat().sort()
@@ -31,6 +37,9 @@ function sha256(bytes: Buffer) {
 
 describe('STRUCT package source conformance', () => {
   it('uses a code-owned, hash-bound inventory for package sources', async () => {
+    expect(normalizeParityPath(String.raw`codec\bytes.ts`)).toBe(
+      'codec/bytes.ts',
+    )
     const packageSources = await sourceFiles(join(packageRoot, 'src'))
     const expectedPackageSources = PARITY_ENTRIES.map(
       ({ packagePath }) => packagePath,

--- a/packages/struct/test/tsconfig.json
+++ b/packages/struct/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/struct/vitest.config.ts
+++ b/packages/struct/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  root: new URL(".", import.meta.url).pathname,
+  oxc: {
+    tsconfig: {
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+      },
+    },
+  },
+});

--- a/packages/struct/vitest.config.ts
+++ b/packages/struct/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
-  root: new URL(".", import.meta.url).pathname,
+  root: fileURLToPath(new URL(".", import.meta.url)),
   oxc: {
     tsconfig: {
       compilerOptions: {

--- a/packages/struct/vitest.config.ts
+++ b/packages/struct/vitest.config.ts
@@ -3,12 +3,4 @@ import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   root: fileURLToPath(new URL(".", import.meta.url)),
-  oxc: {
-    tsconfig: {
-      compilerOptions: {
-        target: "ES2022",
-        module: "ESNext",
-      },
-    },
-  },
 });


### PR DESCRIPTION
## Summary

- make `packages/struct` test/build tooling self-contained rather than relying
  on root/application test contracts
- add package-local parity and model-receipt contracts plus import-boundary,
  artifact, metadata and portability coverage
- install and execute the exact packed artifact from a disposable external
  consumer, proving all seven public exports and two private-path refusals

## Exact-head evidence

- stacked base: `codex/issue-206-struct-import-graph` at
  `ebb6a5262af39602293297140158d104d9bf8260` (#219)
- candidate: `bf90a76ba6956f44f82d3956036f3cb27c0d3974`
- package CI: 9 files / 63 tests
- focused package boundary/export proof: 24 tests
- frozen golden + EPUB-integrity proof: 4 tests
- two real packs: identical 77-entry listings and SHA-256
  `022dc3fe72763b92b2cdb87950dfec6fa177fccc9c51df1e08e0335ec4df0e75`
- external installed consumer: seven contained public resolutions/imports,
  public behavior/declaration probes and two
  `ERR_PACKAGE_PATH_NOT_EXPORTED` refusals
- independent scoped review: approved
- strongest whole-candidate review: approved with no actionable findings

Package runtime source, app/root source and manifests, public exports, schemas,
codec/error behavior, serialized bytes, frozen goldens and compatibility shims
are unchanged. Java/EPUBCheck is an explicit environment refusal; the
Java-independent EPUB integrity/golden tests pass.

This is a stacked draft. It does not publish npm, create a repository, deploy,
activate workflows or change credentials. Reference #208 and #124; do not
close either epic from this slice.
