### PR TITLE
refactor(struct): centralize EPUB SHA-256

### DIFF
--- a/packages/struct/src/index.ts
+++ b/packages/struct/src/index.ts
@@ -1,5 +1,6 @@
 export * from './core.js'
 export * from './ids.js'
+export { sha256HexSync } from './sha256.js'
 export * from './recovery.js'
 export * from './renderers/xhtml.js'
 export * from './renderers/epub.js'

--- a/packages/struct/test/contracts/source-parity.ts
+++ b/packages/struct/test/contracts/source-parity.ts
@@ -70,7 +70,7 @@ export const PARITY_ENTRIES: readonly SourceParityEntry[] = [
     packagePath: "index.ts",
     rule: "root-facade",
     packageSha256:
-      "c16a9ebc3250fb4bb62c364e079cfc05ea3a77563df301954215695d5efb42fd",
+      "c11c52ee11d9104701bd9351466ac92d99e5f0f97136f20decf6cfd57b886a43",
   },
   {
     packagePath: "model-consultation-receipt.ts",

--- a/packages/struct/test/exports.test.ts
+++ b/packages/struct/test/exports.test.ts
@@ -11,6 +11,7 @@ const expected = {
     'legacyStructDigest',
     'legacyStructDigests',
     'legacyStructDigestMatches',
+    'sha256HexSync',
     'orderBlocksByLayout',
     'pageLayoutsFromBlocks',
     'diagnosticCopy',

--- a/src/research/epub.ts
+++ b/src/research/epub.ts
@@ -8,6 +8,7 @@ import {
 } from 'fflate'
 import { XMLValidator } from 'fast-xml-parser'
 import { buildStructEpub } from '@erniesg/struct/renderers/epub'
+import { sha256HexSync } from '@erniesg/struct'
 import {
   renderPublicationXhtml as renderStructPublicationXhtml,
   type StructXhtmlOptions,
@@ -3170,90 +3171,12 @@ function binaryEntry(value: Uint8Array): [Uint8Array, ZipOptions] {
   return [value, { level: 6, mtime: ZIP_MTIME }]
 }
 
-const SHA256_CONSTANTS = new Uint32Array([
-  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
-  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
-  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
-  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
-  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
-  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-])
-
-function rotateRight(value: number, count: number) {
-  return (value >>> count) | (value << (32 - count))
-}
-
-function sha256Sync(bytes: Uint8Array) {
-  const bitLength = bytes.byteLength * 8
-  const paddedLength = Math.ceil((bytes.byteLength + 9) / 64) * 64
-  const padded = new Uint8Array(paddedLength)
-  padded.set(bytes)
-  padded[bytes.byteLength] = 0x80
-  const paddedView = new DataView(padded.buffer)
-  paddedView.setUint32(paddedLength - 8, Math.floor(bitLength / 0x1_0000_0000))
-  paddedView.setUint32(paddedLength - 4, bitLength >>> 0)
-
-  const state = new Uint32Array([
-    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
-    0x1f83d9ab, 0x5be0cd19,
-  ])
-  const words = new Uint32Array(64)
-  for (let offset = 0; offset < paddedLength; offset += 64) {
-    for (let index = 0; index < 16; index += 1) {
-      words[index] = paddedView.getUint32(offset + index * 4)
-    }
-    for (let index = 16; index < 64; index += 1) {
-      const before15 = words[index - 15]
-      const before2 = words[index - 2]
-      const sigma0 =
-        rotateRight(before15, 7) ^ rotateRight(before15, 18) ^ (before15 >>> 3)
-      const sigma1 =
-        rotateRight(before2, 17) ^ rotateRight(before2, 19) ^ (before2 >>> 10)
-      words[index] =
-        (words[index - 16] + sigma0 + words[index - 7] + sigma1) >>> 0
-    }
-
-    let [a, b, c, d, e, f, g, h] = state
-    for (let index = 0; index < 64; index += 1) {
-      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
-      const choice = (e & f) ^ (~e & g)
-      const temporary1 =
-        (h + sum1 + choice + SHA256_CONSTANTS[index] + words[index]) >>> 0
-      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
-      const majority = (a & b) ^ (a & c) ^ (b & c)
-      const temporary2 = (sum0 + majority) >>> 0
-      h = g
-      g = f
-      f = e
-      e = (d + temporary1) >>> 0
-      d = c
-      c = b
-      b = a
-      a = (temporary1 + temporary2) >>> 0
-    }
-    state[0] = (state[0] + a) >>> 0
-    state[1] = (state[1] + b) >>> 0
-    state[2] = (state[2] + c) >>> 0
-    state[3] = (state[3] + d) >>> 0
-    state[4] = (state[4] + e) >>> 0
-    state[5] = (state[5] + f) >>> 0
-    state[6] = (state[6] + g) >>> 0
-    state[7] = (state[7] + h) >>> 0
-  }
-  return [...state].map((word) => word.toString(16).padStart(8, '0')).join('')
-}
-
 function canonicalJsonSha256(value: unknown) {
-  return sha256Sync(strToU8(canonicalJson(value)))
+  return sha256HexSync(strToU8(canonicalJson(value)))
 }
 
 function opaqueCanonicalHyphenValue(kind: string, value: string) {
-  return sha256Sync(strToU8(`${kind}\0${value}`))
+  return sha256HexSync(strToU8(`${kind}\0${value}`))
 }
 
 const PDF_HYPHEN_REMOVAL_REQUIRED_EVIDENCE_SHA256S =
@@ -3998,7 +3921,7 @@ function manifestAdjudicationRecord(decision: HumanAdjudicationRecord) {
     ...decision,
     resolution: {
       ...resolution,
-      transcriptSha256: sha256Sync(strToU8(transcript)),
+      transcriptSha256: sha256HexSync(strToU8(transcript)),
     },
   }
 }
@@ -4014,7 +3937,7 @@ function manifestHumanAdjudications(reconstruction: PdfReconstruction) {
     staleCount: reconstruction.humanAdjudications.stale.length,
     countsByDiagnosticCode:
       reconstruction.humanAdjudications.countsByDiagnosticCode,
-    appliedReceiptSha256: sha256Sync(strToU8(JSON.stringify(applied))),
+    appliedReceiptSha256: sha256HexSync(strToU8(JSON.stringify(applied))),
     applied,
     noteSourceAnchorReceipts:
       reconstruction.humanAdjudications.noteSourceAnchorReceipts,
@@ -4294,7 +4217,7 @@ function parseExportManifest(
 }
 
 function canonicalPaperSha256(paper: ResearchPaper) {
-  return sha256Sync(strToU8(JSON.stringify(paper)))
+  return sha256HexSync(strToU8(JSON.stringify(paper)))
 }
 
 function exportIdentifier(
@@ -4841,7 +4764,7 @@ function inspectAssetReceipts(
     }
     const bytes = files[`EPUB/${asset.href}`]
     if (!bytes) throw new Error(`EPUB is missing declared asset ${asset.href}`)
-    if (sha256Sync(bytes) !== asset.sha256) {
+    if (sha256HexSync(bytes) !== asset.sha256) {
       throw new Error(
         `EPUB asset ${asset.href} SHA-256 does not match its bytes`,
       )


### PR DESCRIPTION
Extract EPUB hashing onto the package-owned SHA-256 seam without changing behavior.

- `src/research/epub.ts`: 6261 -> 6170 LOC at this step
- Reuses the canonical package implementation
- Exact head: `22ad28c79981f8cc7077d4c028e89383acf25039`
- Independently accepted as part of the EPUB extraction lane
- Focused EPUB tests and TypeScript compile passed

Closes #254