### PR TITLE
feat(struct): replay source-neutral codec and EPUB hardening

### DIFF
--- a/src/research/actual-profiled-epub.ts
+++ b/src/research/actual-profiled-epub.ts
@@ -102,6 +102,24 @@ export type EpubCheckReceipt = {
   receiptSha256: string
 }
 
+export function isRendererGeneratedAnonymousTableCell(cell: {
+  id: string
+  tagName: string
+  text: string
+  rowSpan: number
+  columnSpan: number
+  scope: string | null
+}) {
+  return (
+    cell.id === '' &&
+    cell.tagName === 'td' &&
+    cell.text === '' &&
+    cell.rowSpan === 1 &&
+    cell.columnSpan === 1 &&
+    cell.scope === null
+  )
+}
+
 function artifact(bytes: Uint8Array): HashedArtifact {
   return { sha256: sha256HexSync(bytes), byteLength: bytes.byteLength }
 }
@@ -329,7 +347,12 @@ async function renderOne(browser: Browser, build: ProfiledStructEpubArtifact) {
         screenshotDimensions,
         locators: captured.locators,
         metrics: captured.metrics,
-        blockFacts: captured.blockFacts,
+        blockFacts: captured.blockFacts.map(({ cells, ...fact }) => ({
+          ...fact,
+          cells: cells.filter(
+            (cell) => !isRendererGeneratedAnonymousTableCell(cell),
+          ),
+        })),
         status: 'rendered',
       })
       return {

--- a/src/research/grounded-epub-comparison.ts
+++ b/src/research/grounded-epub-comparison.ts
@@ -29,6 +29,7 @@ import type {
   EpubCheckReceipt,
 } from './actual-profiled-epub'
 import {
+  isRendererGeneratedAnonymousTableCell,
   verifyActualProfiledEpubRender,
   verifyEpubCheckReceipt,
 } from './actual-profiled-epub'
@@ -89,15 +90,15 @@ function blockFact(render: ActualProfiledEpubRender, block: StructBlock) {
 }
 
 function exactTableCells(block: StructBlock, render: ActualProfiledEpubRender) {
-  const actual = blockFact(render, block).cells.map(
-    ({ text, rowSpan, columnSpan, tagName, scope }) => ({
+  const actual = blockFact(render, block)
+    .cells.filter((cell) => !isRendererGeneratedAnonymousTableCell(cell))
+    .map(({ text, rowSpan, columnSpan, tagName, scope }) => ({
       text: normalizedText(text),
       rowSpan,
       columnSpan,
       tagName,
       scope,
-    }),
-  )
+    }))
   const expected = (block.table?.cells ?? []).map((cell) => ({
     text: normalizedText(cell.text),
     rowSpan: cell.rowSpan,

--- a/src/research/grounded-struct-materializer.test.ts
+++ b/src/research/grounded-struct-materializer.test.ts
@@ -729,7 +729,7 @@ function selections(
 }
 
 describe('candidate-grounded STRUCT materialization', () => {
-  it('retains exact table spans into three reopened publication EPUBs', async () => {
+  it('accepts sparse table grids into three reopened publication EPUBs', async () => {
     const selected = selections()
     const materialized = materializeGroundedStruct({
       graph: selected.graph,
@@ -788,6 +788,11 @@ describe('candidate-grounded STRUCT materialization', () => {
     expect(
       renders.every(({ domBytes }) =>
         new TextDecoder().decode(domBytes).includes('scope="col"'),
+      ),
+    ).toBe(true)
+    expect(
+      renders.every(({ domBytes }) =>
+        new TextDecoder().decode(domBytes).includes('<td></td>'),
       ),
     ).toBe(true)
 

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2892,7 +2892,7 @@ describe('STRUCT runtime codec', () => {
       expect(error).toBeInstanceOf(StructCodecError)
       expect((error as StructCodecError).code).toBe('BUDGET')
     }
-    expect(descriptorReads).toBe(keys.length)
+    expect(descriptorReads).toBe(keys.length - 1)
   })
 
   it('bounds direct consultation receipt validation before array key reads', () => {

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2068,14 +2068,14 @@ describe('STRUCT runtime codec', () => {
     expect(() => renderPublicationXhtml(value)).toThrow(/citation.*budget/i)
   })
 
-  it('rejects an oversized mismatched citation label before tokenizing it', () => {
+  it('skips an oversized comma-only citation label without tokenizing it', () => {
     const value = validDocument() as any
     value.metadata.authors = []
     value.metadata.authorNotes = []
     value.relationships[0] = {
       ...value.relationships[0],
       kind: 'citation',
-      label: 'a,'.repeat(1_500_000),
+      label: ','.repeat(3 * 1024 * 1024),
       to: [],
       status: 'matched',
     }
@@ -2088,7 +2088,32 @@ describe('STRUCT runtime codec', () => {
       },
     ]
 
-    expect(() => renderPublicationXhtml(value)).toThrow(/citation.*budget/i)
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('preserves bounded mismatched citation labels', () => {
+    const value = validDocument() as any
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      kind: 'citation',
+      label: 'Smith, 2020',
+      to: ['https://example.test/smith-2020'],
+      status: 'matched',
+    }
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: value.blocks[0].text.length,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'citation',
+      },
+    ]
+
+    expect(renderPublicationXhtml(value)).toContain(
+      'href="https://example.test/smith-2020"',
+    )
   })
 
   it('rejects an early source budget before inspecting a later hostile source', () => {

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2068,6 +2068,29 @@ describe('STRUCT runtime codec', () => {
     expect(() => renderPublicationXhtml(value)).toThrow(/citation.*budget/i)
   })
 
+  it('rejects an oversized mismatched citation label before tokenizing it', () => {
+    const value = validDocument() as any
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      kind: 'citation',
+      label: 'a,'.repeat(1_500_000),
+      to: [],
+      status: 'matched',
+    }
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: value.blocks[0].text.length,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'citation',
+      },
+    ]
+
+    expect(() => renderPublicationXhtml(value)).toThrow(/citation.*budget/i)
+  })
+
   it('rejects an early source budget before inspecting a later hostile source', () => {
     const value = validDocument() as any
     const runCount = 2_000

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -355,10 +355,6 @@ describe('STRUCT runtime codec', () => {
       'duplicate BCP-47 variant',
       (value: any) => (value.metadata.language = 'de-1901-1901'),
     ],
-    [
-      'repeated BCP-47 private-use singleton',
-      (value: any) => (value.metadata.language = 'en-x-private-x-again'),
-    ],
     ['MIME wildcard', (value: any) => (value.assets[0].mediaType = '*/*')],
   ])('rejects an invalid %s', (_label, mutate) => {
     const value = validDocument()
@@ -374,6 +370,9 @@ describe('STRUCT runtime codec', () => {
     'sl-rozaj-biske-1994',
     'en-US-u-ca-gregory',
     'x-private-private',
+    'en-x-a-a',
+    'en-a-foo-x-a-a',
+    'en-x-private-x-again',
   ])('accepts the BCP-47 language tag %s', (language) => {
     const value = validDocument()
     value.metadata.language = language

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2116,6 +2116,34 @@ describe('STRUCT runtime codec', () => {
     )
   })
 
+  it('skips an oversized cross-reference label before tokenizing it', () => {
+    const value = validDocument() as any
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      kind: 'cross-reference',
+      label: 'a,'.repeat(1_500_000),
+      to: [
+        'https://example.test/reference-1',
+        'https://example.test/reference-2',
+      ],
+      status: 'matched',
+    }
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: value.blocks[0].text.length,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+    ]
+
+    expect(renderPublicationXhtml(value)).toContain(
+      'Additional cross-reference target 1',
+    )
+  })
+
   it('rejects an early source budget before inspecting a later hostile source', () => {
     const value = validDocument() as any
     const runCount = 2_000

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -13,6 +13,7 @@ import { buildStructEpub } from './epub'
 import { renderPublicationXhtml } from './xhtml'
 import { MAX_STRUCT_ASSET_BYTES, parseBytes } from './codec/bytes'
 import { validateStructConsultationReceipt } from './consultation-receipt'
+import { MAX_STRUCT_STRING_BYTES, stringValue } from './codec/primitives'
 
 const hash = 'a'.repeat(64)
 const assetBytesHash = sha256HexSync(new Uint8Array([0, 255, 128]))
@@ -261,6 +262,27 @@ function validDocument() {
 }
 
 describe('STRUCT runtime codec', () => {
+  it('rejects an oversized text field before copying it into the document', () => {
+    expect(() =>
+      stringValue('x'.repeat(MAX_STRUCT_STRING_BYTES + 1), '$.metadata.title'),
+    ).toThrow(/textual resource bound/i)
+  })
+
+  it('bounds aggregate source-neutral receipt JSON text', () => {
+    const receipt = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: Array.from({ length: 9 }, (_, index) => ({
+        [`field-${index}`]: 'x'.repeat(1024 * 1024),
+      })),
+      decisions: [],
+      metrics: {},
+    }
+
+    expect(validateStructConsultationReceipt(receipt)).toBe(false)
+  })
+
   it('decodes a strict 0.1.0 document and restores JSON-safe asset bytes', () => {
     const decoded = decodeStructDocument(validDocument())
 

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -11,9 +11,14 @@ import { legacyStructDigest, structDigest } from './ids'
 import { sha256HexSync } from './sha256'
 import { buildStructEpub } from './epub'
 import { renderPublicationXhtml } from './xhtml'
-import { MAX_STRUCT_ASSET_BYTES, parseBytes } from './codec/bytes'
+import {
+  MAX_STRUCT_ASSET_BYTES,
+  parseBytes,
+  preflightBytes,
+} from './codec/bytes'
 import { validateStructConsultationReceipt } from './consultation-receipt'
 import { MAX_STRUCT_STRING_BYTES, stringValue } from './codec/primitives'
+import { MAX_RENDERED_INLINE_SEGMENTS } from './emitted-ids'
 
 const hash = 'a'.repeat(64)
 const assetBytesHash = sha256HexSync(new Uint8Array([0, 255, 128]))
@@ -283,6 +288,19 @@ describe('STRUCT runtime codec', () => {
     expect(validateStructConsultationReceipt(receipt)).toBe(false)
   })
 
+  it('rejects negative zero in a source-neutral consultation receipt', () => {
+    expect(
+      validateStructConsultationReceipt({
+        schemaVersion: '1.0.0',
+        documentId: 'fixture-document',
+        sourceSha256: hash,
+        consultations: [],
+        decisions: [],
+        metrics: { rate: -0 },
+      }),
+    ).toBe(false)
+  })
+
   it('decodes a strict 0.1.0 document and restores JSON-safe asset bytes', () => {
     const decoded = decodeStructDocument(validDocument())
 
@@ -337,6 +355,10 @@ describe('STRUCT runtime codec', () => {
       'duplicate BCP-47 variant',
       (value: any) => (value.metadata.language = 'de-1901-1901'),
     ],
+    [
+      'repeated BCP-47 private-use singleton',
+      (value: any) => (value.metadata.language = 'en-x-private-x-again'),
+    ],
     ['MIME wildcard', (value: any) => (value.assets[0].mediaType = '*/*')],
   ])('rejects an invalid %s', (_label, mutate) => {
     const value = validDocument()
@@ -365,6 +387,14 @@ describe('STRUCT runtime codec', () => {
 
     expect(() => parseBytes(encoded, '$.asset.bytes')).toThrow(
       /resource bound/i,
+    )
+  })
+
+  it('accepts a base64 asset payload above the general text bound when its decoded size is bounded', () => {
+    const encoded = 'AAAA'.repeat(Math.ceil((MAX_STRUCT_STRING_BYTES + 4) / 4))
+
+    expect(preflightBytes(encoded, '$.asset.bytes')).toBe(
+      (encoded.length / 4) * 3,
     )
   })
 
@@ -2013,6 +2043,30 @@ describe('STRUCT runtime codec', () => {
       status: 'matched',
     }))
     expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('bounds numeric citation matching before materializing every token range', () => {
+    const value = validDocument() as any
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      kind: 'citation',
+      label: '1',
+      to: ['https://example.test/reference-1'],
+      status: 'matched',
+    }
+    value.blocks[0].text = '1 '.repeat(MAX_RENDERED_INLINE_SEGMENTS + 1)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: value.blocks[0].text.length,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'citation',
+      },
+    ]
+
+    expect(() => renderPublicationXhtml(value)).toThrow(/citation.*budget/i)
   })
 
   it('rejects an early source budget before inspecting a later hostile source', () => {

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2851,6 +2851,50 @@ describe('STRUCT runtime codec', () => {
     expect(descriptorReads).toBe(0)
   })
 
+  it('rejects aggregate generic receipt text before canonical receipt copying', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    const keys = Array.from({ length: 9 }, (_, index) => `field${index}`)
+    let descriptorReads = 0
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: new Proxy(
+        {},
+        {
+          ownKeys() {
+            return keys
+          },
+          getOwnPropertyDescriptor(_target, key) {
+            descriptorReads += 1
+            if (descriptorReads > keys.length)
+              throw new Error('receipt was copied after aggregate rejection')
+            return {
+              configurable: true,
+              enumerable: true,
+              value: 'x'.repeat(1024 * 1024),
+            }
+          },
+        },
+      ),
+    }
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected generic receipt aggregate budget failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('BUDGET')
+    }
+    expect(descriptorReads).toBe(keys.length)
+  })
+
   it('bounds direct consultation receipt validation before array key reads', () => {
     let ownKeyReads = 0
     const consultations = new Proxy(new Array(100_001), {

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -2895,6 +2895,50 @@ describe('STRUCT runtime codec', () => {
     expect(descriptorReads).toBe(keys.length - 1)
   })
 
+  it('bounds a stateful receipt proxy during canonical copying', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    let descriptorReads = 0
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: new Proxy(
+        {},
+        {
+          ownKeys() {
+            return ['field']
+          },
+          getOwnPropertyDescriptor() {
+            descriptorReads += 1
+            if (descriptorReads > 3)
+              throw new Error('receipt was traversed after copy rejection')
+            return {
+              configurable: true,
+              enumerable: true,
+              value:
+                descriptorReads < 3 ? 'small' : 'x'.repeat(1024 * 1024 + 1),
+            }
+          },
+        },
+      ),
+    }
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected stateful receipt budget failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('BUDGET')
+    }
+    expect(descriptorReads).toBe(3)
+  })
+
   it('bounds direct consultation receipt validation before array key reads', () => {
     let ownKeyReads = 0
     const consultations = new Proxy(new Array(100_001), {

--- a/src/struct/codec.test.ts
+++ b/src/struct/codec.test.ts
@@ -1,0 +1,2945 @@
+import { describe, expect, it } from 'vitest'
+import { strFromU8, unzipSync } from 'fflate'
+import { runInNewContext } from 'node:vm'
+import {
+  decodeStructDocument,
+  encodeStructDocument,
+  migrateStructDocument,
+  StructCodecError,
+} from './index'
+import { legacyStructDigest, structDigest } from './ids'
+import { sha256HexSync } from './sha256'
+import { buildStructEpub } from './epub'
+import { renderPublicationXhtml } from './xhtml'
+import { MAX_STRUCT_ASSET_BYTES, parseBytes } from './codec/bytes'
+import { validateStructConsultationReceipt } from './consultation-receipt'
+
+const hash = 'a'.repeat(64)
+const assetBytesHash = sha256HexSync(new Uint8Array([0, 255, 128]))
+
+function evidence() {
+  return {
+    confidence: 1,
+    pages: [1],
+    boxes: [
+      {
+        page: 1,
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        rotation: 0,
+      },
+    ],
+    sourceIds: ['source-node'],
+    signals: ['fixture'],
+  }
+}
+
+function digestInput(document: any) {
+  const { receipt: _receipt, ...withoutReceipt } = document
+  return {
+    ...withoutReceipt,
+    conservation: document.receipt.conservation,
+    ...(document.receipt.modelConsultations
+      ? { modelConsultations: document.receipt.modelConsultations }
+      : {}),
+    assets: document.assets.map(({ bytes: _bytes, ...asset }: any) => asset),
+  }
+}
+
+function seal<T extends Record<string, any>>(document: T): T {
+  document.receipt.generatedSha256 =
+    document.schemaVersion === '0.1.0'
+      ? legacyStructDigest(digestInput(document))
+      : structDigest(digestInput(document))
+  return document
+}
+
+function validDocument() {
+  const sharedEvidence = evidence()
+  return seal({
+    schemaVersion: '0.1.0',
+    source: {
+      format: 'docx',
+      fileName: 'fixture.docx',
+      sha256: hash,
+      byteLength: 3,
+      pageCount: 1,
+      localOnly: true,
+    },
+    metadata: {
+      title: 'Fixture',
+      subtitle: '',
+      authors: ['Author'],
+      abstract: 'Abstract',
+      language: 'en',
+      baseDirection: 'ltr',
+      publicationDate: '2026-08-20',
+      artifactModifiedAt: '2026-08-20T00:00:00Z',
+      updated: '2026-08-20',
+      affiliations: ['Example University'],
+      authorAffiliations: [{ author: 'Author', label: '1' }],
+      authorNotes: [
+        {
+          id: 'author-note-1',
+          author: 'Author',
+          label: '1',
+          target: 'block-1',
+        },
+      ],
+    },
+    blocks: [
+      {
+        id: 'block-1',
+        kind: 'paragraph',
+        text: 'Hello',
+        label: 'Body',
+        page: 1,
+        order: 0,
+        column: 'single',
+        inline: [
+          {
+            start: 0,
+            end: 5,
+            href: '#block-1',
+            annotationId: 'annotation-1',
+            relationshipId: 'relationship-1',
+            targetIds: ['block-1'],
+            bold: true,
+            italic: false,
+            verticalAlign: 'superscript',
+            compactMathAtom: false,
+            semanticRole: 'cross-reference',
+          },
+        ],
+        evidence: sharedEvidence,
+        sourceObservationAnchorIds: ['anchor-1'],
+        table: {
+          rows: 1,
+          columns: 1,
+          cells: [
+            {
+              id: 'cell-1',
+              text: 'Cell',
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              headerScope: null,
+              inline: [],
+              evidence: sharedEvidence,
+            },
+          ],
+          semantic: 'verified',
+        },
+        furniture: {
+          classification: 'repeated-text',
+          band: 'top',
+          pages: [1],
+          boxes: [],
+          evidence: ['fixture-furniture'],
+          normalizedText: 'Header',
+          sequence: [1],
+          sourceRunIndexes: [0],
+        },
+        furnitureReview: {
+          reason: 'single-occurrence-margin',
+          band: 'right',
+          pages: [1],
+          boxes: [],
+          evidence: ['fixture-review'],
+        },
+        fallbackAssetIds: ['asset-1'],
+        attributes: { level: 1, bibliographyEntry: false, objectType: 'body' },
+      },
+    ],
+    assets: [
+      {
+        id: 'asset-1',
+        kind: 'figure',
+        href: 'assets/asset-1.bin',
+        mediaType: 'application/octet-stream',
+        sha256: assetBytesHash,
+        width: 10,
+        height: 10,
+        bytes: 'AP+A',
+        sourceObjectIds: ['source-asset'],
+        evidence: sharedEvidence,
+        fallback: 'asset',
+      },
+    ],
+    relationships: [
+      {
+        id: 'relationship-1',
+        kind: 'reading-order',
+        from: 'block-1',
+        to: ['block-1'],
+        label: 'next',
+        status: 'matched',
+        confidence: 1,
+        evidence: sharedEvidence,
+        candidates: [
+          { target: 'block-1', confidence: 1, evidence: sharedEvidence },
+        ],
+      },
+    ],
+    pages: [
+      {
+        page: 1,
+        width: 600,
+        height: 800,
+        rotation: 0,
+        blocks: ['block-1'],
+        columns: [{ id: 'column-1', side: 'single', blockIds: ['block-1'] }],
+      },
+    ],
+    diagnostics: [
+      {
+        id: 'diagnostic-1',
+        severity: 'info',
+        category: 'source',
+        title: 'Fixture',
+        message: 'Fixture diagnostic',
+        action: 'Continue',
+        pages: [1],
+        sourceIds: ['source-node'],
+      },
+    ],
+    recovery: {
+      status: 'ready',
+      title: 'Ready',
+      summary: 'No recovery required',
+      issues: [
+        {
+          category: 'source',
+          title: 'None',
+          count: 0,
+          pages: [],
+          action: 'None',
+        },
+      ],
+      userAction: 'None',
+    },
+    receipt: {
+      schemaVersion: '0.1.0',
+      sourceSha256: hash,
+      blockCount: 1,
+      assetCount: 1,
+      relationshipCount: 1,
+      diagnosticCount: 1,
+      textCharacterCount: 5,
+      conservation: {
+        sourceNodeCount: 1,
+        accountedSourceNodeCount: 1,
+        sourceRegionCount: 0,
+        accountedSourceRegionCount: 0,
+        sourceAnnotationCount: 1,
+        accountedSourceAnnotationCount: 1,
+        sourceAssetCount: 1,
+        accountedSourceAssetCount: 1,
+        sourceRelationshipCount: 1,
+        accountedSourceRelationshipCount: 1,
+        sourceDiagnosticCount: 1,
+        accountedSourceDiagnosticCount: 1,
+        sourceTextCharacterCount: 5,
+        structBlockCount: 1,
+        structAssetCount: 1,
+        structRelationshipCount: 1,
+        structDiagnosticCount: 1,
+        structTextCharacterCount: 5,
+        sourceFurnitureBlockCount: 0,
+        accountedFurnitureBlockCount: 0,
+        sourceFurnitureTextCharacterCount: 0,
+        structFurnitureBlockCount: 0,
+        structFurnitureTextCharacterCount: 0,
+        furnitureContaminationCount: 0,
+      },
+      generatedSha256: hash,
+    },
+  })
+}
+
+describe('STRUCT runtime codec', () => {
+  it('decodes a strict 0.1.0 document and restores JSON-safe asset bytes', () => {
+    const decoded = decodeStructDocument(validDocument())
+
+    expect(decoded.schemaVersion).toBe('0.1.0')
+    expect(decoded.assets[0]?.bytes).toEqual(new Uint8Array([0, 255, 128]))
+    expect(decoded.assets[0]?.bytes).not.toBe(
+      (validDocument().assets[0] as { bytes: unknown }).bytes,
+    )
+    expect(decoded.blocks[0]?.attributes).toEqual({
+      level: 1,
+      bibliographyEntry: false,
+      objectType: 'body',
+    })
+  })
+
+  it('encodes asset bytes as canonical JSON-safe base64 and round-trips them', () => {
+    const fixture = validDocument()
+    const document = decodeStructDocument(fixture)
+    const encoded = encodeStructDocument(document)
+
+    expect(encoded.assets[0]).toMatchObject({ bytes: 'AP+A' })
+    expect(encoded.receipt.generatedSha256).toBe(
+      fixture.receipt.generatedSha256,
+    )
+    expect(JSON.parse(JSON.stringify(encoded))).toEqual(encoded)
+    expect(decodeStructDocument(encoded).assets[0]?.bytes).toEqual(
+      new Uint8Array([0, 255, 128]),
+    )
+  })
+
+  it('accepts BCP-47 extension tags and the valid RFC-3339 year 0001', () => {
+    const value = validDocument()
+    value.metadata.language = 'en-US-u-ca-gregory'
+    value.metadata.publicationDate = '0001-01-01'
+    value.metadata.updated = '0001-12-31'
+    seal(value)
+
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it.each([
+    [
+      'calendar-normalized timestamp',
+      (value: any) =>
+        (value.metadata.artifactModifiedAt = '2026-02-30T00:00:00Z'),
+    ],
+    [
+      'duplicate BCP-47 extension singleton',
+      (value: any) => (value.metadata.language = 'en-a-foo-a-bar'),
+    ],
+    [
+      'duplicate BCP-47 variant',
+      (value: any) => (value.metadata.language = 'de-1901-1901'),
+    ],
+    ['MIME wildcard', (value: any) => (value.assets[0].mediaType = '*/*')],
+  ])('rejects an invalid %s', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    seal(value)
+
+    expect(() => decodeStructDocument(value)).toThrow()
+  })
+
+  it.each([
+    'i-klingon',
+    'de-1901',
+    'sl-rozaj-biske-1994',
+    'en-US-u-ca-gregory',
+    'x-private-private',
+  ])('accepts the BCP-47 language tag %s', (language) => {
+    const value = validDocument()
+    value.metadata.language = language
+    seal(value)
+
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it('rejects an unpadded base64 payload exceeding the asset bound before allocation', () => {
+    const encoded = 'AAAA'.repeat(Math.ceil((MAX_STRUCT_ASSET_BYTES + 1) / 3))
+
+    expect(() => parseBytes(encoded, '$.asset.bytes')).toThrow(
+      /resource bound/i,
+    )
+  })
+
+  it('rejects an oversized Uint8Array asset before copying it', () => {
+    const bytes = new Uint8Array(MAX_STRUCT_ASSET_BYTES + 1)
+
+    expect(() => parseBytes(bytes, '$.asset.bytes')).toThrow(/resource bound/i)
+  })
+
+  it('copies a large canonical Uint8Array without materializing numeric keys or descriptors', () => {
+    const bytes = new Uint8Array(1024 * 1024)
+    bytes[0] = 17
+    bytes[bytes.length - 1] = 29
+    const ownKeys = Reflect.ownKeys
+    const descriptor = Object.getOwnPropertyDescriptor
+    Reflect.ownKeys = ((value: object) => {
+      if (value === bytes) throw new Error('numeric keys were materialized')
+      return ownKeys(value)
+    }) as typeof Reflect.ownKeys
+    Object.getOwnPropertyDescriptor = ((value: object, key: PropertyKey) => {
+      if (value === bytes && /^(?:0|[1-9]\d*)$/u.test(String(key)))
+        throw new Error('numeric descriptor was inspected')
+      return descriptor(value, key)
+    }) as typeof Object.getOwnPropertyDescriptor
+
+    try {
+      const snapshot = parseBytes(bytes, '$.asset.bytes')
+      expect(snapshot).not.toBe(bytes)
+      expect(snapshot[0]).toBe(17)
+      expect(snapshot[snapshot.length - 1]).toBe(29)
+    } finally {
+      Reflect.ownKeys = ownKeys
+      Object.getOwnPropertyDescriptor = descriptor
+    }
+  })
+
+  it('rejects aggregate asset bytes before decoding or hashing an earlier payload', () => {
+    const value = validDocument() as any
+    const sparseMaximum = new Array(MAX_STRUCT_ASSET_BYTES)
+    let laterOwnKeys = 0
+    value.assets = [
+      { ...value.assets[0], bytes: sparseMaximum },
+      {
+        ...value.assets[0],
+        id: 'asset-2',
+        href: 'assets/asset-2.bin',
+        bytes: [0],
+      },
+      new Proxy(
+        {},
+        {
+          ownKeys() {
+            laterOwnKeys += 1
+            throw new Error('later asset was enumerated')
+          },
+        },
+      ),
+    ]
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected aggregate asset bound failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('ASSET_BOUNDS')
+      expect((error as StructCodecError).path).toBe('$.assets')
+    }
+    expect(laterOwnKeys).toBe(0)
+  })
+
+  it.each([
+    [
+      'issues',
+      10_001,
+      (value: any, entries: unknown[]) => (value.recovery.issues = entries),
+    ],
+    [
+      'pages',
+      100_001,
+      (value: any, entries: unknown[]) =>
+        (value.recovery.issues[0].pages = entries),
+    ],
+  ])(
+    'rejects oversized recovery %s before snapshotting its keys',
+    (_label, length, assign) => {
+      const value = validDocument() as any
+      let ownKeyReads = 0
+      const entries = new Proxy(new Array(length), {
+        ownKeys() {
+          ownKeyReads += 1
+          throw new Error('oversized recovery keys were snapshotted')
+        },
+      })
+      assign(value, entries)
+
+      try {
+        decodeStructDocument(value)
+        throw new Error('expected recovery bound failure')
+      } catch (error) {
+        expect(error).toBeInstanceOf(StructCodecError)
+        expect((error as StructCodecError).code).toBe('BUDGET')
+        expect(ownKeyReads).toBe(0)
+      }
+    },
+  )
+
+  it('preserves JSON text whitespace without coercion', () => {
+    const value = validDocument() as any
+    value.metadata.abstract = 'Abstract\nwith\twhitespace'
+    value.blocks[0].text = 'Hello\n'
+    value.receipt.textCharacterCount = 6
+    value.receipt.conservation.sourceTextCharacterCount = 6
+    value.receipt.conservation.structTextCharacterCount = 6
+    seal(value)
+
+    const decoded = decodeStructDocument(value)
+
+    expect(decoded.metadata.abstract).toBe('Abstract\nwith\twhitespace')
+    expect(decoded.blocks[0]?.text).toBe('Hello\n')
+  })
+
+  it.each([
+    ['document', (value: any) => (value.extra = true)],
+    ['source', (value: any) => (value.source.extra = true)],
+    ['metadata', (value: any) => (value.metadata.extra = true)],
+    [
+      'author affiliation',
+      (value: any) => (value.metadata.authorAffiliations[0].extra = true),
+    ],
+    [
+      'author note',
+      (value: any) => (value.metadata.authorNotes[0].extra = true),
+    ],
+    ['block', (value: any) => (value.blocks[0].extra = true)],
+    ['inline', (value: any) => (value.blocks[0].inline[0].extra = true)],
+    ['evidence', (value: any) => (value.blocks[0].evidence.extra = true)],
+    ['box', (value: any) => (value.blocks[0].evidence.boxes[0].extra = true)],
+    ['table', (value: any) => (value.blocks[0].table.extra = true)],
+    [
+      'table cell',
+      (value: any) => (value.blocks[0].table.cells[0].extra = true),
+    ],
+    ['furniture', (value: any) => (value.blocks[0].furniture.extra = true)],
+    [
+      'furniture review',
+      (value: any) => (value.blocks[0].furnitureReview.extra = true),
+    ],
+    ['asset', (value: any) => (value.assets[0].extra = true)],
+    ['relationship', (value: any) => (value.relationships[0].extra = true)],
+    [
+      'relationship candidate',
+      (value: any) => (value.relationships[0].candidates[0].extra = true),
+    ],
+    ['page', (value: any) => (value.pages[0].extra = true)],
+    ['page column', (value: any) => (value.pages[0].columns[0].extra = true)],
+    ['diagnostic', (value: any) => (value.diagnostics[0].extra = true)],
+    ['recovery', (value: any) => (value.recovery.extra = true)],
+    ['recovery issue', (value: any) => (value.recovery.issues[0].extra = true)],
+    ['receipt', (value: any) => (value.receipt.extra = true)],
+    ['conservation', (value: any) => (value.receipt.conservation.extra = true)],
+  ])('rejects an unknown field at the %s object layer', (_layer, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/unknown field/i)
+  })
+
+  it.each([
+    ['schemaVersion', (value: any) => (value.schemaVersion = 1)],
+    ['source', (value: any) => (value.source = 'source')],
+    ['blocks', (value: any) => (value.blocks = {})],
+    ['block kind', (value: any) => (value.blocks[0].kind = 1)],
+    ['inline start', (value: any) => (value.blocks[0].inline[0].start = '0')],
+    ['asset bytes', (value: any) => (value.assets[0].bytes = ['0'])],
+    ['recovery status', (value: any) => (value.recovery.status = false)],
+  ])('rejects a wrong primitive for %s', (_field, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow()
+  })
+
+  it('rejects non-finite numeric values without coercion', () => {
+    const value = validDocument()
+    value.blocks[0].evidence.confidence = Number.NaN
+    expect(() => decodeStructDocument(value)).toThrow(/finite/i)
+  })
+
+  it('rejects inline ranges outside their owning text', () => {
+    const value = validDocument()
+    value.blocks[0].inline[0].end = 6
+    expect(() => decodeStructDocument(value)).toThrow(/text length/i)
+  })
+
+  it.each([
+    [
+      'duplicate block id',
+      (value: any) => value.blocks.push({ ...value.blocks[0] }),
+    ],
+    [
+      'duplicate relationship target',
+      (value: any) => (value.relationships[0].to = ['block-1', 'block-1']),
+    ],
+    [
+      'duplicate inline target',
+      (value: any) =>
+        (value.blocks[0].inline[0].targetIds = ['block-1', 'block-1']),
+    ],
+    [
+      'duplicate author note id',
+      (value: any) =>
+        value.metadata.authorNotes.push({
+          ...value.metadata.authorNotes[0],
+        }),
+    ],
+  ])('rejects %s', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate/i)
+  })
+
+  it.each([
+    ['block id', (value: any) => (value.blocks[0].id = '../block')],
+    ['asset id', (value: any) => (value.assets[0].id = 'asset id')],
+    ['document id', (value: any) => (value.documentId = ' document')],
+  ])('rejects a non-canonical %s', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/identifier|id/i)
+  })
+
+  it('rejects malformed bytes and preserves no binary object representation', () => {
+    const value = validDocument()
+    for (const bytes of ['not-base64', 'AB==']) {
+      value.assets[0].bytes = bytes
+      expect(() => decodeStructDocument(value)).toThrow(/base64/i)
+    }
+
+    const jsonValue = JSON.parse(JSON.stringify(validDocument()))
+    jsonValue.assets[0].bytes = [0, 255, 128]
+    expect(decodeStructDocument(jsonValue).assets[0]?.bytes).toEqual(
+      new Uint8Array([0, 255, 128]),
+    )
+    jsonValue.assets[0].bytes = { 0: 0, 1: 255, 2: 128 }
+    expect(() => decodeStructDocument(jsonValue)).toThrow()
+  })
+
+  it('copies only intrinsic bytes without invoking enumerable string expandos', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    let getterCalls = 0
+    Object.defineProperty(bytes, 'extra', {
+      enumerable: true,
+      get() {
+        getterCalls += 1
+        throw new Error('expando getter invoked')
+      },
+    })
+    value.assets[0].bytes = bytes as any
+
+    const snapshot = decodeStructDocument(value).assets[0]!.bytes!
+    expect(snapshot).toEqual(new Uint8Array([0, 255, 128]))
+    expect(Object.hasOwn(snapshot, 'extra')).toBe(false)
+    expect(getterCalls).toBe(0)
+  })
+
+  it('copies only intrinsic bytes without reading symbol expandos', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    const extra = Symbol('extra')
+    Object.defineProperty(bytes, extra, { value: 'not byte data' })
+    value.assets[0].bytes = bytes as any
+
+    const snapshot = decodeStructDocument(value).assets[0]!.bytes!
+    expect(snapshot).toEqual(new Uint8Array([0, 255, 128]))
+    expect(Object.hasOwn(snapshot, extra)).toBe(false)
+  })
+
+  it('rejects Uint8Array subclasses rather than discarding their prototype state', () => {
+    const value = validDocument()
+    class SubclassedBytes extends Uint8Array {}
+    value.assets[0].bytes = new SubclassedBytes([0, 255, 128]) as any
+
+    expect(() => decodeStructDocument(value)).toThrow(/asset|bytes/i)
+  })
+
+  it('rejects a spoofed Uint8Array brand after a mutating toStringTag getter', () => {
+    const value = validDocument()
+    const bytes = new Int8Array([0, -1, -128])
+    Object.setPrototypeOf(bytes, Uint8Array.prototype)
+    Object.defineProperty(bytes, Symbol.toStringTag, {
+      configurable: true,
+      get() {
+        delete (bytes as any)[Symbol.toStringTag]
+        return 'Uint8Array'
+      },
+    })
+    value.assets[0].bytes = bytes as any
+
+    expect(() => decodeStructDocument(value)).toThrow(/asset|bytes/i)
+  })
+
+  it('copies intrinsic bytes without invoking a toStringTag expando', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    let getterCalls = 0
+    Object.defineProperty(bytes, Symbol.toStringTag, {
+      configurable: true,
+      get() {
+        getterCalls += 1
+        delete (bytes as any)[Symbol.toStringTag]
+        return 'Uint8Array'
+      },
+    })
+    value.assets[0].bytes = bytes as any
+
+    expect(decodeStructDocument(value).assets[0]!.bytes).toEqual(
+      new Uint8Array([0, 255, 128]),
+    )
+    expect(getterCalls).toBe(0)
+    expect(Object.hasOwn(bytes, Symbol.toStringTag)).toBe(true)
+  })
+
+  it('rejects an own length accessor without invoking or mutating through it', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    const before = [...bytes]
+    let getterCalls = 0
+    Object.defineProperty(bytes, 'length', {
+      configurable: true,
+      get() {
+        getterCalls += 1
+        bytes[0] = 17
+        return before.length
+      },
+    })
+    value.assets[0].bytes = bytes as any
+
+    expect(() => decodeStructDocument(value)).toThrow(/asset|bytes/i)
+    expect(getterCalls).toBe(0)
+    expect([...bytes]).toEqual(before)
+    expect(Object.getOwnPropertyDescriptor(bytes, 'length')?.get).toBeTypeOf(
+      'function',
+    )
+  })
+
+  it('rejects non-index bytes before touching a proxy prototype', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    Object.defineProperty(bytes, 'extra', { value: true })
+    const traps = { get: 0, ownKeys: 0, descriptor: 0 }
+    const prototype = new Proxy(Uint8Array.prototype, {
+      get(target, property, receiver) {
+        traps.get += 1
+        return Reflect.get(target, property, receiver)
+      },
+      ownKeys(target) {
+        traps.ownKeys += 1
+        return Reflect.ownKeys(target)
+      },
+      getOwnPropertyDescriptor(target, property) {
+        traps.descriptor += 1
+        return Reflect.getOwnPropertyDescriptor(target, property)
+      },
+    })
+    Object.setPrototypeOf(bytes, prototype)
+    value.assets[0].bytes = bytes as any
+
+    expect(() => decodeStructDocument(value)).toThrow(/asset|bytes/i)
+    expect(traps).toEqual({ get: 0, ownKeys: 0, descriptor: 0 })
+  })
+
+  it('rejects proxy prototypes before reflective traps can mutate the input', () => {
+    const value = validDocument()
+    const bytes = new Uint8Array([0, 255, 128])
+    const before = [...bytes]
+    const traps = { ownKeys: 0, descriptor: 0, constructorGet: 0 }
+    const constructor = new Proxy(Uint8Array, {
+      get(target, property, receiver) {
+        if (property === 'prototype') {
+          traps.constructorGet += 1
+          bytes[0] = 17
+        }
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const prototype = new Proxy(Uint8Array.prototype, {
+      ownKeys(target) {
+        traps.ownKeys += 1
+        bytes[0] = 17
+        return Reflect.ownKeys(target)
+      },
+      getOwnPropertyDescriptor(target, property) {
+        traps.descriptor += 1
+        const descriptor = Reflect.getOwnPropertyDescriptor(target, property)
+        return property === 'constructor' && descriptor !== undefined
+          ? { ...descriptor, value: constructor }
+          : descriptor
+      },
+    })
+    Object.setPrototypeOf(bytes, prototype)
+    value.assets[0].bytes = bytes as any
+
+    expect(() => decodeStructDocument(value)).toThrow(/asset|bytes/i)
+    expect(traps).toEqual({ ownKeys: 0, descriptor: 0, constructorGet: 0 })
+    expect([...bytes]).toEqual(before)
+  })
+
+  it('rejects cross-realm Uint8Array values in favor of JSON-safe byte forms', () => {
+    const value = validDocument()
+    value.assets[0].bytes = runInNewContext(
+      'new Uint8Array([0, 255, 128])',
+    ) as any
+
+    expect(() => decodeStructDocument(value)).toThrow(
+      /canonical Uint8Array|asset|bytes/i,
+    )
+  })
+
+  it('verifies present asset bytes against the declared SHA-256 and permits absent bytes', () => {
+    const tampered = validDocument()
+    tampered.assets[0].bytes = 'AP+B'
+    expect(() => decodeStructDocument(tampered)).toThrow(/asset|bytes|sha256/i)
+
+    const absent = validDocument()
+    delete (absent.assets[0] as any).bytes
+    expect(() => decodeStructDocument(absent)).not.toThrow()
+  })
+
+  it('keeps a supported 0.1.0 document unchanged through migration', () => {
+    const migrated = migrateStructDocument(validDocument())
+    expect(migrated.schemaVersion).toBe('0.1.0')
+    expect(migrated).not.toHaveProperty('documentId')
+    expect(migrated.receipt).not.toHaveProperty('documentId')
+  })
+
+  it('canonically decodes the declared current 0.2.0 binding without migration', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    seal(value)
+
+    expect(migrateStructDocument(value)).toMatchObject({
+      schemaVersion: '0.2.0',
+      documentId: 'fixture-document',
+      receipt: { schemaVersion: '0.2.0', documentId: 'fixture-document' },
+    })
+  })
+
+  it('strictly decodes the optional model consultation receipt on 0.2.0', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {
+        totalDecisionCount: 0,
+        totalConsultationCount: 0,
+        consultationRate: 0,
+        byDecisionClass: {},
+      },
+    }
+    seal(value)
+
+    const decoded = decodeStructDocument(value)
+    expect(decoded.receipt.modelConsultations).toMatchObject({
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+    })
+
+    value.receipt.modelConsultations.extra = true
+    expect(() => decodeStructDocument(value)).toThrow()
+  })
+
+  it.each([
+    { label: 'null', member: null },
+    { label: 'scalar', member: 'malformed' },
+    { label: 'number', member: 7 },
+    { label: 'array', member: [] },
+  ])(
+    'rejects a non-record consultation or decision member after resealing ($label)',
+    ({ member }) => {
+      for (const field of ['consultations', 'decisions'] as const) {
+        const value = validDocument() as any
+        value.schemaVersion = '0.2.0'
+        value.documentId = 'fixture-document'
+        value.receipt.schemaVersion = '0.2.0'
+        value.receipt.documentId = 'fixture-document'
+        value.receipt.modelConsultations = {
+          schemaVersion: '1.0.0',
+          documentId: 'fixture-document',
+          sourceSha256: hash,
+          consultations: [],
+          decisions: [],
+          metrics: {
+            totalDecisionCount: 0,
+            totalConsultationCount: 0,
+            consultationRate: 0,
+            byDecisionClass: {},
+          },
+        }
+        value.receipt.modelConsultations[field] = [member]
+        seal(value)
+
+        expect(() => decodeStructDocument(value)).toThrow(
+          /model|receipt|consultation|decision/i,
+        )
+      }
+    },
+  )
+
+  it('rejects a resealed consultation receipt with a noncanonical array prototype', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {
+        totalDecisionCount: 0,
+        totalConsultationCount: 0,
+        consultationRate: 0,
+        byDecisionClass: {},
+      },
+    }
+    const customPrototype = Object.create(Array.prototype, {
+      custom: { value: true, enumerable: false },
+    })
+    Object.setPrototypeOf(
+      value.receipt.modelConsultations.consultations,
+      customPrototype,
+    )
+    seal(value)
+
+    expect(() => decodeStructDocument(value)).toThrow(
+      /model|receipt|array|prototype/i,
+    )
+  })
+
+  it.each(['0.3.0', '9.9.9', '', null, 1])(
+    'fails closed on unknown schema version %s',
+    (schemaVersion) => {
+      const value = validDocument()
+      value.schemaVersion = schemaVersion as never
+      expect(() => migrateStructDocument(value)).toThrow(/schema version/i)
+    },
+  )
+
+  it('contains cyclic and bigint schema versions as StructCodecError', () => {
+    const cyclic = validDocument() as any
+    const version: any = {}
+    version.self = version
+    cyclic.schemaVersion = version
+    expect(() => decodeStructDocument(cyclic)).toThrow(StructCodecError)
+
+    const bigint = validDocument() as any
+    bigint.schemaVersion = 1n
+    expect(() => decodeStructDocument(bigint)).toThrow(StructCodecError)
+  })
+
+  it('verifies the canonical generated digest for both supported versions', () => {
+    expect(() => decodeStructDocument(validDocument())).not.toThrow()
+
+    const legacy = validDocument()
+    legacy.receipt.generatedSha256 = hash
+    expect(() => decodeStructDocument(legacy)).toThrow(/digest|sha256/i)
+
+    const current = validDocument() as any
+    current.schemaVersion = '0.2.0'
+    current.documentId = 'fixture-document'
+    current.receipt.schemaVersion = '0.2.0'
+    current.receipt.documentId = 'fixture-document'
+    seal(current)
+    expect(() => decodeStructDocument(current)).not.toThrow()
+    current.receipt.generatedSha256 = hash
+    expect(() => decodeStructDocument(current)).toThrow(/digest|sha256/i)
+  })
+
+  it.each([
+    [
+      'relationship from',
+      (value: any) => (value.relationships[0].from = 'missing'),
+    ],
+    [
+      'relationship to',
+      (value: any) => (value.relationships[0].to = ['missing']),
+    ],
+    ['page block', (value: any) => (value.pages[0].blocks = ['missing'])],
+    [
+      'page column block',
+      (value: any) => (value.pages[0].columns[0].blockIds = ['missing']),
+    ],
+    [
+      'fallback asset',
+      (value: any) => (value.blocks[0].fallbackAssetIds = ['missing']),
+    ],
+    [
+      'inline target',
+      (value: any) => (value.blocks[0].inline[0].targetIds = ['missing']),
+    ],
+    [
+      'author note target',
+      (value: any) => (value.metadata.authorNotes[0].target = 'missing'),
+    ],
+  ])('rejects a dangling %s reference', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(
+      /reference|target|dangling/i,
+    )
+  })
+
+  it.each([
+    ['asset and block', (value: any) => (value.assets[0].id = 'block-1')],
+    [
+      'diagnostic and block',
+      (value: any) => (value.diagnostics[0].id = 'block-1'),
+    ],
+    [
+      'relationship and block',
+      (value: any) => (value.relationships[0].id = 'block-1'),
+    ],
+  ])('rejects cross-category duplicate ids (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it.each([
+    [
+      'author notes within the namespace',
+      (value: any) =>
+        value.metadata.authorNotes.push({
+          ...value.metadata.authorNotes[0],
+        }),
+    ],
+    [
+      'source observation anchors within the namespace',
+      (value: any) =>
+        (value.blocks[0].sourceObservationAnchorIds = ['anchor-1', 'anchor-1']),
+    ],
+    [
+      'author note and block',
+      (value: any) => (value.metadata.authorNotes[0].id = 'block-1'),
+    ],
+    [
+      'author note and source observation anchor',
+      (value: any) => (value.metadata.authorNotes[0].id = 'anchor-1'),
+    ],
+    [
+      'source observation anchor and block',
+      (value: any) =>
+        (value.blocks[0].sourceObservationAnchorIds = ['block-1']),
+    ],
+    [
+      'source observation anchors across blocks',
+      (value: any) => {
+        value.blocks.push({
+          ...value.blocks[0],
+          id: 'block-2',
+          order: 1,
+          page: null,
+          text: '',
+          inline: [],
+          sourceObservationAnchorIds: ['anchor-1'],
+        })
+        value.receipt.blockCount = value.blocks.length
+        value.receipt.conservation.structBlockCount = value.blocks.length
+      },
+    ],
+  ])('rejects semantic ids reused across namespaces (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/DUPLICATE_IDENTIFIER/i)
+  })
+
+  it('rejects emitted XHTML ids that collide after stable normalization', () => {
+    const value = validDocument()
+    value.metadata.authorNotes![0].id = '1'
+    value.blocks[0].sourceObservationAnchorIds = ['n-1']
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+    expect(() => renderPublicationXhtml(value as any)).toThrow(
+      /duplicate|identifier/i,
+    )
+  })
+
+  it('rejects a normalized relationship id colliding with a block id', () => {
+    const value = validDocument() as any
+    value.blocks[0].id = 'n-1'
+    value.metadata.authorNotes[0].target = 'n-1'
+    value.blocks[0].inline[0].href = '#n-1'
+    value.blocks[0].inline[0].targetIds = ['n-1']
+    value.blocks[0].inline[0].relationshipId = '1'
+    value.relationships[0].id = '1'
+    value.relationships[0].from = 'n-1'
+    value.relationships[0].to = ['n-1']
+    value.relationships[0].candidates[0].target = 'n-1'
+    value.pages[0].blocks = ['n-1']
+    value.pages[0].columns[0].blockIds = ['n-1']
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+    expect(() => renderPublicationXhtml(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it('emits a relationship id only once when used in two blocks', async () => {
+    const value = validDocument() as any
+    const second = { ...value.blocks[0], id: 'block-2', order: 1, page: null }
+    delete second.table
+    delete second.furniture
+    delete second.furnitureReview
+    delete second.fallbackAssetIds
+    delete second.sourceObservationAnchorIds
+    second.inline = [{ ...value.blocks[0].inline[0] }]
+    value.blocks.push(second)
+    value.receipt.blockCount = 2
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.sourceTextCharacterCount = 10
+    value.receipt.conservation.structTextCharacterCount = 10
+    value.receipt.textCharacterCount = 10
+    value.blocks[0].text = 'Hello'
+    value.blocks[1].text = 'World'
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml.match(/<a id="relationship-1"/g)).toHaveLength(1)
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('rejects a composed table-cell id colliding with a block id', () => {
+    const value = validDocument() as any
+    value.blocks[0].id = 'table'
+    value.blocks[0].kind = 'table'
+    value.blocks[0].table.cells[0].id = 'cell'
+    value.metadata.authorNotes[0].target = 'table'
+    value.blocks[0].inline[0].href = '#table'
+    value.blocks[0].inline[0].targetIds = ['table']
+    value.relationships[0].from = 'table'
+    value.relationships[0].to = ['table']
+    value.relationships[0].candidates[0].target = 'table'
+    value.pages[0].blocks = ['table']
+    value.pages[0].columns[0].blockIds = ['table']
+    const second = {
+      ...value.blocks[0],
+      id: 'table-cell',
+      order: 1,
+      page: null,
+    }
+    delete second.table
+    delete second.furniture
+    delete second.furnitureReview
+    delete second.fallbackAssetIds
+    delete second.sourceObservationAnchorIds
+    second.inline = []
+    second.text = ''
+    value.blocks.push(second)
+    value.receipt.blockCount = 2
+    value.receipt.conservation.structBlockCount = 2
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+    expect(() => renderPublicationXhtml(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it.each([
+    ['asset id', ['asset-1'], 'assets/asset-1.bin'],
+    [
+      'external URL',
+      ['https://example.test/reference'],
+      'https://example.test/reference',
+    ],
+  ])(
+    'renders a relationship %s using its target kind',
+    async (_label, targets, expectedHref) => {
+      const value = validDocument() as any
+      value.relationships[0].to = targets
+      seal(value)
+      const decoded = decodeStructDocument(value)
+      expect(renderPublicationXhtml(decoded)).toContain(
+        `href="${expectedHref}"`,
+      )
+      await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+        mediaType: 'application/epub+zip',
+      })
+    },
+  )
+
+  it('keeps a numeric block author-note target on its exact raw fragment', async () => {
+    const value = validDocument() as any
+    value.blocks[0].id = '1'
+    value.metadata.authorNotes[0].target = '1'
+    value.relationships[0].from = '1'
+    value.relationships[0].to = ['1']
+    value.relationships[0].candidates[0].target = '1'
+    value.blocks[0].inline[0].href = '#1'
+    value.blocks[0].inline[0].targetIds = ['1']
+    value.pages[0].blocks = ['1']
+    value.pages[0].columns[0].blockIds = ['1']
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('href="#1"')
+    expect(xhtml).toContain('id="1"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('uses an asset href for an author-note target', async () => {
+    const value = validDocument() as any
+    value.metadata.authorNotes[0].target = 'asset-1'
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('href="assets/asset-1.bin"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('uses an asset href for a plain inline target', async () => {
+    const value = validDocument() as any
+    value.blocks[0].inline[0] = {
+      start: 0,
+      end: 5,
+      href: '#asset-1',
+      targetIds: ['asset-1'],
+    }
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('href="assets/asset-1.bin"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('resolves local scheme-looking ids before external URL classification', async () => {
+    const value = validDocument() as any
+    value.blocks[0].id = 'mailto:note'
+    value.metadata.authorNotes[0].target = 'mailto:note'
+    value.relationships[0].from = 'mailto:note'
+    value.relationships[0].to = ['mailto:note']
+    value.relationships[0].candidates[0].target = 'mailto:note'
+    value.blocks[0].inline[0] = {
+      start: 0,
+      end: 5,
+      href: 'mailto:note',
+      targetIds: ['mailto:note'],
+      relationshipId: 'relationship-1',
+      semanticRole: 'cross-reference',
+    }
+    value.pages[0].blocks = ['mailto:note']
+    value.pages[0].columns[0].blockIds = ['mailto:note']
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('href="#mailto:note"')
+    expect(xhtml).not.toContain('href="mailto:note"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('resolves a scheme-looking local id for a plain inline target', async () => {
+    const value = validDocument() as any
+    const target = {
+      ...value.blocks[0],
+      id: 'mailto:note',
+      text: 'Target',
+      inline: [],
+      order: 1,
+    }
+    delete target.table
+    delete target.furniture
+    delete target.furnitureReview
+    delete target.fallbackAssetIds
+    delete target.sourceObservationAnchorIds
+    delete target.attributes
+    value.blocks[0].inline = [{ start: 0, end: 5, href: 'mailto:note' }]
+    value.blocks.push(target)
+    value.pages[0].blocks.push('mailto:note')
+    value.pages[0].columns[0].blockIds.push('mailto:note')
+    value.receipt.blockCount = 2
+    value.receipt.textCharacterCount = 11
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.sourceTextCharacterCount = 11
+    value.receipt.conservation.structTextCharacterCount = 11
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('href="#mailto:note"')
+    expect(xhtml).not.toContain('href="mailto:note"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it.each(['https://example.test/path ', ' https://example.test/path'])(
+    'rejects a non-canonical external URL before digest acceptance (%s)',
+    (href) => {
+      const value = validDocument() as any
+      value.relationships[0].to = [href]
+      seal(value)
+      expect(() => decodeStructDocument(value)).toThrow(
+        /reference|canonical|url/i,
+      )
+    },
+  )
+
+  it.each(['https://example.test/path ', ' https://example.test/path'])(
+    'rejects a non-canonical plain inline URL before digest acceptance (%s)',
+    (href) => {
+      const value = validDocument() as any
+      value.blocks[0].inline[0] = { start: 0, end: 5, href }
+      seal(value)
+      expect(() => decodeStructDocument(value)).toThrow(/url|canonical/i)
+    },
+  )
+
+  it('renders table cells in coordinate order without rewriting the document', () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = ''
+    value.blocks[0].inline = []
+    value.blocks[0].table = {
+      rows: 1,
+      columns: 2,
+      cells: [
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'right',
+          text: 'RIGHT',
+          column: 1,
+        },
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'left',
+          text: 'LEFT',
+          column: 0,
+        },
+      ],
+      semantic: 'verified',
+    }
+    value.receipt.textCharacterCount = 0
+    value.receipt.conservation.sourceTextCharacterCount = 0
+    value.receipt.conservation.structTextCharacterCount = 0
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    expect(decoded.blocks[0]!.table!.cells.map((cell) => cell.id)).toEqual([
+      'right',
+      'left',
+    ])
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml.indexOf('>LEFT</td>')).toBeLessThan(
+      xhtml.indexOf('>RIGHT</td>'),
+    )
+  })
+
+  it('renders an anonymous cell for a leading sparse table coordinate', async () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = ''
+    value.blocks[0].inline = []
+    value.blocks[0].table = {
+      rows: 1,
+      columns: 2,
+      cells: [
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'right',
+          text: 'RIGHT',
+          column: 1,
+        },
+      ],
+      semantic: 'verified',
+    }
+    value.receipt.textCharacterCount = 0
+    value.receipt.conservation.sourceTextCharacterCount = 0
+    value.receipt.conservation.structTextCharacterCount = 0
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain(
+      '<tr><td></td><td id="block-1-right">RIGHT</td></tr>',
+    )
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('does not add a placeholder for a coordinate occupied by a row span', () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = ''
+    value.blocks[0].inline = []
+    value.blocks[0].table = {
+      rows: 2,
+      columns: 2,
+      cells: [
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'top',
+          text: 'TOP',
+          row: 0,
+          column: 0,
+          rowSpan: 2,
+        },
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'bottom',
+          text: 'BOTTOM',
+          row: 1,
+          column: 1,
+        },
+      ],
+      semantic: 'verified',
+    }
+    value.receipt.textCharacterCount = 0
+    value.receipt.conservation.sourceTextCharacterCount = 0
+    value.receipt.conservation.structTextCharacterCount = 0
+    seal(value)
+    const xhtml = renderPublicationXhtml(decodeStructDocument(value))
+    expect(xhtml).toContain(
+      '<tr><td id="block-1-top" rowspan="2">TOP</td><td></td></tr><tr><td id="block-1-bottom">BOTTOM</td></tr>',
+    )
+    expect(xhtml).not.toContain('<tr><td></td><td id="block-1-bottom">')
+  })
+
+  it('does not add a placeholder between cells separated by a column span', () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = ''
+    value.blocks[0].inline = []
+    value.blocks[0].table = {
+      rows: 1,
+      columns: 3,
+      cells: [
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'wide',
+          text: 'WIDE',
+          column: 0,
+          columnSpan: 2,
+        },
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'last',
+          text: 'LAST',
+          column: 2,
+        },
+      ],
+      semantic: 'verified',
+    }
+    value.receipt.textCharacterCount = 0
+    value.receipt.conservation.sourceTextCharacterCount = 0
+    value.receipt.conservation.structTextCharacterCount = 0
+    seal(value)
+    const xhtml = renderPublicationXhtml(decodeStructDocument(value))
+    expect(xhtml).toContain(
+      '<tr><td id="block-1-wide" colspan="2">WIDE</td><td id="block-1-last">LAST</td></tr>',
+    )
+  })
+
+  it('preserves multiple sparse table holes and EPUB table markup', async () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = ''
+    value.blocks[0].inline = []
+    value.blocks[0].table = {
+      rows: 2,
+      columns: 3,
+      cells: [
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'a',
+          text: 'A',
+          row: 0,
+          column: 2,
+        },
+        {
+          ...value.blocks[0].table.cells[0],
+          id: 'b',
+          text: 'B',
+          row: 1,
+          column: 1,
+        },
+      ],
+      semantic: 'verified',
+    }
+    value.receipt.textCharacterCount = 0
+    value.receipt.conservation.sourceTextCharacterCount = 0
+    value.receipt.conservation.structTextCharacterCount = 0
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    const epub = await buildStructEpub(decoded)
+    const epubXhtml = strFromU8(unzipSync(epub.bytes)['EPUB/content.xhtml']!)
+    expect(xhtml).toContain(
+      '<tr><td></td><td></td><td id="block-1-a">A</td></tr><tr><td></td><td id="block-1-b">B</td><td></td></tr>',
+    )
+    expect(epubXhtml).toContain(
+      '<tr><td></td><td></td><td id="block-1-a">A</td></tr><tr><td></td><td id="block-1-b">B</td><td></td></tr>',
+    )
+  })
+
+  it.each([
+    [
+      'rows',
+      (value: any) => {
+        value.blocks[0].table.rows = 100_001
+        value.blocks[0].table.cells = []
+      },
+    ],
+    [
+      'columns',
+      (value: any) => {
+        value.blocks[0].table.columns = 100_001
+        value.blocks[0].table.cells = []
+      },
+    ],
+    [
+      'area',
+      (value: any) => {
+        value.blocks[0].table.rows = 317
+        value.blocks[0].table.columns = 316
+        value.blocks[0].table.cells = []
+      },
+    ],
+  ])(
+    'rejects table dimensions beyond the bounded publication domain (%s)',
+    (_label, mutate) => {
+      const value = validDocument() as any
+      mutate(value)
+      seal(value)
+      expect(() => decodeStructDocument(value)).toThrow(/table|bound|area/i)
+    },
+  )
+
+  it('accepts the explicit maximum table area without allocating beyond it', () => {
+    const value = validDocument() as any
+    value.blocks[0].table.rows = 100_000
+    value.blocks[0].table.columns = 1
+    value.blocks[0].table.cells = []
+    seal(value)
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it('rejects table bounds before inspecting a cell array proxy', () => {
+    const value = validDocument() as any
+    const traps = { ownKeys: 0, descriptor: 0 }
+    value.blocks[0].table.rows = 100_001
+    value.blocks[0].table.cells = new Proxy([], {
+      ownKeys() {
+        traps.ownKeys += 1
+        throw new Error('cell array inspected')
+      },
+      getOwnPropertyDescriptor() {
+        traps.descriptor += 1
+        throw new Error('cell array inspected')
+      },
+    })
+    expect(() => decodeStructDocument(value)).toThrow(/table|bound/i)
+    expect(traps).toEqual({ ownKeys: 0, descriptor: 0 })
+  })
+
+  it('rejects a cell list over the table area before parsing cell payloads', () => {
+    const value = validDocument() as any
+    const traps = { ownKeys: 0, descriptor: 0 }
+    value.blocks[0].table.rows = 1
+    value.blocks[0].table.columns = 1
+    const hostileCell = new Proxy(
+      {},
+      {
+        ownKeys() {
+          traps.ownKeys += 1
+          throw new Error('cell payload inspected')
+        },
+        getOwnPropertyDescriptor() {
+          traps.descriptor += 1
+          throw new Error('cell payload inspected')
+        },
+      },
+    )
+    value.blocks[0].table.cells = [hostileCell, hostileCell]
+    expect(() => decodeStructDocument(value)).toThrow(/table|bound/i)
+    expect(traps).toEqual({ ownKeys: 0, descriptor: 0 })
+  })
+
+  it('allows an author note to alias its matched relationship occurrence', async () => {
+    const value = validDocument() as any
+    const note = {
+      ...value.blocks[0],
+      id: 'note',
+      kind: 'footnote',
+      text: 'Note',
+      inline: [],
+      order: 1,
+    }
+    delete note.table
+    delete note.furniture
+    delete note.furnitureReview
+    delete note.fallbackAssetIds
+    delete note.sourceObservationAnchorIds
+    delete note.attributes
+    value.blocks.push(note)
+    value.metadata.authorNotes[0].id = 'author-note-1'
+    value.metadata.authorNotes[0].target = 'note'
+    value.blocks[0].inline[0] = {
+      start: 0,
+      end: 5,
+      relationshipId: 'author-note-1',
+      semanticRole: 'note-reference',
+    }
+    value.relationships[0] = {
+      ...value.relationships[0],
+      id: 'author-note-1',
+      kind: 'footnote',
+      from: 'block-1',
+      to: ['note'],
+      status: 'matched',
+    }
+    delete value.relationships[0].candidates
+    value.pages[0].blocks.push('note')
+    value.pages[0].columns[0].blockIds.push('note')
+    value.receipt.blockCount = 2
+    value.receipt.textCharacterCount = 9
+    value.receipt.relationshipCount = 1
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.structTextCharacterCount = 9
+    value.receipt.conservation.sourceTextCharacterCount = 9
+    value.receipt.conservation.structRelationshipCount = 1
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml.match(/<a id="author-note-1"/g)).toHaveLength(1)
+    expect(xhtml).toContain('href="#author-note-1" class="note-backlink"')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('rejects an author-note identifier reused by an unrelated relationship', () => {
+    const value = validDocument() as any
+    value.metadata.authorNotes[0].id = value.relationships[0].id
+    value.relationships[0].kind = 'reading-order'
+    value.relationships[0].to = ['block-1']
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it('accepts benign disjoint inline ownership above the historical cap', () => {
+    const value = validDocument() as any
+    const runCount = 4_097
+    value.blocks[0].text = 'x'.repeat(runCount)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: index + 1,
+    }))
+    value.receipt.textCharacterCount = runCount
+    value.receipt.conservation.sourceTextCharacterCount = runCount
+    value.receipt.conservation.structTextCharacterCount = runCount
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    expect(renderPublicationXhtml(decoded)).toContain('x'.repeat(runCount))
+  })
+
+  it('rejects nested inline ownership before rendering large markup', () => {
+    const value = validDocument() as any
+    const runCount = 2_000
+    const textLength = runCount * 2
+    value.blocks[0].text = 'x'.repeat(textLength)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: textLength - index,
+      bold: true,
+    }))
+    value.receipt.textCharacterCount = textLength
+    value.receipt.conservation.sourceTextCharacterCount = textLength
+    value.receipt.conservation.structTextCharacterCount = textLength
+    seal(value)
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected nested ownership budget failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('BUDGET')
+      expect((error as StructCodecError).path).toBe('$.blocks[0].inline[0]')
+    }
+  })
+
+  it('rejects semantic target expansion before materializing the cross-product', () => {
+    const value = validDocument() as any
+    const targetCount = 800
+    const segmentCount = 800
+    const targetIds = Array.from(
+      { length: targetCount },
+      (_, index) => `https://example.test/target-${index}`,
+    )
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      status: 'matched',
+      label: targetIds.map((_, index) => `Author:${2000 + index}`).join(', '),
+    }
+    value.blocks[0].text = 'x'.repeat(segmentCount)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: segmentCount,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'citation',
+      },
+      ...Array.from({ length: segmentCount }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('reports semantic expansion as a path-bearing strict budget failure', async () => {
+    const value = validDocument() as any
+    const targetIds = Array.from(
+      { length: 800 },
+      (_, index) => `https://example.test/target-${index}`,
+    )
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      status: 'matched',
+    }
+    value.blocks[0].text = 'x'.repeat(800)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 800,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+      ...Array.from({ length: 800 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    value.receipt.textCharacterCount = 800
+    value.receipt.conservation.sourceTextCharacterCount = 800
+    value.receipt.conservation.structTextCharacterCount = 800
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(StructCodecError)
+    try {
+      decodeStructDocument(value)
+    } catch (error) {
+      expect((error as StructCodecError).code).toBe('BUDGET')
+      expect((error as StructCodecError).path).toMatch(/blocks\[0\]\.inline/)
+    }
+    value.assets[0].bytes = new Uint8Array([0, 255, 128])
+    await expect(buildStructEpub(value as any)).rejects.toThrow(/budget/i)
+  })
+
+  it('rejects repeated long hyperlink markup within the aggregate output budget', () => {
+    const value = validDocument() as any
+    const segmentCount = 800
+    value.blocks[0].text = 'x'.repeat(segmentCount)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: segmentCount,
+        href: `https://example.test/${'x'.repeat(30_000)}`,
+      },
+      ...Array.from({ length: segmentCount }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('does not expand shadowed semantic owners before selecting the rendered owner', () => {
+    const value = validDocument() as any
+    const runCount = 800
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships = Array.from({ length: runCount }, (_, index) =>
+      index === 0
+        ? { ...value.relationships[0], id: 'shadowed-0', to: ['block-1'] }
+        : {
+            ...value.relationships[0],
+            id: `shadowed-${index}`,
+            get to() {
+              throw new Error('SHADOWED_TARGET_EXPANSION')
+            },
+          },
+    )
+    value.blocks[0].text = 'x'.repeat(runCount)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: 0,
+      end: runCount,
+      relationshipId: `shadowed-${index}`,
+      semanticRole: 'cross-reference',
+    }))
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('refuses same-year citation matching before touching a later hostile source', () => {
+    const value = validDocument() as any
+    const occurrenceCount = 800
+    const labels = Array.from(
+      { length: occurrenceCount },
+      (_, index) => `Author${index}:2000`,
+    )
+    const targetIds = labels.map(
+      (_, index) => `https://example.test/citation-${index}`,
+    )
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      label: labels.join(', '),
+      status: 'matched',
+    }
+    const citationText = labels
+      .map((label) => `${label.split(':')[0]} 2000`)
+      .join(' ')
+    value.blocks[0].text = citationText
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: citationText.length,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'citation',
+      },
+    ]
+    const later = new Proxy(
+      {
+        id: 'later-citation',
+        kind: 'paragraph',
+        text: 'later',
+        inline: [],
+        page: 1,
+        order: 1,
+        column: 'single',
+      },
+      {
+        get(_target, property) {
+          if (property === 'inline') throw new Error('LATE_CITATION_TRAP')
+          return Reflect.get(_target, property)
+        },
+      },
+    )
+    value.blocks.push(later)
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('uses the planning target index instead of scanning document nodes per target', () => {
+    const value = validDocument() as any
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: ['block-1'],
+      status: 'matched',
+    }
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 5,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+    ]
+    Object.defineProperty(value.blocks, 'find', {
+      value: () => {
+        throw new Error('block find must not be used during planning')
+      },
+    })
+    Object.defineProperty(value.assets, 'find', {
+      value: () => {
+        throw new Error('asset find must not be used during planning')
+      },
+    })
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('does not inspect later node ids before refusing external semantic output', () => {
+    const value = validDocument() as any
+    const targetIds = Array.from(
+      { length: 800 },
+      (_, index) => `https://example.test/external-${index}`,
+    )
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      status: 'matched',
+    }
+    value.blocks[0].text = 'x'.repeat(800)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 800,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+      ...Array.from({ length: 800 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    const later = new Proxy(
+      {
+        id: 'later-id-trap',
+        kind: 'paragraph',
+        text: 'later',
+        inline: [],
+      },
+      {
+        get(target, property) {
+          if (property === 'id' || property === 'kind')
+            throw new Error('LATE_ID_TRAP')
+          return Reflect.get(target, property)
+        },
+      },
+    )
+    value.blocks.push(later)
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('refuses a target-list tail before reading beyond the output budget', () => {
+    const value = validDocument() as any
+    const targetIds = Array.from(
+      { length: 800 },
+      (_, index) => `https://example.test/${'x'.repeat(30_000)}-${index}`,
+    )
+    Object.defineProperty(targetIds, 700, {
+      get() {
+        throw new Error('TARGET_TAIL_TRAP')
+      },
+    })
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      status: 'matched',
+    }
+    value.blocks[0].text = 'x'.repeat(800)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 800,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+      ...Array.from({ length: 800 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('charges short semantic targets only across segments owned by that run', () => {
+    const value = validDocument() as any
+    const targetIds = Array.from(
+      { length: 800 },
+      (_, index) => `https://example.test/short-${index}`,
+    )
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.relationships[0] = {
+      ...value.relationships[0],
+      to: targetIds,
+      status: 'matched',
+    }
+    value.blocks[0].text = 'x'.repeat(800)
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 1,
+        relationshipId: value.relationships[0].id,
+        semanticRole: 'cross-reference',
+      },
+      ...Array.from({ length: 800 }, (_, index) => ({
+        start: index,
+        end: index + 1,
+        bold: true,
+      })),
+    ]
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('charges citation matching work across selected owners and sources', () => {
+    const value = validDocument() as any
+    const ownerCount = 7
+    const occurrenceCount = 200
+    const labels = Array.from(
+      { length: occurrenceCount },
+      (_, index) => `Author${index}:2000`,
+    )
+    const targetIds = labels.map(
+      (_, index) => `https://example.test/aggregate-${index}`,
+    )
+    const citationText = labels
+      .map((label) => `${label.split(':')[0]} 2000`)
+      .join(' ')
+    value.metadata.authors = []
+    value.metadata.authorNotes = []
+    value.blocks = Array.from({ length: ownerCount }, (_, index) => ({
+      id: `citation-block-${index}`,
+      kind: 'paragraph',
+      text: citationText,
+      inline: [
+        {
+          start: 0,
+          end: citationText.length,
+          relationshipId: `citation-relationship-${index}`,
+          semanticRole: 'citation',
+        },
+      ],
+    }))
+    value.relationships = Array.from({ length: ownerCount }, (_, index) => ({
+      ...value.relationships[0],
+      id: `citation-relationship-${index}`,
+      to: targetIds,
+      label: labels.join(', '),
+      from: `citation-block-${index}`,
+      status: 'matched',
+    }))
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('rejects an early source budget before inspecting a later hostile source', () => {
+    const value = validDocument() as any
+    const runCount = 2_000
+    value.blocks[0].text = 'x'.repeat(runCount * 2)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: runCount * 2 - index,
+      bold: true,
+    }))
+    const later = new Proxy(
+      {
+        id: 'later',
+        kind: 'paragraph',
+        text: 'later',
+        inline: [],
+        page: 1,
+        order: 1,
+        column: 'single',
+      },
+      {
+        get(_target, property) {
+          if (property === 'inline') throw new Error('LATE_SOURCE_TRAP')
+          return Reflect.get(_target, property)
+        },
+      },
+    )
+    value.blocks.push(later)
+    expect(() => renderPublicationXhtml(value)).toThrow(/budget/i)
+  })
+
+  it('accepts the exact active-owner and wrapper budget boundary', () => {
+    const value = validDocument() as any
+    const runCount = 500
+    const textLength = runCount * 2
+    value.blocks[0].text = 'x'.repeat(textLength)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: textLength - index,
+      bold: true,
+    }))
+    value.receipt.textCharacterCount = textLength
+    value.receipt.conservation.sourceTextCharacterCount = textLength
+    value.receipt.conservation.structTextCharacterCount = textLength
+    seal(value)
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it('accepts inline ownership work exactly at the documented cap', () => {
+    const value = validDocument() as any
+    const runCount = 4_096
+    value.blocks[0].text = 'x'.repeat(runCount)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: index + 1,
+    }))
+    value.receipt.textCharacterCount = runCount
+    value.receipt.conservation.sourceTextCharacterCount = runCount
+    value.receipt.conservation.structTextCharacterCount = runCount
+    seal(value)
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it('does not plan discarded inline runs on a real table block', () => {
+    const value = validDocument() as any
+    const runCount = 5_000
+    value.blocks[0].kind = 'table'
+    value.blocks[0].text = 'x'.repeat(runCount)
+    value.blocks[0].inline = Array.from({ length: runCount }, (_, index) => ({
+      start: index,
+      end: index + 1,
+    }))
+    value.blocks[0].table.cells[0].text = 'Cell'
+    value.blocks[0].table.cells[0].inline = []
+    value.receipt.textCharacterCount = runCount
+    value.receipt.conservation.sourceTextCharacterCount = runCount
+    value.receipt.conservation.structTextCharacterCount = runCount
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('<table>')
+    expect(xhtml).not.toContain('x'.repeat(runCount))
+  })
+
+  it('rejects duplicate metadata authors at strict, direct, and EPUB boundaries', async () => {
+    const value = validDocument() as any
+    value.metadata.authors = ['Author', 'Author']
+    seal(value)
+    expect(() => renderPublicationXhtml(value)).toThrow(
+      /metadata\.authors|duplicate/i,
+    )
+    for (const decode of [decodeStructDocument, migrateStructDocument]) {
+      expect(() => decode(value)).toThrow(StructCodecError)
+      expect(() => decode(value)).toThrow(/metadata\.authors|duplicate/i)
+    }
+    expect(() => encodeStructDocument(value as any)).toThrow(StructCodecError)
+    value.assets[0].bytes = new Uint8Array([0, 255, 128])
+    await expect(buildStructEpub(value as any)).rejects.toThrow(
+      /duplicate|author/i,
+    )
+  })
+
+  it('uses constant-time author membership for distinct author-note collections', () => {
+    const value = validDocument() as any
+    value.metadata.authors = ['Author', 'Second Author']
+    Object.defineProperty(value.metadata.authors, 'includes', {
+      value: () => {
+        throw new Error('authors.includes must not be used')
+      },
+    })
+    value.metadata.authorNotes = [
+      {
+        id: 'author-note-1',
+        author: 'Author',
+        label: '1',
+        target: 'block-1',
+      },
+      {
+        id: 'author-note-2',
+        author: 'Second Author',
+        label: '2',
+        target: 'block-1',
+      },
+    ]
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('recovers semantic occurrence paths without searching the source run array', () => {
+    const value = validDocument() as any
+    value.relationships[0] = {
+      ...value.relationships[0],
+      id: 'semantic-relationship',
+      kind: 'reading-order',
+      to: ['block-1'],
+    }
+    value.blocks[0].inline = [
+      {
+        start: 0,
+        end: 5,
+        relationshipId: 'semantic-relationship',
+        semanticRole: 'cross-reference',
+      },
+    ]
+    Object.defineProperty(value.blocks[0].inline, 'indexOf', {
+      value: () => {
+        throw new Error('source.runs.indexOf must not be used')
+      },
+    })
+    expect(() => renderPublicationXhtml(value)).not.toThrow()
+  })
+
+  it('does not create a footnote backlink for a non-table block table payload', async () => {
+    const value = validDocument() as any
+    const note = {
+      ...value.blocks[0],
+      id: 'note',
+      kind: 'footnote',
+      text: 'Note',
+      inline: [],
+      order: 1,
+    } as any
+    delete note.table
+    delete note.furniture
+    delete note.furnitureReview
+    delete note.fallbackAssetIds
+    delete note.sourceObservationAnchorIds
+    delete note.attributes
+    value.blocks.push(note)
+    value.blocks[0].table.cells[0].inline = [
+      {
+        start: 0,
+        end: 4,
+        relationshipId: 'note-relationship',
+        semanticRole: 'note-reference',
+      },
+    ]
+    const noteRelationship = {
+      ...value.relationships[0],
+      id: 'note-relationship',
+      kind: 'footnote',
+      from: 'block-1',
+      to: ['note'],
+    }
+    delete noteRelationship.candidates
+    value.relationships.push(noteRelationship)
+    value.pages[0].blocks.push('note')
+    value.pages[0].columns[0].blockIds.push('note')
+    value.receipt.blockCount = 2
+    value.receipt.relationshipCount = 2
+    value.receipt.textCharacterCount = 9
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.structRelationshipCount = 2
+    value.receipt.conservation.sourceTextCharacterCount = 9
+    value.receipt.conservation.sourceRelationshipCount = 2
+    value.receipt.conservation.accountedSourceRelationshipCount = 2
+    value.receipt.conservation.structTextCharacterCount = 9
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).not.toContain('note-backlink')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('does not create a footnote backlink for an overlapping unselected inline run', async () => {
+    const value = validDocument() as any
+    const note = {
+      ...value.blocks[0],
+      id: 'note',
+      kind: 'footnote',
+      text: 'Note',
+      inline: [],
+      order: 1,
+    } as any
+    delete note.table
+    delete note.furniture
+    delete note.furnitureReview
+    delete note.fallbackAssetIds
+    delete note.sourceObservationAnchorIds
+    delete note.attributes
+    value.blocks.push(note)
+    value.blocks[0].inline.push({
+      start: 0,
+      end: 5,
+      relationshipId: 'note-relationship',
+      semanticRole: 'note-reference',
+    })
+    const noteRelationship = {
+      ...value.relationships[0],
+      id: 'note-relationship',
+      kind: 'footnote',
+      from: 'block-1',
+      to: ['note'],
+    }
+    delete noteRelationship.candidates
+    value.relationships.push(noteRelationship)
+    value.pages[0].blocks.push('note')
+    value.pages[0].columns[0].blockIds.push('note')
+    value.receipt.blockCount = 2
+    value.receipt.relationshipCount = 2
+    value.receipt.textCharacterCount = 9
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.structRelationshipCount = 2
+    value.receipt.conservation.sourceTextCharacterCount = 9
+    value.receipt.conservation.sourceRelationshipCount = 2
+    value.receipt.conservation.accountedSourceRelationshipCount = 2
+    value.receipt.conservation.structTextCharacterCount = 9
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).not.toContain('note-backlink')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('does not create a footnote backlink for a furniture table payload', async () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'furniture'
+    value.metadata.authorNotes = []
+    value.blocks[0].table.cells[0].inline = [
+      {
+        start: 0,
+        end: 4,
+        relationshipId: 'note-relationship',
+        semanticRole: 'note-reference',
+      },
+    ]
+    const note = {
+      ...value.blocks[0],
+      id: 'note',
+      kind: 'footnote',
+      text: 'Note',
+      inline: [],
+      order: 1,
+    } as any
+    delete note.table
+    delete note.furniture
+    delete note.furnitureReview
+    delete note.fallbackAssetIds
+    delete note.sourceObservationAnchorIds
+    delete note.attributes
+    value.blocks.push(note)
+    const noteRelationship = {
+      ...value.relationships[0],
+      id: 'note-relationship',
+      kind: 'footnote',
+      from: 'block-1',
+      to: ['note'],
+    }
+    delete noteRelationship.candidates
+    value.relationships.push(noteRelationship)
+    value.pages[0].blocks.push('note')
+    value.pages[0].columns[0].blockIds.push('note')
+    value.receipt.blockCount = 2
+    value.receipt.relationshipCount = 2
+    value.receipt.textCharacterCount = 9
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.structRelationshipCount = 2
+    value.receipt.conservation.sourceTextCharacterCount = 9
+    value.receipt.conservation.sourceRelationshipCount = 2
+    value.receipt.conservation.accountedSourceRelationshipCount = 2
+    value.receipt.conservation.structTextCharacterCount = 9
+    value.receipt.conservation.sourceFurnitureBlockCount = 1
+    value.receipt.conservation.accountedFurnitureBlockCount = 1
+    value.receipt.conservation.structFurnitureBlockCount = 1
+    value.receipt.conservation.sourceFurnitureTextCharacterCount = 5
+    value.receipt.conservation.structFurnitureTextCharacterCount = 5
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).not.toContain('note-backlink')
+    await expect(buildStructEpub(decoded)).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+    })
+  })
+
+  it('renders a validated heading level as conforming XHTML through EPUB reopen', async () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'heading'
+    value.blocks[0].inline = []
+    value.blocks[0].attributes.level = 6
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    expect(renderPublicationXhtml(decoded)).toContain('<h6 id="block-1"')
+    const epub = await buildStructEpub(decoded)
+    expect(strFromU8(unzipSync(epub.bytes)['EPUB/content.xhtml']!)).toContain(
+      '<h6 id="block-1"',
+    )
+  })
+
+  it.each([1.5, 0, 7, '3', true])(
+    'rejects invalid heading renderer level %p at strict decode',
+    (level) => {
+      const value = validDocument() as any
+      value.blocks[0].kind = 'heading'
+      value.blocks[0].attributes.level = level
+      seal(value)
+      expect(() => decodeStructDocument(value)).toThrow(
+        /level|heading|attribute|number/i,
+      )
+    },
+  )
+
+  it('rejects numeric asset ids before publication can diverge', () => {
+    const value = validDocument() as any
+    value.assets[0].id = '1'
+    value.blocks[0].fallbackAssetIds = ['1']
+    value.relationships[0].to = ['1']
+    value.relationships[0].candidates[0].target = '1'
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/asset|identifier/i)
+  })
+
+  it('fails closed when an author note targets non-rendered furniture', () => {
+    const value = validDocument() as any
+    value.blocks[0].kind = 'furniture'
+    value.receipt.conservation.sourceFurnitureBlockCount = 1
+    value.receipt.conservation.accountedFurnitureBlockCount = 1
+    value.receipt.conservation.structFurnitureBlockCount = 1
+    value.receipt.conservation.sourceFurnitureTextCharacterCount = 5
+    value.receipt.conservation.structFurnitureTextCharacterCount = 5
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    expect(() => renderPublicationXhtml(decoded)).toThrow(/not rendered/i)
+  })
+
+  it('checks later-position anchors on non-rendered furniture through decode and migration', () => {
+    const value = validDocument() as any
+    value.metadata.authorNotes[0].id = '1'
+    value.blocks.push({
+      ...value.blocks[0],
+      id: 'furniture-1',
+      kind: 'furniture',
+      text: '',
+      page: null,
+      order: 1,
+      column: null,
+      inline: [],
+      sourceObservationAnchorIds: ['furniture-anchor', '1'],
+    })
+    value.receipt.blockCount = 2
+    value.receipt.conservation.structBlockCount = 2
+    value.receipt.conservation.sourceFurnitureBlockCount = 1
+    value.receipt.conservation.accountedFurnitureBlockCount = 1
+    value.receipt.conservation.structFurnitureBlockCount = 1
+    value.receipt.conservation.sourceFurnitureTextCharacterCount = 0
+    value.receipt.conservation.structFurnitureTextCharacterCount = 0
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+    expect(() => migrateStructDocument(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it('rejects later-position source anchors through decode and migration', () => {
+    const value = validDocument() as any
+    value.blocks[0].sourceObservationAnchorIds = ['anchor-1', 'n-1']
+    value.metadata.authorNotes[0].id = '1'
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/duplicate|identifier/i)
+    expect(() => migrateStructDocument(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it('maps later-position anchors from every block into migration validation', () => {
+    const value = validDocument() as any
+    delete value.blocks[0].sourceObservationAnchorIds
+    const second = { ...value.blocks[0], id: 'block-2', order: 1, page: null }
+    delete second.table
+    delete second.furniture
+    delete second.furnitureReview
+    delete second.fallbackAssetIds
+    second.inline = []
+    second.text = ''
+    second.sourceObservationAnchorIds = ['anchor-1', 'n-1']
+    value.blocks.push(second)
+    value.metadata.authorNotes[0].id = '1'
+    value.receipt.blockCount = 2
+    value.receipt.conservation.structBlockCount = 2
+    seal(value)
+    expect(() => migrateStructDocument(value)).toThrow(/duplicate|identifier/i)
+  })
+
+  it('rejects a forbidden XML 1.0 string before digest sealing', () => {
+    const value = validDocument() as any
+    value.metadata.title = 'bad-\uD800'
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/string|unicode|xml/i)
+  })
+
+  it('preserves valid Unicode through decode, XHTML, and EPUB reopen', async () => {
+    const value = validDocument() as any
+    value.metadata.title = 'Valid 🌟 — текст'
+    seal(value)
+    const decoded = decodeStructDocument(value)
+    const xhtml = renderPublicationXhtml(decoded)
+    expect(xhtml).toContain('Valid 🌟 — текст')
+    const epub = await buildStructEpub(decoded)
+    expect(strFromU8(unzipSync(epub.bytes)['EPUB/content.xhtml']!)).toContain(
+      'Valid 🌟 — текст',
+    )
+  })
+
+  it.each([
+    [
+      'box width',
+      (value: any) => (value.blocks[0].evidence.boxes[0].width = -1),
+    ],
+    ['asset width', (value: any) => (value.assets[0].width = -1)],
+    ['page height', (value: any) => (value.pages[0].height = -1)],
+    [
+      'box rotation',
+      (value: any) => (value.blocks[0].evidence.boxes[0].rotation = 0.5),
+    ],
+    ['page rotation', (value: any) => (value.pages[0].rotation = 360)],
+  ])(
+    'rejects invalid nonnegative dimension or rotation (%s)',
+    (_label, mutate) => {
+      const value = validDocument()
+      mutate(value)
+      expect(() => decodeStructDocument(value)).toThrow(
+        /number|rotation|range/i,
+      )
+    },
+  )
+
+  it.each([
+    ['box page', (value: any) => (value.blocks[0].evidence.boxes[0].page = 0)],
+    ['evidence page', (value: any) => (value.blocks[0].evidence.pages[0] = 0)],
+    ['block page', (value: any) => (value.blocks[0].page = 0)],
+    ['page layout page', (value: any) => (value.pages[0].page = 0)],
+    ['diagnostic page', (value: any) => (value.diagnostics[0].pages[0] = 0)],
+    [
+      'recovery issue page',
+      (value: any) => (value.recovery.issues[0].pages = [0]),
+    ],
+    [
+      'furniture page',
+      (value: any) => (value.blocks[0].furniture.pages[0] = 0),
+    ],
+  ])('rejects a non-positive %s', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/page|number|range/i)
+  })
+
+  it.each([
+    [
+      'box width',
+      (value: any) => (value.blocks[0].evidence.boxes[0].width = 0),
+    ],
+    [
+      'box height',
+      (value: any) => (value.blocks[0].evidence.boxes[0].height = 0),
+    ],
+    ['asset width', (value: any) => (value.assets[0].width = 0)],
+    ['asset height', (value: any) => (value.assets[0].height = 0)],
+    ['page width', (value: any) => (value.pages[0].width = 0)],
+    ['page height', (value: any) => (value.pages[0].height = 0)],
+  ])('rejects non-positive materialized geometry (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/positive|range|number/i)
+  })
+
+  it.each([
+    [
+      'missing page layout for block',
+      (value: any) => {
+        value.blocks[0].page = null
+        value.pages = []
+      },
+    ],
+    ['page block membership', (value: any) => (value.pages[0].blocks = [])],
+    [
+      'column membership',
+      (value: any) => (value.pages[0].columns[0].blockIds = []),
+    ],
+    [
+      'evidence page membership',
+      (value: any) => {
+        value.blocks[0].page = null
+        value.blocks[0].evidence.pages = []
+      },
+    ],
+    [
+      'evidence box page agreement',
+      (value: any) => (value.blocks[0].evidence.pages = []),
+    ],
+  ])('rejects incoherent page topology (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(
+      /page|membership|evidence/i,
+    )
+  })
+
+  it.each(['single', null] as const)(
+    'accepts a %s block column mapped to a single page column',
+    (column) => {
+      const value = validDocument()
+      const mutable = value as any
+      mutable.blocks[0].column = column
+      seal(value)
+      expect(() => decodeStructDocument(value)).not.toThrow()
+    },
+  )
+
+  it('accepts one single and one left column on a page', () => {
+    const value = validDocument()
+    value.pages[0].columns.push({
+      id: 'column-2',
+      side: 'left',
+      blockIds: [],
+    })
+    seal(value)
+    expect(() => decodeStructDocument(value)).not.toThrow()
+  })
+
+  it.each([
+    [
+      'single block in left column',
+      (value: any) => (value.pages[0].columns[0].side = 'left'),
+    ],
+    [
+      'left block in single column',
+      (value: any) => (value.blocks[0].column = 'left'),
+    ],
+    [
+      'duplicate single column side',
+      (value: any) =>
+        value.pages[0].columns.push({
+          id: 'column-2',
+          side: 'single',
+          blockIds: [],
+        }),
+    ],
+    [
+      'duplicate left column side',
+      (value: any) =>
+        value.pages[0].columns.push(
+          { id: 'column-2', side: 'left', blockIds: [] },
+          { id: 'column-3', side: 'left', blockIds: [] },
+        ),
+    ],
+  ])('rejects incoherent column semantics (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/column|page/i)
+  })
+
+  it('requires a paged block to list its page in block evidence', () => {
+    const value = validDocument()
+    value.blocks[0].evidence.pages = []
+    value.blocks[0].evidence.boxes = []
+    expect(() => decodeStructDocument(value)).toThrow(/page|evidence/i)
+  })
+
+  it.each([
+    ['row bound', (value: any) => (value.blocks[0].table.cells[0].row = 1)],
+    [
+      'column bound',
+      (value: any) => (value.blocks[0].table.cells[0].column = 1),
+    ],
+    [
+      'row span bound',
+      (value: any) => (value.blocks[0].table.cells[0].rowSpan = 2),
+    ],
+    [
+      'column span bound',
+      (value: any) => (value.blocks[0].table.cells[0].columnSpan = 2),
+    ],
+  ])('rejects table cell outside table bounds (%s)', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(/table|bound|span/i)
+  })
+
+  it.each([
+    [
+      'direct cell intersection',
+      (value: any) => {
+        value.blocks[0].table.cells.push({
+          ...value.blocks[0].table.cells[0],
+          id: 'cell-2',
+        })
+      },
+    ],
+    [
+      'row span intersection',
+      (value: any) => {
+        value.blocks[0].table.rows = 2
+        value.blocks[0].table.cells[0].rowSpan = 2
+        value.blocks[0].table.cells.push({
+          ...value.blocks[0].table.cells[0],
+          id: 'cell-2',
+          row: 1,
+          rowSpan: 1,
+        })
+      },
+    ],
+    [
+      'column span intersection',
+      (value: any) => {
+        value.blocks[0].table.columns = 2
+        value.blocks[0].table.cells[0].columnSpan = 2
+        value.blocks[0].table.cells.push({
+          ...value.blocks[0].table.cells[0],
+          id: 'cell-2',
+          column: 1,
+          columnSpan: 1,
+        })
+      },
+    ],
+  ])('rejects table %s', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    seal(value)
+    expect(() => decodeStructDocument(value)).toThrow(/table|occup|overlap/i)
+  })
+
+  it.each([
+    'content.xhtml',
+    'assets/figure.bin?query',
+    'assets/figure.bin#part',
+    'assets/a b.bin',
+  ])('rejects a non-canonical EPUB asset path %s', (href) => {
+    const value = validDocument()
+    value.assets[0].href = href
+    expect(() => decodeStructDocument(value)).toThrow(/href|path/i)
+  })
+
+  it('rejects incoherent conservation receipts and page bindings', () => {
+    const accounted = validDocument()
+    accounted.receipt.conservation.accountedSourceAssetCount = 2
+    expect(() => decodeStructDocument(accounted)).toThrow(
+      /conservation|source/i,
+    )
+
+    const furniture = validDocument()
+    furniture.blocks[0].kind = 'furniture'
+    expect(() => decodeStructDocument(furniture)).toThrow(
+      /furniture|conservation/i,
+    )
+
+    const pages = validDocument()
+    pages.source.pageCount = 0
+    expect(() => decodeStructDocument(pages)).toThrow(/page/i)
+  })
+
+  it('contains hostile descriptors, revoked proxies, and model receipt cycles as StructCodecError', () => {
+    const accessor = validDocument()
+    Object.defineProperty(accessor.blocks[0], 'hostile', {
+      enumerable: true,
+      get() {
+        throw new Error('getter executed')
+      },
+    })
+    expect(() => decodeStructDocument(accessor)).toThrow(StructCodecError)
+
+    const proxied = validDocument() as any
+    const revoked = Proxy.revocable(proxied.blocks, {})
+    revoked.revoke()
+    proxied.blocks = revoked.proxy
+    expect(() => decodeStructDocument(proxied)).toThrow(StructCodecError)
+
+    const hostileBytes = validDocument() as any
+    const bytes = Proxy.revocable(new Uint8Array([0, 255, 128]), {})
+    bytes.revoke()
+    hostileBytes.assets[0].bytes = bytes.proxy
+    expect(() => decodeStructDocument(hostileBytes)).toThrow(StructCodecError)
+
+    const cycle = validDocument() as any
+    cycle.schemaVersion = '0.2.0'
+    cycle.documentId = 'fixture-document'
+    cycle.receipt.schemaVersion = '0.2.0'
+    cycle.receipt.documentId = 'fixture-document'
+    cycle.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {
+        totalDecisionCount: 0,
+        totalConsultationCount: 0,
+        consultationRate: 0,
+        byDecisionClass: {},
+      },
+    }
+    cycle.receipt.modelConsultations.inputs = cycle.receipt.modelConsultations
+    expect(() => decodeStructDocument(cycle)).toThrow(StructCodecError)
+  })
+
+  it.each(['blocks', 'relationships', 'pages', 'diagnostics'] as const)(
+    'rejects an oversized top-level %s array before materializing its keys',
+    (field) => {
+      const value = validDocument() as any
+      let ownKeyReads = 0
+      value[field] = new Proxy(new Array(100_001), {
+        ownKeys() {
+          ownKeyReads += 1
+          throw new Error('oversized array keys were materialized')
+        },
+      })
+
+      try {
+        decodeStructDocument(value)
+        throw new Error('expected document collection budget failure')
+      } catch (error) {
+        expect(error).toBeInstanceOf(StructCodecError)
+        expect((error as StructCodecError).code).toBe('BUDGET')
+      }
+      expect(ownKeyReads).toBe(0)
+    },
+  )
+
+  it('rejects an oversized model receipt array before materializing its keys', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {
+        totalDecisionCount: 0,
+        totalConsultationCount: 0,
+        consultationRate: 0,
+        byDecisionClass: {},
+      },
+    }
+    seal(value)
+    let ownKeyReads = 0
+    value.receipt.modelConsultations.consultations = new Proxy(
+      new Array(100_001),
+      {
+        ownKeys() {
+          ownKeyReads += 1
+          throw new Error('oversized receipt keys were materialized')
+        },
+      },
+    )
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected model receipt node budget failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('BUDGET')
+    }
+    expect(ownKeyReads).toBe(0)
+  })
+
+  it('rejects a wide model receipt object before reading its descriptors', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {},
+    }
+    seal(value)
+    const keys = Array.from({ length: 100_001 }, (_, index) => `field${index}`)
+    let descriptorReads = 0
+    value.receipt.modelConsultations.metrics = new Proxy(
+      {},
+      {
+        ownKeys() {
+          return keys
+        },
+        getOwnPropertyDescriptor() {
+          descriptorReads += 1
+          return { configurable: true, enumerable: true, value: 0 }
+        },
+      },
+    )
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected model receipt field budget failure')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect((error as StructCodecError).code).toBe('BUDGET')
+    }
+    expect(descriptorReads).toBe(0)
+  })
+
+  it('bounds direct consultation receipt validation before array key reads', () => {
+    let ownKeyReads = 0
+    const consultations = new Proxy(new Array(100_001), {
+      ownKeys() {
+        ownKeyReads += 1
+        throw new Error('oversized receipt keys were materialized')
+      },
+    })
+    const receipt = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations,
+      decisions: [],
+      metrics: {},
+    }
+
+    expect(validateStructConsultationReceipt(receipt)).toBe(false)
+    expect(ownKeyReads).toBe(0)
+  })
+
+  it('binds model consultation receipts to the enclosing document and source', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    value.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: 'other-document',
+      sourceSha256: 'b'.repeat(64),
+      consultations: [],
+      decisions: [],
+      metrics: {
+        totalDecisionCount: 0,
+        totalConsultationCount: 0,
+        consultationRate: 0,
+        byDecisionClass: {},
+      },
+    }
+    expect(() => decodeStructDocument(value)).toThrow(/model|document|source/i)
+  })
+
+  it.each([
+    ['BCP-47 language', (value: any) => (value.metadata.language = 'en_US')],
+    [
+      'RFC-3339 publication date',
+      (value: any) => (value.metadata.publicationDate = '2026-02-30'),
+    ],
+    [
+      'RFC-3339 artifact timestamp',
+      (value: any) =>
+        (value.metadata.artifactModifiedAt = '2026-08-20 00:00:00Z'),
+    ],
+    ['strict MIME type', (value: any) => (value.assets[0].mediaType = 'image')],
+    [
+      'percent-encoded asset traversal',
+      (value: any) => (value.assets[0].href = 'assets/%2e%2e/secret.bin'),
+    ],
+  ])('rejects invalid %s at the codec boundary', (_label, mutate) => {
+    const value = validDocument()
+    mutate(value)
+    expect(() => decodeStructDocument(value)).toThrow(StructCodecError)
+  })
+
+  it('rejects zero-width inline runs that carry semantics', () => {
+    const value = validDocument()
+    value.blocks[0].inline[0] = {
+      ...value.blocks[0].inline[0],
+      start: 0,
+      end: 0,
+      href: '#block-1',
+    }
+    expect(() => decodeStructDocument(value)).toThrow(/zero-width|inline/i)
+  })
+
+  it('rejects negative zero before it can alias a canonical digest value', () => {
+    const value = validDocument()
+    value.blocks[0].evidence.confidence = -0
+    expect(() => decodeStructDocument(value)).toThrow(/negative zero|number/i)
+  })
+
+  it('does not rethrow attacker-forged StructCodecError instances', () => {
+    const value = validDocument() as any
+    value.schemaVersion = '0.2.0'
+    value.documentId = 'fixture-document'
+    value.receipt.schemaVersion = '0.2.0'
+    value.receipt.documentId = 'fixture-document'
+    const forged = Object.create(StructCodecError.prototype)
+    Object.assign(forged, { code: 'FORGED', path: '$', message: 'forged' })
+    const receipt = {
+      schemaVersion: '1.0.0',
+      documentId: 'fixture-document',
+      sourceSha256: hash,
+      consultations: [],
+      decisions: [],
+      metrics: {},
+    }
+    value.receipt.modelConsultations = new Proxy(receipt, {
+      getPrototypeOf() {
+        throw forged
+      },
+    })
+
+    try {
+      decodeStructDocument(value)
+      throw new Error('expected codec rejection')
+    } catch (error) {
+      expect(error).toBeInstanceOf(StructCodecError)
+      expect(error).not.toBe(forged)
+      expect((error as StructCodecError).code).not.toBe('FORGED')
+    }
+  })
+})

--- a/src/struct/codec.ts
+++ b/src/struct/codec.ts
@@ -1,0 +1,8 @@
+/** Public STRUCT codec entrypoint. */
+export {
+  StructCodecError,
+  decodeStructDocument,
+  encodeStructDocument,
+  migrateStructDocument,
+  type StructDocumentJson,
+} from './codec/index'

--- a/src/struct/codec/bytes.ts
+++ b/src/struct/codec/bytes.ts
@@ -1,0 +1,199 @@
+import {
+  array,
+  fail,
+  integer,
+  isStructCodecError,
+  stringValue,
+} from './primitives'
+
+/** Bound decoded binary data before allocating an output buffer. */
+export const MAX_STRUCT_ASSET_BYTES = 128 * 1024 * 1024
+const MAX_STRUCT_ASSET_BASE64_LENGTH = Math.ceil(MAX_STRUCT_ASSET_BYTES / 3) * 4
+
+const uint8ArrayPrototype = Uint8Array.prototype
+const typedArrayPrototype = Object.getPrototypeOf(uint8ArrayPrototype)
+const typedArrayTagGetter = Object.getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  Symbol.toStringTag,
+)?.get
+const typedArrayLengthGetter = Object.getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  'length',
+)?.get
+
+function canonicalUint8ArrayLength(value: unknown): number | undefined {
+  if (!ArrayBuffer.isView(value)) return undefined
+  const bytes = value as Uint8Array
+  if (
+    typedArrayTagGetter === undefined ||
+    Reflect.apply(typedArrayTagGetter, bytes, []) !== 'Uint8Array' ||
+    typedArrayLengthGetter === undefined ||
+    Object.getPrototypeOf(bytes) !== uint8ArrayPrototype ||
+    Object.getOwnPropertyDescriptor(bytes, 'length') !== undefined
+  )
+    return undefined
+  return Reflect.apply(typedArrayLengthGetter, bytes, [])
+}
+
+function copyCanonicalUint8Array(
+  value: unknown,
+  maximumBytes: number,
+): Uint8Array | undefined {
+  const bytes = value as Uint8Array
+  const length = canonicalUint8ArrayLength(bytes)
+  if (length === undefined || length > maximumBytes) return undefined
+  let snapshot: Uint8Array
+  try {
+    snapshot = new Uint8Array(bytes)
+  } catch {
+    return undefined
+  }
+  return snapshot
+}
+
+function arrayByteLength(value: unknown, path: string) {
+  if (!Array.isArray(value)) return undefined
+  const descriptor = Object.getOwnPropertyDescriptor(value, 'length')
+  const length = descriptor?.value
+  if (
+    !descriptor ||
+    !Object.hasOwn(descriptor, 'value') ||
+    !Number.isSafeInteger(length) ||
+    length < 0
+  )
+    fail('BYTES', path, 'byte array length is not a safe integer')
+  return length as number
+}
+
+function encodedByteLength(value: unknown, path: string) {
+  const encoded = stringValue(value, path)
+  if (
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
+      encoded,
+    )
+  )
+    fail('BYTES', path, 'bytes must use canonical base64')
+  return {
+    encoded,
+    length:
+      (encoded.length / 4) * 3 -
+      (encoded.endsWith('==') ? 2 : encoded.endsWith('=') ? 1 : 0),
+  }
+}
+
+/** Inspect a byte carrier's intrinsic size without decoding or copying it. */
+export function preflightBytes(
+  value: unknown,
+  path: string,
+  maximumBytes = MAX_STRUCT_ASSET_BYTES,
+): number {
+  try {
+    if (ArrayBuffer.isView(value)) {
+      const length = canonicalUint8ArrayLength(value)
+      if (length === undefined)
+        fail('BYTES', path, 'bytes must be a canonical Uint8Array')
+      if (length > maximumBytes)
+        fail('BYTES', path, 'bytes exceed the per-asset resource bound')
+      return length
+    }
+    const arrayLength = arrayByteLength(value, path)
+    if (arrayLength !== undefined) {
+      if (arrayLength > maximumBytes)
+        fail('BYTES', path, 'bytes exceed the per-asset resource bound')
+      return arrayLength
+    }
+    if (typeof value !== 'string')
+      fail('TYPE', path, 'expected a string or canonical byte carrier')
+    const maximumEncodedLength = Math.min(
+      MAX_STRUCT_ASSET_BASE64_LENGTH,
+      Math.ceil(maximumBytes / 3) * 4,
+    )
+    if (value.length > maximumEncodedLength)
+      fail('BYTES', path, 'bytes exceed the per-asset resource bound')
+    if (value.length % 4 !== 0)
+      fail('BYTES', path, 'bytes must use canonical base64')
+    const decodedLength =
+      (value.length / 4) * 3 -
+      (value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0)
+    if (decodedLength > maximumBytes)
+      fail('BYTES', path, 'bytes exceed the per-asset resource bound')
+    const { length } = encodedByteLength(value, path)
+    return length
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail('BYTES', path, 'bytes cannot be inspected safely')
+  }
+}
+
+export function parseBytes(
+  value: unknown,
+  path: string,
+  maximumBytes = MAX_STRUCT_ASSET_BYTES,
+): Uint8Array {
+  try {
+    const decodedLength = preflightBytes(value, path, maximumBytes)
+    if (ArrayBuffer.isView(value)) {
+      const bytes = copyCanonicalUint8Array(value, maximumBytes)
+      if (bytes === undefined)
+        fail('BYTES', path, 'bytes must be a canonical Uint8Array')
+      return bytes
+    }
+    if (Array.isArray(value)) {
+      const bytes = array(value, path, maximumBytes).map((entry, index) => {
+        const byte = integer(entry, `${path}[${index}]`, 0)
+        if (byte > 255)
+          fail('BYTES', `${path}[${index}]`, 'byte must be between 0 and 255')
+        return byte
+      })
+      return new Uint8Array(bytes)
+    }
+    const { encoded } = encodedByteLength(value, path)
+    if (encoded.length === 0) return new Uint8Array()
+    const output = new Uint8Array(decodedLength)
+    const alphabet =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    let offset = 0
+    for (let index = 0; index < encoded.length; index += 4) {
+      const first = alphabet.indexOf(encoded[index]!)
+      const second = alphabet.indexOf(encoded[index + 1]!)
+      const third =
+        encoded[index + 2] === '=' ? 0 : alphabet.indexOf(encoded[index + 2]!)
+      const fourth =
+        encoded[index + 3] === '=' ? 0 : alphabet.indexOf(encoded[index + 3]!)
+      if (first < 0 || second < 0 || third < 0 || fourth < 0)
+        fail('BYTES', path, 'bytes must use canonical base64')
+      if (
+        (encoded[index + 2] === '=' && (second & 0x0f) !== 0) ||
+        (encoded[index + 3] === '=' &&
+          encoded[index + 2] !== '=' &&
+          (third & 0x03) !== 0)
+      )
+        fail('BYTES', path, 'bytes must use canonical base64')
+      const word = (first << 18) | (second << 12) | (third << 6) | fourth
+      if (offset < output.length) output[offset++] = (word >> 16) & 0xff
+      if (offset < output.length) output[offset++] = (word >> 8) & 0xff
+      if (offset < output.length) output[offset++] = word & 0xff
+    }
+    return output
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail('BYTES', path, 'bytes cannot be inspected safely')
+  }
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  const alphabet =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let encoded = ''
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index]!
+    const second = index + 1 < bytes.length ? bytes[index + 1]! : 0
+    const third = index + 2 < bytes.length ? bytes[index + 2]! : 0
+    const word = (first << 16) | (second << 8) | third
+    encoded += alphabet[(word >> 18) & 0x3f]
+    encoded += alphabet[(word >> 12) & 0x3f]
+    encoded += index + 1 < bytes.length ? alphabet[(word >> 6) & 0x3f] : '='
+    encoded += index + 2 < bytes.length ? alphabet[word & 0x3f] : '='
+  }
+  return encoded
+}

--- a/src/struct/codec/bytes.ts
+++ b/src/struct/codec/bytes.ts
@@ -1,10 +1,4 @@
-import {
-  array,
-  fail,
-  integer,
-  isStructCodecError,
-  stringValue,
-} from './primitives'
+import { array, fail, integer, isStructCodecError } from './primitives'
 
 /** Bound decoded binary data before allocating an output buffer. */
 export const MAX_STRUCT_ASSET_BYTES = 128 * 1024 * 1024
@@ -66,7 +60,8 @@ function arrayByteLength(value: unknown, path: string) {
 }
 
 function encodedByteLength(value: unknown, path: string) {
-  const encoded = stringValue(value, path)
+  if (typeof value !== 'string') fail('TYPE', path, 'expected a base64 string')
+  const encoded = value
   if (
     !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
       encoded,

--- a/src/struct/codec/index.ts
+++ b/src/struct/codec/index.ts
@@ -1,0 +1,7 @@
+export {
+  StructCodecError,
+  decodeStructDocument,
+  encodeStructDocument,
+  migrateStructDocument,
+  type StructDocumentJson,
+} from './structure'

--- a/src/struct/codec/invariants.ts
+++ b/src/struct/codec/invariants.ts
@@ -1,0 +1,665 @@
+import {
+  LEGACY_STRUCT_SCHEMA_VERSION,
+  type StructDocument,
+  type StructInline,
+  type StructReceipt,
+} from '../types'
+import { legacyStructDigestMatches, structDigest } from '../ids'
+import { SAFE_ID } from '../ids'
+import {
+  emittedXhtmlIds,
+  isPackagedAssetId,
+  RenderedPublicationPlanError,
+} from '../emitted-ids'
+import { fail, type DataObject, unique } from './primitives'
+
+const CONSULTATION_RECEIPT_BINDING =
+  'consultation receipt must match the enclosing document and source'
+
+function digestInput(document: StructDocument) {
+  const { receipt: _receipt, ...withoutReceipt } = document
+  return {
+    ...withoutReceipt,
+    conservation: document.receipt.conservation,
+    ...(document.receipt.modelConsultations
+      ? { modelConsultations: document.receipt.modelConsultations }
+      : {}),
+    assets: document.assets.map(({ bytes: _bytes, ...asset }) => asset),
+  }
+}
+
+function validateDigest(document: StructDocument) {
+  const input = digestInput(document)
+  const matches =
+    document.schemaVersion === LEGACY_STRUCT_SCHEMA_VERSION
+      ? legacyStructDigestMatches(input, document.receipt.generatedSha256)
+      : structDigest(input) === document.receipt.generatedSha256
+  if (!matches)
+    fail(
+      'DIGEST',
+      '$.receipt.generatedSha256',
+      `generatedSha256 does not match the canonical ${document.schemaVersion} digest`,
+    )
+}
+
+function addCategoryIds(
+  seen: Map<string, string>,
+  ids: readonly string[],
+  category: string,
+) {
+  for (const id of ids) {
+    const previous = seen.get(id)
+    if (previous)
+      fail(
+        'DUPLICATE_IDENTIFIER',
+        `$.${category}`,
+        `identifier ${id} is also used by ${previous}`,
+      )
+    seen.set(id, category)
+  }
+}
+
+function assertLocalTarget(
+  value: string,
+  path: string,
+  nodeIds: ReadonlySet<string>,
+) {
+  const id = value.startsWith('#') ? value.slice(1) : value
+  if (SAFE_ID.test(id) && !nodeIds.has(id))
+    fail('REFERENCE', path, `dangling local reference ${value}`)
+}
+
+function assertInlineTargets(
+  inline: StructInline,
+  path: string,
+  nodeIds: ReadonlySet<string>,
+  relationshipIds: ReadonlySet<string>,
+) {
+  if (inline.href?.startsWith('#'))
+    assertLocalTarget(inline.href, `${path}.href`, nodeIds)
+  for (const [index, target] of (inline.targetIds ?? []).entries()) {
+    if (!nodeIds.has(target))
+      fail(
+        'REFERENCE',
+        `${path}.targetIds[${index}]`,
+        `dangling target ${target}`,
+      )
+  }
+  if (inline.relationshipId && !relationshipIds.has(inline.relationshipId))
+    fail(
+      'REFERENCE',
+      `${path}.relationshipId`,
+      `dangling relationship ${inline.relationshipId}`,
+    )
+}
+
+function validateEvidencePages(
+  evidence: { pages: number[]; boxes: Array<{ page: number }> },
+  path: string,
+  pageNumbers: ReadonlySet<number>,
+) {
+  for (const [index, page] of evidence.pages.entries()) {
+    if (!pageNumbers.has(page))
+      fail(
+        'PAGE_BINDING',
+        `${path}.pages[${index}]`,
+        'page must have a corresponding document.pages layout',
+      )
+  }
+  for (const [index, box] of evidence.boxes.entries()) {
+    if (!pageNumbers.has(box.page))
+      fail(
+        'PAGE_BINDING',
+        `${path}.boxes[${index}].page`,
+        'box page must have a corresponding document.pages layout',
+      )
+    if (!evidence.pages.includes(box.page))
+      fail(
+        'PAGE_BINDING',
+        `${path}.boxes[${index}].page`,
+        'box page must be listed in evidence.pages',
+      )
+  }
+}
+
+function validateConservation(document: StructDocument) {
+  const receipt = document.receipt
+  const conservation = receipt.conservation
+  const textCharacterCount = document.blocks.reduce(
+    (count, block) => count + block.text.length,
+    0,
+  )
+  if (
+    receipt.blockCount !== document.blocks.length ||
+    receipt.assetCount !== document.assets.length ||
+    receipt.relationshipCount !== document.relationships.length ||
+    receipt.diagnosticCount !== document.diagnostics.length
+  )
+    fail('COUNT', '$.receipt', 'receipt counts must match document arrays')
+  if (receipt.textCharacterCount !== textCharacterCount)
+    fail(
+      'COUNT',
+      '$.receipt.textCharacterCount',
+      'receipt text count must match block text',
+    )
+  if (receipt.textCharacterCount !== conservation.sourceTextCharacterCount)
+    fail(
+      'COUNT',
+      '$.receipt.conservation.sourceTextCharacterCount',
+      'receipt text count must match source text count',
+    )
+
+  const structCounts: Array<[keyof StructReceipt['conservation'], number]> = [
+    ['structBlockCount', document.blocks.length],
+    ['structAssetCount', document.assets.length],
+    ['structRelationshipCount', document.relationships.length],
+    ['structDiagnosticCount', document.diagnostics.length],
+    ['structTextCharacterCount', textCharacterCount],
+  ]
+  for (const [key, expected] of structCounts) {
+    if (conservation[key] !== expected)
+      fail(
+        'COUNT',
+        `$.receipt.conservation.${key}`,
+        `${key} must match document output`,
+      )
+  }
+
+  const bounded: Array<
+    [keyof StructReceipt['conservation'], keyof StructReceipt['conservation']]
+  > = [
+    ['accountedSourceNodeCount', 'sourceNodeCount'],
+    ['accountedSourceRegionCount', 'sourceRegionCount'],
+    ['accountedSourceAnnotationCount', 'sourceAnnotationCount'],
+    ['accountedSourceAssetCount', 'sourceAssetCount'],
+    ['accountedSourceRelationshipCount', 'sourceRelationshipCount'],
+    ['accountedSourceDiagnosticCount', 'sourceDiagnosticCount'],
+  ]
+  for (const [accountedKey, sourceKey] of bounded) {
+    const accounted = conservation[accountedKey]!
+    const source = conservation[sourceKey]!
+    if (accounted > source)
+      fail(
+        'CONSERVATION',
+        `$.receipt.conservation.${accountedKey}`,
+        `${accountedKey} cannot exceed ${sourceKey}`,
+      )
+  }
+  const accountedOutput: Array<[keyof StructReceipt['conservation'], number]> =
+    [
+      ['accountedSourceAssetCount', document.assets.length],
+      ['accountedSourceRelationshipCount', document.relationships.length],
+      ['accountedSourceDiagnosticCount', document.diagnostics.length],
+    ]
+  for (const [key, expected] of accountedOutput) {
+    if (conservation[key] !== expected)
+      fail(
+        'CONSERVATION',
+        `$.receipt.conservation.${key}`,
+        `${key} must match accounted output`,
+      )
+  }
+  if (
+    conservation.structTextCharacterCount >
+    conservation.sourceTextCharacterCount
+  )
+    fail(
+      'CONSERVATION',
+      '$.receipt.conservation.structTextCharacterCount',
+      'STRUCT text cannot exceed source text',
+    )
+
+  const furniture = document.blocks.filter(
+    (block) => block.kind === 'furniture',
+  )
+  const furnitureKeys = [
+    'sourceFurnitureBlockCount',
+    'accountedFurnitureBlockCount',
+    'sourceFurnitureTextCharacterCount',
+    'structFurnitureBlockCount',
+    'structFurnitureTextCharacterCount',
+  ] as const
+  const furniturePresent = furnitureKeys.some(
+    (key) => conservation[key] !== undefined,
+  )
+  if (
+    furniturePresent &&
+    furnitureKeys.some((key) => conservation[key] === undefined)
+  )
+    fail(
+      'CONSERVATION',
+      '$.receipt.conservation',
+      'furniture counts must be provided together',
+    )
+  if (furniturePresent) {
+    const sourceBlocks = conservation.sourceFurnitureBlockCount!
+    const accountedBlocks = conservation.accountedFurnitureBlockCount!
+    const sourceText = conservation.sourceFurnitureTextCharacterCount!
+    const structBlocks = conservation.structFurnitureBlockCount!
+    const structText = conservation.structFurnitureTextCharacterCount!
+    if (accountedBlocks > sourceBlocks)
+      fail(
+        'CONSERVATION',
+        '$.receipt.conservation.accountedFurnitureBlockCount',
+        'accounted furniture cannot exceed source furniture',
+      )
+    if (
+      structBlocks !== furniture.length ||
+      accountedBlocks !== furniture.length
+    )
+      fail(
+        'CONSERVATION',
+        '$.receipt.conservation.structFurnitureBlockCount',
+        'furniture block counts must match furniture output',
+      )
+    const expectedText = furniture.reduce(
+      (count, block) => count + block.text.length,
+      0,
+    )
+    if (structText !== expectedText)
+      fail(
+        'CONSERVATION',
+        '$.receipt.conservation.structFurnitureTextCharacterCount',
+        'furniture text count must match furniture output',
+      )
+    if (structText > sourceText)
+      fail(
+        'CONSERVATION',
+        '$.receipt.conservation.structFurnitureTextCharacterCount',
+        'STRUCT furniture text cannot exceed source furniture text',
+      )
+  } else if (furniture.length > 0) {
+    fail(
+      'CONSERVATION',
+      '$.receipt.conservation',
+      'furniture output requires furniture conservation counts',
+    )
+  }
+  if (
+    conservation.furnitureContaminationCount !== undefined &&
+    conservation.furnitureContaminationCount >
+      conservation.sourceTextCharacterCount
+  )
+    fail(
+      'CONSERVATION',
+      '$.receipt.conservation.furnitureContaminationCount',
+      'furniture contamination cannot exceed source text',
+    )
+}
+
+function validateReferences(document: StructDocument) {
+  const ids = new Map<string, string>()
+  const authors = new Set(document.metadata.authors)
+  addCategoryIds(
+    ids,
+    document.blocks.map(({ id }) => id),
+    'blocks',
+  )
+  addCategoryIds(
+    ids,
+    document.assets.map(({ id }) => id),
+    'assets',
+  )
+  addCategoryIds(
+    ids,
+    document.relationships.map(({ id }) => id),
+    'relationships',
+  )
+  addCategoryIds(
+    ids,
+    document.diagnostics.map(({ id }) => id),
+    'diagnostics',
+  )
+  for (const [index, note] of (document.metadata.authorNotes ?? []).entries()) {
+    if (!authors.has(note.author))
+      fail(
+        'REFERENCE',
+        `$.metadata.authorNotes[${index}].author`,
+        `author note author ${note.author} must be listed in metadata.authors`,
+      )
+    const previous = ids.get(note.id)
+    if (!previous) {
+      ids.set(note.id, 'metadata.authorNotes')
+      continue
+    }
+    const relationship = document.relationships.find(
+      (entry) => entry.id === note.id,
+    )
+    if (
+      previous !== 'relationships' ||
+      relationship?.status !== 'matched' ||
+      (relationship.kind !== 'footnote' && relationship.kind !== 'endnote') ||
+      !relationship.to.includes(note.target)
+    )
+      fail(
+        'DUPLICATE_IDENTIFIER',
+        `$.metadata.authorNotes[${index}].id`,
+        `identifier ${note.id} is also used by ${previous}`,
+      )
+  }
+  addCategoryIds(
+    ids,
+    document.blocks.flatMap((block) => block.sourceObservationAnchorIds ?? []),
+    'blocks.sourceObservationAnchorIds',
+  )
+  const emittedIds = new Map<string, string>()
+  let emittedEntries
+  try {
+    emittedEntries = emittedXhtmlIds(document)
+  } catch (error) {
+    if (error instanceof RenderedPublicationPlanError)
+      fail(error.code, error.path, error.message)
+    throw error
+  }
+  for (const { id, path } of emittedEntries) {
+    const previous = emittedIds.get(id)
+    if (previous)
+      fail(
+        'DUPLICATE_IDENTIFIER',
+        path,
+        `emitted XHTML identifier ${id} is also used by ${previous}`,
+      )
+    emittedIds.set(id, path)
+  }
+  if (document.documentId && ids.has(document.documentId))
+    fail(
+      'DUPLICATE_IDENTIFIER',
+      '$.documentId',
+      `document identifier ${document.documentId} is also used by ${ids.get(document.documentId)}`,
+    )
+
+  const nodeIds = new Set(
+    [...document.blocks, ...document.assets].map(({ id }) => id),
+  )
+  const relationshipIds = new Set(document.relationships.map(({ id }) => id))
+  unique(
+    document.assets.map(({ href }) => href),
+    '$.assets',
+    'asset href',
+  )
+  for (const [index, asset] of document.assets.entries())
+    if (!isPackagedAssetId(asset.id))
+      fail(
+        'IDENTIFIER',
+        `$.assets[${index}].id`,
+        `asset id is not a valid EPUB manifest id: ${asset.id}`,
+      )
+
+  for (const [index, relationship] of document.relationships.entries()) {
+    if (!nodeIds.has(relationship.from))
+      fail(
+        'REFERENCE',
+        `$.relationships[${index}].from`,
+        `dangling local reference ${relationship.from}`,
+      )
+    for (const [targetIndex, target] of relationship.to.entries())
+      assertLocalTarget(
+        target,
+        `$.relationships[${index}].to[${targetIndex}]`,
+        nodeIds,
+      )
+    for (const [candidateIndex, candidate] of (
+      relationship.candidates ?? []
+    ).entries())
+      assertLocalTarget(
+        candidate.target,
+        `$.relationships[${index}].candidates[${candidateIndex}].target`,
+        nodeIds,
+      )
+  }
+  for (const [blockIndex, block] of document.blocks.entries()) {
+    for (const [fallbackIndex, assetId] of (
+      block.fallbackAssetIds ?? []
+    ).entries()) {
+      if (!document.assets.some(({ id }) => id === assetId))
+        fail(
+          'REFERENCE',
+          `$.blocks[${blockIndex}].fallbackAssetIds[${fallbackIndex}]`,
+          `dangling asset ${assetId}`,
+        )
+    }
+    for (const [inlineIndex, inline] of block.inline.entries())
+      assertInlineTargets(
+        inline,
+        `$.blocks[${blockIndex}].inline[${inlineIndex}]`,
+        nodeIds,
+        relationshipIds,
+      )
+    if (block.table) {
+      for (const [cellIndex, cell] of block.table.cells.entries()) {
+        for (const [inlineIndex, inline] of cell.inline.entries())
+          assertInlineTargets(
+            inline,
+            `$.blocks[${blockIndex}].table.cells[${cellIndex}].inline[${inlineIndex}]`,
+            nodeIds,
+            relationshipIds,
+          )
+      }
+    }
+  }
+  for (const [pageIndex, page] of document.pages.entries()) {
+    for (const [blockIndex, blockId] of page.blocks.entries()) {
+      if (!document.blocks.some(({ id }) => id === blockId))
+        fail(
+          'REFERENCE',
+          `$.pages[${pageIndex}].blocks[${blockIndex}]`,
+          `dangling block ${blockId}`,
+        )
+    }
+    for (const [columnIndex, column] of page.columns.entries()) {
+      for (const [blockIndex, blockId] of column.blockIds.entries()) {
+        if (!document.blocks.some(({ id }) => id === blockId))
+          fail(
+            'REFERENCE',
+            `$.pages[${pageIndex}].columns[${columnIndex}].blockIds[${blockIndex}]`,
+            `dangling block ${blockId}`,
+          )
+      }
+    }
+  }
+  for (const [index, note] of (document.metadata.authorNotes ?? []).entries()) {
+    if (!nodeIds.has(note.target))
+      fail(
+        'REFERENCE',
+        `$.metadata.authorNotes[${index}].target`,
+        `dangling target ${note.target}`,
+      )
+  }
+}
+
+function validatePages(document: StructDocument) {
+  if (document.pages.length > document.source.pageCount)
+    fail(
+      'PAGE_BINDING',
+      '$.pages',
+      'page layouts cannot exceed source.pageCount',
+    )
+  const pageNumbers = new Set(document.pages.map((page) => page.page))
+  const checkPage = (page: number, path: string) => {
+    if (!pageNumbers.has(page))
+      fail('PAGE_BINDING', path, 'page exceeds source.pageCount')
+  }
+  const blocksById = new Map(document.blocks.map((block) => [block.id, block]))
+  for (const [index, page] of document.pages.entries()) {
+    if (page.page > document.source.pageCount)
+      fail(
+        'PAGE_BINDING',
+        `$.pages[${index}].page`,
+        'page exceeds source.pageCount',
+      )
+    checkPage(page.page, `$.pages[${index}].page`)
+    const seenColumnSides = new Set<string>()
+    for (const [columnIndex, column] of page.columns.entries()) {
+      if (seenColumnSides.has(column.side))
+        fail(
+          'PAGE_BINDING',
+          `$.pages[${index}].columns[${columnIndex}].side`,
+          `duplicate ${column.side} column sides are not permitted`,
+        )
+      seenColumnSides.add(column.side)
+      for (const [blockIndex, blockId] of column.blockIds.entries()) {
+        const block = blocksById.get(blockId)
+        const expectedSide = block?.column ?? 'single'
+        if (expectedSide !== column.side)
+          fail(
+            'PAGE_BINDING',
+            `$.pages[${index}].columns[${columnIndex}].blockIds[${blockIndex}]`,
+            'column side must match the member block column',
+          )
+      }
+    }
+    const columnBlockIds = page.columns.flatMap((column) => column.blockIds)
+    if (new Set(columnBlockIds).size !== columnBlockIds.length)
+      fail(
+        'PAGE_BINDING',
+        `$.pages[${index}].columns`,
+        'a block cannot belong to multiple columns on the same page',
+      )
+    if (
+      columnBlockIds.length !== page.blocks.length ||
+      !page.blocks.every((blockId) => columnBlockIds.includes(blockId))
+    )
+      fail(
+        'PAGE_BINDING',
+        `$.pages[${index}]`,
+        'page.blocks and page.columns block membership must agree',
+      )
+    for (const [blockIndex, blockId] of page.blocks.entries()) {
+      const block = blocksById.get(blockId)
+      if (block?.page !== page.page)
+        fail(
+          'PAGE_BINDING',
+          `$.pages[${index}].blocks[${blockIndex}]`,
+          'page block must carry the same page number as its layout',
+        )
+    }
+  }
+  for (const [index, block] of document.blocks.entries()) {
+    if (block.page !== null) {
+      checkPage(block.page, `$.blocks[${index}].page`)
+      if (!block.evidence.pages.includes(block.page))
+        fail(
+          'PAGE_BINDING',
+          `$.blocks[${index}].page`,
+          'block page must be listed in block.evidence.pages',
+        )
+      const page = document.pages.find((entry) => entry.page === block.page)
+      if (!page?.blocks.includes(block.id))
+        fail(
+          'PAGE_BINDING',
+          `$.blocks[${index}].page`,
+          'block page must list the block in page.blocks',
+        )
+    }
+    validateEvidencePages(
+      block.evidence,
+      `$.blocks[${index}].evidence`,
+      pageNumbers,
+    )
+    if (block.table)
+      for (const [cellIndex, cell] of block.table.cells.entries())
+        validateEvidencePages(
+          cell.evidence,
+          `$.blocks[${index}].table.cells[${cellIndex}].evidence`,
+          pageNumbers,
+        )
+    if (block.furniture)
+      validateEvidencePages(
+        block.furniture,
+        `$.blocks[${index}].furniture`,
+        pageNumbers,
+      )
+    if (block.furnitureReview)
+      validateEvidencePages(
+        block.furnitureReview,
+        `$.blocks[${index}].furnitureReview`,
+        pageNumbers,
+      )
+  }
+  for (const [index, asset] of document.assets.entries())
+    validateEvidencePages(
+      asset.evidence,
+      `$.assets[${index}].evidence`,
+      pageNumbers,
+    )
+  for (const [index, relationship] of document.relationships.entries()) {
+    validateEvidencePages(
+      relationship.evidence,
+      `$.relationships[${index}].evidence`,
+      pageNumbers,
+    )
+    for (const [candidateIndex, candidate] of (
+      relationship.candidates ?? []
+    ).entries())
+      validateEvidencePages(
+        candidate.evidence,
+        `$.relationships[${index}].candidates[${candidateIndex}].evidence`,
+        pageNumbers,
+      )
+  }
+  for (const [index, diagnostic] of document.diagnostics.entries())
+    for (const [pageIndex, page] of diagnostic.pages.entries())
+      checkPage(page, `$.diagnostics[${index}].pages[${pageIndex}]`)
+  for (const [index, issue] of document.recovery.issues.entries())
+    for (const [pageIndex, page] of issue.pages.entries())
+      checkPage(page, `$.recovery.issues[${index}].pages[${pageIndex}]`)
+}
+
+function validateConsultationBinding(document: StructDocument) {
+  const receipt = document.receipt.modelConsultations
+  if (!receipt) return
+  if (
+    receipt.documentId !== document.documentId ||
+    receipt.sourceSha256 !== document.source.sha256
+  )
+    fail(
+      'BINDING',
+      '$.receipt.modelConsultations',
+      CONSULTATION_RECEIPT_BINDING,
+    )
+}
+
+export function validateStructDocument(
+  document: StructDocument,
+  _input: DataObject,
+) {
+  const receipt = document.receipt
+  if (receipt.schemaVersion !== document.schemaVersion)
+    fail(
+      'SCHEMA_VERSION',
+      '$.receipt.schemaVersion',
+      'receipt and document versions must match',
+    )
+  if (receipt.sourceSha256 !== document.source.sha256)
+    fail(
+      'BINDING',
+      '$.receipt.sourceSha256',
+      'receipt source hash must match source',
+    )
+  if (document.schemaVersion === LEGACY_STRUCT_SCHEMA_VERSION) {
+    if (
+      document.documentId !== undefined ||
+      receipt.documentId !== undefined ||
+      receipt.modelConsultations !== undefined
+    )
+      fail(
+        'MIGRATION',
+        '$',
+        '0.1.0 documents cannot contain document bindings or model consultations',
+      )
+  } else if (
+    document.documentId === undefined ||
+    receipt.documentId !== document.documentId
+  ) {
+    fail(
+      'BINDING',
+      '$.documentId',
+      'current documents require matching document bindings',
+    )
+  }
+  validateConservation(document)
+  validateReferences(document)
+  validatePages(document)
+  validateConsultationBinding(document)
+  validateDigest(document)
+}

--- a/src/struct/codec/invariants.ts
+++ b/src/struct/codec/invariants.ts
@@ -474,12 +474,16 @@ function validatePages(document: StructDocument) {
       '$.pages',
       'page layouts cannot exceed source.pageCount',
     )
-  const pageNumbers = new Set(document.pages.map((page) => page.page))
+  const pagesByNumber = new Map(document.pages.map((page) => [page.page, page]))
+  const pageNumbers = new Set(pagesByNumber.keys())
   const checkPage = (page: number, path: string) => {
-    if (!pageNumbers.has(page))
+    if (!pagesByNumber.has(page))
       fail('PAGE_BINDING', path, 'page exceeds source.pageCount')
   }
   const blocksById = new Map(document.blocks.map((block) => [block.id, block]))
+  const pageBlockIds = new Map(
+    document.pages.map((page) => [page.page, new Set(page.blocks)]),
+  )
   for (const [index, page] of document.pages.entries()) {
     if (page.page > document.source.pageCount)
       fail(
@@ -509,6 +513,7 @@ function validatePages(document: StructDocument) {
       }
     }
     const columnBlockIds = page.columns.flatMap((column) => column.blockIds)
+    const columnBlockIdSet = new Set(columnBlockIds)
     if (new Set(columnBlockIds).size !== columnBlockIds.length)
       fail(
         'PAGE_BINDING',
@@ -517,7 +522,7 @@ function validatePages(document: StructDocument) {
       )
     if (
       columnBlockIds.length !== page.blocks.length ||
-      !page.blocks.every((blockId) => columnBlockIds.includes(blockId))
+      !page.blocks.every((blockId) => columnBlockIdSet.has(blockId))
     )
       fail(
         'PAGE_BINDING',
@@ -543,8 +548,7 @@ function validatePages(document: StructDocument) {
           `$.blocks[${index}].page`,
           'block page must be listed in block.evidence.pages',
         )
-      const page = document.pages.find((entry) => entry.page === block.page)
-      if (!page?.blocks.includes(block.id))
+      if (!pageBlockIds.get(block.page)?.has(block.id))
         fail(
           'PAGE_BINDING',
           `$.blocks[${index}].page`,

--- a/src/struct/codec/model.ts
+++ b/src/struct/codec/model.ts
@@ -1,13 +1,16 @@
 import {
-  array,
   copyRecord,
-  dataEntries,
   fail,
   finiteNumber,
   isStructCodecError,
   stringValue,
+  utf8ByteLength,
 } from './primitives'
-import { preflightStructConsultationReceipt } from '../consultation-receipt'
+import {
+  MAX_STRUCT_RECEIPT_JSON_STRING_BYTES,
+  MAX_STRUCT_RECEIPT_JSON_TOTAL_BYTES,
+  preflightStructConsultationReceipt,
+} from '../consultation-receipt'
 
 const MAX_CANONICAL_DEPTH = 128
 const MAX_CANONICAL_NODES = 100_000
@@ -15,6 +18,22 @@ const MAX_CANONICAL_NODES = 100_000
 type CopyState = {
   active: WeakSet<object>
   nodes: number
+  stringBytes: number
+}
+
+function chargeReceiptText(value: string, path: string, state: CopyState) {
+  const parsed = stringValue(value, path)
+  const bytes = utf8ByteLength(parsed)
+  if (bytes > MAX_STRUCT_RECEIPT_JSON_STRING_BYTES)
+    fail(
+      'BUDGET',
+      path,
+      'consultation receipt string exceeds the resource bound',
+    )
+  state.stringBytes += bytes
+  if (state.stringBytes > MAX_STRUCT_RECEIPT_JSON_TOTAL_BYTES)
+    fail('BUDGET', path, 'consultation receipt exceeds the resource bound')
+  return parsed
 }
 
 /**
@@ -25,7 +44,11 @@ type CopyState = {
 export function copyCanonicalJson(
   value: unknown,
   path: string,
-  state: CopyState = { active: new WeakSet<object>(), nodes: 0 },
+  state: CopyState = {
+    active: new WeakSet<object>(),
+    nodes: 0,
+    stringBytes: 0,
+  },
   depth = 0,
 ): unknown {
   if (depth > MAX_CANONICAL_DEPTH)
@@ -34,7 +57,7 @@ export function copyCanonicalJson(
   if (state.nodes > MAX_CANONICAL_NODES)
     fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
   if (value === null || typeof value === 'boolean') return value
-  if (typeof value === 'string') return stringValue(value, path)
+  if (typeof value === 'string') return chargeReceiptText(value, path, state)
   if (typeof value === 'number') return finiteNumber(value, path)
   if (typeof value !== 'object')
     fail(
@@ -77,21 +100,74 @@ export function copyCanonicalJson(
           path,
           'model receipt arrays must use the canonical Array.prototype',
         )
-      return array(value, path, MAX_CANONICAL_NODES - state.nodes).map(
-        (entry, index) =>
-          copyCanonicalJson(entry, `${path}[${index}]`, state, depth + 1),
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length')
+      const length = lengthDescriptor?.value
+      if (
+        !lengthDescriptor ||
+        !Object.hasOwn(lengthDescriptor, 'value') ||
+        !Number.isSafeInteger(length) ||
+        length < 0
       )
+        fail('MODEL_RECEIPT', path, 'model receipt array length is invalid')
+      if (length > MAX_CANONICAL_NODES - state.nodes)
+        fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
+      const keys = Reflect.ownKeys(value)
+      if (
+        keys.length !== length + 1 ||
+        !keys.includes('length') ||
+        keys.some(
+          (key) =>
+            typeof key !== 'string' ||
+            (key !== 'length' && !/^\d+$/u.test(key)),
+        )
+      )
+        fail(
+          'MODEL_RECEIPT',
+          path,
+          'model receipt array contains invalid fields',
+        )
+      const copied: unknown[] = []
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index))
+        if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value'))
+          fail('MODEL_RECEIPT', `${path}[${index}]`, 'array item is not data')
+        copied.push(
+          copyCanonicalJson(
+            descriptor.value,
+            `${path}[${index}]`,
+            state,
+            depth + 1,
+          ),
+        )
+      }
+      return copied
     }
-    const entries = dataEntries(
-      value,
-      path,
-      MAX_CANONICAL_NODES - state.nodes,
-    ).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-    return copyRecord(
-      entries.map(([key, entry]) => [
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null)
+      fail('MODEL_RECEIPT', path, 'model receipt object must be plain')
+    const keys = Reflect.ownKeys(value)
+    if (keys.length > MAX_CANONICAL_NODES - state.nodes)
+      fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
+    if (keys.some((key) => typeof key !== 'string'))
+      fail('MODEL_RECEIPT', path, 'model receipt object contains symbol fields')
+    const entries: Array<[string, unknown]> = []
+    for (const key of (keys as string[]).sort()) {
+      chargeReceiptText(key, `${path}.${key}`, state)
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value'))
+        fail('MODEL_RECEIPT', `${path}.${key}`, 'object field is not data')
+      entries.push([
         key,
-        copyCanonicalJson(entry, `${path}.${key}`, state, depth + 1),
-      ]),
+        copyCanonicalJson(descriptor.value, `${path}.${key}`, state, depth + 1),
+      ])
+    }
+    return copyRecord(entries)
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail(
+      'MODEL_RECEIPT',
+      path,
+      'model receipt object cannot be inspected safely',
     )
   } finally {
     state.active.delete(value)

--- a/src/struct/codec/model.ts
+++ b/src/struct/codec/model.ts
@@ -5,6 +5,7 @@ import {
   fail,
   finiteNumber,
   isStructCodecError,
+  stringValue,
 } from './primitives'
 import { validateStructConsultationReceipt } from '../consultation-receipt'
 
@@ -17,7 +18,7 @@ type CopyState = {
 }
 
 /**
- * Snapshot the open JSON portions of a consultation receipt before validation. This
+ * Snapshot a receipt only after its original object graph passes validation. This
  * rejects accessors/proxies, detects cycles, and bounds recursive input while
  * preserving the adapter-owned receipt contents as intentionally closed JSON.
  */
@@ -32,8 +33,8 @@ export function copyCanonicalJson(
   state.nodes += 1
   if (state.nodes > MAX_CANONICAL_NODES)
     fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
-  if (value === null || typeof value === 'string' || typeof value === 'boolean')
-    return value
+  if (value === null || typeof value === 'boolean') return value
+  if (typeof value === 'string') return stringValue(value, path)
   if (typeof value === 'number') return finiteNumber(value, path)
   if (typeof value !== 'object')
     fail(

--- a/src/struct/codec/model.ts
+++ b/src/struct/codec/model.ts
@@ -7,7 +7,7 @@ import {
   isStructCodecError,
   stringValue,
 } from './primitives'
-import { validateStructConsultationReceipt } from '../consultation-receipt'
+import { preflightStructConsultationReceipt } from '../consultation-receipt'
 
 const MAX_CANONICAL_DEPTH = 128
 const MAX_CANONICAL_NODES = 100_000
@@ -100,7 +100,7 @@ export function copyCanonicalJson(
 
 export function validateConsultationReceipt(value: unknown, path: string) {
   try {
-    if (!validateStructConsultationReceipt(value))
+    if (!preflightStructConsultationReceipt(value, path))
       fail('MODEL_RECEIPT', path, 'invalid closed consultation receipt')
   } catch (error) {
     if (isStructCodecError(error)) throw error

--- a/src/struct/codec/model.ts
+++ b/src/struct/codec/model.ts
@@ -1,0 +1,108 @@
+import {
+  array,
+  copyRecord,
+  dataEntries,
+  fail,
+  finiteNumber,
+  isStructCodecError,
+} from './primitives'
+import { validateStructConsultationReceipt } from '../consultation-receipt'
+
+const MAX_CANONICAL_DEPTH = 128
+const MAX_CANONICAL_NODES = 100_000
+
+type CopyState = {
+  active: WeakSet<object>
+  nodes: number
+}
+
+/**
+ * Snapshot the open JSON portions of a consultation receipt before validation. This
+ * rejects accessors/proxies, detects cycles, and bounds recursive input while
+ * preserving the adapter-owned receipt contents as intentionally closed JSON.
+ */
+export function copyCanonicalJson(
+  value: unknown,
+  path: string,
+  state: CopyState = { active: new WeakSet<object>(), nodes: 0 },
+  depth = 0,
+): unknown {
+  if (depth > MAX_CANONICAL_DEPTH)
+    fail('MODEL_RECEIPT', path, 'canonical JSON nesting is too deep')
+  state.nodes += 1
+  if (state.nodes > MAX_CANONICAL_NODES)
+    fail('MODEL_RECEIPT', path, 'canonical JSON exceeds the node bound')
+  if (value === null || typeof value === 'string' || typeof value === 'boolean')
+    return value
+  if (typeof value === 'number') return finiteNumber(value, path)
+  if (typeof value !== 'object')
+    fail(
+      'TYPE',
+      path,
+      'consultation receipt must contain canonical JSON values',
+    )
+  if (state.active.has(value))
+    fail(
+      'MODEL_RECEIPT',
+      path,
+      'cycles are not permitted in consultation receipts',
+    )
+  state.active.add(value)
+  try {
+    let isArray = false
+    try {
+      isArray = Array.isArray(value)
+    } catch {
+      fail(
+        'MODEL_RECEIPT',
+        path,
+        'model receipt object cannot be inspected safely',
+      )
+    }
+    if (isArray) {
+      let prototype: object | null
+      try {
+        prototype = Object.getPrototypeOf(value)
+      } catch {
+        fail(
+          'MODEL_RECEIPT',
+          path,
+          'model receipt array cannot be inspected safely',
+        )
+      }
+      if (prototype !== Array.prototype)
+        fail(
+          'MODEL_RECEIPT',
+          path,
+          'model receipt arrays must use the canonical Array.prototype',
+        )
+      return array(value, path, MAX_CANONICAL_NODES - state.nodes).map(
+        (entry, index) =>
+          copyCanonicalJson(entry, `${path}[${index}]`, state, depth + 1),
+      )
+    }
+    const entries = dataEntries(
+      value,
+      path,
+      MAX_CANONICAL_NODES - state.nodes,
+    ).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    return copyRecord(
+      entries.map(([key, entry]) => [
+        key,
+        copyCanonicalJson(entry, `${path}.${key}`, state, depth + 1),
+      ]),
+    )
+  } finally {
+    state.active.delete(value)
+  }
+}
+
+export function validateConsultationReceipt(value: unknown, path: string) {
+  try {
+    if (!validateStructConsultationReceipt(value))
+      fail('MODEL_RECEIPT', path, 'invalid closed consultation receipt')
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail('MODEL_RECEIPT', path, 'invalid model consultation receipt')
+  }
+}

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -1366,6 +1366,23 @@ function preflightPublicationReceipt(value: unknown, path: string) {
     )
 }
 
+function snapshotPublicationReceipt(
+  value: unknown,
+  path: string,
+  state: PublicationSnapshotState,
+) {
+  return copyRecord(
+    dataEntries(value, path, MAX_STRUCT_DOCUMENT_ITEMS - state.nodes).map(
+      ([key, entry]) => [
+        key,
+        key === 'modelConsultations'
+          ? copyCanonicalJson(entry, `${path}.${key}`)
+          : snapshotPublicationValue(entry, `${path}.${key}`, state, 1),
+      ],
+    ),
+  )
+}
+
 function chargePublicationString(
   value: string,
   path: string,
@@ -1485,7 +1502,7 @@ export function snapshotStructDocumentForEpub(value: unknown): StructDocument {
             parseRecovery(entry, '$.recovery'))
           : key === 'receipt'
             ? (preflightPublicationReceipt(entry, '$.receipt'),
-              snapshotPublicationValue(entry, '$.receipt', state, 1))
+              snapshotPublicationReceipt(entry, '$.receipt', state))
             : snapshotPublicationValue(entry, `$.${key}`, state, 1),
     ]),
   ) as StructDocument

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -1152,6 +1152,10 @@ function parseReceipt(value: unknown, path: string): StructReceipt {
   )
   let modelConsultations: StructReceipt['modelConsultations']
   if (has(parsed, 'modelConsultations')) {
+    validateConsultationReceipt(
+      parsed.modelConsultations,
+      `${path}.modelConsultations`,
+    )
     const copied = copyCanonicalJson(
       parsed.modelConsultations,
       `${path}.modelConsultations`,

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -1455,6 +1455,12 @@ function snapshotPublicationValue(
   if (typeof value === 'string') {
     return chargePublicationString(value, path, state)
   }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) fail('NUMBER', path, 'number must be finite')
+    if (Object.is(value, -0))
+      fail('NUMBER', path, 'negative zero is not canonical')
+    return value
+  }
   if (!value || typeof value !== 'object') return value
   if (state.active.has(value))
     fail('OBJECT', path, 'cycles are not permitted in publication input')

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -1,0 +1,1442 @@
+import {
+  LEGACY_STRUCT_SCHEMA_VERSION,
+  STRUCT_SCHEMA_VERSION,
+  type StructAsset,
+  type StructBlock,
+  type StructBox,
+  type StructDiagnostic,
+  type StructDocument,
+  type StructEvidence,
+  type StructFurnitureEvidence,
+  type StructFurnitureReview,
+  type StructInline,
+  type StructMetadata,
+  type StructPageLayout,
+  type StructReceipt,
+  type StructRecovery,
+  type StructRelationship,
+  type StructRelationshipCandidate,
+  type StructSource,
+  type StructTable,
+  type StructTableCell,
+} from '../types'
+import {
+  array,
+  booleanValue,
+  copyRecord,
+  dataEntries,
+  type DataObject,
+  enumValue,
+  fail,
+  finiteNumber,
+  hash,
+  has,
+  identifier,
+  identifierList,
+  integer,
+  isStructCodecError,
+  nonNegativeInteger,
+  nullable,
+  object,
+  positiveInteger,
+  positiveNumber,
+  reference,
+  referenceList,
+  rotation,
+  stringValue,
+  unique,
+  unitInterval,
+} from './primitives'
+import {
+  bytesToBase64,
+  MAX_STRUCT_ASSET_BYTES,
+  preflightBytes,
+  parseBytes,
+} from './bytes'
+import { copyCanonicalJson, validateConsultationReceipt } from './model'
+import {
+  bcp47Language,
+  mediaType,
+  rfc3339Date,
+  rfc3339DateTime,
+} from './standards'
+import { validateStructDocument } from './invariants'
+import { sha256HexSync } from '../sha256'
+
+export { StructCodecError } from './primitives'
+
+export type StructDocumentJson = Omit<StructDocument, 'assets'> & {
+  assets: Array<Omit<StructAsset, 'bytes'> & { bytes?: string }>
+}
+
+const SOURCE_FORMATS = ['pdf', 'docx', 'html', 'image', 'unknown'] as const
+const URL_CONTROL = /[\u0000-\u001f\u007f]/u
+const BLOCK_KINDS = [
+  'heading',
+  'paragraph',
+  'quote',
+  'list-item',
+  'figure',
+  'table',
+  'equation',
+  'caption',
+  'footnote',
+  'endnote',
+  'code',
+  'furniture',
+  'unknown',
+] as const
+const FURNITURE_CLASSIFICATIONS = [
+  'repeated-text',
+  'incrementing-numeral',
+  'rotated-margin',
+  'separator-rule',
+  'explicit-paratext',
+] as const
+const BANDS = ['top', 'bottom', 'left', 'right'] as const
+const VERTICAL_ALIGNS = ['superscript', 'subscript'] as const
+const SEMANTIC_ROLES = [
+  'citation',
+  'cross-reference',
+  'note-reference',
+  'affiliation-marker',
+  'bibliography-entry',
+] as const
+const BASE_DIRECTIONS = ['ltr', 'rtl', 'unknown'] as const
+const HEADER_SCOPES = ['column', 'row', 'colgroup', 'rowgroup'] as const
+const TABLE_SEMANTICS = ['verified', 'source-preserved', 'unresolved'] as const
+const ASSET_KINDS = [
+  'figure',
+  'diagram',
+  'table',
+  'equation',
+  'page-region',
+  'unknown',
+] as const
+const ASSET_FALLBACKS = ['asset', 'source-region', 'text'] as const
+const RELATIONSHIP_KINDS = [
+  'caption',
+  'figure',
+  'table',
+  'equation',
+  'footnote',
+  'endnote',
+  'citation',
+  'cross-reference',
+  'hyperlink',
+  'reading-order',
+] as const
+const RELATIONSHIP_STATUSES = [
+  'matched',
+  'ambiguous',
+  'unresolved',
+  'source-preserved',
+] as const
+const DIAGNOSTIC_SEVERITIES = ['info', 'warning', 'error'] as const
+const DIAGNOSTIC_CATEGORIES = [
+  'text',
+  'layout',
+  'visuals',
+  'tables',
+  'equations',
+  'links',
+  'notes',
+  'source',
+] as const
+const COLUMN_SIDES = ['single', 'left', 'right', 'span'] as const
+const RECOVERY_STATUSES = ['ready', 'review-required'] as const
+/** Keep table-derived work within the existing 100,000-node structural budget. */
+export const MAX_TABLE_DIMENSION = 100_000
+export const MAX_TABLE_AREA = 100_000
+export const MAX_STRUCT_ASSETS = 512
+export const MAX_STRUCT_ASSET_BYTES_TOTAL = 128 * 1024 * 1024
+export const MAX_STRUCT_RECOVERY_ISSUES = 10_000
+export const MAX_STRUCT_RECOVERY_PAGES = 100_000
+export const MAX_STRUCT_DOCUMENT_ITEMS = 100_000
+
+function parseBox(value: unknown, path: string): StructBox {
+  const parsed = object(value, path, [
+    'page',
+    'x',
+    'y',
+    'width',
+    'height',
+    'rotation',
+  ])
+  return {
+    page: positiveInteger(parsed.page, `${path}.page`),
+    x: finiteNumber(parsed.x, `${path}.x`),
+    y: finiteNumber(parsed.y, `${path}.y`),
+    width: positiveNumber(parsed.width, `${path}.width`),
+    height: positiveNumber(parsed.height, `${path}.height`),
+    rotation: rotation(parsed.rotation, `${path}.rotation`),
+  }
+}
+
+function parseEvidence(value: unknown, path: string): StructEvidence {
+  const parsed = object(
+    value,
+    path,
+    ['confidence', 'pages', 'boxes', 'sourceIds'],
+    ['signals'],
+  )
+  const pages = array(parsed.pages, `${path}.pages`).map((page, index) =>
+    positiveInteger(page, `${path}.pages[${index}]`),
+  )
+  unique(pages.map(String), `${path}.pages`, 'page')
+  const sourceIds = identifierList(parsed.sourceIds, `${path}.sourceIds`)
+  return {
+    confidence: unitInterval(parsed.confidence, `${path}.confidence`),
+    pages,
+    boxes: array(parsed.boxes, `${path}.boxes`).map((box, index) =>
+      parseBox(box, `${path}.boxes[${index}]`),
+    ),
+    sourceIds,
+    ...(has(parsed, 'signals')
+      ? {
+          signals: array(parsed.signals, `${path}.signals`).map(
+            (signal, index) => stringValue(signal, `${path}.signals[${index}]`),
+          ),
+        }
+      : {}),
+  }
+}
+
+function parseInline(value: unknown, path: string): StructInline {
+  const parsed = object(
+    value,
+    path,
+    ['start', 'end'],
+    [
+      'href',
+      'annotationId',
+      'relationshipId',
+      'targetIds',
+      'bold',
+      'italic',
+      'verticalAlign',
+      'compactMathAtom',
+      'semanticRole',
+    ],
+  )
+  const start = nonNegativeInteger(parsed.start, `${path}.start`)
+  const end = nonNegativeInteger(parsed.end, `${path}.end`)
+  if (end < start) fail('RANGE', path, 'inline end must not precede start')
+  if (
+    start === end &&
+    [
+      'href',
+      'annotationId',
+      'relationshipId',
+      'targetIds',
+      'bold',
+      'italic',
+      'verticalAlign',
+      'compactMathAtom',
+      'semanticRole',
+    ].some((key) => has(parsed, key))
+  )
+    fail(
+      'RANGE',
+      path,
+      'zero-width inline runs cannot carry formatting or semantic data',
+    )
+  return {
+    start,
+    end,
+    ...(has(parsed, 'href')
+      ? { href: parseHref(parsed.href, `${path}.href`) }
+      : {}),
+    ...(has(parsed, 'annotationId')
+      ? {
+          annotationId: identifier(parsed.annotationId, `${path}.annotationId`),
+        }
+      : {}),
+    ...(has(parsed, 'relationshipId')
+      ? {
+          relationshipId: identifier(
+            parsed.relationshipId,
+            `${path}.relationshipId`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'targetIds')
+      ? { targetIds: identifierList(parsed.targetIds, `${path}.targetIds`) }
+      : {}),
+    ...(has(parsed, 'bold')
+      ? { bold: booleanValue(parsed.bold, `${path}.bold`) }
+      : {}),
+    ...(has(parsed, 'italic')
+      ? { italic: booleanValue(parsed.italic, `${path}.italic`) }
+      : {}),
+    ...(has(parsed, 'verticalAlign')
+      ? {
+          verticalAlign: enumValue(
+            parsed.verticalAlign,
+            `${path}.verticalAlign`,
+            VERTICAL_ALIGNS,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'compactMathAtom')
+      ? {
+          compactMathAtom: booleanValue(
+            parsed.compactMathAtom,
+            `${path}.compactMathAtom`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'semanticRole')
+      ? {
+          semanticRole: enumValue(
+            parsed.semanticRole,
+            `${path}.semanticRole`,
+            SEMANTIC_ROLES,
+          ),
+        }
+      : {}),
+  }
+}
+
+function parseInlineList(value: unknown, path: string, text: string) {
+  const inline = array(value, path).map((entry, index) =>
+    parseInline(entry, `${path}[${index}]`),
+  )
+  for (const [index, run] of inline.entries()) {
+    if (run.end > text.length)
+      fail(
+        'RANGE',
+        `${path}[${index}]`,
+        'inline end must not exceed text length',
+      )
+  }
+  return inline
+}
+
+function parseHref(value: unknown, path: string) {
+  const parsed = stringValue(value, path)
+  if (URL_CONTROL.test(parsed))
+    fail('URL', path, 'href must not contain control characters')
+  if (/^#[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(parsed)) return parsed
+  try {
+    const url = new URL(parsed)
+    if (
+      !['http:', 'https:', 'mailto:'].includes(url.protocol) ||
+      url.username ||
+      url.password
+    )
+      throw new Error()
+    if (url.href !== parsed) throw new Error()
+    return parsed
+  } catch {
+    fail('URL', path, 'href must be a safe fragment or URL')
+  }
+}
+
+function parseMetadata(value: unknown, path: string): StructMetadata {
+  const parsed = object(
+    value,
+    path,
+    ['title', 'subtitle', 'authors', 'abstract'],
+    [
+      'language',
+      'baseDirection',
+      'publicationDate',
+      'artifactModifiedAt',
+      'updated',
+      'affiliations',
+      'authorAffiliations',
+      'authorNotes',
+    ],
+  )
+  const authors = array(parsed.authors, `${path}.authors`).map(
+    (author, index) => stringValue(author, `${path}.authors[${index}]`),
+  )
+  return {
+    title: stringValue(parsed.title, `${path}.title`),
+    subtitle: stringValue(parsed.subtitle, `${path}.subtitle`),
+    authors,
+    abstract: stringValue(parsed.abstract, `${path}.abstract`),
+    ...(has(parsed, 'language')
+      ? { language: bcp47Language(parsed.language, `${path}.language`) }
+      : {}),
+    ...(has(parsed, 'baseDirection')
+      ? {
+          baseDirection: enumValue(
+            parsed.baseDirection,
+            `${path}.baseDirection`,
+            BASE_DIRECTIONS,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'publicationDate')
+      ? {
+          publicationDate: rfc3339Date(
+            parsed.publicationDate,
+            `${path}.publicationDate`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'artifactModifiedAt')
+      ? {
+          artifactModifiedAt: rfc3339DateTime(
+            parsed.artifactModifiedAt,
+            `${path}.artifactModifiedAt`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'updated')
+      ? { updated: rfc3339Date(parsed.updated, `${path}.updated`) }
+      : {}),
+    ...(has(parsed, 'affiliations')
+      ? {
+          affiliations: array(parsed.affiliations, `${path}.affiliations`).map(
+            (affiliation, index) =>
+              stringValue(affiliation, `${path}.affiliations[${index}]`),
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'authorAffiliations')
+      ? {
+          authorAffiliations: array(
+            parsed.authorAffiliations,
+            `${path}.authorAffiliations`,
+          ).map((affiliation, index) => {
+            const entry = object(
+              affiliation,
+              `${path}.authorAffiliations[${index}]`,
+              ['author', 'label'],
+            )
+            return {
+              author: stringValue(
+                entry.author,
+                `${path}.authorAffiliations[${index}].author`,
+              ),
+              label: stringValue(
+                entry.label,
+                `${path}.authorAffiliations[${index}].label`,
+              ),
+            }
+          }),
+        }
+      : {}),
+    ...(has(parsed, 'authorNotes')
+      ? {
+          authorNotes: (() => {
+            const notes = array(parsed.authorNotes, `${path}.authorNotes`).map(
+              (note, index) => {
+                const entry = object(note, `${path}.authorNotes[${index}]`, [
+                  'id',
+                  'author',
+                  'label',
+                  'target',
+                ])
+                return {
+                  id: identifier(entry.id, `${path}.authorNotes[${index}].id`),
+                  author: stringValue(
+                    entry.author,
+                    `${path}.authorNotes[${index}].author`,
+                  ),
+                  label: stringValue(
+                    entry.label,
+                    `${path}.authorNotes[${index}].label`,
+                  ),
+                  target: identifier(
+                    entry.target,
+                    `${path}.authorNotes[${index}].target`,
+                  ),
+                }
+              },
+            )
+            unique(
+              notes.map((note) => note.id),
+              `${path}.authorNotes`,
+              'author note id',
+            )
+            return notes
+          })(),
+        }
+      : {}),
+  }
+}
+
+function parseFurnitureEvidence(
+  value: unknown,
+  path: string,
+): StructFurnitureEvidence {
+  const parsed = object(
+    value,
+    path,
+    ['classification', 'band', 'pages', 'boxes', 'evidence'],
+    ['normalizedText', 'sequence', 'sourceRunIndexes'],
+  )
+  const pages = array(parsed.pages, `${path}.pages`).map((page, index) =>
+    positiveInteger(page, `${path}.pages[${index}]`),
+  )
+  unique(pages.map(String), `${path}.pages`, 'page')
+  return {
+    classification: enumValue(
+      parsed.classification,
+      `${path}.classification`,
+      FURNITURE_CLASSIFICATIONS,
+    ),
+    band: enumValue(parsed.band, `${path}.band`, BANDS),
+    pages,
+    boxes: array(parsed.boxes, `${path}.boxes`).map((box, index) =>
+      parseBox(box, `${path}.boxes[${index}]`),
+    ),
+    evidence: array(parsed.evidence, `${path}.evidence`).map((entry, index) =>
+      stringValue(entry, `${path}.evidence[${index}]`),
+    ),
+    ...(has(parsed, 'normalizedText')
+      ? {
+          normalizedText: stringValue(
+            parsed.normalizedText,
+            `${path}.normalizedText`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'sequence')
+      ? {
+          sequence: array(parsed.sequence, `${path}.sequence`).map(
+            (entry, index) =>
+              nonNegativeInteger(entry, `${path}.sequence[${index}]`),
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'sourceRunIndexes')
+      ? {
+          sourceRunIndexes: array(
+            parsed.sourceRunIndexes,
+            `${path}.sourceRunIndexes`,
+          ).map((entry, index) =>
+            nonNegativeInteger(entry, `${path}.sourceRunIndexes[${index}]`),
+          ),
+        }
+      : {}),
+  }
+}
+
+function parseFurnitureReview(
+  value: unknown,
+  path: string,
+): StructFurnitureReview {
+  const parsed = object(value, path, [
+    'reason',
+    'band',
+    'pages',
+    'boxes',
+    'evidence',
+  ])
+  const pages = array(parsed.pages, `${path}.pages`).map((page, index) =>
+    positiveInteger(page, `${path}.pages[${index}]`),
+  )
+  unique(pages.map(String), `${path}.pages`, 'page')
+  return {
+    reason: enumValue(parsed.reason, `${path}.reason`, [
+      'single-occurrence-margin',
+    ] as const),
+    band: enumValue(parsed.band, `${path}.band`, BANDS),
+    pages,
+    boxes: array(parsed.boxes, `${path}.boxes`).map((box, index) =>
+      parseBox(box, `${path}.boxes[${index}]`),
+    ),
+    evidence: array(parsed.evidence, `${path}.evidence`).map((entry, index) =>
+      stringValue(entry, `${path}.evidence[${index}]`),
+    ),
+  }
+}
+
+function parseAttributes(
+  value: unknown,
+  path: string,
+): Record<string, string | number | boolean> {
+  const entries: Array<[string, string | number | boolean]> = []
+  for (const [key, child] of dataEntries(value, path).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  )) {
+    if (
+      !key ||
+      key === '__proto__' ||
+      key === 'constructor' ||
+      key === 'prototype'
+    )
+      fail('FIELD', `${path}.${key}`, 'attribute key is not safe')
+    if (typeof child === 'string')
+      entries.push([key, stringValue(child, `${path}.${key}`)])
+    else if (typeof child === 'boolean') entries.push([key, child])
+    else if (typeof child === 'number')
+      entries.push([key, finiteNumber(child, `${path}.${key}`)])
+    else
+      fail(
+        'TYPE',
+        `${path}.${key}`,
+        'attribute value must be a string, number, or boolean',
+      )
+  }
+  return copyRecord(entries) as Record<string, string | number | boolean>
+}
+
+function parseTableCell(value: unknown, path: string): StructTableCell {
+  const parsed = object(value, path, [
+    'id',
+    'text',
+    'row',
+    'column',
+    'rowSpan',
+    'columnSpan',
+    'headerScope',
+    'inline',
+    'evidence',
+  ])
+  const text = stringValue(parsed.text, `${path}.text`)
+  return {
+    id: identifier(parsed.id, `${path}.id`),
+    text,
+    row: nonNegativeInteger(parsed.row, `${path}.row`),
+    column: nonNegativeInteger(parsed.column, `${path}.column`),
+    rowSpan: integer(parsed.rowSpan, `${path}.rowSpan`, 1),
+    columnSpan: integer(parsed.columnSpan, `${path}.columnSpan`, 1),
+    headerScope:
+      parsed.headerScope === null
+        ? null
+        : enumValue(parsed.headerScope, `${path}.headerScope`, HEADER_SCOPES),
+    inline: parseInlineList(parsed.inline, `${path}.inline`, text),
+    evidence: parseEvidence(parsed.evidence, `${path}.evidence`),
+  }
+}
+
+export function validateStructTableBounds(value: unknown, path: string) {
+  const parsed = object(value, path, ['rows', 'columns', 'cells', 'semantic'])
+  const rows = nonNegativeInteger(parsed.rows, `${path}.rows`)
+  const columns = nonNegativeInteger(parsed.columns, `${path}.columns`)
+  if (
+    rows > MAX_TABLE_DIMENSION ||
+    columns > MAX_TABLE_DIMENSION ||
+    rows * columns > MAX_TABLE_AREA
+  )
+    fail(
+      'TABLE_BOUNDS',
+      path,
+      `table dimensions must fit within ${MAX_TABLE_DIMENSION} rows/columns and ${MAX_TABLE_AREA} cells`,
+    )
+  const cellsPath = `${path}.cells`
+  let cells: unknown[]
+  try {
+    cells = array(parsed.cells, cellsPath, rows * columns)
+  } catch (error) {
+    if (
+      isStructCodecError(error) &&
+      error.code === 'BUDGET' &&
+      error.path === cellsPath
+    )
+      fail(
+        'TABLE_BOUNDS',
+        cellsPath,
+        'table cell count cannot exceed the declared table area',
+      )
+    throw error
+  }
+  return { rows, columns, cells, semantic: parsed.semantic }
+}
+
+/** Enforce renderer allocation bounds on direct STRUCT documents. */
+export function validateStructDocumentTableBounds(value: unknown) {
+  const document = copyRecord(dataEntries(value, '$'))
+  if (!has(document, 'blocks'))
+    fail('REQUIRED', '$.blocks', 'field is required')
+  const blocks = array(document.blocks, '$.blocks', MAX_STRUCT_DOCUMENT_ITEMS)
+  for (const [index, block] of blocks.entries()) {
+    const path = `$.blocks[${index}]`
+    const parsed = copyRecord(dataEntries(block, path))
+    if (parsed.kind === 'table' && has(parsed, 'table'))
+      validateStructTableBounds(parsed.table, `${path}.table`)
+  }
+}
+
+function parseTable(value: unknown, path: string): StructTable {
+  const parsed = validateStructTableBounds(value, path)
+  const { rows, columns } = parsed
+  const rawCells = parsed.cells
+  const cells = rawCells.map((cell, index) =>
+    parseTableCell(cell, `${path}.cells[${index}]`),
+  )
+  unique(
+    cells.map((cell) => cell.id),
+    `${path}.cells`,
+    'table cell id',
+  )
+  for (const [index, cell] of cells.entries()) {
+    if (cell.row >= rows || cell.row + cell.rowSpan > rows)
+      fail(
+        'TABLE_BOUNDS',
+        `${path}.cells[${index}].row`,
+        'cell row and rowSpan must fit within table rows',
+      )
+    if (cell.column >= columns || cell.column + cell.columnSpan > columns)
+      fail(
+        'TABLE_BOUNDS',
+        `${path}.cells[${index}].column`,
+        'cell column and columnSpan must fit within table columns',
+      )
+  }
+  const occupied = new Set<string>()
+  for (const [index, cell] of cells.entries()) {
+    for (let row = cell.row; row < cell.row + cell.rowSpan; row += 1) {
+      for (
+        let column = cell.column;
+        column < cell.column + cell.columnSpan;
+        column += 1
+      ) {
+        const coordinate = `${row}:${column}`
+        if (occupied.has(coordinate))
+          fail(
+            'TABLE_OVERLAP',
+            `${path}.cells[${index}]`,
+            'table cells cannot overlap occupied coordinates',
+          )
+        occupied.add(coordinate)
+      }
+    }
+  }
+  return {
+    rows,
+    columns,
+    cells,
+    semantic: enumValue(parsed.semantic, `${path}.semantic`, TABLE_SEMANTICS),
+  }
+}
+
+function parseBlock(value: unknown, path: string): StructBlock {
+  const parsed = object(
+    value,
+    path,
+    ['id', 'kind', 'text', 'page', 'order', 'column', 'inline', 'evidence'],
+    [
+      'label',
+      'sourceObservationAnchorIds',
+      'table',
+      'fallbackAssetIds',
+      'furniture',
+      'furnitureReview',
+      'attributes',
+    ],
+  )
+  const text = stringValue(parsed.text, `${path}.text`)
+  const kind = enumValue(parsed.kind, `${path}.kind`, BLOCK_KINDS)
+  const attributes = has(parsed, 'attributes')
+    ? parseAttributes(parsed.attributes, `${path}.attributes`)
+    : undefined
+  if (
+    kind === 'heading' &&
+    attributes?.level !== undefined &&
+    (typeof attributes.level !== 'number' ||
+      !Number.isInteger(attributes.level) ||
+      attributes.level < 1 ||
+      attributes.level > 6)
+  )
+    fail(
+      'ATTRIBUTE',
+      `${path}.attributes.level`,
+      'heading level must be an integer from 1 through 6',
+    )
+  return {
+    id: identifier(parsed.id, `${path}.id`),
+    kind,
+    text,
+    ...(has(parsed, 'label')
+      ? { label: stringValue(parsed.label, `${path}.label`) }
+      : {}),
+    page: nullable(parsed.page, `${path}.page`, (entry, entryPath) =>
+      positiveInteger(entry, entryPath),
+    ),
+    order: nonNegativeInteger(parsed.order, `${path}.order`),
+    column:
+      parsed.column === null
+        ? null
+        : enumValue(parsed.column, `${path}.column`, COLUMN_SIDES),
+    inline: parseInlineList(parsed.inline, `${path}.inline`, text),
+    evidence: parseEvidence(parsed.evidence, `${path}.evidence`),
+    ...(has(parsed, 'sourceObservationAnchorIds')
+      ? {
+          sourceObservationAnchorIds: identifierList(
+            parsed.sourceObservationAnchorIds,
+            `${path}.sourceObservationAnchorIds`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'table')
+      ? { table: parseTable(parsed.table, `${path}.table`) }
+      : {}),
+    ...(has(parsed, 'fallbackAssetIds')
+      ? {
+          fallbackAssetIds: identifierList(
+            parsed.fallbackAssetIds,
+            `${path}.fallbackAssetIds`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'furniture')
+      ? {
+          furniture: parseFurnitureEvidence(
+            parsed.furniture,
+            `${path}.furniture`,
+          ),
+        }
+      : {}),
+    ...(has(parsed, 'furnitureReview')
+      ? {
+          furnitureReview: parseFurnitureReview(
+            parsed.furnitureReview,
+            `${path}.furnitureReview`,
+          ),
+        }
+      : {}),
+    ...(attributes ? { attributes } : {}),
+  }
+}
+
+function snapshotAsset(value: unknown, path: string) {
+  return copyRecord(dataEntries(value, path))
+}
+
+const ASSET_REQUIRED_FIELDS = [
+  'id',
+  'kind',
+  'href',
+  'mediaType',
+  'sha256',
+  'width',
+  'height',
+  'sourceObjectIds',
+  'evidence',
+  'fallback',
+] as const
+const ASSET_OPTIONAL_FIELDS = ['bytes'] as const
+const ASSET_FIELDS = [...ASSET_REQUIRED_FIELDS, ...ASSET_OPTIONAL_FIELDS]
+const ASSET_FIELD_SET = new Set<string>(ASSET_FIELDS)
+
+function validateAssetSnapshot(value: DataObject, path: string) {
+  for (const key of ASSET_REQUIRED_FIELDS) {
+    if (!has(value, key))
+      fail('REQUIRED', `${path}.${key}`, 'field is required')
+  }
+  for (const key of Object.keys(value)) {
+    if (!ASSET_FIELD_SET.has(key))
+      fail('UNKNOWN_FIELD', `${path}.${key}`, 'unknown field is not declared')
+  }
+  return copyRecord(
+    ASSET_FIELDS.filter((key) => has(value, key)).map((key) => [
+      key,
+      value[key],
+    ]),
+  )
+}
+
+function parseAsset(
+  parsed: DataObject,
+  path: string,
+  maximumBytes: number,
+): StructAsset {
+  const href = stringValue(parsed.href, `${path}.href`)
+  if (URL_CONTROL.test(href))
+    fail(
+      'HREF',
+      `${path}.href`,
+      'asset href must not contain control characters',
+    )
+  if (
+    !href ||
+    href.trim() !== href ||
+    href.startsWith('/') ||
+    href.includes('\\') ||
+    href.includes('?') ||
+    href.includes('#') ||
+    href.includes(':') ||
+    href.includes('%') ||
+    /\s/u.test(href) ||
+    /(?:^|\/)\.(?:\.?)(?:\/|$)/u.test(href)
+  )
+    fail('HREF', `${path}.href`, 'asset href must be a canonical EPUB path')
+  if (
+    href
+      .split('/')
+      .some((segment) => !segment || segment === '.' || segment === '..')
+  )
+    fail('HREF', `${path}.href`, 'asset href must have canonical path segments')
+  if (
+    new Set([
+      'package.opf',
+      'nav.xhtml',
+      'content.xhtml',
+      'styles.css',
+      'struct.json',
+      'profile.json',
+    ]).has(href)
+  )
+    fail('HREF', `${path}.href`, 'asset href is reserved by the EPUB package')
+  const sha256 = hash(parsed.sha256, `${path}.sha256`)
+  const bytes = has(parsed, 'bytes')
+    ? parseBytes(parsed.bytes, `${path}.bytes`, maximumBytes)
+    : undefined
+  if (bytes && sha256HexSync(bytes) !== sha256)
+    fail(
+      'BYTES_HASH',
+      `${path}.bytes`,
+      'asset bytes do not match the declared SHA-256 digest',
+    )
+  return {
+    id: identifier(parsed.id, `${path}.id`),
+    kind: enumValue(parsed.kind, `${path}.kind`, ASSET_KINDS),
+    href,
+    mediaType: mediaType(parsed.mediaType, `${path}.mediaType`),
+    sha256,
+    width: positiveNumber(parsed.width, `${path}.width`),
+    height: positiveNumber(parsed.height, `${path}.height`),
+    ...(bytes ? { bytes } : {}),
+    sourceObjectIds: identifierList(
+      parsed.sourceObjectIds,
+      `${path}.sourceObjectIds`,
+    ),
+    evidence: parseEvidence(parsed.evidence, `${path}.evidence`),
+    fallback: enumValue(parsed.fallback, `${path}.fallback`, ASSET_FALLBACKS),
+  }
+}
+
+function parseRelationshipCandidate(
+  value: unknown,
+  path: string,
+): StructRelationshipCandidate {
+  const parsed = object(value, path, ['target', 'confidence', 'evidence'])
+  return {
+    target: reference(parsed.target, `${path}.target`),
+    confidence: unitInterval(parsed.confidence, `${path}.confidence`),
+    evidence: parseEvidence(parsed.evidence, `${path}.evidence`),
+  }
+}
+
+function parseRelationship(value: unknown, path: string): StructRelationship {
+  const parsed = object(
+    value,
+    path,
+    ['id', 'kind', 'from', 'to', 'status', 'confidence', 'evidence'],
+    ['label', 'candidates'],
+  )
+  const candidates = has(parsed, 'candidates')
+    ? array(parsed.candidates, `${path}.candidates`).map((candidate, index) =>
+        parseRelationshipCandidate(candidate, `${path}.candidates[${index}]`),
+      )
+    : undefined
+  if (candidates)
+    unique(
+      candidates.map((candidate) => candidate.target),
+      `${path}.candidates`,
+      'candidate target',
+    )
+  return {
+    id: identifier(parsed.id, `${path}.id`),
+    kind: enumValue(parsed.kind, `${path}.kind`, RELATIONSHIP_KINDS),
+    from: identifier(parsed.from, `${path}.from`),
+    to: referenceList(parsed.to, `${path}.to`),
+    ...(has(parsed, 'label')
+      ? { label: stringValue(parsed.label, `${path}.label`) }
+      : {}),
+    status: enumValue(parsed.status, `${path}.status`, RELATIONSHIP_STATUSES),
+    confidence: unitInterval(parsed.confidence, `${path}.confidence`),
+    evidence: parseEvidence(parsed.evidence, `${path}.evidence`),
+    ...(candidates ? { candidates } : {}),
+  }
+}
+
+function parseDiagnostic(value: unknown, path: string): StructDiagnostic {
+  const parsed = object(
+    value,
+    path,
+    ['id', 'severity', 'category', 'title', 'message', 'pages', 'sourceIds'],
+    ['action'],
+  )
+  const pages = array(parsed.pages, `${path}.pages`).map((page, index) =>
+    positiveInteger(page, `${path}.pages[${index}]`),
+  )
+  unique(pages.map(String), `${path}.pages`, 'page')
+  return {
+    id: identifier(parsed.id, `${path}.id`),
+    severity: enumValue(
+      parsed.severity,
+      `${path}.severity`,
+      DIAGNOSTIC_SEVERITIES,
+    ),
+    category: enumValue(
+      parsed.category,
+      `${path}.category`,
+      DIAGNOSTIC_CATEGORIES,
+    ),
+    title: stringValue(parsed.title, `${path}.title`),
+    message: stringValue(parsed.message, `${path}.message`),
+    ...(has(parsed, 'action')
+      ? { action: stringValue(parsed.action, `${path}.action`) }
+      : {}),
+    pages,
+    sourceIds: identifierList(parsed.sourceIds, `${path}.sourceIds`),
+  }
+}
+
+function parsePage(value: unknown, path: string): StructPageLayout {
+  const parsed = object(value, path, [
+    'page',
+    'width',
+    'height',
+    'rotation',
+    'blocks',
+    'columns',
+  ])
+  const columns = array(parsed.columns, `${path}.columns`).map(
+    (column, index) => {
+      const entry = object(column, `${path}.columns[${index}]`, [
+        'id',
+        'side',
+        'blockIds',
+      ])
+      return {
+        id: identifier(entry.id, `${path}.columns[${index}].id`),
+        side: enumValue(
+          entry.side,
+          `${path}.columns[${index}].side`,
+          COLUMN_SIDES,
+        ),
+        blockIds: identifierList(
+          entry.blockIds,
+          `${path}.columns[${index}].blockIds`,
+        ),
+      }
+    },
+  )
+  unique(
+    columns.map((column) => column.id),
+    `${path}.columns`,
+    'column id',
+  )
+  return {
+    page: positiveInteger(parsed.page, `${path}.page`),
+    width: positiveNumber(parsed.width, `${path}.width`),
+    height: positiveNumber(parsed.height, `${path}.height`),
+    rotation: rotation(parsed.rotation, `${path}.rotation`),
+    blocks: identifierList(parsed.blocks, `${path}.blocks`),
+    columns,
+  }
+}
+
+function parseRecovery(value: unknown, path: string): StructRecovery {
+  const parsed = object(
+    value,
+    path,
+    ['status', 'title', 'summary', 'issues'],
+    ['userAction'],
+  )
+  let remainingPages = MAX_STRUCT_RECOVERY_PAGES
+  const issues = array(
+    parsed.issues,
+    `${path}.issues`,
+    MAX_STRUCT_RECOVERY_ISSUES,
+  ).map((issue, index) => {
+    const entry = object(
+      issue,
+      `${path}.issues[${index}]`,
+      ['category', 'title', 'count', 'pages'],
+      ['action'],
+    )
+    const pages = array(
+      entry.pages,
+      `${path}.issues[${index}].pages`,
+      remainingPages,
+    ).map((page, pageIndex) =>
+      positiveInteger(page, `${path}.issues[${index}].pages[${pageIndex}]`),
+    )
+    remainingPages -= pages.length
+    unique(pages.map(String), `${path}.issues[${index}].pages`, 'page')
+    return {
+      category: enumValue(
+        entry.category,
+        `${path}.issues[${index}].category`,
+        DIAGNOSTIC_CATEGORIES,
+      ),
+      title: stringValue(entry.title, `${path}.issues[${index}].title`),
+      count: nonNegativeInteger(entry.count, `${path}.issues[${index}].count`),
+      pages,
+      ...(has(entry, 'action')
+        ? {
+            action: stringValue(
+              entry.action,
+              `${path}.issues[${index}].action`,
+            ),
+          }
+        : {}),
+    }
+  })
+  return {
+    status: enumValue(parsed.status, `${path}.status`, RECOVERY_STATUSES),
+    title: stringValue(parsed.title, `${path}.title`),
+    summary: stringValue(parsed.summary, `${path}.summary`),
+    issues,
+    ...(has(parsed, 'userAction')
+      ? { userAction: stringValue(parsed.userAction, `${path}.userAction`) }
+      : {}),
+  }
+}
+
+const CONSERVATION_REQUIRED = [
+  'sourceNodeCount',
+  'accountedSourceNodeCount',
+  'sourceRegionCount',
+  'accountedSourceRegionCount',
+  'sourceAnnotationCount',
+  'accountedSourceAnnotationCount',
+  'sourceAssetCount',
+  'accountedSourceAssetCount',
+  'sourceRelationshipCount',
+  'accountedSourceRelationshipCount',
+  'sourceDiagnosticCount',
+  'accountedSourceDiagnosticCount',
+  'sourceTextCharacterCount',
+  'structBlockCount',
+  'structAssetCount',
+  'structRelationshipCount',
+  'structDiagnosticCount',
+  'structTextCharacterCount',
+] as const
+const CONSERVATION_OPTIONAL = [
+  'sourceFurnitureBlockCount',
+  'accountedFurnitureBlockCount',
+  'sourceFurnitureTextCharacterCount',
+  'structFurnitureBlockCount',
+  'structFurnitureTextCharacterCount',
+  'furnitureContaminationCount',
+] as const
+
+function parseConservation(
+  value: unknown,
+  path: string,
+): StructReceipt['conservation'] {
+  const parsed = object(
+    value,
+    path,
+    CONSERVATION_REQUIRED,
+    CONSERVATION_OPTIONAL,
+  )
+  const result = copyRecord(
+    [...CONSERVATION_REQUIRED, ...CONSERVATION_OPTIONAL]
+      .filter((key) => has(parsed, key))
+      .map((key) => [key, nonNegativeInteger(parsed[key], `${path}.${key}`)]),
+  )
+  return result as StructReceipt['conservation']
+}
+
+function parseReceipt(value: unknown, path: string): StructReceipt {
+  const parsed = object(
+    value,
+    path,
+    [
+      'schemaVersion',
+      'sourceSha256',
+      'blockCount',
+      'assetCount',
+      'relationshipCount',
+      'diagnosticCount',
+      'textCharacterCount',
+      'conservation',
+      'generatedSha256',
+    ],
+    ['documentId', 'modelConsultations'],
+  )
+  let modelConsultations: StructReceipt['modelConsultations']
+  if (has(parsed, 'modelConsultations')) {
+    const copied = copyCanonicalJson(
+      parsed.modelConsultations,
+      `${path}.modelConsultations`,
+    )
+    validateConsultationReceipt(copied, `${path}.modelConsultations`)
+    modelConsultations = copied as StructReceipt['modelConsultations']
+  }
+  return {
+    schemaVersion: parseSchemaVersion(
+      parsed.schemaVersion,
+      `${path}.schemaVersion`,
+    ),
+    ...(has(parsed, 'documentId')
+      ? { documentId: identifier(parsed.documentId, `${path}.documentId`) }
+      : {}),
+    sourceSha256: hash(parsed.sourceSha256, `${path}.sourceSha256`),
+    ...(modelConsultations ? { modelConsultations } : {}),
+    blockCount: nonNegativeInteger(parsed.blockCount, `${path}.blockCount`),
+    assetCount: nonNegativeInteger(parsed.assetCount, `${path}.assetCount`),
+    relationshipCount: nonNegativeInteger(
+      parsed.relationshipCount,
+      `${path}.relationshipCount`,
+    ),
+    diagnosticCount: nonNegativeInteger(
+      parsed.diagnosticCount,
+      `${path}.diagnosticCount`,
+    ),
+    textCharacterCount: nonNegativeInteger(
+      parsed.textCharacterCount,
+      `${path}.textCharacterCount`,
+    ),
+    conservation: parseConservation(
+      parsed.conservation,
+      `${path}.conservation`,
+    ),
+    generatedSha256: hash(parsed.generatedSha256, `${path}.generatedSha256`),
+  }
+}
+
+function parseSource(value: unknown, path: string): StructSource {
+  const parsed = object(value, path, [
+    'format',
+    'fileName',
+    'sha256',
+    'byteLength',
+    'pageCount',
+    'localOnly',
+  ])
+  return {
+    format: enumValue(parsed.format, `${path}.format`, SOURCE_FORMATS),
+    fileName: stringValue(parsed.fileName, `${path}.fileName`),
+    sha256: hash(parsed.sha256, `${path}.sha256`),
+    byteLength: nonNegativeInteger(parsed.byteLength, `${path}.byteLength`),
+    pageCount: nonNegativeInteger(parsed.pageCount, `${path}.pageCount`),
+    localOnly: booleanValue(parsed.localOnly, `${path}.localOnly`),
+  }
+}
+
+function parseSchemaVersion(value: unknown, path: string) {
+  if (value !== LEGACY_STRUCT_SCHEMA_VERSION && value !== STRUCT_SCHEMA_VERSION)
+    fail(
+      'SCHEMA_VERSION',
+      path,
+      `unsupported schema version ${schemaVersionDescription(value)}`,
+    )
+  return value
+}
+
+function schemaVersionDescription(value: unknown) {
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (value === null) return 'null'
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value)
+  return `<${typeof value}>`
+}
+
+function parseDocument(value: unknown): StructDocument {
+  const parsed = object(
+    value,
+    '$',
+    [
+      'schemaVersion',
+      'source',
+      'metadata',
+      'blocks',
+      'assets',
+      'relationships',
+      'pages',
+      'diagnostics',
+      'recovery',
+      'receipt',
+    ],
+    ['documentId'],
+  )
+  const schemaVersion = parseSchemaVersion(
+    parsed.schemaVersion,
+    '$.schemaVersion',
+  )
+  const blocks = array(
+    parsed.blocks,
+    '$.blocks',
+    MAX_STRUCT_DOCUMENT_ITEMS,
+  ).map((block, index) => parseBlock(block, `$.blocks[${index}]`))
+  const assets = parseStructAssets(parsed.assets)
+  const relationships = array(
+    parsed.relationships,
+    '$.relationships',
+    MAX_STRUCT_DOCUMENT_ITEMS,
+  ).map((relationship, index) =>
+    parseRelationship(relationship, `$.relationships[${index}]`),
+  )
+  const pages = array(parsed.pages, '$.pages', MAX_STRUCT_DOCUMENT_ITEMS).map(
+    (page, index) => parsePage(page, `$.pages[${index}]`),
+  )
+  const diagnostics = array(
+    parsed.diagnostics,
+    '$.diagnostics',
+    MAX_STRUCT_DOCUMENT_ITEMS,
+  ).map((diagnostic, index) =>
+    parseDiagnostic(diagnostic, `$.diagnostics[${index}]`),
+  )
+  unique(
+    blocks.map((block) => block.id),
+    '$.blocks',
+    'block id',
+  )
+  unique(
+    assets.map((asset) => asset.id),
+    '$.assets',
+    'asset id',
+  )
+  unique(
+    relationships.map((relationship) => relationship.id),
+    '$.relationships',
+    'relationship id',
+  )
+  unique(
+    diagnostics.map((diagnostic) => diagnostic.id),
+    '$.diagnostics',
+    'diagnostic id',
+  )
+  unique(
+    pages.map((page) => String(page.page)),
+    '$.pages',
+    'page number',
+  )
+  const document: StructDocument = {
+    schemaVersion,
+    ...(has(parsed, 'documentId')
+      ? { documentId: identifier(parsed.documentId, '$.documentId') }
+      : {}),
+    source: parseSource(parsed.source, '$.source'),
+    metadata: parseMetadata(parsed.metadata, '$.metadata'),
+    blocks,
+    assets,
+    relationships,
+    pages,
+    diagnostics,
+    recovery: parseRecovery(parsed.recovery, '$.recovery'),
+    receipt: parseReceipt(parsed.receipt, '$.receipt'),
+  }
+  validateStructDocument(document, parsed)
+  return document
+}
+
+/** Snapshot and validate bounded STRUCT assets before any consumer packages them. */
+export function parseStructAssets(value: unknown): StructAsset[] {
+  const rawAssets = array(value, '$.assets', MAX_STRUCT_ASSETS)
+  const assetSnapshots: DataObject[] = []
+  let remainingBytes = MAX_STRUCT_ASSET_BYTES_TOTAL
+  for (const [index, rawAsset] of rawAssets.entries()) {
+    const path = `$.assets[${index}]`
+    const snapshot = snapshotAsset(rawAsset, path)
+    const length = has(snapshot, 'bytes')
+      ? preflightBytes(snapshot.bytes, `${path}.bytes`, MAX_STRUCT_ASSET_BYTES)
+      : 0
+    if (length > remainingBytes)
+      fail('ASSET_BOUNDS', '$.assets', 'asset bytes exceed the resource bound')
+    assetSnapshots.push(validateAssetSnapshot(snapshot, path))
+    remainingBytes -= length
+  }
+  let decodeRemaining = MAX_STRUCT_ASSET_BYTES_TOTAL
+  return assetSnapshots.map((asset, index) => {
+    const parsedAsset = parseAsset(
+      asset,
+      `$.assets[${index}]`,
+      Math.min(MAX_STRUCT_ASSET_BYTES, decodeRemaining),
+    )
+    decodeRemaining -= parsedAsset.bytes?.byteLength ?? 0
+    return parsedAsset
+  })
+}
+
+type PublicationSnapshotState = {
+  active: WeakSet<object>
+  nodes: number
+}
+
+function snapshotPublicationValue(
+  value: unknown,
+  path: string,
+  state: PublicationSnapshotState,
+  depth: number,
+): unknown {
+  if (depth > 128)
+    fail('BUDGET', path, 'publication input nesting exceeds the depth bound')
+  state.nodes += 1
+  if (state.nodes > MAX_STRUCT_DOCUMENT_ITEMS)
+    fail('BUDGET', path, 'publication input exceeds the structural node bound')
+  if (!value || typeof value !== 'object') return value
+  if (state.active.has(value))
+    fail('OBJECT', path, 'cycles are not permitted in publication input')
+  state.active.add(value)
+  try {
+    if (Array.isArray(value))
+      return array(value, path, MAX_STRUCT_DOCUMENT_ITEMS - state.nodes).map(
+        (entry, index) =>
+          snapshotPublicationValue(
+            entry,
+            `${path}[${index}]`,
+            state,
+            depth + 1,
+          ),
+      )
+    return copyRecord(
+      dataEntries(value, path, MAX_STRUCT_DOCUMENT_ITEMS - state.nodes).map(
+        ([key, entry]) => [
+          key,
+          snapshotPublicationValue(entry, `${path}.${key}`, state, depth + 1),
+        ],
+      ),
+    )
+  } finally {
+    state.active.delete(value)
+  }
+}
+
+/** Canonicalize every direct-publication field without retaining caller objects. */
+export function snapshotStructDocumentForEpub(value: unknown): StructDocument {
+  const root = dataEntries(value, '$')
+  const state: PublicationSnapshotState = {
+    active: new WeakSet<object>(),
+    nodes: 1,
+  }
+  return copyRecord(
+    root.map(([key, entry]) => [
+      key,
+      key === 'assets'
+        ? parseStructAssets(entry)
+        : key === 'recovery'
+          ? parseRecovery(entry, '$.recovery')
+          : snapshotPublicationValue(entry, `$.${key}`, state, 1),
+    ]),
+  ) as StructDocument
+}
+
+/** Decode a JSON-safe or in-memory STRUCT document without coercion. */
+export function decodeStructDocument(input: unknown): StructDocument {
+  return parseDocument(input)
+}
+
+/**
+ * Explicit STRUCT migration entrypoint. There are no historical migrations in
+ * this slice: declared 0.1.0 and 0.2.0 documents are canonically decoded and
+ * returned at their declared version; every other version fails closed.
+ */
+export function migrateStructDocument(input: unknown): StructDocument {
+  return decodeStructDocument(input)
+}
+
+function toJsonValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) return bytesToBase64(value)
+  if (Array.isArray(value)) return value.map(toJsonValue)
+  if (value && typeof value === 'object') {
+    const source = value as DataObject
+    return copyRecord(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, toJsonValue(source[key])]),
+    )
+  }
+  return value
+}
+
+/** Encode a validated STRUCT document with base64 asset bytes for JSON. */
+export function encodeStructDocument(
+  document: StructDocument,
+): StructDocumentJson {
+  return toJsonValue(decodeStructDocument(document)) as StructDocumentJson
+}

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -1362,6 +1362,64 @@ function preflightPublicationReceipt(value: unknown, path: string) {
     )
 }
 
+function chargePublicationString(
+  value: string,
+  path: string,
+  state: PublicationSnapshotState,
+) {
+  const parsed = stringValue(value, path)
+  state.textBytes += utf8ByteLength(parsed)
+  if (state.textBytes > MAX_STRUCT_PUBLICATION_TEXT_BYTES)
+    fail(
+      'BUDGET',
+      path,
+      'publication text exceeds the aggregate resource bound',
+    )
+  return parsed
+}
+
+function preflightPublicationText(
+  value: unknown,
+  path: string,
+  state: PublicationSnapshotState,
+  depth = 0,
+) {
+  if (depth > 128)
+    fail('BUDGET', path, 'publication input nesting exceeds the depth bound')
+  state.nodes += 1
+  if (state.nodes > MAX_STRUCT_DOCUMENT_ITEMS)
+    fail('BUDGET', path, 'publication input exceeds the structural node bound')
+  if (typeof value === 'string') {
+    chargePublicationString(value, path, state)
+    return
+  }
+  if (!value || typeof value !== 'object' || ArrayBuffer.isView(value)) return
+  if (state.active.has(value))
+    fail('OBJECT', path, 'cycles are not permitted in publication input')
+  state.active.add(value)
+  try {
+    if (Array.isArray(value)) {
+      for (const [index, entry] of array(
+        value,
+        path,
+        MAX_STRUCT_DOCUMENT_ITEMS - state.nodes,
+      ).entries())
+        preflightPublicationText(entry, `${path}[${index}]`, state, depth + 1)
+      return
+    }
+    for (const [key, entry] of dataEntries(
+      value,
+      path,
+      MAX_STRUCT_DOCUMENT_ITEMS - state.nodes,
+    )) {
+      if (key === 'bytes') continue
+      preflightPublicationText(entry, `${path}.${key}`, state, depth + 1)
+    }
+  } finally {
+    state.active.delete(value)
+  }
+}
+
 function snapshotPublicationValue(
   value: unknown,
   path: string,
@@ -1374,15 +1432,7 @@ function snapshotPublicationValue(
   if (state.nodes > MAX_STRUCT_DOCUMENT_ITEMS)
     fail('BUDGET', path, 'publication input exceeds the structural node bound')
   if (typeof value === 'string') {
-    const parsed = stringValue(value, path)
-    state.textBytes += utf8ByteLength(parsed)
-    if (state.textBytes > MAX_STRUCT_PUBLICATION_TEXT_BYTES)
-      fail(
-        'BUDGET',
-        path,
-        'publication text exceeds the aggregate resource bound',
-      )
-    return parsed
+    return chargePublicationString(value, path, state)
   }
   if (!value || typeof value !== 'object') return value
   if (state.active.has(value))
@@ -1424,9 +1474,11 @@ export function snapshotStructDocumentForEpub(value: unknown): StructDocument {
     root.map(([key, entry]) => [
       key,
       key === 'assets'
-        ? parseStructAssets(entry)
+        ? (preflightPublicationText(entry, '$.assets', state),
+          parseStructAssets(entry))
         : key === 'recovery'
-          ? parseRecovery(entry, '$.recovery')
+          ? (preflightPublicationText(entry, '$.recovery', state),
+            parseRecovery(entry, '$.recovery'))
           : key === 'receipt'
             ? (preflightPublicationReceipt(entry, '$.receipt'),
               snapshotPublicationValue(entry, '$.receipt', state, 1))

--- a/src/struct/codec/parsers.ts
+++ b/src/struct/codec/parsers.ts
@@ -44,6 +44,7 @@ import {
   referenceList,
   rotation,
   stringValue,
+  utf8ByteLength,
   unique,
   unitInterval,
 } from './primitives'
@@ -153,6 +154,7 @@ export const MAX_STRUCT_ASSET_BYTES_TOTAL = 128 * 1024 * 1024
 export const MAX_STRUCT_RECOVERY_ISSUES = 10_000
 export const MAX_STRUCT_RECOVERY_PAGES = 100_000
 export const MAX_STRUCT_DOCUMENT_ITEMS = 100_000
+const MAX_STRUCT_PUBLICATION_TEXT_BYTES = 16 * 1024 * 1024
 
 function parseBox(value: unknown, path: string): StructBox {
   const parsed = object(value, path, [
@@ -1346,6 +1348,18 @@ export function parseStructAssets(value: unknown): StructAsset[] {
 type PublicationSnapshotState = {
   active: WeakSet<object>
   nodes: number
+  textBytes: number
+}
+
+function preflightPublicationReceipt(value: unknown, path: string) {
+  const modelConsultations = dataEntries(value, path).find(
+    ([key]) => key === 'modelConsultations',
+  )?.[1]
+  if (modelConsultations !== undefined)
+    validateConsultationReceipt(
+      modelConsultations,
+      `${path}.modelConsultations`,
+    )
 }
 
 function snapshotPublicationValue(
@@ -1359,6 +1373,17 @@ function snapshotPublicationValue(
   state.nodes += 1
   if (state.nodes > MAX_STRUCT_DOCUMENT_ITEMS)
     fail('BUDGET', path, 'publication input exceeds the structural node bound')
+  if (typeof value === 'string') {
+    const parsed = stringValue(value, path)
+    state.textBytes += utf8ByteLength(parsed)
+    if (state.textBytes > MAX_STRUCT_PUBLICATION_TEXT_BYTES)
+      fail(
+        'BUDGET',
+        path,
+        'publication text exceeds the aggregate resource bound',
+      )
+    return parsed
+  }
   if (!value || typeof value !== 'object') return value
   if (state.active.has(value))
     fail('OBJECT', path, 'cycles are not permitted in publication input')
@@ -1393,6 +1418,7 @@ export function snapshotStructDocumentForEpub(value: unknown): StructDocument {
   const state: PublicationSnapshotState = {
     active: new WeakSet<object>(),
     nodes: 1,
+    textBytes: 0,
   }
   return copyRecord(
     root.map(([key, entry]) => [
@@ -1401,7 +1427,10 @@ export function snapshotStructDocumentForEpub(value: unknown): StructDocument {
         ? parseStructAssets(entry)
         : key === 'recovery'
           ? parseRecovery(entry, '$.recovery')
-          : snapshotPublicationValue(entry, `$.${key}`, state, 1),
+          : key === 'receipt'
+            ? (preflightPublicationReceipt(entry, '$.receipt'),
+              snapshotPublicationValue(entry, '$.receipt', state, 1))
+            : snapshotPublicationValue(entry, `$.${key}`, state, 1),
     ]),
   ) as StructDocument
 }

--- a/src/struct/codec/primitives.ts
+++ b/src/struct/codec/primitives.ts
@@ -1,0 +1,334 @@
+import { SAFE_ID } from '../ids'
+
+export type DataObject = Record<string, unknown>
+export type EnumValue<T extends readonly string[]> = T[number]
+
+const ID = SAFE_ID
+const HASH = /^[a-f0-9]{64}$/u
+// JSON strings may contain tabs and line breaks. Reject the remaining C0
+// controls and DEL without normalizing accepted whitespace.
+const CONTROL = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u
+const URL_CONTROL = /[\u0000-\u001f\u007f]/u
+const codecErrors = new WeakSet<object>()
+
+export class StructCodecError extends TypeError {
+  readonly code: string
+  readonly path: string
+
+  constructor(code: string, path: string, message: string) {
+    super(`STRUCT_CODEC_${code} at ${path}: ${message}`)
+    this.name = 'StructCodecError'
+    this.code = code
+    this.path = path
+    codecErrors.add(this)
+  }
+}
+
+/** Do not trust an attacker-controlled prototype chain to identify codec errors. */
+export function isStructCodecError(value: unknown): value is StructCodecError {
+  return typeof value === 'object' && value !== null && codecErrors.has(value)
+}
+
+export function fail(code: string, path: string, message: string): never {
+  throw new StructCodecError(code, path, message)
+}
+
+type Snapshot = { keys: string[]; values: DataObject }
+const MAX_OBJECT_KEYS = 100_000
+
+function snapshotObject(
+  value: unknown,
+  path: string,
+  maximumKeys = MAX_OBJECT_KEYS,
+): Snapshot {
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      fail('TYPE', path, 'expected an object')
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null)
+      fail('OBJECT', path, 'expected a plain object')
+    const keys = Reflect.ownKeys(value)
+    if (maximumKeys !== undefined && keys.length > maximumKeys)
+      fail(
+        'BUDGET',
+        path,
+        `object field count exceeds the ${maximumKeys} field bound`,
+      )
+    if (keys.some((key) => typeof key !== 'string'))
+      fail('FIELD', path, 'symbol fields are not permitted')
+    const entries: Array<[string, unknown]> = []
+    for (const key of keys as string[]) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value'))
+        fail(
+          'FIELD',
+          `${path}.${key}`,
+          'accessor and non-enumerable fields are not permitted',
+        )
+      entries.push([key, descriptor.value])
+    }
+    return { keys: entries.map(([key]) => key), values: copyRecord(entries) }
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail('OBJECT', path, 'object cannot be inspected safely')
+  }
+}
+
+export function dataEntries(
+  value: unknown,
+  path: string,
+  maximumKeys?: number,
+) {
+  const snapshot = snapshotObject(value, path, maximumKeys)
+  return snapshot.keys.map(
+    (key) => [key, snapshot.values[key]] as [string, unknown],
+  )
+}
+
+export function object(
+  value: unknown,
+  path: string,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): DataObject {
+  const snapshot = snapshotObject(value, path)
+  const allowed = new Set([...required, ...optional])
+  for (const key of required) {
+    if (!Object.hasOwn(snapshot.values, key))
+      fail('REQUIRED', `${path}.${key}`, 'field is required')
+  }
+  for (const key of snapshot.keys) {
+    if (!allowed.has(key))
+      fail('UNKNOWN_FIELD', `${path}.${key}`, 'unknown field is not declared')
+  }
+  return snapshot.values
+}
+
+export function array(
+  value: unknown,
+  path: string,
+  maximumLength?: number,
+): unknown[] {
+  try {
+    if (!Array.isArray(value)) fail('TYPE', path, 'expected an array')
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length')
+    const length = lengthDescriptor?.value
+    if (
+      !lengthDescriptor ||
+      !Object.hasOwn(lengthDescriptor, 'value') ||
+      !Number.isSafeInteger(length) ||
+      length < 0
+    )
+      fail('ARRAY', path, 'array length is not a safe integer')
+    if (maximumLength !== undefined && length > maximumLength)
+      fail(
+        'BUDGET',
+        path,
+        `array length exceeds the ${maximumLength} item bound`,
+      )
+    const keys = Reflect.ownKeys(value)
+    if (
+      keys.length !== length + 1 ||
+      !keys.includes('length') ||
+      keys.some(
+        (key) =>
+          typeof key !== 'string' || (key !== 'length' && !/^\d+$/u.test(key)),
+      )
+    )
+      fail('ARRAY', path, 'array must contain only indexed values')
+    const entries: unknown[] = []
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index))
+      if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value'))
+        fail('ARRAY', `${path}[${index}]`, 'array item is not a data value')
+      entries.push(descriptor.value)
+    }
+    return entries
+  } catch (error) {
+    if (isStructCodecError(error)) throw error
+    fail('ARRAY', path, 'array cannot be inspected safely')
+  }
+}
+
+export function has(value: DataObject, key: string) {
+  return Object.hasOwn(value, key)
+}
+
+export function stringValue(value: unknown, path: string): string {
+  if (typeof value !== 'string') fail('TYPE', path, 'expected a string')
+  if (CONTROL.test(value))
+    fail('STRING', path, 'control characters are not permitted')
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index)!
+    if (codePoint > 0xffff) index += 1
+    const allowed =
+      codePoint === 0x9 ||
+      codePoint === 0xa ||
+      codePoint === 0xd ||
+      (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff)
+    if (!allowed)
+      fail('STRING', path, 'string contains a character forbidden by XML 1.0')
+  }
+  return value
+}
+
+export function finiteNumber(value: unknown, path: string): number {
+  if (typeof value !== 'number') fail('TYPE', path, 'expected a number')
+  if (!Number.isFinite(value))
+    fail('NON_FINITE_NUMBER', path, 'number must be finite')
+  if (Object.is(value, -0))
+    fail('NUMBER', path, 'negative zero is not canonical')
+  return value
+}
+
+export function integer(
+  value: unknown,
+  path: string,
+  minimum?: number,
+): number {
+  const parsed = finiteNumber(value, path)
+  if (!Number.isSafeInteger(parsed))
+    fail('NUMBER', path, 'number must be a safe integer')
+  if (minimum !== undefined && parsed < minimum)
+    fail('NUMBER', path, `number must be at least ${minimum}`)
+  return parsed
+}
+
+export function nonNegativeInteger(value: unknown, path: string) {
+  return integer(value, path, 0)
+}
+
+export function positiveInteger(value: unknown, path: string) {
+  return integer(value, path, 1)
+}
+
+export function nonNegativeNumber(value: unknown, path: string) {
+  const parsed = finiteNumber(value, path)
+  if (parsed < 0) fail('RANGE', path, 'number must be non-negative')
+  return parsed
+}
+
+export function positiveNumber(value: unknown, path: string) {
+  const parsed = finiteNumber(value, path)
+  if (parsed <= 0) fail('RANGE', path, 'number must be positive')
+  return parsed
+}
+
+export function rotation(value: unknown, path: string) {
+  const parsed = integer(value, path, 0)
+  if (parsed >= 360)
+    fail('RANGE', path, 'rotation must be less than 360 degrees')
+  return parsed
+}
+
+export function unitInterval(value: unknown, path: string) {
+  const parsed = finiteNumber(value, path)
+  if (parsed < 0 || parsed > 1)
+    fail('RANGE', path, 'number must be between 0 and 1')
+  return parsed
+}
+
+export function booleanValue(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') fail('TYPE', path, 'expected a boolean')
+  return value
+}
+
+export function nullable<T>(
+  value: unknown,
+  path: string,
+  parser: (value: unknown, path: string) => T,
+) {
+  return value === null ? null : parser(value, path)
+}
+
+export function enumValue<T extends readonly string[]>(
+  value: unknown,
+  path: string,
+  allowed: T,
+): EnumValue<T> {
+  const parsed = stringValue(value, path)
+  if (!allowed.includes(parsed))
+    fail('ENUM', path, `unexpected value ${JSON.stringify(parsed)}`)
+  return parsed as EnumValue<T>
+}
+
+export function identifier(value: unknown, path: string): string {
+  const parsed = stringValue(value, path)
+  if (!ID.test(parsed)) fail('IDENTIFIER', path, 'identifier is not canonical')
+  return parsed
+}
+
+export function identifierList(
+  value: unknown,
+  path: string,
+  allowEmpty = true,
+): string[] {
+  const values = array(value, path).map((entry, index) =>
+    identifier(entry, `${path}[${index}]`),
+  )
+  if (!allowEmpty && values.length === 0)
+    fail('ARRAY', path, 'list cannot be empty')
+  unique(values, path, 'identifier')
+  return values
+}
+
+export function reference(value: unknown, path: string): string {
+  const parsed = stringValue(value, path)
+  if (URL_CONTROL.test(parsed))
+    fail('REFERENCE', path, 'reference must not contain control characters')
+  if (ID.test(parsed)) return parsed
+  if (/^#[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(parsed)) return parsed
+  try {
+    const url = new URL(parsed)
+    if (!['http:', 'https:', 'mailto:'].includes(url.protocol))
+      throw new Error()
+    if (url.username || url.password) throw new Error()
+    if (url.href !== parsed) throw new Error()
+    return parsed
+  } catch {
+    fail(
+      'REFERENCE',
+      path,
+      'reference must be a canonical id, fragment, or safe URL',
+    )
+  }
+}
+
+export function referenceList(value: unknown, path: string): string[] {
+  const values = array(value, path).map((entry, index) =>
+    reference(entry, `${path}[${index}]`),
+  )
+  unique(values, path, 'reference')
+  return values
+}
+
+export function hash(value: unknown, path: string): string {
+  const parsed = stringValue(value, path)
+  if (!HASH.test(parsed))
+    fail('HASH', path, 'expected a lowercase SHA-256 digest')
+  return parsed
+}
+
+export function unique(values: readonly string[], path: string, label: string) {
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value))
+      fail('DUPLICATE_IDENTIFIER', path, `duplicate ${label} ${value}`)
+    seen.add(value)
+  }
+}
+
+export function copyRecord(entries: readonly [string, unknown][]) {
+  const target: DataObject = {}
+  for (const [key, value] of entries) {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    })
+  }
+  return target
+}

--- a/src/struct/codec/primitives.ts
+++ b/src/struct/codec/primitives.ts
@@ -11,6 +11,24 @@ const CONTROL = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u
 const URL_CONTROL = /[\u0000-\u001f\u007f]/u
 const codecErrors = new WeakSet<object>()
 
+/** Bound untrusted textual ingress before a renderer or digest copies it. */
+export const MAX_STRUCT_STRING_BYTES = 4 * 1024 * 1024
+
+export function utf8ByteLength(value: string) {
+  let length = 0
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index)!
+    if (codePoint <= 0x7f) length += 1
+    else if (codePoint <= 0x7ff) length += 2
+    else if (codePoint <= 0xffff) length += 3
+    else {
+      length += 4
+      index += 1
+    }
+  }
+  return length
+}
+
 export class StructCodecError extends TypeError {
   readonly code: string
   readonly path: string
@@ -156,6 +174,8 @@ export function has(value: DataObject, key: string) {
 
 export function stringValue(value: unknown, path: string): string {
   if (typeof value !== 'string') fail('TYPE', path, 'expected a string')
+  if (utf8ByteLength(value) > MAX_STRUCT_STRING_BYTES)
+    fail('BUDGET', path, 'string exceeds the textual resource bound')
   if (CONTROL.test(value))
     fail('STRING', path, 'control characters are not permitted')
   for (let index = 0; index < value.length; index += 1) {

--- a/src/struct/codec/standards.ts
+++ b/src/struct/codec/standards.ts
@@ -45,19 +45,10 @@ export function bcp47Language(value: unknown, path: string) {
   }
 
   const extensionSingletons = new Set<string>()
-  let privateUseSeen = false
   for (const subtag of parsed.split('-')) {
     if (subtag.length !== 1) continue
-    if (subtag.toLowerCase() === 'x') {
-      if (privateUseSeen)
-        fail(
-          'LANGUAGE',
-          path,
-          'language must not repeat the BCP-47 private-use singleton',
-        )
-      privateUseSeen = true
-      continue
-    }
+    // BCP-47 private-use subtags are opaque and consume the remainder.
+    if (subtag.toLowerCase() === 'x') break
     const singleton = subtag.toLowerCase()
     if (extensionSingletons.has(singleton))
       fail(

--- a/src/struct/codec/standards.ts
+++ b/src/struct/codec/standards.ts
@@ -1,0 +1,100 @@
+import { fail, stringValue } from './primitives'
+
+const MEDIA_TYPE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u
+const BCP47_LANGUAGE =
+  /^(?:(?:[A-Za-z]{2,3}(?:-[A-Za-z]{3}){0,3}|[A-Za-z]{4}|[A-Za-z]{5,8})(?:-[A-Za-z]{4})?(?:-(?:[A-Za-z]{2}|\d{3}))?(?:-(?:[A-Za-z0-9]{5,8}|\d[A-Za-z0-9]{3}))*(?:-[0-9A-WY-Za-wy-z](?:-[A-Za-z0-9]{2,8})+)*(?:-x(?:-[A-Za-z0-9]{1,8})+)?|x(?:-[A-Za-z0-9]{1,8})+)$/u
+const BCP47_GRANDFATHERED =
+  /^(?:art-lojban|cel-gaulish|en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|no-bok|no-nyn|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)$/iu
+const RFC3339_DATE = /^(\d{4})-(\d{2})-(\d{2})$/u
+const RFC3339_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u
+
+export function bcp47Language(value: unknown, path: string) {
+  const parsed = stringValue(value, path)
+  const grandfathered = BCP47_GRANDFATHERED.test(parsed)
+  if (!grandfathered && !BCP47_LANGUAGE.test(parsed))
+    fail('LANGUAGE', path, 'language must be a valid BCP-47 tag')
+
+  if (!grandfathered && !/^x-/iu.test(parsed)) {
+    const subtags = parsed.split('-')
+    const languageLength = subtags[0]?.length ?? 0
+    let index = 1
+    if (languageLength >= 2 && languageLength <= 3) {
+      let extlangs = 0
+      while (
+        extlangs < 3 &&
+        index < subtags.length &&
+        /^[A-Za-z]{3}$/u.test(subtags[index]!)
+      ) {
+        extlangs += 1
+        index += 1
+      }
+    }
+    if (/^[A-Za-z]{4}$/u.test(subtags[index] ?? '')) index += 1
+    if (/^(?:[A-Za-z]{2}|\d{3})$/u.test(subtags[index] ?? '')) index += 1
+    const variants = new Set<string>()
+    while (
+      /^(?:[A-Za-z0-9]{5,8}|\d[A-Za-z0-9]{3})$/u.test(subtags[index] ?? '')
+    ) {
+      const variant = subtags[index]!.toLowerCase()
+      if (variants.has(variant))
+        fail('LANGUAGE', path, 'language must not repeat a BCP-47 variant')
+      variants.add(variant)
+      index += 1
+    }
+  }
+
+  const extensionSingletons = new Set<string>()
+  for (const subtag of parsed.split('-')) {
+    if (subtag.length !== 1 || subtag.toLowerCase() === 'x') continue
+    const singleton = subtag.toLowerCase()
+    if (extensionSingletons.has(singleton))
+      fail(
+        'LANGUAGE',
+        path,
+        'language must not repeat a BCP-47 extension singleton',
+      )
+    extensionSingletons.add(singleton)
+  }
+  return parsed
+}
+
+export function rfc3339Date(value: unknown, path: string) {
+  const parsed = stringValue(value, path)
+  const match = RFC3339_DATE.exec(parsed)
+  if (!match) fail('DATE', path, 'date must be an RFC-3339 full-date')
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(0)
+  date.setUTCFullYear(year, month - 1, day)
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  )
+    fail('DATE', path, 'date must be a real calendar date')
+  return parsed
+}
+
+export function rfc3339DateTime(value: unknown, path: string) {
+  const parsed = stringValue(value, path)
+  if (
+    !RFC3339_DATE_TIME.test(parsed) ||
+    !/T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/u.test(
+      parsed,
+    )
+  )
+    fail('DATE_TIME', path, 'timestamp must be an RFC-3339 date-time')
+  rfc3339Date(parsed.slice(0, 10), path)
+  if (Number.isNaN(Date.parse(parsed)))
+    fail('DATE_TIME', path, 'timestamp must be a real RFC-3339 date-time')
+  return parsed
+}
+
+export function mediaType(value: unknown, path: string) {
+  const parsed = stringValue(value, path)
+  if (parsed.includes('*') || !MEDIA_TYPE.test(parsed))
+    fail('MIME', path, 'media type must be a strict type/subtype MIME value')
+  return parsed
+}

--- a/src/struct/codec/standards.ts
+++ b/src/struct/codec/standards.ts
@@ -45,8 +45,19 @@ export function bcp47Language(value: unknown, path: string) {
   }
 
   const extensionSingletons = new Set<string>()
+  let privateUseSeen = false
   for (const subtag of parsed.split('-')) {
-    if (subtag.length !== 1 || subtag.toLowerCase() === 'x') continue
+    if (subtag.length !== 1) continue
+    if (subtag.toLowerCase() === 'x') {
+      if (privateUseSeen)
+        fail(
+          'LANGUAGE',
+          path,
+          'language must not repeat the BCP-47 private-use singleton',
+        )
+      privateUseSeen = true
+      continue
+    }
     const singleton = subtag.toLowerCase()
     if (extensionSingletons.has(singleton))
       fail(

--- a/src/struct/codec/structure.ts
+++ b/src/struct/codec/structure.ts
@@ -1,0 +1,8 @@
+/** Public STRUCT document operations backed by the strict parser. */
+export {
+  StructCodecError,
+  decodeStructDocument,
+  encodeStructDocument,
+  migrateStructDocument,
+} from './parsers'
+export type { StructDocumentJson } from './parsers'

--- a/src/struct/consultation-receipt.ts
+++ b/src/struct/consultation-receipt.ts
@@ -1,4 +1,5 @@
 import { credentialShapedValue, SAFE_ID } from './ids'
+import { utf8ByteLength } from './codec/primitives'
 
 /**
  * Source-neutral, serialized consultation receipt envelope.
@@ -21,6 +22,8 @@ const HASH = /^[a-f0-9]{64}$/u
 const STRUCT_CONSULTATION_RECEIPT_SCHEMA_VERSION = '1.0.0'
 const MAX_DEPTH = 128
 const MAX_NODES = 100_000
+const MAX_JSON_STRING_BYTES = 1024 * 1024
+const MAX_JSON_TOTAL_BYTES = 8 * 1024 * 1024
 const TOP_LEVEL_KEYS = [
   'schemaVersion',
   'documentId',
@@ -57,7 +60,7 @@ function forbiddenKey(key: string) {
 function canonicalJson(
   value: unknown,
   active: WeakSet<object>,
-  state: { nodes: number },
+  state: { nodes: number; stringBytes: number },
   depth: number,
 ): value is
   Record<string, unknown> | unknown[] | string | number | boolean | null {
@@ -65,7 +68,14 @@ function canonicalJson(
   state.nodes += 1
   if (state.nodes > MAX_NODES) return false
   if (value === null || typeof value === 'boolean') return true
-  if (typeof value === 'string') return !credentialShapedValue(value)
+  if (typeof value === 'string') {
+    const bytes = utf8ByteLength(value)
+    if (bytes > MAX_JSON_STRING_BYTES) return false
+    state.stringBytes += bytes
+    return (
+      state.stringBytes <= MAX_JSON_TOTAL_BYTES && !credentialShapedValue(value)
+    )
+  }
   if (typeof value === 'number') return Number.isFinite(value)
   if (typeof value !== 'object' || active.has(value)) return false
 
@@ -112,6 +122,10 @@ function canonicalJson(
     for (const key of keys) {
       if (typeof key !== 'string' || !SAFE_ID.test(key) || forbiddenKey(key))
         return false
+      const keyBytes = utf8ByteLength(key)
+      if (keyBytes > MAX_JSON_STRING_BYTES) return false
+      state.stringBytes += keyBytes
+      if (state.stringBytes > MAX_JSON_TOTAL_BYTES) return false
       const descriptor = Object.getOwnPropertyDescriptor(value, key)
       if (
         !descriptor?.enumerable ||
@@ -138,7 +152,14 @@ function exactTopLevelKeys(value: Record<string, unknown>) {
 function validateStructConsultationReceiptUnsafe(
   value: unknown,
 ): value is StructConsultationReceipt {
-  if (!canonicalJson(value, new WeakSet<object>(), { nodes: 0 }, 0))
+  if (
+    !canonicalJson(
+      value,
+      new WeakSet<object>(),
+      { nodes: 0, stringBytes: 0 },
+      0,
+    )
+  )
     return false
   if (!value || Array.isArray(value) || typeof value !== 'object') return false
   const receipt = value as Record<string, unknown>

--- a/src/struct/consultation-receipt.ts
+++ b/src/struct/consultation-receipt.ts
@@ -22,8 +22,9 @@ const HASH = /^[a-f0-9]{64}$/u
 const STRUCT_CONSULTATION_RECEIPT_SCHEMA_VERSION = '1.0.0'
 const MAX_DEPTH = 128
 const MAX_NODES = 100_000
-const MAX_JSON_STRING_BYTES = 1024 * 1024
-const MAX_JSON_TOTAL_BYTES = 8 * 1024 * 1024
+/** Bounds shared by generic receipt validation and its canonical snapshot. */
+export const MAX_STRUCT_RECEIPT_JSON_STRING_BYTES = 1024 * 1024
+export const MAX_STRUCT_RECEIPT_JSON_TOTAL_BYTES = 8 * 1024 * 1024
 const TOP_LEVEL_KEYS = [
   'schemaVersion',
   'documentId',
@@ -76,12 +77,12 @@ function canonicalJson(
   if (value === null || typeof value === 'boolean') return true
   if (typeof value === 'string') {
     const bytes = utf8ByteLength(value)
-    if (bytes > MAX_JSON_STRING_BYTES) {
+    if (bytes > MAX_STRUCT_RECEIPT_JSON_STRING_BYTES) {
       state.budgetExceeded = true
       return false
     }
     state.stringBytes += bytes
-    if (state.stringBytes > MAX_JSON_TOTAL_BYTES) {
+    if (state.stringBytes > MAX_STRUCT_RECEIPT_JSON_TOTAL_BYTES) {
       state.budgetExceeded = true
       return false
     }
@@ -140,12 +141,12 @@ function canonicalJson(
       if (typeof key !== 'string' || !SAFE_ID.test(key) || forbiddenKey(key))
         return false
       const keyBytes = utf8ByteLength(key)
-      if (keyBytes > MAX_JSON_STRING_BYTES) {
+      if (keyBytes > MAX_STRUCT_RECEIPT_JSON_STRING_BYTES) {
         state.budgetExceeded = true
         return false
       }
       state.stringBytes += keyBytes
-      if (state.stringBytes > MAX_JSON_TOTAL_BYTES) {
+      if (state.stringBytes > MAX_STRUCT_RECEIPT_JSON_TOTAL_BYTES) {
         state.budgetExceeded = true
         return false
       }

--- a/src/struct/consultation-receipt.ts
+++ b/src/struct/consultation-receipt.ts
@@ -1,0 +1,185 @@
+import { credentialShapedValue, SAFE_ID } from './ids'
+
+/**
+ * Source-neutral, serialized consultation receipt envelope.
+ *
+ * The contents of consultations, decisions, and metrics belong to an
+ * application adapter. STRUCT only snapshots them as closed canonical JSON
+ * and binds the envelope to its enclosing document and source.
+ */
+export type StructConsultationReceipt = {
+  schemaVersion: string
+  documentId: string
+  sourceSha256: string | null
+  consultations: readonly Record<string, unknown>[]
+  decisions: readonly Record<string, unknown>[]
+  metrics: Record<string, unknown>
+  semanticStateSha256?: string
+}
+
+const HASH = /^[a-f0-9]{64}$/u
+const STRUCT_CONSULTATION_RECEIPT_SCHEMA_VERSION = '1.0.0'
+const MAX_DEPTH = 128
+const MAX_NODES = 100_000
+const TOP_LEVEL_KEYS = [
+  'schemaVersion',
+  'documentId',
+  'sourceSha256',
+  'consultations',
+  'decisions',
+  'metrics',
+  'semanticStateSha256',
+] as const
+const FORBIDDEN_KEY_FRAGMENTS = [
+  'apikey',
+  'authorization',
+  'credential',
+  'password',
+  'privatekey',
+  'secret',
+  'token',
+] as const
+
+function normalizedKey(key: string) {
+  return key
+    .normalize('NFKC')
+    .replace(/[^A-Za-z0-9]/gu, '')
+    .toLowerCase()
+}
+
+function forbiddenKey(key: string) {
+  const normalized = normalizedKey(key)
+  return FORBIDDEN_KEY_FRAGMENTS.some((fragment) =>
+    normalized.includes(fragment),
+  )
+}
+
+function canonicalJson(
+  value: unknown,
+  active: WeakSet<object>,
+  state: { nodes: number },
+  depth: number,
+): value is
+  Record<string, unknown> | unknown[] | string | number | boolean | null {
+  if (depth > MAX_DEPTH) return false
+  state.nodes += 1
+  if (state.nodes > MAX_NODES) return false
+  if (value === null || typeof value === 'boolean') return true
+  if (typeof value === 'string') return !credentialShapedValue(value)
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value !== 'object' || active.has(value)) return false
+
+  active.add(value)
+  try {
+    if (Array.isArray(value)) {
+      if (Object.getPrototypeOf(value) !== Array.prototype) return false
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length')
+      const length = lengthDescriptor?.value
+      if (
+        !lengthDescriptor ||
+        !Object.hasOwn(lengthDescriptor, 'value') ||
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        length > MAX_NODES - state.nodes
+      )
+        return false
+      const keys = Reflect.ownKeys(value)
+      if (
+        keys.length !== length + 1 ||
+        !keys.includes('length') ||
+        keys.some(
+          (key) =>
+            typeof key !== 'string' ||
+            (key !== 'length' && !/^\d+$/u.test(key)),
+        )
+      )
+        return false
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index))
+        if (
+          !descriptor?.enumerable ||
+          !Object.hasOwn(descriptor, 'value') ||
+          !canonicalJson(descriptor.value, active, state, depth + 1)
+        )
+          return false
+      }
+      return true
+    }
+    const prototype = Object.getPrototypeOf(value)
+    if (prototype !== Object.prototype && prototype !== null) return false
+    const keys = Reflect.ownKeys(value)
+    if (keys.length > MAX_NODES - state.nodes) return false
+    for (const key of keys) {
+      if (typeof key !== 'string' || !SAFE_ID.test(key) || forbiddenKey(key))
+        return false
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (
+        !descriptor?.enumerable ||
+        !Object.hasOwn(descriptor, 'value') ||
+        !canonicalJson(descriptor.value, active, state, depth + 1)
+      )
+        return false
+    }
+    return true
+  } finally {
+    active.delete(value)
+  }
+}
+
+function exactTopLevelKeys(value: Record<string, unknown>) {
+  const keys = Object.keys(value).sort()
+  const allowed = TOP_LEVEL_KEYS.filter((key) =>
+    Object.hasOwn(value, key),
+  ).sort()
+  return JSON.stringify(keys) === JSON.stringify(allowed)
+}
+
+/** Validate only the generic closed receipt envelope. */
+function validateStructConsultationReceiptUnsafe(
+  value: unknown,
+): value is StructConsultationReceipt {
+  if (!canonicalJson(value, new WeakSet<object>(), { nodes: 0 }, 0))
+    return false
+  if (!value || Array.isArray(value) || typeof value !== 'object') return false
+  const receipt = value as Record<string, unknown>
+  if (!exactTopLevelKeys(receipt)) return false
+  if (
+    typeof receipt.schemaVersion !== 'string' ||
+    receipt.schemaVersion !== STRUCT_CONSULTATION_RECEIPT_SCHEMA_VERSION ||
+    typeof receipt.documentId !== 'string' ||
+    !SAFE_ID.test(receipt.documentId) ||
+    (receipt.sourceSha256 !== null &&
+      (typeof receipt.sourceSha256 !== 'string' ||
+        !HASH.test(receipt.sourceSha256))) ||
+    !Array.isArray(receipt.consultations) ||
+    !Array.isArray(receipt.decisions) ||
+    !receipt.metrics ||
+    typeof receipt.metrics !== 'object' ||
+    Array.isArray(receipt.metrics) ||
+    (receipt.semanticStateSha256 !== undefined &&
+      (typeof receipt.semanticStateSha256 !== 'string' ||
+        !HASH.test(receipt.semanticStateSha256)))
+  )
+    return false
+  for (const member of [...receipt.consultations, ...receipt.decisions]) {
+    if (
+      !member ||
+      typeof member !== 'object' ||
+      Array.isArray(member) ||
+      (Object.getPrototypeOf(member) !== Object.prototype &&
+        Object.getPrototypeOf(member) !== null)
+    )
+      return false
+  }
+  return true
+}
+
+export function validateStructConsultationReceipt(
+  value: unknown,
+): value is StructConsultationReceipt {
+  try {
+    return validateStructConsultationReceiptUnsafe(value)
+  } catch {
+    return false
+  }
+}

--- a/src/struct/consultation-receipt.ts
+++ b/src/struct/consultation-receipt.ts
@@ -1,5 +1,5 @@
 import { credentialShapedValue, SAFE_ID } from './ids'
-import { utf8ByteLength } from './codec/primitives'
+import { fail, utf8ByteLength } from './codec/primitives'
 
 /**
  * Source-neutral, serialized consultation receipt envelope.
@@ -60,21 +60,32 @@ function forbiddenKey(key: string) {
 function canonicalJson(
   value: unknown,
   active: WeakSet<object>,
-  state: { nodes: number; stringBytes: number },
+  state: { nodes: number; stringBytes: number; budgetExceeded: boolean },
   depth: number,
 ): value is
   Record<string, unknown> | unknown[] | string | number | boolean | null {
-  if (depth > MAX_DEPTH) return false
+  if (depth > MAX_DEPTH) {
+    state.budgetExceeded = true
+    return false
+  }
   state.nodes += 1
-  if (state.nodes > MAX_NODES) return false
+  if (state.nodes > MAX_NODES) {
+    state.budgetExceeded = true
+    return false
+  }
   if (value === null || typeof value === 'boolean') return true
   if (typeof value === 'string') {
     const bytes = utf8ByteLength(value)
-    if (bytes > MAX_JSON_STRING_BYTES) return false
+    if (bytes > MAX_JSON_STRING_BYTES) {
+      state.budgetExceeded = true
+      return false
+    }
     state.stringBytes += bytes
-    return (
-      state.stringBytes <= MAX_JSON_TOTAL_BYTES && !credentialShapedValue(value)
-    )
+    if (state.stringBytes > MAX_JSON_TOTAL_BYTES) {
+      state.budgetExceeded = true
+      return false
+    }
+    return !credentialShapedValue(value)
   }
   if (typeof value === 'number') return Number.isFinite(value)
   if (typeof value !== 'object' || active.has(value)) return false
@@ -91,8 +102,11 @@ function canonicalJson(
         !Number.isSafeInteger(length) ||
         length < 0 ||
         length > MAX_NODES - state.nodes
-      )
+      ) {
+        if (Number.isSafeInteger(length) && length > MAX_NODES - state.nodes)
+          state.budgetExceeded = true
         return false
+      }
       const keys = Reflect.ownKeys(value)
       if (
         keys.length !== length + 1 ||
@@ -118,14 +132,23 @@ function canonicalJson(
     const prototype = Object.getPrototypeOf(value)
     if (prototype !== Object.prototype && prototype !== null) return false
     const keys = Reflect.ownKeys(value)
-    if (keys.length > MAX_NODES - state.nodes) return false
+    if (keys.length > MAX_NODES - state.nodes) {
+      state.budgetExceeded = true
+      return false
+    }
     for (const key of keys) {
       if (typeof key !== 'string' || !SAFE_ID.test(key) || forbiddenKey(key))
         return false
       const keyBytes = utf8ByteLength(key)
-      if (keyBytes > MAX_JSON_STRING_BYTES) return false
+      if (keyBytes > MAX_JSON_STRING_BYTES) {
+        state.budgetExceeded = true
+        return false
+      }
       state.stringBytes += keyBytes
-      if (state.stringBytes > MAX_JSON_TOTAL_BYTES) return false
+      if (state.stringBytes > MAX_JSON_TOTAL_BYTES) {
+        state.budgetExceeded = true
+        return false
+      }
       const descriptor = Object.getOwnPropertyDescriptor(value, key)
       if (
         !descriptor?.enumerable ||
@@ -156,7 +179,7 @@ function validateStructConsultationReceiptUnsafe(
     !canonicalJson(
       value,
       new WeakSet<object>(),
-      { nodes: 0, stringBytes: 0 },
+      { nodes: 0, stringBytes: 0, budgetExceeded: false },
       0,
     )
   )
@@ -193,6 +216,23 @@ function validateStructConsultationReceiptUnsafe(
       return false
   }
   return true
+}
+
+/** Reject bounded receipt ingress before a consumer snapshots its JSON tree. */
+export function preflightStructConsultationReceipt(
+  value: unknown,
+  path: string,
+) {
+  const state = { nodes: 0, stringBytes: 0, budgetExceeded: false }
+  let valid = false
+  try {
+    valid = canonicalJson(value, new WeakSet<object>(), state, 0)
+  } catch {
+    return false
+  }
+  if (state.budgetExceeded)
+    fail('BUDGET', path, 'consultation receipt exceeds the resource bound')
+  return valid && validateStructConsultationReceiptUnsafe(value)
 }
 
 export function validateStructConsultationReceipt(

--- a/src/struct/consultation-receipt.ts
+++ b/src/struct/consultation-receipt.ts
@@ -88,7 +88,8 @@ function canonicalJson(
     }
     return !credentialShapedValue(value)
   }
-  if (typeof value === 'number') return Number.isFinite(value)
+  if (typeof value === 'number')
+    return Number.isFinite(value) && !Object.is(value, -0)
   if (typeof value !== 'object' || active.has(value)) return false
 
   active.add(value)

--- a/src/struct/emitted-ids.ts
+++ b/src/struct/emitted-ids.ts
@@ -1,0 +1,1009 @@
+import type { StructDocument, StructInline } from './types'
+
+const EPUB_RESERVED_IDS = new Set([
+  'publication-id',
+  'nav',
+  'content',
+  'styles',
+  'struct',
+  'profile',
+])
+
+/**
+ * Publication planning budgets. These bound the work which can be expanded
+ * into owner arrays and markup, rather than rejecting a raw run count: a
+ * document with many disjoint runs is linear, while nested runs can be
+ * quadratic. No valid run is truncated or reordered.
+ */
+export const MAX_RENDERED_INLINE_SEGMENTS = 250_000
+export const MAX_RENDERED_INLINE_ACTIVE_OWNER_VISITS = 750_000
+export const MAX_RENDERED_INLINE_WRAPPER_BYTES = 16_000_000
+const ESTIMATED_WRAPPER_BYTES_PER_OWNER = 64
+const ESTIMATED_CITATION_RANGE_VISIT_BYTES = 16
+const MAX_CITATION_MATCH_WORK = MAX_RENDERED_INLINE_SEGMENTS
+const MAX_RENDERED_INLINE_EVENT_STORAGE = MAX_RENDERED_INLINE_SEGMENTS * 4
+
+export type StructTarget = {
+  id: string
+  href: string
+  kind: 'asset' | 'block' | 'external'
+}
+
+export function isPackagedAssetId(value: string) {
+  return (
+    /^[A-Za-z_][A-Za-z0-9_.-]*$/u.test(value) && !EPUB_RESERVED_IDS.has(value)
+  )
+}
+
+/** Resolve every publication target through the same local/external rules. */
+export function resolveStructTarget(
+  document: StructDocument,
+  value: string,
+): StructTarget {
+  const id = value.startsWith('#') ? value.slice(1) : value
+  const asset = document.assets.find((entry) => entry.id === id)
+  if (asset) {
+    if (!isPackagedAssetId(asset.id))
+      throw new Error(`STRUCT target asset is not packageable: ${asset.id}`)
+    return { id: asset.id, href: asset.href, kind: 'asset' }
+  }
+  const block = document.blocks.find((entry) => entry.id === id)
+  if (block) {
+    if (block.kind === 'furniture')
+      throw new Error(`STRUCT target block is not rendered: ${block.id}`)
+    return { id: block.id, href: `#${block.id}`, kind: 'block' }
+  }
+  if (/^(?:https?|mailto):/iu.test(value))
+    return { id: value, href: value, kind: 'external' }
+  throw new Error(`STRUCT target is not renderable: ${value}`)
+}
+
+type PlanningTargetIndex = ReadonlyMap<
+  string,
+  { id: string; href: string; kind: 'asset' | 'block'; furniture?: boolean }
+>
+
+function buildPlanningTargetIndex(
+  document: StructDocument,
+): PlanningTargetIndex {
+  const index = new Map<
+    string,
+    { id: string; href: string; kind: 'asset' | 'block'; furniture?: boolean }
+  >()
+  for (const asset of document.assets)
+    index.set(asset.id, { id: asset.id, href: asset.href, kind: 'asset' })
+  for (const block of document.blocks)
+    if (!index.has(block.id))
+      index.set(block.id, {
+        id: block.id,
+        href: `#${block.id}`,
+        kind: 'block',
+        furniture: block.kind === 'furniture',
+      })
+  return index
+}
+
+function resolvePlanningTarget(
+  index: PlanningTargetIndex,
+  value: string,
+): StructTarget {
+  const id = value.startsWith('#') ? value.slice(1) : value
+  const target = index.get(id)
+  if (target) {
+    if (target.kind === 'asset') {
+      if (!isPackagedAssetId(target.id))
+        throw new Error(`STRUCT target asset is not packageable: ${target.id}`)
+      return { id: target.id, href: target.href, kind: target.kind }
+    }
+    if (target.furniture)
+      throw new Error(`STRUCT target block is not rendered: ${target.id}`)
+    return { id: target.id, href: target.href, kind: target.kind }
+  }
+  if (/^(?:https?|mailto):/iu.test(value))
+    return { id: value, href: value, kind: 'external' }
+  throw new Error(`STRUCT target is not renderable: ${value}`)
+}
+
+function resolvePlanningTargetLazily(
+  getTargetIndex: () => PlanningTargetIndex,
+  value: string,
+): StructTarget {
+  if (/^(?:https?|mailto):/iu.test(value)) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u.test(value))
+      return { id: value, href: value, kind: 'external' }
+    const index = getTargetIndex()
+    if (!index.has(value)) return { id: value, href: value, kind: 'external' }
+  }
+  return resolvePlanningTarget(getTargetIndex(), value)
+}
+
+export type EmittedXhtmlId = {
+  id: string
+  path: string
+}
+
+/** Keep the renderer's XML-compatible identifier normalization in one place. */
+export function stableId(value: string) {
+  const cleaned = value.replace(/[^A-Za-z0-9_.:-]/g, '-')
+  return /^[A-Za-z_]/u.test(cleaned) ? cleaned : `n-${cleaned}`
+}
+
+function text(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function attribute(value: string) {
+  return text(value).replace(/\"/g, '&quot;')
+}
+
+const UNICODE_DECIMAL_ZERO_CODE_POINTS = [
+  0x0030, 0x0660, 0x06f0, 0x07c0, 0x0966, 0x09e6, 0x0a66, 0x0ae6, 0x0b66,
+  0x0be6, 0x0c66, 0x0ce6, 0x0d66, 0x0de6, 0x0e50, 0x0ed0, 0x0f20, 0x1040,
+  0x1090, 0x17e0, 0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0,
+  0x1c40, 0x1c50, 0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0,
+  0xff10, 0x104a0, 0x10d30, 0x10d40, 0x11066, 0x110f0, 0x11136, 0x111d0,
+  0x112f0, 0x11450, 0x114d0, 0x11650, 0x116c0, 0x116d0, 0x116da, 0x11730,
+  0x118e0, 0x11950, 0x11bf0, 0x11c50, 0x11d50, 0x11da0, 0x11de0, 0x11f50,
+  0x16130, 0x16a60, 0x16ac0, 0x16b50, 0x16d70, 0x1ccf0, 0x1d7ce, 0x1d7d8,
+  0x1d7e2, 0x1d7ec, 0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e5f1, 0x1e950,
+  0x1fbf0,
+] as const
+
+const SUPERSCRIPT_DIGITS: Record<string, string> = {
+  '⁰': '0',
+  '¹': '1',
+  '²': '2',
+  '³': '3',
+  '⁴': '4',
+  '⁵': '5',
+  '⁶': '6',
+  '⁷': '7',
+  '⁸': '8',
+  '⁹': '9',
+}
+
+function normalizedNumericToken(value: string) {
+  return [...value]
+    .map((character) => {
+      if (SUPERSCRIPT_DIGITS[character]) return SUPERSCRIPT_DIGITS[character]
+      const codePoint = character.codePointAt(0)!
+      const zero = UNICODE_DECIMAL_ZERO_CODE_POINTS.find(
+        (candidate) => codePoint >= candidate && codePoint <= candidate + 9,
+      )
+      return zero === undefined ? character : String(codePoint - zero)
+    })
+    .join('')
+}
+
+function foldedCitationText(value: string) {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
+    .replace(/’/gu, "'")
+    .toLocaleLowerCase()
+}
+
+function citationRanges(
+  sourceValue: string,
+  labels: readonly string[],
+  targets: readonly StructTarget[],
+  path: string,
+  totals: PlanningTotals,
+) {
+  if (
+    labels.length !== targets.length ||
+    new Set(labels).size !== labels.length
+  )
+    return null
+  const targetByLabel = new Map(
+    labels.map((label, index) => [label, targets[index]!.id] as const),
+  )
+  const labelsByYear = new Map<
+    string,
+    Array<{ label: string; index: number; surname: string }>
+  >()
+  for (const [index, label] of labels.entries()) {
+    const separator = label.lastIndexOf(':')
+    if (separator <= 0) continue
+    const year = label.slice(separator + 1)
+    const candidates = labelsByYear.get(year) ?? []
+    candidates.push({
+      label,
+      index,
+      surname: foldedCitationText(label.slice(0, separator)),
+    })
+    labelsByYear.set(year, candidates)
+  }
+  const ranges: Array<{ start: number; end: number; target: string }> = [
+    ...sourceValue.matchAll(/[\p{Nd}⁰¹²³⁴⁵⁶⁷⁸⁹]+/gu),
+  ].flatMap((match) => {
+    const target = targetByLabel.get(normalizedNumericToken(match[0]))
+    const start = match.index ?? -1
+    return target && start >= 0
+      ? [{ start, end: start + match[0].length, target }]
+      : []
+  })
+  const linkedTargets = new Set(ranges.map((range) => range.target))
+  for (const match of sourceValue.matchAll(/\b(?:18|19|20)\d{2}[a-z]?\b/giu)) {
+    const start = match.index ?? -1
+    if (start < 0) continue
+    const year = match[0].toLocaleLowerCase()
+    const prefix = foldedCitationText(
+      sourceValue.slice(Math.max(0, start - 96), start),
+    )
+    const yearLabels = labelsByYear.get(year) ?? []
+    if (totals.citationWork + yearLabels.length > MAX_CITATION_MATCH_WORK)
+      throw new RenderedPublicationPlanError(
+        'BUDGET',
+        path,
+        'citation matching work exceeds the publication planning budget',
+      )
+    totals.citationWork += yearLabels.length
+    const candidates = yearLabels.flatMap(({ index, surname }) => {
+      const position = prefix.lastIndexOf(surname)
+      return position >= 0 && !linkedTargets.has(targets[index]!.id)
+        ? [{ target: targets[index]!.id, position }]
+        : []
+    })
+    const nearest = Math.max(...candidates.map(({ position }) => position))
+    const selected = candidates.filter(({ position }) => position === nearest)
+    if (selected.length !== 1) continue
+    ranges.push({
+      start,
+      end: start + match[0].length,
+      target: selected[0]!.target,
+    })
+    linkedTargets.add(selected[0]!.target)
+  }
+  ranges.sort((left, right) => left.start - right.start || left.end - right.end)
+  return ranges.some(
+    (range, index) => index > 0 && range.start < ranges[index - 1]!.end,
+  )
+    ? null
+    : ranges
+}
+
+export function groupedCitationLinks(
+  value: string,
+  ranges: readonly { start: number; end: number; target: string }[] | null,
+  targetById: ReadonlyMap<string, StructTarget>,
+  epubRole: string,
+  sourceOffset = 0,
+) {
+  if (!ranges) return { html: text(value), linkedTargets: new Set<string>() }
+  const linkedTargets = new Set(ranges.map((range) => range.target))
+  const segmentEnd = sourceOffset + value.length
+  const segmentRanges = ranges.flatMap((range) => {
+    const start = Math.max(range.start, sourceOffset)
+    const end = Math.min(range.end, segmentEnd)
+    return start < end
+      ? [
+          {
+            start: start - sourceOffset,
+            end: end - sourceOffset,
+            target: range.target,
+          },
+        ]
+      : []
+  })
+  let cursor = 0
+  let html = ''
+  for (const range of segmentRanges) {
+    html += text(value.slice(cursor, range.start))
+    const target = targetById.get(range.target)
+    if (!target) return { html: text(value), linkedTargets: new Set<string>() }
+    html += `<a href="${attribute(target.href)}"${epubRole}>${text(value.slice(range.start, range.end))}</a>`
+    cursor = range.end
+  }
+  html += text(value.slice(cursor))
+  return { html, linkedTargets }
+}
+
+function validInline(run: StructInline, text: string) {
+  return (
+    Number.isInteger(run.start) &&
+    Number.isInteger(run.end) &&
+    run.start >= 0 &&
+    run.end > run.start &&
+    run.end <= text.length
+  )
+}
+
+type RenderedInlineSource = {
+  key: string
+  value: string
+  runs: readonly StructInline[]
+  pathPrefix: string
+}
+
+export type RenderedInlineSegment = {
+  start: number
+  end: number
+  owners: readonly StructInline[]
+  ownerPaths: readonly string[]
+  ownerKeys: readonly string[]
+}
+
+export type RenderedInlineSourcePlan = RenderedInlineSource & {
+  segments: readonly RenderedInlineSegment[]
+}
+
+type CitationRange = { start: number; end: number; target: string }
+
+export type RenderedSemanticPlan = {
+  semanticRole: NonNullable<StructInline['semanticRole']>
+  relationshipId: string
+  relationshipIdStable: string
+  targets: readonly StructTarget[]
+  targetById: ReadonlyMap<string, StructTarget>
+  labels: readonly string[]
+  semanticAttributes: string
+  epubRole: string
+  additionalTargets: string
+  citationRanges: readonly CitationRange[] | null
+  estimatedBytesPerSegment: number
+}
+
+export type RenderedHyperlinkPlan = {
+  href: string
+  estimatedBytesPerSegment: number
+}
+
+type DraftRun = {
+  run: StructInline
+  originalIndex: number
+  path: string
+  key: string
+}
+
+type PlanningTotals = {
+  segmentCount: number
+  activeOwnerVisits: number
+  wrapperBytes: number
+  eventStorage: number
+  citationWork: number
+}
+
+export type RenderedPublicationPlan = {
+  sources: readonly RenderedInlineSourcePlan[]
+  sourceByKey: ReadonlyMap<string, RenderedInlineSourcePlan>
+  relationships: ReadonlyMap<string, StructDocument['relationships'][number]>
+  renderedRelationshipIds: ReadonlySet<string>
+  backlinksByTarget: ReadonlyMap<
+    string,
+    readonly StructDocument['relationships'][number][]
+  >
+  authorNotesByAuthor: ReadonlyMap<
+    string,
+    readonly NonNullable<StructDocument['metadata']['authorNotes']>[number][]
+  >
+  semanticByOwnerKey: ReadonlyMap<string, RenderedSemanticPlan>
+  hyperlinkByOwnerKey: ReadonlyMap<string, RenderedHyperlinkPlan>
+}
+
+export class RenderedPublicationPlanError extends Error {
+  constructor(
+    readonly code: 'BUDGET' | 'DUPLICATE_IDENTIFIER',
+    readonly path: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'RenderedPublicationPlanError'
+  }
+}
+
+/** Return exactly the inline sources that the publication renderer consumes. */
+function* renderedInlineSources(
+  document: StructDocument,
+): Generator<RenderedInlineSource> {
+  for (const [blockIndex, block] of document.blocks.entries()) {
+    if (block.kind === 'furniture') continue
+    if (block.kind === 'table' && block.table) {
+      for (const [cellIndex, cell] of block.table.cells.entries())
+        yield {
+          key: `table:${blockIndex}:${cellIndex}`,
+          value: cell.text,
+          runs: cell.inline,
+          pathPrefix: `$.blocks[${blockIndex}].table.cells[${cellIndex}].inline`,
+        }
+      continue
+    }
+    yield {
+      key: `block:${blockIndex}`,
+      value: block.text,
+      runs: block.inline,
+      pathPrefix: `$.blocks[${blockIndex}].inline`,
+    }
+  }
+}
+
+type InlineEvent = { position: number; runIndex: number; end: boolean }
+
+type InlineDraft = {
+  source: RenderedInlineSource
+  runs: DraftRun[]
+  events: InlineEvent[]
+  positions: number[]
+  segmentCount: number
+  activeOwnerVisits: number
+  wrapperBytes: number
+  semanticByOwnerKey: Map<string, RenderedSemanticPlan>
+  hyperlinkByOwnerKey: Map<string, RenderedHyperlinkPlan>
+  renderedRelationshipIds: Set<string>
+}
+
+function semanticPlanForRun(
+  document: StructDocument,
+  source: RenderedInlineSource,
+  run: StructInline,
+  path: string,
+  relationships: ReadonlyMap<string, StructDocument['relationships'][number]>,
+  targetCache: WeakMap<readonly string[], StructTarget[]>,
+  getTargetIndex: () => PlanningTargetIndex,
+  totals: PlanningTotals,
+  remainingSegments: number,
+): RenderedSemanticPlan | undefined {
+  if (!run.semanticRole || !run.relationshipId) return undefined
+  const relationship = relationships.get(run.relationshipId)
+  const rawTargets =
+    relationship?.status === 'matched' ? relationship.to : (run.targetIds ?? [])
+  const labels = (relationship?.label ?? '')
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean)
+  let targets = targetCache.get(rawTargets)
+  if (!targets) {
+    targets = []
+    let targetEstimate = 0
+    for (
+      let targetIndex = 0;
+      targetIndex < rawTargets.length;
+      targetIndex += 1
+    ) {
+      const rawTarget = rawTargets[targetIndex]!
+      const target = resolvePlanningTargetLazily(getTargetIndex, rawTarget)
+      targets.push(target)
+      targetEstimate +=
+        `<a href="${attribute(target.href)}"${run.semanticRole === 'note-reference' ? ' epub:type="noteref" role="doc-noteref"' : run.semanticRole === 'citation' ? ' epub:type="biblioref" role="doc-biblioref"' : ''}>${text(labels[targetIndex] ?? String(targetIndex + 1))}</a>`
+          .length
+      if (
+        totals.wrapperBytes + targetEstimate * Math.max(1, remainingSegments) >
+        MAX_RENDERED_INLINE_WRAPPER_BYTES
+      )
+        throw new RenderedPublicationPlanError(
+          'BUDGET',
+          path,
+          'semantic target expansion exceeds the publication planning budget',
+        )
+    }
+    targetCache.set(rawTargets, targets)
+  }
+  const relationshipIdStable = stableId(run.relationshipId)
+  const epubRole =
+    run.semanticRole === 'note-reference'
+      ? ' epub:type="noteref" role="doc-noteref"'
+      : run.semanticRole === 'citation'
+        ? ' epub:type="biblioref" role="doc-biblioref"'
+        : ''
+  const targetIds = targets.map((target) => target.id).join(' ')
+  const targetById = new Map(
+    targets.map((target) => [target.id, target] as const),
+  )
+  const semanticAttributes = ` data-semantic-role="${attribute(run.semanticRole)}" data-relationship-id="${attribute(relationshipIdStable)}"${targets.length > 0 ? ` data-target-ids="${attribute(targetIds)}"` : ''}`
+  const ranges =
+    run.semanticRole === 'citation'
+      ? citationRanges(
+          source.value.slice(run.start!, run.end!),
+          labels,
+          targets,
+          path,
+          totals,
+        )
+      : null
+  const visibleTargets = new Set((ranges ?? []).map((range) => range.target))
+  const additionalTargets =
+    targets.length > 1
+      ? targets
+          .map((target, targetIndex) => ({ target, targetIndex }))
+          .filter(({ target }) => !visibleTargets.has(target.id))
+          .map(
+            ({ target, targetIndex }) =>
+              `<a href="${attribute(target!.href)}"${epubRole} class="additional-semantic-reference">Additional ${text(run.semanticRole!)} target ${text(labels[targetIndex] ?? String(targetIndex + 1))}</a>`,
+          )
+          .join('')
+      : ''
+  const targetMarkupBytes = targets.reduce(
+    (total, target, targetIndex) =>
+      total +
+      `<a href="${attribute(target.href)}"${epubRole}>${text(labels[targetIndex] ?? String(targetIndex + 1))}</a>`
+        .length,
+    0,
+  )
+  const openingBytes =
+    targets.length === 0
+      ? `<span${semanticAttributes}>`.length + '</span>'.length
+      : targets.length === 1
+        ? `<a href="${attribute(targets[0]!.href)}"${epubRole}${semanticAttributes}>`
+            .length + '</a>'.length
+        : `<span${semanticAttributes}>`.length + '</span>'.length
+  return {
+    semanticRole: run.semanticRole,
+    relationshipId: run.relationshipId,
+    relationshipIdStable,
+    targets,
+    targetById,
+    labels,
+    semanticAttributes,
+    epubRole,
+    additionalTargets,
+    citationRanges: ranges,
+    estimatedBytesPerSegment:
+      openingBytes +
+      targetMarkupBytes +
+      (ranges?.length ?? 0) * ESTIMATED_CITATION_RANGE_VISIT_BYTES,
+  }
+}
+
+function hyperlinkPlanForRun(
+  document: StructDocument,
+  run: StructInline,
+  getTargetIndex: () => PlanningTargetIndex,
+): RenderedHyperlinkPlan | undefined {
+  if (!run.href && !run.targetIds?.length) return undefined
+  const internalTarget = run.targetIds?.[0]
+  const rawHref = run.href
+  const href = rawHref?.startsWith('#')
+    ? internalTarget || getTargetIndex().has(rawHref.slice(1))
+      ? resolvePlanningTarget(getTargetIndex(), internalTarget ?? rawHref).href
+      : rawHref
+    : rawHref
+      ? /^(?:https?|mailto):/iu.test(rawHref)
+        ? resolvePlanningTargetLazily(getTargetIndex, rawHref).href
+        : rawHref
+      : internalTarget
+        ? (() => {
+            return resolvePlanningTarget(getTargetIndex(), internalTarget).href
+          })()
+        : undefined
+  if (!href) return undefined
+  return {
+    href,
+    estimatedBytesPerSegment: `<a href="${attribute(href)}"></a>`.length,
+  }
+}
+
+function draftInlinePlan(
+  document: StructDocument,
+  source: RenderedInlineSource,
+  relationships: ReadonlyMap<string, StructDocument['relationships'][number]>,
+  targetCache: WeakMap<readonly string[], StructTarget[]>,
+  getTargetIndex: () => PlanningTargetIndex,
+  seenSemanticIds: Set<string>,
+  totals: PlanningTotals,
+): InlineDraft {
+  if (source.runs.length * 2 > MAX_RENDERED_INLINE_EVENT_STORAGE)
+    throw new RenderedPublicationPlanError(
+      'BUDGET',
+      `${source.pathPrefix}[0]`,
+      'inline event storage exceeds the publication planning budget',
+    )
+  const runs: DraftRun[] = []
+  for (const [originalIndex, run] of source.runs.entries()) {
+    if (!validInline(run, source.value)) continue
+    const path = `${source.pathPrefix}[${originalIndex}]`
+    runs.push({
+      run,
+      originalIndex,
+      path,
+      key: `${source.key}:${originalIndex}`,
+    })
+  }
+  runs.sort(
+    (left, right) =>
+      left.run.start - right.run.start || right.run.end - left.run.end,
+  )
+  const boundaries = new Set<number>([0, source.value.length])
+  const events: InlineEvent[] = []
+  runs.forEach(({ run }, runIndex) => {
+    boundaries.add(run.start)
+    boundaries.add(run.end)
+    events.push(
+      { position: run.start, runIndex, end: false },
+      { position: run.end, runIndex, end: true },
+    )
+  })
+  events.sort((left, right) => left.position - right.position)
+  totals.eventStorage += events.length
+  if (totals.eventStorage > MAX_RENDERED_INLINE_EVENT_STORAGE)
+    throw new RenderedPublicationPlanError(
+      'BUDGET',
+      `${source.pathPrefix}[0]`,
+      'inline event storage exceeds the publication planning budget',
+    )
+  const positions = [...boundaries].sort((left, right) => left - right)
+  const active = new Set<number>()
+  let eventIndex = 0
+  let segmentCount = 0
+  let activeOwnerVisits = 0
+  let wrapperBytes = 0
+  const semanticByOwnerKey = new Map<string, RenderedSemanticPlan>()
+  const hyperlinkByOwnerKey = new Map<string, RenderedHyperlinkPlan>()
+  const renderedRelationshipIds = new Set<string>()
+  const selectedOwners: Array<{
+    semanticIndex: number
+    hyperlinkIndex: number
+  }> = []
+  const semanticSegmentCounts = new Map<number, number>()
+  for (
+    let positionIndex = 0;
+    positionIndex < positions.length - 1;
+    positionIndex += 1
+  ) {
+    const position = positions[positionIndex]!
+    while (events[eventIndex]?.position === position) {
+      const event = events[eventIndex++]!
+      if (event.end) active.delete(event.runIndex)
+      else active.add(event.runIndex)
+    }
+    const next = positions[positionIndex + 1]!
+    if (next <= position) continue
+    segmentCount += 1
+    activeOwnerVisits += active.size
+    wrapperBytes += active.size * ESTIMATED_WRAPPER_BYTES_PER_OWNER
+    totals.segmentCount += 1
+    totals.activeOwnerVisits += active.size
+    totals.wrapperBytes += active.size * ESTIMATED_WRAPPER_BYTES_PER_OWNER
+    if (
+      totals.segmentCount > MAX_RENDERED_INLINE_SEGMENTS ||
+      totals.activeOwnerVisits > MAX_RENDERED_INLINE_ACTIVE_OWNER_VISITS ||
+      totals.wrapperBytes > MAX_RENDERED_INLINE_WRAPPER_BYTES
+    )
+      throw new RenderedPublicationPlanError(
+        'BUDGET',
+        `${source.pathPrefix}[0]`,
+        'inline ownership work exceeds publication budgets',
+      )
+    let semanticIndex = -1
+    for (const runIndex of active) {
+      const candidate = runs[runIndex]!
+      if (candidate.run.semanticRole && candidate.run.relationshipId) {
+        semanticIndex = runIndex
+        break
+      }
+    }
+    let hyperlinkIndex = -1
+    if (semanticIndex < 0)
+      for (const runIndex of active) {
+        const hyperlinkRun = runs[runIndex]!
+        if (hyperlinkRun.run.href || hyperlinkRun.run.targetIds?.length) {
+          hyperlinkIndex = runIndex
+          break
+        }
+      }
+    selectedOwners.push({ semanticIndex, hyperlinkIndex })
+    if (semanticIndex >= 0)
+      semanticSegmentCounts.set(
+        semanticIndex,
+        (semanticSegmentCounts.get(semanticIndex) ?? 0) + 1,
+      )
+  }
+  for (const { semanticIndex, hyperlinkIndex } of selectedOwners) {
+    if (semanticIndex >= 0) {
+      const semanticRun = runs[semanticIndex]!
+      let semantic = semanticByOwnerKey.get(semanticRun.key)
+      if (!semantic) {
+        semantic = semanticPlanForRun(
+          document,
+          source,
+          semanticRun.run,
+          semanticRun.path,
+          relationships,
+          targetCache,
+          getTargetIndex,
+          totals,
+          semanticSegmentCounts.get(semanticIndex)!,
+        )
+        if (!semantic) continue
+        semanticByOwnerKey.set(semanticRun.key, semantic)
+      }
+      wrapperBytes += semantic.estimatedBytesPerSegment
+      totals.wrapperBytes += semantic.estimatedBytesPerSegment
+      if (!seenSemanticIds.has(semantic.relationshipIdStable)) {
+        wrapperBytes += semantic.additionalTargets.length
+        totals.wrapperBytes += semantic.additionalTargets.length
+        seenSemanticIds.add(semantic.relationshipIdStable)
+      }
+      renderedRelationshipIds.add(semantic.relationshipId)
+    } else if (hyperlinkIndex >= 0) {
+      const hyperlinkRun = runs[hyperlinkIndex]!
+      let hyperlink = hyperlinkByOwnerKey.get(hyperlinkRun.key)
+      if (!hyperlink) {
+        hyperlink = hyperlinkPlanForRun(
+          document,
+          hyperlinkRun.run,
+          getTargetIndex,
+        )
+        if (!hyperlink) continue
+        hyperlinkByOwnerKey.set(hyperlinkRun.key, hyperlink)
+      }
+      wrapperBytes += hyperlink.estimatedBytesPerSegment
+      totals.wrapperBytes += hyperlink.estimatedBytesPerSegment
+    }
+    if (totals.wrapperBytes > MAX_RENDERED_INLINE_WRAPPER_BYTES)
+      throw new RenderedPublicationPlanError(
+        'BUDGET',
+        `${source.pathPrefix}[0]`,
+        'inline ownership work exceeds publication budgets',
+      )
+  }
+  return {
+    source,
+    runs,
+    events,
+    positions,
+    segmentCount,
+    activeOwnerVisits,
+    wrapperBytes,
+    semanticByOwnerKey,
+    hyperlinkByOwnerKey,
+    renderedRelationshipIds,
+  }
+}
+
+/** Build the owner plan shared by XHTML rendering, emitted IDs, and backlinks. */
+export function renderedInlinePlan(
+  value: string,
+  runs: readonly StructInline[],
+): RenderedInlineSegment[] {
+  const relationships = new Map<
+    string,
+    StructDocument['relationships'][number]
+  >()
+  const draft = draftInlinePlan(
+    {} as StructDocument,
+    { key: 'direct', value, runs, pathPrefix: '$.blocks.inline' },
+    relationships,
+    new WeakMap(),
+    () => new Map(),
+    new Set(),
+    {
+      segmentCount: 0,
+      activeOwnerVisits: 0,
+      wrapperBytes: 0,
+      eventStorage: 0,
+      citationWork: 0,
+    },
+  )
+  if (
+    draft.segmentCount > MAX_RENDERED_INLINE_SEGMENTS ||
+    draft.activeOwnerVisits > MAX_RENDERED_INLINE_ACTIVE_OWNER_VISITS ||
+    draft.wrapperBytes > MAX_RENDERED_INLINE_WRAPPER_BYTES
+  )
+    throw new RenderedPublicationPlanError(
+      'BUDGET',
+      '$.blocks.inline',
+      'inline ownership work exceeds the publication planning budget',
+    )
+  return materializeInlinePlan(draft)
+}
+
+function materializeInlinePlan(draft: InlineDraft): RenderedInlineSegment[] {
+  const active = new Set<number>()
+  let eventIndex = 0
+  const segments: RenderedInlineSegment[] = []
+  for (
+    let positionIndex = 0;
+    positionIndex < draft.positions.length - 1;
+    positionIndex += 1
+  ) {
+    const position = draft.positions[positionIndex]!
+    while (draft.events[eventIndex]?.position === position) {
+      const event = draft.events[eventIndex++]!
+      if (event.end) active.delete(event.runIndex)
+      else active.add(event.runIndex)
+    }
+    const end = draft.positions[positionIndex + 1]!
+    if (end <= position) continue
+    const ownerIndexes = [...active].sort((left, right) => left - right)
+    segments.push({
+      start: position,
+      end,
+      owners: ownerIndexes.map((index) => draft.runs[index]!.run),
+      ownerPaths: ownerIndexes.map((index) => draft.runs[index]!.path),
+      ownerKeys: ownerIndexes.map((index) => draft.runs[index]!.key),
+    })
+  }
+  return segments
+}
+
+/** Build one document-local publication plan before any rendered owner arrays. */
+export function buildRenderedPublicationPlan(
+  document: StructDocument,
+): RenderedPublicationPlan {
+  const authors = document.metadata.authors
+  const authorNotes = document.metadata.authorNotes ?? []
+  const seenAuthors = new Set<string>()
+  for (const [index, author] of authors.entries()) {
+    if (seenAuthors.has(author))
+      throw new RenderedPublicationPlanError(
+        'DUPLICATE_IDENTIFIER',
+        `$.metadata.authors[${index}]`,
+        `duplicate metadata author ${author} is ambiguous without a stable identity`,
+      )
+    seenAuthors.add(author)
+  }
+  const relationships = new Map(
+    document.relationships.map((relationship) => [
+      relationship.id,
+      relationship,
+    ]),
+  )
+  const seenSemanticIds = new Set(
+    (authorNotes ?? [])
+      .filter((note) => {
+        const relationship = relationships.get(note.id)
+        return (
+          relationship?.status === 'matched' &&
+          (relationship.kind === 'footnote' ||
+            relationship.kind === 'endnote') &&
+          relationship.to.includes(note.target)
+        )
+      })
+      .map((note) => stableId(note.id)),
+  )
+  const targetCache = new WeakMap<readonly string[], StructTarget[]>()
+  let targetIndex: PlanningTargetIndex | undefined
+  const getTargetIndex = () =>
+    (targetIndex ??= buildPlanningTargetIndex(document))
+  const drafts: InlineDraft[] = []
+  const totals: PlanningTotals = {
+    segmentCount: 0,
+    activeOwnerVisits: 0,
+    wrapperBytes: 0,
+    eventStorage: 0,
+    citationWork: 0,
+  }
+  const renderedRelationshipIds = new Set<string>()
+  for (const note of authorNotes)
+    if (seenSemanticIds.has(stableId(note.id)))
+      renderedRelationshipIds.add(note.id)
+  for (const source of renderedInlineSources(document)) {
+    const draft = draftInlinePlan(
+      document,
+      source,
+      relationships,
+      targetCache,
+      getTargetIndex,
+      seenSemanticIds,
+      totals,
+    )
+    for (const relationshipId of draft.renderedRelationshipIds)
+      renderedRelationshipIds.add(relationshipId)
+    drafts.push(draft)
+  }
+  const sources = drafts.map((draft) => ({
+    ...draft.source,
+    segments: materializeInlinePlan(draft),
+  }))
+  const sourceByKey = new Map(sources.map((source) => [source.key, source]))
+  const semanticByOwnerKey = new Map<string, RenderedSemanticPlan>()
+  const hyperlinkByOwnerKey = new Map<string, RenderedHyperlinkPlan>()
+  for (const draft of drafts)
+    for (const [key, semantic] of draft.semanticByOwnerKey)
+      semanticByOwnerKey.set(key, semantic)
+  for (const draft of drafts)
+    for (const [key, hyperlink] of draft.hyperlinkByOwnerKey)
+      hyperlinkByOwnerKey.set(key, hyperlink)
+  const backlinksByTarget = new Map<
+    string,
+    StructDocument['relationships'][number][]
+  >()
+  for (const relationship of document.relationships) {
+    if (
+      relationship.status !== 'matched' ||
+      !renderedRelationshipIds.has(relationship.id) ||
+      (relationship.kind !== 'footnote' && relationship.kind !== 'endnote')
+    )
+      continue
+    for (const target of relationship.to) {
+      const backlinks = backlinksByTarget.get(target) ?? []
+      backlinks.push(relationship)
+      backlinksByTarget.set(target, backlinks)
+    }
+  }
+  const authorNotesByAuthor = new Map<string, typeof authorNotes>()
+  for (const note of authorNotes) {
+    const notes = authorNotesByAuthor.get(note.author) ?? []
+    notes.push(note)
+    authorNotesByAuthor.set(note.author, notes)
+  }
+  return {
+    sources,
+    sourceByKey,
+    relationships,
+    renderedRelationshipIds,
+    backlinksByTarget,
+    authorNotesByAuthor,
+    semanticByOwnerKey,
+    hyperlinkByOwnerKey,
+  }
+}
+
+/** Return relationship IDs that have an owner in the actual rendered plan. */
+export function renderedInlineRelationshipIds(document: StructDocument) {
+  return buildRenderedPublicationPlan(document).renderedRelationshipIds
+}
+
+/**
+ * Describe every id that the publication XHTML renderer can emit. Relationship
+ * ids are document-scoped: one relationship occurrence receives the id and
+ * later occurrences reuse its data without emitting another id attribute.
+ */
+export function emittedXhtmlIds(
+  document: StructDocument,
+  publicationPlan = buildRenderedPublicationPlan(document),
+): EmittedXhtmlId[] {
+  const entries: EmittedXhtmlId[] = []
+  for (const [blockIndex, block] of document.blocks.entries()) {
+    if (block.kind === 'furniture') continue
+    entries.push({ id: block.id, path: `$.blocks[${blockIndex}].id` })
+    for (const [anchorIndex, anchor] of (
+      block.sourceObservationAnchorIds ?? []
+    ).entries()) {
+      entries.push({
+        id: anchor,
+        path: `$.blocks[${blockIndex}].sourceObservationAnchorIds[${anchorIndex}]`,
+      })
+    }
+    if (block.kind === 'table' && block.table) {
+      for (const [cellIndex, cell] of block.table.cells.entries()) {
+        entries.push({
+          id: `${block.id}-${cell.id}`,
+          path: `$.blocks[${blockIndex}].table.cells[${cellIndex}].id`,
+        })
+      }
+    }
+  }
+  const relationshipIds = new Set<string>()
+  const authorNoteAliasIds = new Set(
+    (document.metadata.authorNotes ?? [])
+      .filter((note) => {
+        const relationship = publicationPlan.relationships.get(note.id)
+        return (
+          relationship?.status === 'matched' &&
+          (relationship.kind === 'footnote' ||
+            relationship.kind === 'endnote') &&
+          relationship.to.includes(note.target)
+        )
+      })
+      .map((note) => note.id),
+  )
+  for (const [index, note] of (document.metadata.authorNotes ?? []).entries())
+    entries.push({
+      id: stableId(note.id),
+      path: `$.metadata.authorNotes[${index}].id`,
+    })
+  for (const source of publicationPlan.sources) {
+    for (const segment of source.segments) {
+      const ownerIndex = segment.owners.findIndex(
+        (owner) => owner.relationshipId && owner.semanticRole,
+      )
+      const run = ownerIndex >= 0 ? segment.owners[ownerIndex] : undefined
+      if (
+        !run?.relationshipId ||
+        relationshipIds.has(run.relationshipId) ||
+        authorNoteAliasIds.has(run.relationshipId)
+      )
+        continue
+      relationshipIds.add(run.relationshipId)
+      entries.push({
+        id: stableId(run.relationshipId),
+        path: `${segment.ownerPaths[ownerIndex]}.relationshipId`,
+      })
+    }
+  }
+  return entries
+}

--- a/src/struct/emitted-ids.ts
+++ b/src/struct/emitted-ids.ts
@@ -440,6 +440,19 @@ type InlineDraft = {
   renderedRelationshipIds: Set<string>
 }
 
+function citationLabelCountExceedsTargets(value: string, targetCount: number) {
+  let labels = 0
+  let start = 0
+  for (let index = 0; index <= value.length; index += 1) {
+    if (index !== value.length && value[index] !== ',') continue
+    let cursor = start
+    while (cursor < index && /\s/u.test(value[cursor]!)) cursor += 1
+    if (cursor < index && ++labels > targetCount) return true
+    start = index + 1
+  }
+  return false
+}
+
 function semanticPlanForRun(
   document: StructDocument,
   source: RenderedInlineSource,
@@ -455,7 +468,17 @@ function semanticPlanForRun(
   const relationship = relationships.get(run.relationshipId)
   const rawTargets =
     relationship?.status === 'matched' ? relationship.to : (run.targetIds ?? [])
-  const labels = (relationship?.label ?? '')
+  const rawLabel = relationship?.label ?? ''
+  if (
+    run.semanticRole === 'citation' &&
+    citationLabelCountExceedsTargets(rawLabel, rawTargets.length)
+  )
+    throw new RenderedPublicationPlanError(
+      'BUDGET',
+      path,
+      'citation label work exceeds the publication planning budget',
+    )
+  const labels = rawLabel
     .split(',')
     .map((label) => label.trim())
     .filter(Boolean)

--- a/src/struct/emitted-ids.ts
+++ b/src/struct/emitted-ids.ts
@@ -217,15 +217,20 @@ function citationRanges(
     })
     labelsByYear.set(year, candidates)
   }
-  const ranges: Array<{ start: number; end: number; target: string }> = [
-    ...sourceValue.matchAll(/[\p{Nd}⁰¹²³⁴⁵⁶⁷⁸⁹]+/gu),
-  ].flatMap((match) => {
+  const ranges: Array<{ start: number; end: number; target: string }> = []
+  for (const match of sourceValue.matchAll(/[\p{Nd}⁰¹²³⁴⁵⁶⁷⁸⁹]+/gu)) {
+    if (totals.citationWork >= MAX_CITATION_MATCH_WORK)
+      throw new RenderedPublicationPlanError(
+        'BUDGET',
+        path,
+        'citation matching work exceeds the publication planning budget',
+      )
+    totals.citationWork += 1
     const target = targetByLabel.get(normalizedNumericToken(match[0]))
     const start = match.index ?? -1
-    return target && start >= 0
-      ? [{ start, end: start + match[0].length, target }]
-      : []
-  })
+    if (target && start >= 0)
+      ranges.push({ start, end: start + match[0].length, target })
+  }
   const linkedTargets = new Set(ranges.map((range) => range.target))
   for (const match of sourceValue.matchAll(/\b(?:18|19|20)\d{2}[a-z]?\b/giu)) {
     const start = match.index ?? -1

--- a/src/struct/emitted-ids.ts
+++ b/src/struct/emitted-ids.ts
@@ -440,17 +440,17 @@ type InlineDraft = {
   renderedRelationshipIds: Set<string>
 }
 
-function citationLabelCountExceedsTargets(value: string, targetCount: number) {
-  let labels = 0
-  let start = 0
-  for (let index = 0; index <= value.length; index += 1) {
-    if (index !== value.length && value[index] !== ',') continue
-    let cursor = start
-    while (cursor < index && /\s/u.test(value[cursor]!)) cursor += 1
-    if (cursor < index && ++labels > targetCount) return true
-    start = index + 1
-  }
-  return false
+function boundedCitationLabels(value: string) {
+  let segments = 1
+  for (let index = 0; index < value.length; index += 1)
+    if (value[index] === ',' && ++segments > MAX_CITATION_MATCH_WORK)
+      // Preserve the existing no-range outcome without allocating an
+      // attacker-controlled token array.
+      return []
+  return value
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean)
 }
 
 function semanticPlanForRun(
@@ -469,19 +469,13 @@ function semanticPlanForRun(
   const rawTargets =
     relationship?.status === 'matched' ? relationship.to : (run.targetIds ?? [])
   const rawLabel = relationship?.label ?? ''
-  if (
-    run.semanticRole === 'citation' &&
-    citationLabelCountExceedsTargets(rawLabel, rawTargets.length)
-  )
-    throw new RenderedPublicationPlanError(
-      'BUDGET',
-      path,
-      'citation label work exceeds the publication planning budget',
-    )
-  const labels = rawLabel
-    .split(',')
-    .map((label) => label.trim())
-    .filter(Boolean)
+  const labels =
+    run.semanticRole === 'citation'
+      ? boundedCitationLabels(rawLabel)
+      : rawLabel
+          .split(',')
+          .map((label) => label.trim())
+          .filter(Boolean)
   let targets = targetCache.get(rawTargets)
   if (!targets) {
     targets = []

--- a/src/struct/emitted-ids.ts
+++ b/src/struct/emitted-ids.ts
@@ -440,12 +440,12 @@ type InlineDraft = {
   renderedRelationshipIds: Set<string>
 }
 
-function boundedCitationLabels(value: string) {
+function boundedRelationshipLabels(value: string) {
   let segments = 1
   for (let index = 0; index < value.length; index += 1)
     if (value[index] === ',' && ++segments > MAX_CITATION_MATCH_WORK)
-      // Preserve the existing no-range outcome without allocating an
-      // attacker-controlled token array.
+      // Preserve fallback labels without allocating an attacker-controlled
+      // token array for any semantic relationship role.
       return []
   return value
     .split(',')
@@ -469,13 +469,7 @@ function semanticPlanForRun(
   const rawTargets =
     relationship?.status === 'matched' ? relationship.to : (run.targetIds ?? [])
   const rawLabel = relationship?.label ?? ''
-  const labels =
-    run.semanticRole === 'citation'
-      ? boundedCitationLabels(rawLabel)
-      : rawLabel
-          .split(',')
-          .map((label) => label.trim())
-          .filter(Boolean)
+  const labels = boundedRelationshipLabels(rawLabel)
   let targets = targetCache.get(rawTargets)
   if (!targets) {
     targets = []

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -188,6 +188,30 @@ describe('STRUCT EPUB href integrity', () => {
     )
   })
 
+  it('rejects aggregate recovery text before direct EPUB parsing', async () => {
+    const document = documentWithHref('#target')
+    const large = 'x'.repeat(4 * 1024 * 1024 - 1)
+    document.recovery = {
+      status: 'ready',
+      title: large,
+      summary: large,
+      issues: [
+        {
+          category: 'source',
+          title: large,
+          count: 1,
+          pages: [1],
+          action: large,
+        },
+      ],
+      userAction: large,
+    }
+
+    await expect(buildStructEpub(document)).rejects.toThrow(
+      /aggregate resource bound/i,
+    )
+  })
+
   it('enforces the post-compression boundary for an incompressible archive', () => {
     const payload = new Uint8Array(16 * 1024)
     for (let index = 0; index < payload.length; index += 1)

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -172,6 +172,18 @@ describe('STRUCT EPUB href integrity', () => {
     )
   })
 
+  it.each([NaN, Infinity, -Infinity, -0])(
+    'rejects non-canonical number %s through the direct EPUB boundary',
+    async (number) => {
+      const document = documentWithHref('#target')
+      document.blocks[0]!.evidence.confidence = number
+
+      await expect(buildStructEpub(document)).rejects.toThrow(
+        /number|finite|negative zero/i,
+      )
+    },
+  )
+
   it('rejects oversized generic receipt JSON before direct EPUB snapshotting', async () => {
     const document = documentWithHref('#target')
     document.receipt.modelConsultations = {

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -2,6 +2,7 @@ import { strFromU8, unzipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
 import { buildStructEpub } from './epub'
 import { legacyStructDigest, structDigest } from './ids'
+import { sha256HexSync } from './sha256'
 import type { StructDocument } from './types'
 
 function refreshReceipt(document: StructDocument) {
@@ -207,6 +208,33 @@ describe('STRUCT EPUB href integrity', () => {
     ).rejects.toThrow('STRUCT_EPUB_PROFILE_INVALID')
   })
 
+  it('snapshots a valid profile before EPUB packaging reads it again', async () => {
+    const css = 'body { color: black; }'
+    let cssReads = 0
+    const profile = new Proxy(
+      {
+        id: 'mobile',
+        version: '1.0.0',
+        fileName: 'publication-mobile.epub',
+        pageProgressionDirection: 'ltr' as const,
+        renditionFlow: 'paginated' as const,
+        configurationSha256: 'c'.repeat(64),
+        css,
+      },
+      {
+        get(target, property, receiver) {
+          if (property === 'css') cssReads += 1
+          return Reflect.get(target, property, receiver)
+        },
+      },
+    )
+
+    const epub = await buildStructEpub(documentWithHref('#target'), { profile })
+
+    expect(strFromU8(unzipSync(epub.bytes)['EPUB/styles.css']!)).toBe(css)
+    expect(cssReads).toBe(1)
+  })
+
   it.each([
     ['same-document fragment', '#target'],
     ['packaged XHTML fragment', 'content.xhtml#target'],
@@ -338,17 +366,18 @@ describe('STRUCT EPUB href integrity', () => {
     'does not alias a %s href to a different packaged document',
     async (_label, href, packagedHref) => {
       const document = documentWithHref(href)
+      const assetBytes = new TextEncoder().encode(
+        '<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Different exact path</p></body></html>',
+      )
       document.assets.push({
         id: `supplement-${document.assets.length}`,
         kind: 'figure',
         href: packagedHref,
         mediaType: 'application/xhtml+xml',
-        sha256: 'd'.repeat(64),
+        sha256: sha256HexSync(assetBytes),
         width: 1,
         height: 1,
-        bytes: new TextEncoder().encode(
-          '<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Different exact path</p></body></html>',
-        ),
+        bytes: assetBytes,
         sourceObjectIds: ['fixture-supplement'],
         evidence: {
           confidence: 1,
@@ -402,15 +431,18 @@ describe('STRUCT EPUB href integrity', () => {
 
   it('rejects malformed packaged XHTML assets', async () => {
     const document = documentWithHref('#target')
+    const assetBytes = new TextEncoder().encode(
+      '<html><body><a href="#missing"></body>',
+    )
     document.assets.push({
       id: 'supplement',
       kind: 'figure',
       href: 'supplement.xhtml',
       mediaType: 'application/xhtml+xml',
-      sha256: 'd'.repeat(64),
+      sha256: sha256HexSync(assetBytes),
       width: 1,
       height: 1,
-      bytes: new TextEncoder().encode('<html><body><a href="#missing"></body>'),
+      bytes: assetBytes,
       sourceObjectIds: ['fixture-supplement'],
       evidence: {
         confidence: 1,
@@ -427,17 +459,18 @@ describe('STRUCT EPUB href integrity', () => {
 
   it('rejects dangling namespaced hrefs in packaged XHTML assets', async () => {
     const document = documentWithHref('#target')
+    const assetBytes = new TextEncoder().encode(
+      '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink"><body><a xlink:href="#missing">Missing</a></body></html>',
+    )
     document.assets.push({
       id: 'namespaced-supplement',
       kind: 'figure',
       href: 'namespaced-supplement.xhtml',
       mediaType: 'application/xhtml+xml',
-      sha256: 'e'.repeat(64),
+      sha256: sha256HexSync(assetBytes),
       width: 1,
       height: 1,
-      bytes: new TextEncoder().encode(
-        '<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink"><body><a xlink:href="#missing">Missing</a></body></html>',
-      ),
+      bytes: assetBytes,
       sourceObjectIds: ['fixture-namespaced-supplement'],
       evidence: {
         confidence: 1,

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -188,6 +188,42 @@ describe('STRUCT EPUB href integrity', () => {
     )
   })
 
+  it('bounds a stateful generic receipt proxy during direct EPUB snapshotting', async () => {
+    const document = documentWithHref('#target')
+    let descriptorReads = 0
+    document.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: document.documentId!,
+      sourceSha256: document.source.sha256,
+      consultations: [],
+      decisions: [],
+      metrics: new Proxy(
+        {},
+        {
+          ownKeys() {
+            return ['field']
+          },
+          getOwnPropertyDescriptor() {
+            descriptorReads += 1
+            if (descriptorReads > 3)
+              throw new Error('receipt was traversed after copy rejection')
+            return {
+              configurable: true,
+              enumerable: true,
+              value:
+                descriptorReads < 3 ? 'small' : 'x'.repeat(10 * 1024 * 1024),
+            }
+          },
+        },
+      ),
+    }
+
+    await expect(buildStructEpub(document)).rejects.toThrow(
+      'INVALID_MODEL_CONSULTATION_RECEIPT',
+    )
+    expect(descriptorReads).toBe(3)
+  })
+
   it('rejects aggregate recovery text before direct EPUB parsing', async () => {
     const document = documentWithHref('#target')
     const large = 'x'.repeat(4 * 1024 * 1024 - 1)

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -1,6 +1,7 @@
 import { strFromU8, unzipSync, zipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
 import { assertStructEpubArchiveByteLength, buildStructEpub } from './epub'
+import { MAX_STRUCT_STRING_BYTES } from './codec/primitives'
 import { legacyStructDigest, structDigest } from './ids'
 import { sha256HexSync } from './sha256'
 import type { StructDocument } from './types'
@@ -162,6 +163,31 @@ function legacyDocumentWithHref(href: string, locale?: string): StructDocument {
 }
 
 describe('STRUCT EPUB href integrity', () => {
+  it('rejects an oversized title through the direct EPUB boundary', async () => {
+    const document = documentWithHref('#target')
+    document.metadata.title = 'x'.repeat(MAX_STRUCT_STRING_BYTES + 1)
+
+    await expect(buildStructEpub(document)).rejects.toThrow(
+      /textual resource bound/i,
+    )
+  })
+
+  it('rejects oversized generic receipt JSON before direct EPUB snapshotting', async () => {
+    const document = documentWithHref('#target')
+    document.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: document.documentId!,
+      sourceSha256: document.source.sha256,
+      consultations: [{ adapterNote: 'x'.repeat(1024 * 1024 + 1) }],
+      decisions: [],
+      metrics: {},
+    }
+
+    await expect(buildStructEpub(document)).rejects.toThrow(
+      'INVALID_MODEL_CONSULTATION_RECEIPT',
+    )
+  })
+
   it('enforces the post-compression boundary for an incompressible archive', () => {
     const payload = new Uint8Array(16 * 1024)
     for (let index = 0; index < payload.length; index += 1)

--- a/src/struct/epub-integrity.test.ts
+++ b/src/struct/epub-integrity.test.ts
@@ -1,6 +1,6 @@
-import { strFromU8, unzipSync } from 'fflate'
+import { strFromU8, unzipSync, zipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
-import { buildStructEpub } from './epub'
+import { assertStructEpubArchiveByteLength, buildStructEpub } from './epub'
 import { legacyStructDigest, structDigest } from './ids'
 import { sha256HexSync } from './sha256'
 import type { StructDocument } from './types'
@@ -162,6 +162,39 @@ function legacyDocumentWithHref(href: string, locale?: string): StructDocument {
 }
 
 describe('STRUCT EPUB href integrity', () => {
+  it('enforces the post-compression boundary for an incompressible archive', () => {
+    const payload = new Uint8Array(16 * 1024)
+    for (let index = 0; index < payload.length; index += 1)
+      payload[index] = (index * 73 + 19) % 256
+    const archive = zipSync({ 'payload.bin': payload })
+
+    expect(() =>
+      assertStructEpubArchiveByteLength(archive, archive.byteLength - 1),
+    ).toThrow('STRUCT_EPUB_ARCHIVE_RESOURCE_LIMIT')
+    expect(() =>
+      assertStructEpubArchiveByteLength(archive, archive.byteLength),
+    ).not.toThrow()
+  })
+
+  it('packages a closed source-neutral consultation receipt without app receipt semantics', async () => {
+    const document = documentWithHref('#target')
+    document.receipt.modelConsultations = {
+      schemaVersion: '1.0.0',
+      documentId: document.documentId!,
+      sourceSha256: document.source.sha256,
+      consultations: [{ adapterDecision: 'defer', status: 'pending' }],
+      decisions: [],
+      metrics: { adapter: 'source-neutral', pendingCount: 1 },
+    }
+
+    await expect(
+      buildStructEpub(refreshReceipt(document)),
+    ).resolves.toMatchObject({
+      mediaType: 'application/epub+zip',
+      mode: 'publication',
+    })
+  })
+
   it('reopens an exact profiled stylesheet and immutable profile receipt', async () => {
     const profile = {
       id: 'mobile',

--- a/src/struct/epub.ts
+++ b/src/struct/epub.ts
@@ -7,8 +7,21 @@ import {
   type ZipOptions,
 } from 'fflate'
 import { XMLParser, XMLValidator } from 'fast-xml-parser'
+import {
+  snapshotStructDocumentForEpub,
+  validateStructDocumentTableBounds,
+} from './codec/parsers'
+import { isStructCodecError } from './codec/primitives'
+import {
+  bcp47Language,
+  mediaType,
+  rfc3339Date,
+  rfc3339DateTime,
+} from './codec/standards'
 import { sha256HexSync } from './sha256'
 import { legacyStructDigestMatches, structDigest } from './ids'
+import { validateStructConsultationReceipt } from './consultation-receipt'
+import { isPackagedAssetId } from './emitted-ids'
 import { validateModelConsultationReceipt } from './model-consultation-receipt'
 import { renderPublicationXhtml } from './xhtml'
 import {
@@ -25,6 +38,8 @@ table { border-collapse: collapse; width: 100%; }
 td, th { border: 1px solid currentColor; padding: 0.25rem; }
 figure { break-inside: avoid; margin: 1.5rem 0; }
 .visually-hidden, .additional-semantic-reference { clip: rect(0 0 0 0); clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; white-space: nowrap; width: 1px; }`
+const MAX_STRUCT_EPUB_PROFILE_CSS_BYTES = 4 * 1024 * 1024
+const MAX_STRUCT_EPUB_ARCHIVE_BYTES = 256 * 1024 * 1024
 
 export type StructEpubProfile = {
   id: string
@@ -53,13 +68,48 @@ export type StructEpubExport = {
 
 export type UnprofiledStructEpubExport = Omit<StructEpubExport, 'profile'>
 
-function validProfile(profile: StructEpubProfile) {
+type StructEpubProfileSnapshot = Record<keyof StructEpubProfile, unknown>
+
+function snapshotProfile(
+  value: unknown,
+): StructEpubProfileSnapshot | undefined {
+  try {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      return undefined
+    const record = value as Record<string, unknown>
+    return {
+      id: record.id,
+      version: record.version,
+      fileName: record.fileName,
+      pageProgressionDirection: record.pageProgressionDirection,
+      renditionFlow: record.renditionFlow,
+      configurationSha256: record.configurationSha256,
+      css: record.css,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function validProfile(
+  profile: StructEpubProfileSnapshot,
+): profile is StructEpubProfile {
   return (
+    typeof profile.id === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(profile.id) &&
+    typeof profile.version === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(profile.version) &&
+    typeof profile.fileName === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\.epub$/u.test(profile.fileName) &&
+    (profile.pageProgressionDirection === 'ltr' ||
+      profile.pageProgressionDirection === 'rtl') &&
+    (profile.renditionFlow === 'paginated' ||
+      profile.renditionFlow === 'scrolled-continuous') &&
+    typeof profile.configurationSha256 === 'string' &&
     /^[a-f0-9]{64}$/u.test(profile.configurationSha256) &&
+    typeof profile.css === 'string' &&
     profile.css.length > 0 &&
+    utf8ByteLength(profile.css) <= MAX_STRUCT_EPUB_PROFILE_CSS_BYTES &&
     !/[\u0000]/u.test(profile.css)
   )
 }
@@ -94,6 +144,80 @@ function entry(value: string, level: 0 | 6 = 6): [Uint8Array, ZipOptions] {
 
 function binaryEntry(value: Uint8Array): [Uint8Array, ZipOptions] {
   return [value, { level: 6, mtime: ZIP_MTIME }]
+}
+
+function utf8ByteLength(value: string) {
+  let length = 0
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index)!
+    if (codePoint <= 0x7f) length += 1
+    else if (codePoint <= 0x7ff) length += 2
+    else if (codePoint <= 0xffff) length += 3
+    else {
+      length += 4
+      index += 1
+    }
+  }
+  return length
+}
+
+function artifactFileName(value: string) {
+  return value.split(/[\\/]/u).at(-1) || 'source'
+}
+
+function assertBuilderScalars(document: StructDocument) {
+  const { language, publicationDate, artifactModifiedAt, updated } =
+    document.metadata
+  if (language !== undefined) bcp47Language(language, '$.metadata.language')
+  if (publicationDate !== undefined)
+    rfc3339Date(publicationDate, '$.metadata.publicationDate')
+  if (updated !== undefined) rfc3339Date(updated, '$.metadata.updated')
+  if (artifactModifiedAt !== undefined)
+    rfc3339DateTime(artifactModifiedAt, '$.metadata.artifactModifiedAt')
+  for (const asset of document.assets) {
+    mediaType(asset.mediaType, '$.assets.mediaType')
+    if (asset.href.includes('%'))
+      throw new Error(`STRUCT EPUB asset ${asset.id} has an ambiguous href`)
+  }
+}
+
+function assertNoNegativeZero(value: unknown, seen = new WeakSet<object>()) {
+  if (typeof value === 'number') {
+    if (Object.is(value, -0))
+      throw new Error('STRUCT EPUB input contains negative zero')
+    return
+  }
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    ArrayBuffer.isView(value) ||
+    seen.has(value)
+  )
+    return
+  seen.add(value)
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor || !Object.hasOwn(descriptor, 'value'))
+      throw new Error('STRUCT EPUB input must contain data properties')
+    assertNoNegativeZero(descriptor.value, seen)
+  }
+}
+
+function assertNoSemanticZeroWidthRuns(document: StructDocument) {
+  for (const block of document.blocks) {
+    for (const runs of [
+      block.inline,
+      ...(block.table?.cells.map((cell) => cell.inline) ?? []),
+    ])
+      for (const run of runs)
+        if (
+          run.start === run.end &&
+          Object.keys(run).some((key) => key !== 'start' && key !== 'end')
+        )
+          throw new Error(
+            'STRUCT EPUB input contains a semantic zero-width inline run',
+          )
+  }
 }
 
 function slug(value: string) {
@@ -250,7 +374,10 @@ function assertStructReceiptIntegrity(document: StructDocument) {
 
   const modelConsultations = receipt.modelConsultations
   if (modelConsultations !== undefined) {
-    if (!validateModelConsultationReceipt(modelConsultations)) {
+    if (
+      !validateStructConsultationReceipt(modelConsultations) ||
+      !validateModelConsultationReceipt(modelConsultations)
+    ) {
       throw new Error('INVALID_MODEL_CONSULTATION_RECEIPT')
     }
     if (
@@ -260,10 +387,7 @@ function assertStructReceiptIntegrity(document: StructDocument) {
     ) {
       throw new Error('PENDING_MODEL_CONSULTATION_RECEIPT')
     }
-    if (
-      document.source.format !== 'pdf' ||
-      modelConsultations.sourceSha256 !== document.source.sha256
-    ) {
+    if (modelConsultations.sourceSha256 !== document.source.sha256) {
       throw new Error('MODEL_CONSULTATION_SOURCE_MISMATCH')
     }
     if (modelConsultations.documentId !== document.documentId) {
@@ -302,10 +426,41 @@ export async function buildStructEpub(
   document: StructDocument,
   options: StructEpubOptions = {},
 ): Promise<StructEpubExport> {
+  validateStructDocumentTableBounds(document)
+  try {
+    document = snapshotStructDocumentForEpub(document)
+  } catch (error) {
+    if (
+      isStructCodecError(error) &&
+      ((error.code === 'BUDGET' && error.path === '$.assets') ||
+        error.code === 'ASSET_BOUNDS' ||
+        (error.path.startsWith('$.assets[') &&
+          error.path.endsWith('.bytes') &&
+          (error.code === 'BYTES' || error.code === 'TYPE')))
+    )
+      throw new Error('STRUCT_EPUB_ASSET_RESOURCE_LIMIT', { cause: error })
+    if (
+      isStructCodecError(error) &&
+      error.path.startsWith('$.receipt.modelConsultations')
+    )
+      throw new Error('INVALID_MODEL_CONSULTATION_RECEIPT', { cause: error })
+    throw error
+  }
+  validateStructDocumentTableBounds(document)
+  assertBuilderScalars(document)
+  assertNoSemanticZeroWidthRuns(document)
   assertStructReceiptIntegrity(document)
-  const profile = options.profile
-  if (profile && !validProfile(profile)) {
-    throw new Error('STRUCT_EPUB_PROFILE_INVALID')
+  if (document.recovery.status !== 'ready')
+    throw new Error('STRUCT_EPUB_RECOVERY_REVIEW_REQUIRED')
+  assertNoNegativeZero(document)
+  const requestedProfile = options.profile
+  let profile: StructEpubProfile | undefined
+  if (requestedProfile !== undefined) {
+    const snapshot = snapshotProfile(requestedProfile)
+    if (!snapshot || !validProfile(snapshot)) {
+      throw new Error('STRUCT_EPUB_PROFILE_INVALID')
+    }
+    profile = snapshot
   }
   const retainedProfile = profile ? profileReceipt(profile) : undefined
   const identifier = `urn:sha256:${document.receipt.generatedSha256}${retainedProfile ? `:${retainedProfile.id}:${retainedProfile.version}:${retainedProfile.configurationSha256.slice(0, 16)}` : ''}`
@@ -320,13 +475,10 @@ export async function buildStructEpub(
     }
     return asset as typeof asset & { bytes: Uint8Array }
   })
-  const reservedIds = new Set([
-    'publication-id',
-    'nav',
-    'content',
-    'styles',
-    'struct',
-  ])
+  const assetBytes = assets.reduce(
+    (total, asset) => total + asset.bytes.byteLength,
+    0,
+  )
   const reservedHrefs = new Set([
     'package.opf',
     'nav.xhtml',
@@ -338,11 +490,7 @@ export async function buildStructEpub(
   const assetIds = new Set<string>()
   const assetHrefs = new Set<string>()
   for (const asset of assets) {
-    if (
-      reservedIds.has(asset.id) ||
-      assetIds.has(asset.id) ||
-      !/^[A-Za-z_][A-Za-z0-9_.-]*$/u.test(asset.id)
-    ) {
+    if (assetIds.has(asset.id) || !isPackagedAssetId(asset.id)) {
       throw new Error(
         `STRUCT EPUB asset id is duplicate or reserved: ${asset.id}`,
       )
@@ -394,25 +542,43 @@ export async function buildStructEpub(
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="${attribute(language)}"><head><title>Contents</title></head><body><nav epub:type="toc"><h1>Contents</h1><ol><li><a href="content.xhtml">${text(document.metadata.title)}</a></li>${headings.map((block) => `<li><a href="content.xhtml#${attribute(block.id)}">${text(block.text)}</a></li>`).join('')}</ol></nav></body></html>
 `
   const content = renderPublicationXhtml(document)
+  const structArtifact = {
+    schemaVersion: document.schemaVersion,
+    source: {
+      ...document.source,
+      fileName: artifactFileName(document.source.fileName),
+    },
+    receipt: document.receipt,
+  }
+  const serializedStructArtifact = `${JSON.stringify(structArtifact)}\n`
+  const serializedProfile = retainedProfile
+    ? `${JSON.stringify(retainedProfile)}\n`
+    : undefined
+  const container =
+    '<?xml version="1.0" encoding="UTF-8"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>'
+  const archiveBytes =
+    utf8ByteLength(EPUB_MIMETYPE) +
+    utf8ByteLength(container) +
+    utf8ByteLength(packageDocument) +
+    utf8ByteLength(nav) +
+    utf8ByteLength(content) +
+    utf8ByteLength(profile?.css ?? EPUB_CSS) +
+    utf8ByteLength(serializedStructArtifact) +
+    (serializedProfile ? utf8ByteLength(serializedProfile) : 0) +
+    assetBytes
+  if (archiveBytes > MAX_STRUCT_EPUB_ARCHIVE_BYTES)
+    throw new Error('STRUCT_EPUB_ARCHIVE_RESOURCE_LIMIT')
   const archive: Zippable = {
     mimetype: entry(EPUB_MIMETYPE, 0),
-    'META-INF/container.xml': entry(
-      '<?xml version="1.0" encoding="UTF-8"?><container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
-    ),
+    'META-INF/container.xml': entry(container),
     'EPUB/package.opf': entry(packageDocument),
     'EPUB/nav.xhtml': entry(nav),
     'EPUB/content.xhtml': entry(content),
     'EPUB/styles.css': entry(profile?.css ?? EPUB_CSS),
-    'EPUB/struct.json': entry(
-      `${JSON.stringify({
-        schemaVersion: document.schemaVersion,
-        source: document.source,
-        receipt: document.receipt,
-      })}\n`,
-    ),
+    'EPUB/struct.json': entry(serializedStructArtifact),
     ...(retainedProfile
       ? {
-          'EPUB/profile.json': entry(`${JSON.stringify(retainedProfile)}\n`),
+          'EPUB/profile.json': entry(serializedProfile!),
         }
       : {}),
     ...Object.fromEntries(
@@ -444,7 +610,7 @@ export async function buildStructEpub(
     if (
       !reopenedProfile ||
       !reopenedCss ||
-      strFromU8(reopenedProfile) !== `${JSON.stringify(retainedProfile)}\n` ||
+      strFromU8(reopenedProfile) !== serializedProfile ||
       sha256HexSync(reopenedCss) !== retainedProfile.cssSha256
     ) {
       throw new Error('STRUCT_EPUB_PROFILE_REOPEN_MISMATCH')

--- a/src/struct/epub.ts
+++ b/src/struct/epub.ts
@@ -22,7 +22,6 @@ import { sha256HexSync } from './sha256'
 import { legacyStructDigestMatches, structDigest } from './ids'
 import { validateStructConsultationReceipt } from './consultation-receipt'
 import { isPackagedAssetId } from './emitted-ids'
-import { validateModelConsultationReceipt } from './model-consultation-receipt'
 import { renderPublicationXhtml } from './xhtml'
 import {
   LEGACY_STRUCT_SCHEMA_VERSION,
@@ -40,6 +39,20 @@ figure { break-inside: avoid; margin: 1.5rem 0; }
 .visually-hidden, .additional-semantic-reference { clip: rect(0 0 0 0); clip-path: inset(50%); height: 1px; overflow: hidden; position: absolute; white-space: nowrap; width: 1px; }`
 const MAX_STRUCT_EPUB_PROFILE_CSS_BYTES = 4 * 1024 * 1024
 const MAX_STRUCT_EPUB_ARCHIVE_BYTES = 256 * 1024 * 1024
+const ZIP_ARCHIVE_OVERHEAD_RESERVE = 64 * 1024
+
+/** Reject post-compression archives that exceed the package resource ceiling. */
+export function assertStructEpubArchiveByteLength(
+  bytes: Uint8Array,
+  maximumBytes = MAX_STRUCT_EPUB_ARCHIVE_BYTES,
+) {
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes < 0 ||
+    bytes.byteLength > maximumBytes
+  )
+    throw new Error('STRUCT_EPUB_ARCHIVE_RESOURCE_LIMIT')
+}
 
 export type StructEpubProfile = {
   id: string
@@ -374,18 +387,8 @@ function assertStructReceiptIntegrity(document: StructDocument) {
 
   const modelConsultations = receipt.modelConsultations
   if (modelConsultations !== undefined) {
-    if (
-      !validateStructConsultationReceipt(modelConsultations) ||
-      !validateModelConsultationReceipt(modelConsultations)
-    ) {
+    if (!validateStructConsultationReceipt(modelConsultations)) {
       throw new Error('INVALID_MODEL_CONSULTATION_RECEIPT')
-    }
-    if (
-      modelConsultations.consultations.some(
-        ({ status }) => status === 'pending',
-      )
-    ) {
-      throw new Error('PENDING_MODEL_CONSULTATION_RECEIPT')
     }
     if (modelConsultations.sourceSha256 !== document.source.sha256) {
       throw new Error('MODEL_CONSULTATION_SOURCE_MISMATCH')
@@ -566,7 +569,10 @@ export async function buildStructEpub(
     utf8ByteLength(serializedStructArtifact) +
     (serializedProfile ? utf8ByteLength(serializedProfile) : 0) +
     assetBytes
-  if (archiveBytes > MAX_STRUCT_EPUB_ARCHIVE_BYTES)
+  if (
+    archiveBytes >
+    MAX_STRUCT_EPUB_ARCHIVE_BYTES - ZIP_ARCHIVE_OVERHEAD_RESERVE
+  )
     throw new Error('STRUCT_EPUB_ARCHIVE_RESOURCE_LIMIT')
   const archive: Zippable = {
     mimetype: entry(EPUB_MIMETYPE, 0),
@@ -603,6 +609,7 @@ export async function buildStructEpub(
     ),
   )
   const bytes = zipSync(archive)
+  assertStructEpubArchiveByteLength(bytes)
   if (retainedProfile) {
     const reopened = unzipSync(bytes)
     const reopenedProfile = reopened['EPUB/profile.json']

--- a/src/struct/ids.ts
+++ b/src/struct/ids.ts
@@ -1,5 +1,27 @@
 import { sha256HexSync } from './sha256'
 
+/** Canonical identifier primitive shared by the STRUCT core and adapters. */
+export const SAFE_ID_FORMAT = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/u
+export const CREDENTIAL_SHAPED_ID_PATTERNS = [
+  /^sk-(?:proj-)?[A-Za-z0-9._:-]{8,}$/iu,
+  /^(?:AKIA|ASIA)[A-Z0-9]{12,}$/u,
+  /^bearer[.:-][A-Za-z0-9._:-]{8,}$/iu,
+  /^eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}$/iu,
+  /^(?:-----)?BEGIN[.:-]?(?:(?:RSA|EC|OPENSSH)[.:-]?)?PRIVATE[.:-]?KEY/iu,
+  /^xox[baprs]-[A-Za-z0-9._:-]{8,}$/iu,
+  /^(?:gh[pousr]|github_pat)_/iu,
+] as const
+
+export function credentialShapedValue(value: string) {
+  return CREDENTIAL_SHAPED_ID_PATTERNS.some((pattern) => pattern.test(value))
+}
+
+export const SAFE_ID = {
+  test(value: string) {
+    return SAFE_ID_FORMAT.test(value) && !credentialShapedValue(value)
+  },
+}
+
 /** Stable IDs are content-addressed so reflowing a page cannot rename a node. */
 export function structId(namespace: string, value: string) {
   return `struct-${namespace}-${sha256HexSync(value).slice(0, 24)}`

--- a/src/struct/index.ts
+++ b/src/struct/index.ts
@@ -1,9 +1,16 @@
 export * from './types'
-export * from './ids'
 export {
   validateModelConsultationReceipt,
   type ModelFallbackReceipt,
 } from './model-consultation-receipt'
+export {
+  StructCodecError,
+  decodeStructDocument,
+  encodeStructDocument,
+  migrateStructDocument,
+  type StructDocumentJson,
+} from './codec'
+export * from './ids'
 export * from './reading-order'
 export * from './recovery'
 export * from './from-reconstruction'

--- a/src/struct/struct.test.ts
+++ b/src/struct/struct.test.ts
@@ -200,6 +200,14 @@ describe('STRUCT canonical document graph', () => {
     const modelConsultations = withReceipt.modelConsultations!
 
     const graph = buildStructDocument(withReceipt)
+    graph.recovery = recoverySummary({ ready: true, diagnostics: [] })
+    const { receipt, ...withoutReceiptFields } = graph
+    receipt.generatedSha256 = structDigest({
+      ...withoutReceiptFields,
+      conservation: receipt.conservation,
+      modelConsultations,
+      assets: graph.assets.map(({ bytes: _bytes, ...asset }) => asset),
+    })
 
     expect(graph.receipt.modelConsultations).toEqual(modelConsultations)
     expect(graph.receipt.generatedSha256).not.toBe(

--- a/src/struct/struct.test.ts
+++ b/src/struct/struct.test.ts
@@ -263,7 +263,7 @@ describe('STRUCT canonical document graph', () => {
       documentId: 'another-document',
     }
     await expect(buildStructEpub(staleDigest)).rejects.toThrow(
-      'INVALID_MODEL_CONSULTATION_RECEIPT',
+      'MODEL_CONSULTATION_DOCUMENT_MISMATCH',
     )
 
     const wrongDocument = structuredClone(graph)
@@ -429,13 +429,6 @@ describe('STRUCT canonical document graph', () => {
     reconstruction.modelConsultations = pendingReceipt
 
     expect(() => buildStructDocument(reconstruction)).toThrow(
-      'PENDING_MODEL_CONSULTATION_RECEIPT',
-    )
-
-    delete reconstruction.modelConsultations
-    const graph = buildStructDocument(reconstruction)
-    graph.receipt.modelConsultations = pendingReceipt
-    await expect(buildStructEpub(graph)).rejects.toThrow(
       'PENDING_MODEL_CONSULTATION_RECEIPT',
     )
 

--- a/src/struct/types.ts
+++ b/src/struct/types.ts
@@ -1,4 +1,4 @@
-import type { ModelFallbackReceipt } from './model-consultation-receipt'
+import type { StructConsultationReceipt } from './consultation-receipt'
 
 /**
  * Source-agnostic document structure used between extraction and typesetting.
@@ -264,7 +264,7 @@ export type StructReceipt = {
   documentId?: string
   sourceSha256: string
   /** Closed, source-bound audit trail for any bounded model decisions. */
-  modelConsultations?: ModelFallbackReceipt
+  modelConsultations?: StructConsultationReceipt
   blockCount: number
   assetCount: number
   relationshipCount: number

--- a/src/struct/xhtml.ts
+++ b/src/struct/xhtml.ts
@@ -1,9 +1,19 @@
 import type {
   StructBlock,
   StructDocument,
-  StructInline,
   StructTable,
+  StructTableCell,
 } from './types'
+import {
+  buildRenderedPublicationPlan,
+  emittedXhtmlIds,
+  groupedCitationLinks,
+  resolveStructTarget,
+  stableId,
+  type EmittedXhtmlId,
+  type RenderedInlineSourcePlan,
+  type RenderedPublicationPlan,
+} from './emitted-ids'
 
 export type StructXhtmlOptions = {
   embedStyles?: boolean
@@ -28,182 +38,19 @@ function attribute(value: string) {
   return text(value).replace(/"/g, '&quot;')
 }
 
-function stableId(value: string) {
-  const cleaned = value.replace(/[^A-Za-z0-9_.:-]/g, '-')
-  return /^[A-Za-z_]/u.test(cleaned) ? cleaned : `n-${cleaned}`
-}
-
-const UNICODE_DECIMAL_ZERO_CODE_POINTS = [
-  0x0030, 0x0660, 0x06f0, 0x07c0, 0x0966, 0x09e6, 0x0a66, 0x0ae6, 0x0b66,
-  0x0be6, 0x0c66, 0x0ce6, 0x0d66, 0x0de6, 0x0e50, 0x0ed0, 0x0f20, 0x1040,
-  0x1090, 0x17e0, 0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0,
-  0x1c40, 0x1c50, 0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0,
-  0xff10, 0x104a0, 0x10d30, 0x10d40, 0x11066, 0x110f0, 0x11136, 0x111d0,
-  0x112f0, 0x11450, 0x114d0, 0x11650, 0x116c0, 0x116d0, 0x116da, 0x11730,
-  0x118e0, 0x11950, 0x11bf0, 0x11c50, 0x11d50, 0x11da0, 0x11de0, 0x11f50,
-  0x16130, 0x16a60, 0x16ac0, 0x16b50, 0x16d70, 0x1ccf0, 0x1d7ce, 0x1d7d8,
-  0x1d7e2, 0x1d7ec, 0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e5f1, 0x1e950,
-  0x1fbf0,
-] as const
-
-const SUPERSCRIPT_DIGITS: Record<string, string> = {
-  '⁰': '0',
-  '¹': '1',
-  '²': '2',
-  '³': '3',
-  '⁴': '4',
-  '⁵': '5',
-  '⁶': '6',
-  '⁷': '7',
-  '⁸': '8',
-  '⁹': '9',
-}
-
-function normalizedNumericToken(value: string) {
-  return [...value]
-    .map((character) => {
-      if (SUPERSCRIPT_DIGITS[character]) return SUPERSCRIPT_DIGITS[character]
-      const codePoint = character.codePointAt(0)!
-      const zero = UNICODE_DECIMAL_ZERO_CODE_POINTS.find(
-        (candidate) => codePoint >= candidate && codePoint <= candidate + 9,
-      )
-      return zero === undefined ? character : String(codePoint - zero)
-    })
-    .join('')
-}
-
-function foldedCitationText(value: string) {
-  return value
-    .normalize('NFKD')
-    .replace(/\p{M}/gu, '')
-    .replace(/’/gu, "'")
-    .toLocaleLowerCase()
-}
-
-function groupedCitationLinks(
-  value: string,
-  labels: readonly string[],
-  targets: readonly string[],
-  epubRole: string,
-  sourceValue = value,
-  sourceOffset = 0,
-) {
-  if (
-    labels.length !== targets.length ||
-    new Set(labels).size !== labels.length
-  ) {
-    return { html: text(value), linkedTargets: new Set<string>() }
-  }
-  const targetByLabel = new Map(
-    labels.map((label, index) => [label, targets[index]] as const),
-  )
-  const ranges = [...sourceValue.matchAll(/[\p{Nd}⁰¹²³⁴⁵⁶⁷⁸⁹]+/gu)].flatMap(
-    (match) => {
-      const target = targetByLabel.get(normalizedNumericToken(match[0]))
-      const start = match.index ?? -1
-      return target && start >= 0
-        ? [{ start, end: start + match[0].length, target }]
-        : []
-    },
-  )
-  const linkedTargets = new Set(ranges.map((range) => range.target))
-  for (const match of sourceValue.matchAll(/\b(?:18|19|20)\d{2}[a-z]?\b/giu)) {
-    const start = match.index ?? -1
-    if (start < 0) continue
-    const year = match[0].toLocaleLowerCase()
-    const prefix = foldedCitationText(
-      sourceValue.slice(Math.max(0, start - 96), start),
-    )
-    const candidates = labels.flatMap((label, index) => {
-      const separator = label.lastIndexOf(':')
-      if (separator <= 0 || label.slice(separator + 1) !== year) return []
-      const surname = foldedCitationText(label.slice(0, separator))
-      const position = prefix.lastIndexOf(surname)
-      return position >= 0 && !linkedTargets.has(targets[index])
-        ? [{ target: targets[index], position }]
-        : []
-    })
-    const nearest = Math.max(...candidates.map(({ position }) => position))
-    const selected = candidates.filter(({ position }) => position === nearest)
-    if (selected.length !== 1) continue
-    ranges.push({
-      start,
-      end: start + match[0].length,
-      target: selected[0].target,
-    })
-    linkedTargets.add(selected[0].target)
-  }
-  ranges.sort((left, right) => left.start - right.start || left.end - right.end)
-  if (
-    ranges.some(
-      (range, index) => index > 0 && range.start < ranges[index - 1].end,
-    )
-  ) {
-    return { html: text(value), linkedTargets: new Set<string>() }
-  }
-  const segmentEnd = sourceOffset + value.length
-  const segmentRanges = ranges.flatMap((range) => {
-    const start = Math.max(range.start, sourceOffset)
-    const end = Math.min(range.end, segmentEnd)
-    return start < end
-      ? [
-          {
-            start: start - sourceOffset,
-            end: end - sourceOffset,
-            target: range.target,
-          },
-        ]
-      : []
-  })
-  let cursor = 0
-  let html = ''
-  for (const range of segmentRanges) {
-    html += text(value.slice(cursor, range.start))
-    html += `<a href="#${attribute(range.target)}"${epubRole}>${text(value.slice(range.start, range.end))}</a>`
-    cursor = range.end
-  }
-  html += text(value.slice(cursor))
-  return { html, linkedTargets }
-}
-
 function renderInline(
   document: StructDocument,
-  value: string,
-  runs: readonly StructInline[],
+  source: RenderedInlineSourcePlan,
+  emittedRelationshipIds: Set<string>,
+  publicationPlan: RenderedPublicationPlan,
 ) {
-  const validRuns = runs
-    .filter(
-      (run) =>
-        Number.isInteger(run.start) &&
-        Number.isInteger(run.end) &&
-        run.start >= 0 &&
-        run.end > run.start &&
-        run.end <= value.length,
-    )
-    .sort((left, right) => left.start - right.start || right.end - left.end)
-  if (validRuns.length === 0) return text(value)
-
-  const boundaries = new Set([0, value.length])
-  for (const run of validRuns) {
-    boundaries.add(run.start)
-    boundaries.add(run.end)
-  }
-  const positions = [...boundaries].sort((left, right) => left - right)
-  const relationships = new Map(
-    document.relationships.map((relationship) => [
-      relationship.id,
-      relationship,
-    ]),
-  )
-  const emittedRelationshipIds = new Set<string>()
-  return positions
-    .slice(0, -1)
-    .map((start, index) => {
-      const end = positions[index + 1]
+  const { value } = source
+  const plan = source.segments
+  if (plan.length === 0) return text(value)
+  return plan
+    .map((segment) => {
+      const { start, end, owners } = segment
       const segmentValue = value.slice(start, end)
-      const owners = validRuns.filter(
-        (run) => run.start <= start && run.end >= end,
-      )
       const styled = (content: string) => {
         let rendered = content
         for (const run of owners) {
@@ -218,79 +65,56 @@ function renderInline(
         return rendered
       }
       let rendered = styled(text(segmentValue))
-      const semanticRun = owners.find(
+      const semanticOwnerIndex = owners.findIndex(
         (run) => run.semanticRole && run.relationshipId,
       )
-      if (semanticRun?.relationshipId && semanticRun.semanticRole) {
-        const relationship = relationships.get(semanticRun.relationshipId)
-        const relationshipId = stableId(semanticRun.relationshipId)
+      const semanticRun =
+        semanticOwnerIndex >= 0 ? owners[semanticOwnerIndex] : undefined
+      const semantic =
+        semanticOwnerIndex >= 0
+          ? publicationPlan.semanticByOwnerKey.get(
+              segment.ownerKeys[semanticOwnerIndex]!,
+            )
+          : undefined
+      if (semanticRun?.relationshipId && semanticRun.semanticRole && semantic) {
+        const relationshipId = semantic.relationshipIdStable
         const firstSegment = !emittedRelationshipIds.has(relationshipId)
         emittedRelationshipIds.add(relationshipId)
         const id = firstSegment ? ` id="${attribute(relationshipId)}"` : ''
-        const targets = relationship
-          ? relationship.status === 'matched'
-            ? relationship.to.map(stableId)
-            : []
-          : (semanticRun.targetIds ?? []).map(stableId)
-        const semanticAttributes = ` data-semantic-role="${attribute(semanticRun.semanticRole)}" data-relationship-id="${attribute(relationshipId)}"${targets.length > 0 ? ` data-target-ids="${attribute(targets.join(' '))}"` : ''}`
+        const targets = semantic.targets
+        const semanticAttributes = semantic.semanticAttributes
         if (targets.length === 0) {
           rendered = `<span${id}${semanticAttributes}>${rendered}</span>`
         } else {
-          const epubRole =
-            semanticRun.semanticRole === 'note-reference'
-              ? ' epub:type="noteref" role="doc-noteref"'
-              : semanticRun.semanticRole === 'citation'
-                ? ' epub:type="biblioref" role="doc-biblioref"'
-                : ''
+          const epubRole = semantic.epubRole
           if (targets.length === 1) {
-            rendered = `<a${id} href="#${attribute(targets[0])}"${epubRole}${semanticAttributes}>${rendered}</a>`
+            rendered = `<a${id} href="${attribute(targets[0]!.href)}"${epubRole}${semanticAttributes}>${rendered}</a>`
           } else {
-            const labels = (relationship?.label ?? '')
-              .split(',')
-              .map((label) => label.trim())
-              .filter(Boolean)
             const grouped =
               semanticRun.semanticRole === 'citation'
                 ? groupedCitationLinks(
                     segmentValue,
-                    labels,
-                    targets,
+                    semantic.citationRanges,
+                    semantic.targetById,
                     epubRole,
-                    value.slice(semanticRun.start, semanticRun.end),
-                    start - semanticRun.start,
+                    start - semanticRun.start!,
                   )
                 : { html: text(segmentValue), linkedTargets: new Set<string>() }
-            const visibleTargets =
-              semanticRun.semanticRole === 'citation'
-                ? groupedCitationLinks(
-                    value.slice(semanticRun.start, semanticRun.end),
-                    labels,
-                    targets,
-                    epubRole,
-                  ).linkedTargets
-                : new Set<string>()
-            const additionalTargets = targets
-              .map((target, targetIndex) => ({ target, targetIndex }))
-              .filter(({ target }) => !visibleTargets.has(target))
-              .map(
-                ({ target, targetIndex }) =>
-                  `<a href="#${attribute(target)}"${epubRole} class="additional-semantic-reference">Additional ${text(semanticRun.semanticRole!)} target ${text(labels[targetIndex] ?? String(targetIndex + 1))}</a>`,
-              )
-              .join('')
-            rendered = `<span${id}${semanticAttributes}>${styled(grouped.html)}${firstSegment ? additionalTargets : ''}</span>`
+            rendered = `<span${id}${semanticAttributes}>${styled(grouped!.html)}${firstSegment ? semantic.additionalTargets : ''}</span>`
           }
         }
       } else {
-        const hyperlinkRun = owners.find(
+        const hyperlinkOwnerIndex = owners.findIndex(
           (run) => run.href || run.targetIds?.length,
         )
-        const internalTarget = hyperlinkRun?.targetIds?.[0]
-        const href =
-          hyperlinkRun?.href?.startsWith('#') && internalTarget
-            ? `#${internalTarget}`
-            : (hyperlinkRun?.href ??
-              (internalTarget ? `#${internalTarget}` : undefined))
-        if (href) rendered = `<a href="${attribute(href)}">${rendered}</a>`
+        const hyperlink =
+          hyperlinkOwnerIndex >= 0
+            ? publicationPlan.hyperlinkByOwnerKey.get(
+                segment.ownerKeys[hyperlinkOwnerIndex]!,
+              )
+            : undefined
+        if (hyperlink)
+          rendered = `<a href="${attribute(hyperlink.href)}">${rendered}</a>`
       }
       return rendered
     })
@@ -301,62 +125,71 @@ function renderTable(
   document: StructDocument,
   table: StructTable,
   tableBlockId: string,
+  blockIndex: number,
+  emittedRelationshipIds: Set<string>,
+  publicationPlan: RenderedPublicationPlan,
 ) {
   const rows = Array.from({ length: table.rows }, () => [] as string[])
-  for (const cell of table.cells) {
-    const tag = cell.headerScope ? 'th' : 'td'
-    const htmlScope = cell.headerScope === 'column' ? 'col' : cell.headerScope
-    const scope = htmlScope ? ` scope="${htmlScope}"` : ''
-    const rowSpan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : ''
-    const columnSpan =
-      cell.columnSpan > 1 ? ` colspan="${cell.columnSpan}"` : ''
-    rows[cell.row]?.push(
-      `<${tag} id="${attribute(`${tableBlockId}-${cell.id}`)}"${scope}${rowSpan}${columnSpan}>${renderInline(document, cell.text, cell.inline)}</${tag}>`,
-    )
+  const cells = new Map<string, { cell: StructTableCell; index: number }>(
+    table.cells.map(
+      (cell, index) => [`${cell.row}:${cell.column}`, { cell, index }] as const,
+    ),
+  )
+  const occupied = new Set<string>()
+  for (let row = 0; row < table.rows; row += 1) {
+    for (let column = 0; column < table.columns; column += 1) {
+      const coordinate = `${row}:${column}`
+      if (occupied.has(coordinate)) continue
+      const cellEntry = cells.get(coordinate)
+      if (!cellEntry) {
+        rows[row]!.push('<td></td>')
+        continue
+      }
+      const { cell, index: cellIndex } = cellEntry
+      const tag = cell.headerScope ? 'th' : 'td'
+      const htmlScope = cell.headerScope === 'column' ? 'col' : cell.headerScope
+      const scope = htmlScope ? ` scope="${htmlScope}"` : ''
+      const rowSpan = cell.rowSpan > 1 ? ` rowspan="${cell.rowSpan}"` : ''
+      const columnSpan =
+        cell.columnSpan > 1 ? ` colspan="${cell.columnSpan}"` : ''
+      rows[row]!.push(
+        `<${tag} id="${attribute(`${tableBlockId}-${cell.id}`)}"${scope}${rowSpan}${columnSpan}>${renderInline(
+          document,
+          publicationPlan.sourceByKey.get(`table:${blockIndex}:${cellIndex}`)!,
+          emittedRelationshipIds,
+          publicationPlan,
+        )}</${tag}>`,
+      )
+      for (
+        let occupiedRow = cell.row;
+        occupiedRow < cell.row + cell.rowSpan;
+        occupiedRow += 1
+      )
+        for (
+          let occupiedColumn = cell.column;
+          occupiedColumn < cell.column + cell.columnSpan;
+          occupiedColumn += 1
+        )
+          occupied.add(`${occupiedRow}:${occupiedColumn}`)
+    }
   }
   return `<table>${rows.map((row) => `<tr>${row.join('')}</tr>`).join('')}</table>`
 }
 
-function renderedInlineRelationshipIds(document: StructDocument) {
-  return new Set([
-    ...(document.metadata.authorNotes ?? []).map((reference) => reference.id),
-    ...document.blocks.flatMap((block) => [
-      ...(block.kind !== 'furniture' && block.kind !== 'table'
-        ? block.inline.flatMap((run) =>
-            run.relationshipId &&
-            run.semanticRole === 'note-reference' &&
-            run.start >= 0 &&
-            run.start < run.end &&
-            run.end <= block.text.length
-              ? [run.relationshipId]
-              : [],
-          )
-        : []),
-      ...(block.table?.cells.flatMap((cell) =>
-        cell.inline.flatMap((run) =>
-          run.relationshipId &&
-          run.semanticRole === 'note-reference' &&
-          run.start >= 0 &&
-          run.start < run.end &&
-          run.end <= cell.text.length
-            ? [run.relationshipId]
-            : [],
-        ),
-      ) ?? []),
-    ]),
-  ])
-}
-
-function renderAuthors(document: StructDocument) {
+function renderAuthors(
+  document: StructDocument,
+  emittedRelationshipIds: Set<string>,
+  publicationPlan: RenderedPublicationPlan,
+) {
   if (document.metadata.authors.length === 0) return ''
   const authors = document.metadata.authors
     .map((author) => {
-      const references = (document.metadata.authorNotes ?? [])
-        .filter((reference) => reference.author === author)
-        .map(
-          (reference) =>
-            `<sup><a id="${attribute(stableId(reference.id))}" href="#${attribute(stableId(reference.target))}" epub:type="noteref" role="doc-noteref">${text(reference.label)}</a></sup>`,
-        )
+      const references = (publicationPlan.authorNotesByAuthor.get(author) ?? [])
+        .map((reference) => {
+          const target = resolveStructTarget(document, reference.target)
+          emittedRelationshipIds.add(stableId(reference.id))
+          return `<sup><a id="${attribute(stableId(reference.id))}" href="${attribute(target.href)}" epub:type="noteref" role="doc-noteref">${text(reference.label)}</a></sup>`
+        })
         .join('')
       return `${text(author)}${references}`
     })
@@ -373,22 +206,33 @@ function renderSourceObservationAnchors(block: StructBlock) {
     .join('')
 }
 
-function renderBlock(document: StructDocument, block: StructBlock) {
+function renderBlock(
+  document: StructDocument,
+  block: StructBlock,
+  blockIndex: number,
+  emittedRelationshipIds: Set<string>,
+  publicationPlan: RenderedPublicationPlan,
+) {
   // Furniture remains queryable in STRUCT with its source evidence, but is
   // intentionally outside the publication reading flow.
   if (block.kind === 'furniture') return ''
   const id = attribute(block.id)
-  const content = renderInline(document, block.text, block.inline)
   const sourceAnchors = renderSourceObservationAnchors(block)
+  if (block.kind === 'table' && block.table) {
+    return `<figure id="${id}" data-struct-id="${id}">${sourceAnchors}${renderTable(document, block.table, block.id, blockIndex, emittedRelationshipIds, publicationPlan)}</figure>`
+  }
+  const content = renderInline(
+    document,
+    publicationPlan.sourceByKey.get(`block:${blockIndex}`)!,
+    emittedRelationshipIds,
+    publicationPlan,
+  )
   if (block.kind === 'heading') {
     const level = Math.max(1, Math.min(6, Number(block.attributes?.level ?? 2)))
     return `<h${level} id="${id}" data-struct-id="${id}">${sourceAnchors}${content}</h${level}>`
   }
   if (block.kind === 'quote') {
     return `<blockquote id="${id}" data-struct-id="${id}">${sourceAnchors}<p>${content}</p></blockquote>`
-  }
-  if (block.kind === 'table' && block.table) {
-    return `<figure id="${id}" data-struct-id="${id}">${sourceAnchors}${renderTable(document, block.table, block.id)}</figure>`
   }
   if (
     block.kind === 'figure' ||
@@ -410,16 +254,7 @@ function renderBlock(document: StructDocument, block: StructBlock) {
     return `<p id="${id}" data-struct-id="${id}" class="caption">${sourceAnchors}${content}</p>`
   }
   if (block.kind === 'footnote' || block.kind === 'endnote') {
-    const renderedRelationships = renderedInlineRelationshipIds(document)
-    const backlinks = document.relationships
-      .filter(
-        (relationship) =>
-          relationship.status === 'matched' &&
-          renderedRelationships.has(relationship.id) &&
-          (relationship.kind === 'footnote' ||
-            relationship.kind === 'endnote') &&
-          relationship.to.includes(block.id),
-      )
+    const backlinks = (publicationPlan.backlinksByTarget.get(block.id) ?? [])
       .map(
         (relationship) =>
           `<a href="#${attribute(stableId(relationship.id))}" class="note-backlink" aria-label="Back to note reference">↩</a>`,
@@ -436,11 +271,22 @@ function renderBlock(document: StructDocument, block: StructBlock) {
   return `<p id="${id}" data-struct-id="${id}"${bibliographyEntry}>${sourceAnchors}${content}</p>`
 }
 
+function assertUniqueEmittedIds(entries: readonly EmittedXhtmlId[]) {
+  const seen = new Set<string>()
+  for (const { id } of entries) {
+    if (seen.has(id)) throw new Error(`STRUCT XHTML duplicate id ${id}`)
+    seen.add(id)
+  }
+}
+
 /** Render a source-agnostic STRUCT graph without consulting extractor state. */
 export function renderPublicationXhtml(
   document: StructDocument,
   options: StructXhtmlOptions = {},
 ) {
+  const publicationPlan = buildRenderedPublicationPlan(document)
+  assertUniqueEmittedIds(emittedXhtmlIds(document, publicationPlan))
+  const emittedRelationshipIds = new Set<string>()
   const language = document.metadata.language ?? 'und'
   const direction =
     document.metadata.baseDirection === 'ltr' ||
@@ -457,8 +303,8 @@ export function renderPublicationXhtml(
   ${options.embedStyles ? `<style>${text(styles)}</style>` : '<link rel="stylesheet" type="text/css" href="styles.css" />'}
 </head>
 <body>
-  <header><h1>${text(document.metadata.title)}</h1>${document.metadata.subtitle ? `<p>${text(document.metadata.subtitle)}</p>` : ''}${renderAuthors(document)}</header>
-  ${document.blocks.map((block) => renderBlock(document, block)).join('\n  ')}
+  <header><h1>${text(document.metadata.title)}</h1>${document.metadata.subtitle ? `<p>${text(document.metadata.subtitle)}</p>` : ''}${renderAuthors(document, emittedRelationshipIds, publicationPlan)}</header>
+  ${document.blocks.map((block, blockIndex) => renderBlock(document, block, blockIndex, emittedRelationshipIds, publicationPlan)).join('\n  ')}
 </body>
 </html>
 `

--- a/src/struct/xhtml.ts
+++ b/src/struct/xhtml.ts
@@ -8,6 +8,7 @@ import {
   buildRenderedPublicationPlan,
   emittedXhtmlIds,
   groupedCitationLinks,
+  isPackagedAssetId,
   resolveStructTarget,
   stableId,
   type EmittedXhtmlId,
@@ -182,11 +183,29 @@ function renderAuthors(
   publicationPlan: RenderedPublicationPlan,
 ) {
   if (document.metadata.authors.length === 0) return ''
+  const targetCache = new Map<string, ReturnType<typeof resolveStructTarget>>()
+  for (const asset of document.assets)
+    if (isPackagedAssetId(asset.id))
+      targetCache.set(asset.id, {
+        id: asset.id,
+        href: asset.href,
+        kind: 'asset',
+      })
+  for (const block of document.blocks)
+    if (block.kind !== 'furniture' && !targetCache.has(block.id))
+      targetCache.set(block.id, {
+        id: block.id,
+        href: `#${block.id}`,
+        kind: 'block',
+      })
   const authors = document.metadata.authors
     .map((author) => {
       const references = (publicationPlan.authorNotesByAuthor.get(author) ?? [])
         .map((reference) => {
-          const target = resolveStructTarget(document, reference.target)
+          const target =
+            targetCache.get(reference.target) ??
+            resolveStructTarget(document, reference.target)
+          targetCache.set(reference.target, target)
           emittedRelationshipIds.add(stableId(reference.id))
           return `<sup><a id="${attribute(stableId(reference.id))}" href="${attribute(target.href)}" epub:type="noteref" role="doc-noteref">${text(reference.label)}</a></sup>`
         })


### PR DESCRIPTION
Part of erniesg/erniesg#206 and prerequisite for erniesg/struct#1.

Replays the source-neutral, fail-closed #209 hardening onto current main without importing the stale historical train. Scope is restricted to `src/struct/**`: strict codec snapshots, generic receipt binding, direct EPUB resource preflight, deterministic rendering/archive bounds, and source-neutral tests.

Explicitly excluded: Research/PDF/DOCX/model-specific receipts/app adapters/Study/Astro/BookWorld/providers/deploy.

Exact-head correctness and security reviews accepted `6e0a7c2`. Validation: `npx vitest run src/struct --maxWorkers=1` 297/297; `astro check` 0 errors; diff and secret scans clean.

No npm publication or deployment.