### PR TITLE
Add canonical Study PDF to EPUB experiment

### DIFF
--- a/src/components/study/pdf-to-epub-route.test.ts
+++ b/src/components/study/pdf-to-epub-route.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const routePath = fileURLToPath(
+  new URL('../../pages/study/experiments/pdf-to-epub.astro', import.meta.url),
+)
+
+describe('the canonical Study PDF to EPUB route', () => {
+  it('uses the browser-local PublicationImporter and stays out of search indexes', () => {
+    const source = readFileSync(routePath, 'utf8')
+
+    expect(source).toContain(
+      "import PublicationImporter from '@/components/research/PublicationImporter'",
+    )
+    expect(source).toContain(
+      'canonicalPath="/study/experiments/pdf-to-epub"',
+    )
+    expect(source).toMatch(/<Layout[\s\S]*?noindex/)
+    expect(source).toMatch(/conversion[^<]*browser/i)
+    expect(source).toContain(
+      '<PublicationImporter showIntro={false} client:load />',
+    )
+  })
+})

--- a/src/pages/study/experiments/pdf-to-epub.astro
+++ b/src/pages/study/experiments/pdf-to-epub.astro
@@ -1,0 +1,23 @@
+---
+import Container from '@/components/Container.astro'
+import PublicationImporter from '@/components/research/PublicationImporter'
+import Layout from '@/layouts/Layout.astro'
+---
+
+<Layout
+  title="PDF to EPUB"
+  description="Convert a PDF into a reflowable EPUB locally in your browser."
+  canonicalPath="/study/experiments/pdf-to-epub"
+  noindex
+>
+  <Container class="flex flex-col gap-y-8 pb-24">
+    <header class="flex flex-col gap-y-3 border-b pb-6">
+      <h1 class="text-3xl font-bold">PDF to EPUB</h1>
+      <p class="max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        Conversion stays in your browser, so your file remains on this device.
+      </p>
+    </header>
+
+    <PublicationImporter showIntro={false} client:load />
+  </Container>
+</Layout>


### PR DESCRIPTION
Adds the canonical browser-local PDF→EPUB experiment at /study/experiments/pdf-to-epub.\n\nPart of #70.\n\n- Reuses the existing PublicationImporter; no Research runtime or adapter changes.\n- Covers the canonical route, noindex metadata, and importer loading with a focused test.\n- Verified: focused Vitest (1/1), staging build (133 pages), and local Chromium smoke (HTTP 200, file control present, noindex,follow).\n\nNo deployment or route activation.