### PR TITLE
refactor(pdf): isolate raster table candidates

### DIFF
--- a/src/research/pdf-table-scope-line-bands.ts
+++ b/src/research/pdf-table-scope-line-bands.ts
@@ -623,7 +623,7 @@ export function tabularLineBandProof(rows: TableLineRow[]) {
 }
 
 export function tableLineEntryKey(entry: TableLineEntry) {
-  return `${entry.region.id}/${entry.line.id}`
+  return JSON.stringify([entry.region.id, entry.line.id])
 }
 
 export function normalizedTableFontName(value: string) {

--- a/src/research/pdf-table-scope.test.ts
+++ b/src/research/pdf-table-scope.test.ts
@@ -10,6 +10,7 @@ import type {
 } from './import-types'
 import { reconstructPageRegions } from './pdf-regions'
 import { resolvePdfTableScope } from './pdf-table-scope'
+import { tableLineEntryKey } from './pdf-table-scope-line-bands'
 
 function box(
   x: number,
@@ -108,6 +109,24 @@ function nativeObject(
     assetId: `asset-${id}`,
   }
 }
+
+describe('table line identities', () => {
+  const keyFor = (regionId: string, lineId: string, index: number) => {
+    const y = 0.1 + index * 0.03
+    const sourceLine = line(lineId, y, [0.1, 0.2])
+    const region = textRegion(regionId, box(0.1, y, 0.2, 0.016), [sourceLine])
+    return tableLineEntryKey({ region, line: sourceLine })
+  }
+
+  it('keeps delimiter-bearing source IDs as distinct tuple members', () => {
+    expect(keyFor('region/a', 'line', 0)).not.toBe(
+      keyFor('region', 'a/line', 1),
+    )
+    expect(keyFor('region:a', 'line', 2)).not.toBe(
+      keyFor('region', 'a:line', 3),
+    )
+  })
+})
 
 function objectRegion(
   id: string,


### PR DESCRIPTION
Closes #248

Extracts raster candidate/lineage, deterministic geometry/caption/text-grid proofing, and the line-band layout/proof engine across sequential commits, reducing pdf-table-scope.ts from 4,895 to 3,452 lines (1,443-line reduction). The final repairs restore the base collision-safe regionId/lineId identity, add a regression for colon-bearing IDs, and apply the locked repository formatter. Focused Vitest passed 96 tests; focused TypeScript, Prettier on all changed modules, diff, and secret checks passed.