### PR TITLE
fix(pdf): fail closed without grounded evidence

### DIFF
--- a/benchmarks/pdf/benchmark-readiness-registry-v1.json
+++ b/benchmarks/pdf/benchmark-readiness-registry-v1.json
@@ -159,6 +159,24 @@
     "blindSplitIdentitySha256": null,
     "committedBeforePrivateLabelReveal": false
   },
+  "nativeReaderEvidence": {
+    "exportEvidence": null,
+    "apple-books": {
+      "status": "unavailable-blocker",
+      "readerIdentity": null,
+      "executionReceipt": null
+    },
+    "independent-desktop-epub-reader": {
+      "status": "unavailable-blocker",
+      "readerIdentity": null,
+      "executionReceipt": null
+    },
+    "target-eink-reader-device": {
+      "status": "unavailable-blocker",
+      "readerIdentity": null,
+      "executionReceipt": null
+    }
+  },
   "discoveryOrder": {
     "status": "not-recorded",
     "caseIds": []
@@ -284,10 +302,22 @@
       "test": "tools/pdf-private-fidelity.test.mjs",
       "testSha256": "18b6f9fd8654e7ab652de6c7f63964e15fcffb09cf6cc948724632c3ece3acfe",
       "testDependencies": [
-        { "path": "tools/pdf-private-fidelity.cases-support.mjs", "fileSha256": "ad74ee51c59fd6d1308a016fc474788bca9c7b4a6eb6e6ce20674d30779cce45" },
-        { "path": "tools/pdf-private-fidelity-semantic.cases.mjs", "fileSha256": "525d6d1813aca7fc320d1fc75b338bb3e676f73ee7420ee4267e5dd083e7e755" },
-        { "path": "tools/pdf-private-fidelity-receipt.cases.mjs", "fileSha256": "86839b8991575d7d23ef04a23421996dafdff759d5039b87c14b2730727868a0" },
-        { "path": "tools/pdf-private-fidelity-boundary.cases.mjs", "fileSha256": "56afdbd4e3ad4114c95179caf3783ff002a7740b63f5871e4a75141a040308da" }
+        {
+          "path": "tools/pdf-private-fidelity.cases-support.mjs",
+          "fileSha256": "ad74ee51c59fd6d1308a016fc474788bca9c7b4a6eb6e6ce20674d30779cce45"
+        },
+        {
+          "path": "tools/pdf-private-fidelity-semantic.cases.mjs",
+          "fileSha256": "525d6d1813aca7fc320d1fc75b338bb3e676f73ee7420ee4267e5dd083e7e755"
+        },
+        {
+          "path": "tools/pdf-private-fidelity-receipt.cases.mjs",
+          "fileSha256": "86839b8991575d7d23ef04a23421996dafdff759d5039b87c14b2730727868a0"
+        },
+        {
+          "path": "tools/pdf-private-fidelity-boundary.cases.mjs",
+          "fileSha256": "56afdbd4e3ad4114c95179caf3783ff002a7740b63f5871e4a75141a040308da"
+        }
       ],
       "calibration": null
     }

--- a/benchmarks/pdf/extraction-bakeoff-report-v1.json
+++ b/benchmarks/pdf/extraction-bakeoff-report-v1.json
@@ -33,14 +33,16 @@
           "documentId": "heldout-one",
           "split": "held-out",
           "layout": "one-column",
-          "status": "passed",
+          "status": "failed",
           "verification": {
-            "status": "passed",
-            "issueCodes": [],
-            "issueCount": 0
+            "status": "failed",
+            "issueCodes": [
+              "missing-source-run"
+            ],
+            "issueCount": 1
           },
-          "outputHash": "f74fa39356ad082e442413559cacfecfe06a60969ff9145829cc3ba7dfb2f45d",
-          "byteStable": true,
+          "outputHash": null,
+          "byteStable": false,
           "latencyMsPerPage": 1,
           "costUsdPerPage": 0,
           "caseScores": [
@@ -49,16 +51,19 @@
               "documentId": "heldout-one",
               "stratum": "sectioning",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -66,16 +71,19 @@
               "documentId": "heldout-one",
               "stratum": "prose-continuity",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -83,16 +91,19 @@
               "documentId": "heldout-one",
               "stratum": "boilerplate-exclusion",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -100,16 +111,19 @@
               "documentId": "heldout-one",
               "stratum": "code-listings",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -117,16 +131,19 @@
               "documentId": "heldout-one",
               "stratum": "tables",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -134,16 +151,19 @@
               "documentId": "heldout-one",
               "stratum": "figures-diagrams",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -151,16 +171,19 @@
               "documentId": "heldout-one",
               "stratum": "equations",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -168,16 +191,19 @@
               "documentId": "heldout-one",
               "stratum": "footnotes-citations",
               "layout": "one-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             }
           ]
@@ -186,14 +212,16 @@
           "documentId": "heldout-two",
           "split": "held-out",
           "layout": "two-column",
-          "status": "passed",
+          "status": "failed",
           "verification": {
-            "status": "passed",
-            "issueCodes": [],
-            "issueCount": 0
+            "status": "failed",
+            "issueCodes": [
+              "missing-source-run"
+            ],
+            "issueCount": 1
           },
-          "outputHash": "56f0eca85a79cbdb5456b76202f99698141f0915981b881db2519d81163c3422",
-          "byteStable": true,
+          "outputHash": null,
+          "byteStable": false,
           "latencyMsPerPage": 1,
           "costUsdPerPage": 0,
           "caseScores": [
@@ -202,16 +230,19 @@
               "documentId": "heldout-two",
               "stratum": "sectioning",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -219,16 +250,19 @@
               "documentId": "heldout-two",
               "stratum": "prose-continuity",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -236,16 +270,19 @@
               "documentId": "heldout-two",
               "stratum": "boilerplate-exclusion",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -253,16 +290,19 @@
               "documentId": "heldout-two",
               "stratum": "code-listings",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -270,16 +310,19 @@
               "documentId": "heldout-two",
               "stratum": "tables",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -287,16 +330,19 @@
               "documentId": "heldout-two",
               "stratum": "figures-diagrams",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -304,16 +350,19 @@
               "documentId": "heldout-two",
               "stratum": "equations",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             },
             {
@@ -321,38 +370,41 @@
               "documentId": "heldout-two",
               "stratum": "footnotes-citations",
               "layout": "two-column",
-              "score": 0.8,
+              "score": 0,
               "typePrecision": 1,
-              "typeRecall": 0.5,
-              "sourceRecall": 0.5,
+              "typeRecall": 0,
+              "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
-                "status": "passed",
-                "issueCodes": [],
-                "issueCount": 0
+                "status": "failed",
+                "issueCodes": [
+                  "missing-source-run"
+                ],
+                "issueCount": 1
               }
             }
           ]
         }
       ],
       "byStratumAndLayout": {
-        "boilerplate-exclusion/one-column": 0.8,
-        "boilerplate-exclusion/two-column": 0.8,
-        "code-listings/one-column": 0.8,
-        "code-listings/two-column": 0.8,
-        "equations/one-column": 0.8,
-        "equations/two-column": 0.8,
-        "figures-diagrams/one-column": 0.8,
-        "figures-diagrams/two-column": 0.8,
-        "footnotes-citations/one-column": 0.8,
-        "footnotes-citations/two-column": 0.8,
-        "prose-continuity/one-column": 0.8,
-        "prose-continuity/two-column": 0.8,
-        "sectioning/one-column": 0.8,
-        "sectioning/two-column": 0.8,
-        "tables/one-column": 0.8,
-        "tables/two-column": 0.8
+        "boilerplate-exclusion/one-column": 0,
+        "boilerplate-exclusion/two-column": 0,
+        "code-listings/one-column": 0,
+        "code-listings/two-column": 0,
+        "equations/one-column": 0,
+        "equations/two-column": 0,
+        "figures-diagrams/one-column": 0,
+        "figures-diagrams/two-column": 0,
+        "footnotes-citations/one-column": 0,
+        "footnotes-citations/two-column": 0,
+        "prose-continuity/one-column": 0,
+        "prose-continuity/two-column": 0,
+        "sectioning/one-column": 0,
+        "sectioning/two-column": 0,
+        "tables/one-column": 0,
+        "tables/two-column": 0
       },
       "disqualified": false
     },
@@ -386,6 +438,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -405,6 +458,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -424,6 +478,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -443,6 +498,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -462,6 +518,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -481,6 +538,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -500,6 +558,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -519,6 +578,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -557,6 +617,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -576,6 +637,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -595,6 +657,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -614,6 +677,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -633,6 +697,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -652,6 +717,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -671,6 +737,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -690,6 +757,7 @@
               "sourceRecall": 0,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": null,
               "verification": {
                 "status": "failed",
                 "issueCodes": [
@@ -733,7 +801,7 @@
             "issueCodes": [],
             "issueCount": 0
           },
-          "outputHash": "06ad4f63c333174d3d855db815ca91d05a46f47f043b9c914645995099d2635e",
+          "outputHash": "0155265d8a94a00f06cb4d060b9e2b47092789a4cbbc9a3f74fca4ded9218496",
           "byteStable": true,
           "latencyMsPerPage": 1,
           "costUsdPerPage": 0,
@@ -749,6 +817,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -766,6 +835,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -783,6 +853,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -800,6 +871,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -817,6 +889,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -834,6 +907,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -851,6 +925,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -868,6 +943,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "c0569616a9ca78e1fcdf1273674c9c1af42c520fa6f31dbbc48d95454a3f2d2f",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -886,7 +962,7 @@
             "issueCodes": [],
             "issueCount": 0
           },
-          "outputHash": "36c1634902376d92e27c994b90865a517a1d1c95a58bd0189f147a4943257f6e",
+          "outputHash": "1f013555af8289b6b78462a43c615646317f86862538766dcb3fdfbaed13b463",
           "byteStable": true,
           "latencyMsPerPage": 1,
           "costUsdPerPage": 0,
@@ -902,6 +978,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -919,6 +996,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -936,6 +1014,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -953,6 +1032,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -970,6 +1050,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -987,6 +1068,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -1004,6 +1086,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -1021,6 +1104,7 @@
               "sourceRecall": 1,
               "assetRecall": 1,
               "boilerplateContamination": 0,
+              "structureHash": "88f07c8948ad9e7227b2429f1d8e4623c33ab63309a790fb189df306710245cd",
               "verification": {
                 "status": "passed",
                 "issueCodes": [],
@@ -1056,7 +1140,7 @@
       "stratum": "boilerplate-exclusion",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1069,7 +1153,7 @@
       "stratum": "boilerplate-exclusion",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1082,7 +1166,7 @@
       "stratum": "code-listings",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1095,7 +1179,7 @@
       "stratum": "code-listings",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1108,7 +1192,7 @@
       "stratum": "equations",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1121,7 +1205,7 @@
       "stratum": "equations",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1134,7 +1218,7 @@
       "stratum": "figures-diagrams",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1147,7 +1231,7 @@
       "stratum": "figures-diagrams",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1160,7 +1244,7 @@
       "stratum": "footnotes-citations",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1173,7 +1257,7 @@
       "stratum": "footnotes-citations",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1186,7 +1270,7 @@
       "stratum": "prose-continuity",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1199,7 +1283,7 @@
       "stratum": "prose-continuity",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1212,7 +1296,7 @@
       "stratum": "sectioning",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1225,7 +1309,7 @@
       "stratum": "sectioning",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1238,7 +1322,7 @@
       "stratum": "tables",
       "layout": "one-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1251,7 +1335,7 @@
       "stratum": "tables",
       "layout": "two-column",
       "scores": {
-        "geometric-baseline": 0.8,
+        "geometric-baseline": 0,
         "llm-authored": 0,
         "llm-grounded": 1
       },
@@ -1439,5 +1523,11 @@
       "reason": "verification"
     }
   ],
-  "reportSha256": "e6c606e68fc42dde1778953bc8ca99ebcdcc3e24efe2064f6f24841ad3398269"
+  "authority": {
+    "kind": "synthetic-contract-self-test",
+    "realProviderCalls": 0,
+    "realProviderAuthority": false,
+    "promotionEligible": false
+  },
+  "reportSha256": "1659b5bb7fa7a67f592f80d289073331faba1b0a7ec5ab21aa8e62e92cace6cf"
 }

--- a/docs/issues/051-close-grounded-codex-and-holdout-gap.md
+++ b/docs/issues/051-close-grounded-codex-and-holdout-gap.md
@@ -1,0 +1,55 @@
+# Close the grounded-Codex and holdout gap in staged PDF-to-EPUB
+
+provider: vm-codex
+depends-on: 041,046
+
+## Goal
+
+Close the truth and promotion-evidence gap between the staged browser-local
+PDF-to-EPUB experiment and the verified owner-local grounded-Codex pipeline,
+without uploading private papers or weakening semantic release gates.
+
+## Acceptance tests
+
+- Browser-local PDF conversion is explicitly identified as deterministic and
+  not Codex-assisted. Without a verified grounded-refinement receipt it can
+  produce only a readable review artifact, never a publication-grade EPUB.
+- DOCX publication behavior remains unchanged.
+- The synthetic extraction bakeoff carries machine-validated authority fields
+  proving it made no real provider calls and is promotion-ineligible.
+- Benchmark readiness requires exact-artifact evidence from Apple Books, an
+  independent desktop EPUB reader, and a target e-ink reader/device. Browser
+  XHTML rendering cannot satisfy any native-reader requirement.
+- Current unavailable native-reader states and missing private blind-test data
+  remain blockers. No checked-in result is relabelled ready.
+- A later owner-local execution must bind source, evidence graph, MinerU,
+  Codex, exact EPUB, comparator, and EPUBCheck identities before it can satisfy
+  the real-provider criterion.
+
+## Validation command
+
+```bash
+npx vitest run src/components/research/PublicationImporter.test.tsx
+npx vitest run tools/pdf-extraction-bakeoff.test.mjs tools/pdf-benchmark-readiness.test.mjs --maxWorkers=1
+npm test
+npm run build
+scripts/agent-evidence
+```
+
+## Allowed secrets
+
+None for this code slice. Real owner-local evidence remains a separate trusted
+VM execution and must not put source bytes, prompts, credentials, or private
+labels in GitHub.
+
+## Artifact outputs
+
+Fail-closed staging copy/export behavior, synthetic-authority metadata, native
+reader readiness fields and validators, focused regressions, and exact-head
+evidence. GitHub tracking issue: #290.
+
+## Stop conditions
+
+Stop before adding hosted private-document upload, an API-key path, Cloudflare
+resource provisioning, paper-specific parser branches, holdout replacement,
+or any promotion claim based only on package/browser validity.

--- a/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
+++ b/docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": "1.0.0",
   "decisionId": "extraction-architecture-v1",
-  "owner": "llm-grounded",
-  "humanDecisionRequired": false,
+  "owner": "pending",
+  "humanDecisionRequired": true,
   "perStratum": {
-    "boilerplate-exclusion": "llm-grounded",
-    "code-listings": "llm-grounded",
-    "equations": "llm-grounded",
-    "figures-diagrams": "llm-grounded",
-    "footnotes-citations": "llm-grounded",
-    "prose-continuity": "llm-grounded",
-    "sectioning": "llm-grounded",
-    "tables": "llm-grounded"
+    "boilerplate-exclusion": "pending",
+    "code-listings": "pending",
+    "equations": "pending",
+    "figures-diagrams": "pending",
+    "footnotes-citations": "pending",
+    "prose-continuity": "pending",
+    "sectioning": "pending",
+    "tables": "pending"
   },
   "geometricRole": "Remain the source-run, asset-bound, and publication verifier in every arm; it may provide the fail-closed fallback.",
   "reversalCriteria": [
@@ -20,5 +20,5 @@
     "Any unverified span, model-authored alt text, or model-authored asset bounds disqualifies the candidate regardless of score."
   ],
   "heldOutIdentitySha256": "b95c199887b1a35bdae8558e660c0e6fddaf41b09c655d57dfd64ee29505c545",
-  "reportSha256": "e6c606e68fc42dde1778953bc8ca99ebcdcc3e24efe2064f6f24841ad3398269"
+  "reportSha256": "1659b5bb7fa7a67f592f80d289073331faba1b0a7ec5ab21aa8e62e92cace6cf"
 }

--- a/docs/research/semantic-responsive-typesetting/fidelity-eval-set.md
+++ b/docs/research/semantic-responsive-typesetting/fidelity-eval-set.md
@@ -271,6 +271,43 @@ labels private through candidate freeze, execute independently of the candidate
 owner, and disclose results only after scoring. No such holdout is implemented
 by this repository today.
 
+## Native-reader promotion evidence
+
+Browser rendering is supplementary and never substitutes for native-reader
+promotion evidence. The readiness registry requires one hash-bound
+`pdf-benchmark-native-reader-execution-receipt` for the same exact EPUB
+artifact from each of Apple Books, an independent desktop EPUB reader, and the
+target e-ink reader or device. The registry first binds immutable export
+evidence: its own file hash, a retained repository EPUB artifact hash, and an
+repository-bound export receipt whose canonical identity is checked. Each
+reader has a separately hash-bound reader/device identity record and execution
+receipt; that receipt references the identity, export-evidence, and export-
+receipt file hashes plus the verified receipt identity and exact EPUB digest.
+Chromium and WebKit are not accepted reader types for these fields. A `.epub`
+suffix is insufficient: the retained bytes must be a ZIP EPUB with stored first
+`mimetype`, `META-INF/container.xml`, and an existing OPF rootfile.
+
+The export evidence also binds a successful repository-hash-bound EPUBCheck
+execution receipt for that exact digest. Its exact fields include checker
+identity and version, deterministic input/output identities, and passed status;
+missing, forged, mismatched, or failed receipt evidence blocks promotion.
+The checker identity/version must equal the repository-bound
+`src/publication/toolchain-manifest.json` EPUBCheck package/JAR pin, and its
+output identity is the canonical hash of a separate bound execution transcript
+recording the `epubcheck` command, exact artifact digest, exit code, status, and
+stdout/stderr digests.
+
+These repository-bound artifacts are structurally validated evidence only.
+They do not prove that a named native reader or EPUBCheck actually executed;
+until a separate trusted attestation verifier is implemented, readiness records
+`trustedAttestationVerified: false`, reports no promotion-authoritative reader
+verification, and remains blocked even for a complete structurally valid bundle.
+
+Until that external evidence exists, each registry entry remains
+`unavailable-blocker` with no receipt. That state is intentional and keeps
+promotion closed rather than turning browser fixture coverage into a false
+native-reader claim.
+
 Compare an imported or local baseline with a local candidate on the exact same
 frozen source and case identity:
 

--- a/docs/schemas/extraction-bakeoff-report.schema.json
+++ b/docs/schemas/extraction-bakeoff-report.schema.json
@@ -14,6 +14,7 @@
     "arms",
     "comparison",
     "disagreements",
+    "authority",
     "reportSha256"
   ],
   "properties": {
@@ -49,6 +50,7 @@
       "type": "array",
       "items": { "$ref": "#/$defs/disagreement" }
     },
+    "authority": { "$ref": "#/$defs/syntheticAuthority" },
     "reportSha256": { "$ref": "#/$defs/sha256" }
   },
   "$defs": {
@@ -59,6 +61,22 @@
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$"
     },
     "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "syntheticAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "realProviderCalls",
+        "realProviderAuthority",
+        "promotionEligible"
+      ],
+      "properties": {
+        "kind": { "const": "synthetic-contract-self-test" },
+        "realProviderCalls": { "const": 0 },
+        "realProviderAuthority": { "const": false },
+        "promotionEligible": { "const": false }
+      }
+    },
     "identity": {
       "type": "object",
       "additionalProperties": false,
@@ -117,6 +135,9 @@
         "typeRecall": { "type": "number", "minimum": 0, "maximum": 1 },
         "sourceRecall": { "type": "number", "minimum": 0, "maximum": 1 },
         "assetRecall": { "type": "number", "minimum": 0, "maximum": 1 },
+        "structureHash": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/sha256" }]
+        },
         "boilerplateContamination": {
           "type": "number",
           "minimum": 0,

--- a/docs/schemas/extraction-bakeoff-report.schema.json
+++ b/docs/schemas/extraction-bakeoff-report.schema.json
@@ -14,7 +14,6 @@
     "arms",
     "comparison",
     "disagreements",
-    "authority",
     "reportSha256"
   ],
   "properties": {
@@ -50,7 +49,7 @@
       "type": "array",
       "items": { "$ref": "#/$defs/disagreement" }
     },
-    "authority": { "$ref": "#/$defs/syntheticAuthority" },
+    "authority": { "$ref": "#/$defs/authority" },
     "reportSha256": { "$ref": "#/$defs/sha256" }
   },
   "$defs": {
@@ -76,6 +75,30 @@
         "realProviderAuthority": { "const": false },
         "promotionEligible": { "const": false }
       }
+    },
+    "ownerLocalRealProviderAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "realProviderCalls",
+        "realProviderAuthority",
+        "promotionEligible",
+        "providerExecutionReceiptSha256"
+      ],
+      "properties": {
+        "kind": { "const": "owner-local-real-provider-evidence" },
+        "realProviderCalls": { "type": "integer", "minimum": 1 },
+        "realProviderAuthority": { "const": true },
+        "promotionEligible": { "const": false },
+        "providerExecutionReceiptSha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "authority": {
+      "oneOf": [
+        { "$ref": "#/$defs/syntheticAuthority" },
+        { "$ref": "#/$defs/ownerLocalRealProviderAuthority" }
+      ]
     },
     "identity": {
       "type": "object",
@@ -122,6 +145,7 @@
         "typeRecall",
         "sourceRecall",
         "assetRecall",
+        "structureHash",
         "boilerplateContamination",
         "verification"
       ],

--- a/docs/schemas/extraction-bakeoff-report.schema.json
+++ b/docs/schemas/extraction-bakeoff-report.schema.json
@@ -168,7 +168,27 @@
           "maximum": 1
         },
         "verification": { "$ref": "#/$defs/verification" }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "verification": {
+                "properties": {
+                  "status": { "const": "passed" }
+                },
+                "required": ["status"]
+              }
+            },
+            "required": ["verification"]
+          },
+          "then": {
+            "properties": {
+              "structureHash": { "$ref": "#/$defs/sha256" }
+            }
+          }
+        }
+      ]
     },
     "document": {
       "type": "object",

--- a/docs/schemas/pdf-benchmark-readiness-registry.schema.json
+++ b/docs/schemas/pdf-benchmark-readiness-registry.schema.json
@@ -15,6 +15,7 @@
     "documentBindings",
     "splits",
     "candidateCommitment",
+    "nativeReaderEvidence",
     "discoveryOrder",
     "reviewBundles",
     "metricImplementations"
@@ -121,6 +122,9 @@
     },
     "candidateCommitment": {
       "$ref": "#/$defs/candidateCommitment"
+    },
+    "nativeReaderEvidence": {
+      "$ref": "#/$defs/nativeReaderEvidence"
     },
     "discoveryOrder": {
       "type": "object",
@@ -379,6 +383,69 @@
           }
         }
       ]
+    },
+    "nativeReaderEvidenceEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "readerIdentity", "executionReceipt"],
+      "properties": {
+        "status": { "enum": ["unavailable-blocker", "passed"] },
+        "readerIdentity": {
+          "oneOf": [{ "$ref": "#/$defs/fileBinding" }, { "type": "null" }]
+        },
+        "executionReceipt": {
+          "oneOf": [{ "$ref": "#/$defs/fileBinding" }, { "type": "null" }]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "unavailable-blocker" } },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "readerIdentity": { "type": "null" },
+              "executionReceipt": { "type": "null" }
+            }
+          },
+          "else": {
+            "properties": {
+              "readerIdentity": { "$ref": "#/$defs/fileBinding" },
+              "executionReceipt": { "$ref": "#/$defs/fileBinding" }
+            }
+          }
+        }
+      ]
+    },
+    "nativeReaderEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exportEvidence",
+        "apple-books",
+        "independent-desktop-epub-reader",
+        "target-eink-reader-device"
+      ],
+      "properties": {
+        "exportEvidence": {
+          "oneOf": [
+            { "$ref": "#/$defs/exactEpubExportEvidenceBinding" },
+            { "type": "null" }
+          ]
+        },
+        "apple-books": { "$ref": "#/$defs/nativeReaderEvidenceEntry" },
+        "independent-desktop-epub-reader": {
+          "$ref": "#/$defs/nativeReaderEvidenceEntry"
+        },
+        "target-eink-reader-device": {
+          "$ref": "#/$defs/nativeReaderEvidenceEntry"
+        }
+      }
+    },
+    "exactEpubExportEvidenceBinding": {
+      "description": "Hash-bound export evidence whose validator requires a retained EPUB, export receipt, pinned publication toolchain manifest, and successful EPUBCheck transcript and receipt.",
+      "$ref": "#/$defs/fileBinding"
     },
     "split": {
       "type": "object",

--- a/docs/schemas/pdf-benchmark-readiness-registry.schema.json
+++ b/docs/schemas/pdf-benchmark-readiness-registry.schema.json
@@ -15,7 +15,6 @@
     "documentBindings",
     "splits",
     "candidateCommitment",
-    "nativeReaderEvidence",
     "discoveryOrder",
     "reviewBundles",
     "metricImplementations"

--- a/docs/superpowers/plans/2026-09-01-pdf-epub-grounded-evidence.md
+++ b/docs/superpowers/plans/2026-09-01-pdf-epub-grounded-evidence.md
@@ -1,0 +1,54 @@
+# PDF-to-EPUB Grounded Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make staged PDF conversion and promotion evidence fail closed when grounded Codex, a private blind test, or native-reader proof is absent.
+
+**Architecture:** Preserve the static browser-local conversion boundary and the separate owner-local Node/Codex boundary. Correct the browser export policy and copy, then extend existing benchmark generators and readiness validation rather than inventing alternate promotion paths.
+
+**Tech Stack:** React, TypeScript, Vitest, Node.js CLIs, JSON benchmark receipts.
+
+**Spec:** `docs/issues/051-close-grounded-codex-and-holdout-gap.md`
+
+## Global Constraints
+
+- Never upload a selected PDF or source-derived crop from the static staging route.
+- Never treat a synthetic provider identity or browser renderer as promotion evidence.
+- Keep current benchmark and native-reader gaps fail-closed.
+- Use test-first RED/GREEN evidence for every behavior change.
+
+---
+
+### Task 1: Fail-closed browser export policy
+
+**Files:** `src/components/research/PublicationImporter.tsx`, `src/components/research/PublicationImporter.test.tsx`
+
+- [ ] Add focused regressions asserting PDF mode is never `publication`, DOCX remains unchanged, and browser copy says Codex is not consulted.
+- [ ] Run the focused Vitest and confirm RED.
+- [ ] Implement the minimal mode selection and copy change.
+- [ ] Re-run the focused Vitest and confirm GREEN.
+
+### Task 2: Mark synthetic bakeoff authority
+
+**Files:** `tools/pdf-extraction-bakeoff.mjs`, its test, and `benchmarks/pdf/extraction-bakeoff-report-v1.json`
+
+- [ ] Add tests rejecting promotion-eligible or real-provider claims on the synthetic corpus.
+- [ ] Run the focused Vitest and confirm RED.
+- [ ] Add and validate the authority object without changing scores.
+- [ ] Re-run the generator and tests; confirm deterministic GREEN output.
+
+### Task 3: Require native-reader exact-artifact evidence
+
+**Files:** `tools/pdf-benchmark-readiness.mjs`, its test, `benchmarks/pdf/benchmark-readiness-registry-v1.json`, and `docs/research/semantic-responsive-typesetting/fidelity-eval-set.md`
+
+- [ ] Add negative tests for unavailable readers and Chromium/WebKit substitution, plus a shape-valid positive fixture.
+- [ ] Run the focused Vitest and confirm RED.
+- [ ] Extend registry parsing and readiness reasons with native-reader evidence.
+- [ ] Record current readers as `unavailable-blocker`, document the distinction, and confirm GREEN while readiness stays false.
+
+### Task 4: Integrated verification and review
+
+- [ ] Run the three focused commands from the spec.
+- [ ] Run `npm test`, `npm run build`, `scripts/agent-evidence`, and `git diff --check`.
+- [ ] Obtain fresh independent exact-head review; fix every actionable finding and re-review changed scope.
+- [ ] Push the issue branch, create a PR linked to #290, wait for required checks, and merge only if repository policy authorizes the exact head.

--- a/src/components/research/PublicationImporter.test.tsx
+++ b/src/components/research/PublicationImporter.test.tsx
@@ -5,6 +5,7 @@ import {
   type EpubExport,
 } from '../../research/epub'
 import type {
+  DocumentReconstruction,
   PdfLineBoundaryDecision,
   PdfPageRegion,
 } from '../../research/import-types'
@@ -19,6 +20,7 @@ vi.mock('./EpubDownloadLink', () => ({ default: () => null }))
 
 import PublicationImporter, {
   EquationTranscriptAdjudicationCard,
+  browserEpubBuildMode,
   formatImportElapsed,
   importProgressIsIndeterminate,
   importErrorCode,
@@ -30,6 +32,24 @@ import PublicationImporter, {
 } from './PublicationImporter'
 
 describe('publication importer OCR controls', () => {
+  it('keeps a deterministically ready browser PDF in readable fallback mode', () => {
+    const readyPdf = {
+      source: { format: undefined },
+      readiness: { ready: true },
+    } as DocumentReconstruction
+
+    expect(browserEpubBuildMode(readyPdf)).toBe('readable-fallback')
+  })
+
+  it('preserves publication mode for a ready DOCX import', () => {
+    const readyDocx = {
+      source: { format: 'docx' },
+      readiness: { ready: true },
+    } as DocumentReconstruction
+
+    expect(browserEpubBuildMode(readyDocx)).toBe('publication')
+  })
+
   it('does not present final structural analysis as fake 100% progress', () => {
     expect(
       importProgressIsIndeterminate({
@@ -232,6 +252,15 @@ describe('publication importer OCR controls', () => {
     expect(markup).toContain('preserved as source-page images')
     expect(markup).toContain('does not start OCR')
     expect(markup).not.toContain('publication-ocr-language')
+  })
+
+  it('states that uploaded PDFs are reconstructed locally without Codex', () => {
+    const markup = renderToStaticMarkup(<PublicationImporter />)
+
+    expect(markup).toContain(
+      'Uploaded PDFs are reconstructed deterministically on this device.',
+    )
+    expect(markup).toContain('Codex is not consulted in this browser route.')
   })
 
   it('states the actual 50 MiB local upload limit', () => {

--- a/src/components/research/PublicationImporter.test.tsx
+++ b/src/components/research/PublicationImporter.test.tsx
@@ -263,6 +263,17 @@ describe('publication importer OCR controls', () => {
     expect(markup).toContain('Codex is not consulted in this browser route.')
   })
 
+  it('keeps the deterministic no-Codex disclosure on compact converter routes', () => {
+    const markup = renderToStaticMarkup(
+      <PublicationImporter showIntro={false} />,
+    )
+
+    expect(markup).toContain(
+      'Uploaded PDFs are reconstructed deterministically on this device.',
+    )
+    expect(markup).toContain('Codex is not consulted in this browser route.')
+  })
+
   it('states the actual 50 MiB local upload limit', () => {
     const markup = renderToStaticMarkup(<PublicationImporter />)
 

--- a/src/components/research/PublicationImporter.tsx
+++ b/src/components/research/PublicationImporter.tsx
@@ -995,6 +995,14 @@ function isPdfReconstruction(
   return result.source.format !== 'docx'
 }
 
+export function browserEpubBuildMode(
+  result: DocumentReconstruction,
+): EpubExport['mode'] {
+  return result.source.format === 'docx' && result.readiness.ready
+    ? 'publication'
+    : 'readable-fallback'
+}
+
 export default function PublicationImporter({
   showIntro = true,
   initialPaperUrl,
@@ -1412,7 +1420,7 @@ export default function PublicationImporter({
             ? await buildEpubInWorker(
                 result,
                 profile,
-                result.readiness.ready ? 'publication' : 'readable-fallback',
+                browserEpubBuildMode(result),
                 {
                   signal: controller.signal,
                   onProgress: (progress) => {
@@ -1609,7 +1617,9 @@ export default function PublicationImporter({
           <h2 id="studio-heading">Make an EPUB from a PDF or DOCX</h2>
           <p>
             Upload a paper or paste a direct PDF link. PDF reconstruction and
-            structured DOCX import run in your browser.
+            structured DOCX import run in your browser. Uploaded PDFs are
+            reconstructed deterministically on this device. Codex is not
+            consulted in this browser route.
           </p>
         </div>
       )}
@@ -1839,39 +1849,39 @@ export default function PublicationImporter({
           {!reviewMode &&
             state.status === 'review-required' &&
             hasActionableRecovery(userRecovery) && (
-            <div className="publication-ocr-gate" role="alert">
-              <span>Review summary</span>
-              <h3>
-                {userRecovery?.title ??
-                  'Your readable EPUB is ready for review.'}
-              </h3>
-              <p>{userRecovery?.summary}</p>
-              {userRecovery && userRecovery.issues.length > 0 && (
-                <ul
-                  className="publication-blocking-issues"
-                  aria-label="Review items"
-                >
-                  {userRecovery.issues.map((issue) => (
-                    <li
-                      key={`${issue.category}:${issue.title}:${issue.action ?? ''}:${issue.pages.join(',')}`}
-                    >
-                      <strong>{issue.title}</strong>
-                      <span>{issue.count}</span>
-                      {issue.pages.length > 0 && (
-                        <small>Pages {issue.pages.join(', ')}</small>
-                      )}
-                      {issue.action && <small>{issue.action}</small>}
-                    </li>
-                  ))}
-                </ul>
-              )}
-              {userRecovery?.userAction && (
-                <p>
-                  <strong>What to do:</strong> {userRecovery.userAction}
-                </p>
-              )}
-            </div>
-          )}
+              <div className="publication-ocr-gate" role="alert">
+                <span>Review summary</span>
+                <h3>
+                  {userRecovery?.title ??
+                    'Your readable EPUB is ready for review.'}
+                </h3>
+                <p>{userRecovery?.summary}</p>
+                {userRecovery && userRecovery.issues.length > 0 && (
+                  <ul
+                    className="publication-blocking-issues"
+                    aria-label="Review items"
+                  >
+                    {userRecovery.issues.map((issue) => (
+                      <li
+                        key={`${issue.category}:${issue.title}:${issue.action ?? ''}:${issue.pages.join(',')}`}
+                      >
+                        <strong>{issue.title}</strong>
+                        <span>{issue.count}</span>
+                        {issue.pages.length > 0 && (
+                          <small>Pages {issue.pages.join(', ')}</small>
+                        )}
+                        {issue.action && <small>{issue.action}</small>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {userRecovery?.userAction && (
+                  <p>
+                    <strong>What to do:</strong> {userRecovery.userAction}
+                  </p>
+                )}
+              </div>
+            )}
 
           {state.epubs?.[0] && (
             <EpubRenditionPreview

--- a/src/components/research/PublicationImporter.tsx
+++ b/src/components/research/PublicationImporter.tsx
@@ -1624,6 +1624,13 @@ export default function PublicationImporter({
         </div>
       )}
 
+      {!showIntro && (
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          Uploaded PDFs are reconstructed deterministically on this device.
+          Codex is not consulted in this browser route.
+        </p>
+      )}
+
       {reviewMode && (
         <div className="publication-decision-file">
           <label htmlFor="publication-decisions">

--- a/src/research/extraction-bakeoff.test.ts
+++ b/src/research/extraction-bakeoff.test.ts
@@ -14,6 +14,7 @@ import type {
   StructuredExtractionNodeType,
   StructuredExtractionProposal,
 } from './structured-extraction'
+import { structuredExtractionHash } from './structured-extraction'
 
 const hashA = 'a'.repeat(64)
 const hashB = 'b'.repeat(64)
@@ -169,9 +170,75 @@ describe('extraction architecture bake-off', () => {
       ]),
     )
     expect(report.reportSha256).toMatch(/^[a-f0-9]{64}$/u)
-    expect(createExtractionArchitectureDecision({ report }).reportSha256).toBe(
-      report.reportSha256,
-    )
+    const decision = createExtractionArchitectureDecision({ report })
+    expect(decision.reportSha256).toBe(report.reportSha256)
+    expect(decision.owner).toBe('pending')
+    expect(decision.humanDecisionRequired).toBe(true)
+  })
+
+  it('never promotes report-only authority claims', async () => {
+    const report = await runExtractionBakeoff({
+      corpus: corpus(),
+      arms: [
+        arm('geometric-baseline'),
+        arm('llm-authored'),
+        arm('llm-grounded'),
+      ],
+    })
+    const withAuthority = (authority: unknown) => {
+      const { reportSha256: _reportSha256, ...withoutHash } = report
+      const candidate = {
+        ...withoutHash,
+        comparison: withoutHash.comparison.map((row) => ({
+          ...row,
+          winner: 'llm-grounded' as const,
+        })),
+        authority,
+      }
+      return {
+        ...candidate,
+        reportSha256: structuredExtractionHash(candidate),
+      } as typeof report
+    }
+
+    for (const candidate of [
+      report,
+      withAuthority({
+        kind: 'real-provider-promotion-evidence',
+        realProviderCalls: 0,
+        realProviderAuthority: true,
+        promotionEligible: true,
+      }),
+      withAuthority({
+        kind: 'wrong-provider-authority',
+        realProviderCalls: 1,
+        realProviderAuthority: true,
+        promotionEligible: true,
+      }),
+      withAuthority({
+        kind: 'real-provider-promotion-evidence',
+        realProviderCalls: '1',
+        realProviderAuthority: true,
+        promotionEligible: true,
+      }),
+    ]) {
+      const decision = createExtractionArchitectureDecision({
+        report: candidate,
+      })
+      expect(decision.owner).toBe('pending')
+      expect(decision.humanDecisionRequired).toBe(true)
+    }
+
+    const forged = createExtractionArchitectureDecision({
+      report: withAuthority({
+        kind: 'real-provider-promotion-evidence',
+        realProviderCalls: 1,
+        realProviderAuthority: true,
+        promotionEligible: true,
+      }),
+    })
+    expect(forged.owner).toBe('pending')
+    expect(forged.humanDecisionRequired).toBe(true)
   })
 
   it('disqualifies a byte-unstable candidate rather than publishing the first result', async () => {

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -137,12 +137,29 @@ export type ExtractionBakeoffComparisonRow = {
   disagreementDocumentIds: string[]
 }
 
-export type ExtractionBakeoffAuthority = {
+export type SyntheticExtractionBakeoffAuthority = {
   kind: 'synthetic-contract-self-test'
   realProviderCalls: 0
   realProviderAuthority: false
   promotionEligible: false
 }
+
+/**
+ * A privacy-safe receipt emitted by an owner-local real-provider run. It is
+ * deliberately non-promotable: a report cannot substitute for the separate
+ * human architecture decision or prove the contents of the private run.
+ */
+export type OwnerLocalRealProviderExtractionBakeoffAuthority = {
+  kind: 'owner-local-real-provider-evidence'
+  realProviderCalls: number
+  realProviderAuthority: true
+  promotionEligible: false
+  providerExecutionReceiptSha256: string
+}
+
+export type ExtractionBakeoffAuthority =
+  | SyntheticExtractionBakeoffAuthority
+  | OwnerLocalRealProviderExtractionBakeoffAuthority
 
 export type ExtractionBakeoffReport = {
   schemaVersion: typeof EXTRACTION_BAKEOFF_SCHEMA_VERSION

--- a/src/research/extraction-bakeoff.ts
+++ b/src/research/extraction-bakeoff.ts
@@ -137,6 +137,13 @@ export type ExtractionBakeoffComparisonRow = {
   disagreementDocumentIds: string[]
 }
 
+export type ExtractionBakeoffAuthority = {
+  kind: 'synthetic-contract-self-test'
+  realProviderCalls: 0
+  realProviderAuthority: false
+  promotionEligible: false
+}
+
 export type ExtractionBakeoffReport = {
   schemaVersion: typeof EXTRACTION_BAKEOFF_SCHEMA_VERSION
   corpusId: string
@@ -162,6 +169,7 @@ export type ExtractionBakeoffReport = {
     arms: ExtractionBakeoffArmId[]
     reason: 'verification' | 'structure' | 'score'
   }>
+  authority?: ExtractionBakeoffAuthority
   reportSha256: string
 }
 
@@ -452,18 +460,14 @@ function caseEvidenceProjection(
     ...(caseInput.expectedExcludedBoilerplateRunIds ?? []),
   ])
   const assetIds = new Set(caseInput.expectedAssetIds ?? [])
-  const sourceRuns = context.sourceRuns.filter(({ id }) =>
-    sourceRunIds.has(id),
-  )
+  const sourceRuns = context.sourceRuns.filter(({ id }) => sourceRunIds.has(id))
   const sourceLines = (context.sourceLines ?? [])
     .map((line) => ({
       ...line,
       sourceRunIds: line.sourceRunIds.filter((id) => sourceRunIds.has(id)),
     }))
     .filter(({ sourceRunIds: ids }) => ids.length > 0)
-  const sourceAssets = context.sourceAssets.filter(({ id }) =>
-    assetIds.has(id),
-  )
+  const sourceAssets = context.sourceAssets.filter(({ id }) => assetIds.has(id))
   const sourceLinks = (context.sourceLinks ?? []).filter(
     ({ sourceRunIds: runIds, sourceAssetIds: linkAssetIds }) =>
       runIds.every((id) => sourceRunIds.has(id)) &&
@@ -508,9 +512,7 @@ function caseEvidenceProjection(
     ...(provenArtifacts.length > 0 ? { provenArtifacts } : {}),
     ...(caseInput.expectedExcludedBoilerplateRunIds
       ? {
-          boilerplateRunIds: [
-            ...caseInput.expectedExcludedBoilerplateRunIds,
-          ],
+          boilerplateRunIds: [...caseInput.expectedExcludedBoilerplateRunIds],
         }
       : {}),
   }
@@ -1255,18 +1257,9 @@ export function createExtractionArchitectureDecision({
       perStratum[row.stratum] =
         previous === 'pending' || winner === 'pending' ? 'pending' : 'tie'
   }
-  const winners = Object.values(perStratum).filter(
-    (value): value is ExtractionBakeoffArmId =>
-      EXTRACTION_BAKEOFF_ARMS.includes(value as ExtractionBakeoffArmId),
-  )
-  const uniqueWinners = [...new Set(winners)]
-  const unresolved = Object.values(perStratum).some(
-    (value) => value === 'tie' || value === 'pending',
-  )
-  const humanDecisionRequired = unresolved || uniqueWinners.length !== 1
-  const owner: ExtractionArchitectureDecision['owner'] = humanDecisionRequired
-    ? 'pending'
-    : uniqueWinners[0]!
+  for (const stratum of Object.keys(perStratum)) perStratum[stratum] = 'pending'
+  const humanDecisionRequired = true
+  const owner: ExtractionArchitectureDecision['owner'] = 'pending'
   return {
     schemaVersion: EXTRACTION_BAKEOFF_SCHEMA_VERSION,
     decisionId,

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1553,7 +1553,6 @@ function crc32(bytes) {
 
 function strictZipIndex(bytes) {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
-  let endOffset = -1
   for (
     let offset = bytes.byteLength - 22;
     offset >= Math.max(0, bytes.byteLength - 65_557);
@@ -1575,13 +1574,17 @@ function strictZipIndex(bytes) {
     ) {
       continue
     }
-    endOffset = offset
-    break
+    try {
+      return strictZipIndexAt(bytes, view, offset, entryCount, centralOffset)
+    } catch {
+      // A comment may contain a plausible EOCD header. Only a candidate whose
+      // bounded central and local records fully validate is authoritative.
+    }
   }
-  if (endOffset < 0) throw new Error('missing ZIP end record')
-  const entryCount = view.getUint16(endOffset + 10, true)
-  const centralSize = view.getUint32(endOffset + 12, true)
-  const centralOffset = view.getUint32(endOffset + 16, true)
+  throw new Error('missing ZIP end record')
+}
+
+function strictZipIndexAt(bytes, view, endOffset, entryCount, centralOffset) {
   const entries = []
   const names = new Set()
   let cursor = centralOffset

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -20,12 +20,15 @@ const DEFAULT_SCHEMA_PATH = resolve(
 const DEFAULT_SCHEMA_ID =
   'https://ernie.sg/schemas/pdf-benchmark-readiness-registry-1.0.0.json'
 const DEFAULT_SCHEMA_SHA256 =
-  '97a7a359e988f6a30dd8202fd28806df1c5e50b935999416c0304625e8e0bf4e'
+  '4b1f161abffadff696e022b074af6a91aacd75c6f9f02e9dc0ea7e85ceffe2df'
 const PUBLIC_ERROR_CODE = /^(?:INVALID|MISSING|PDF)_[A-Z0-9_]+$/
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/
 const SAFE_FAILURE_CLASS = /^[a-z][a-z0-9]*(?:-[a-z0-9]+){0,11}$/
 const SHA256 = /^[a-f0-9]{64}$/
 const MAX_GOVERNANCE_JSON_BYTES = 16 * 1024 * 1024
+const MAX_EPUB_COMPRESSED_BYTES = 256 * 1024 * 1024
+const MAX_EPUB_INFLATED_BYTES = 512 * 1024 * 1024
+const MAX_EPUB_ENTRIES = 544
 const PROMOTION_PROTOCOL_IMPLEMENTED = false
 const CANDIDATE_COMPONENT_KINDS = [
   'provider',
@@ -166,6 +169,7 @@ async function verifyRepositoryFileBinding(
   repositoryPath,
   expectedSha256,
   code = 'PDF_BENCHMARK_METRIC_BINDING_MISMATCH',
+  maxBytes = null,
 ) {
   try {
     const absolute = resolveRepositoryPath(repositoryPath)
@@ -177,12 +181,20 @@ async function verifyRepositoryFileBinding(
     if (
       !details.isFile() ||
       details.isSymbolicLink() ||
+      (maxBytes !== null &&
+        (details.size <= 0 || details.size > maxBytes)) ||
       (fileRealPath !== repositoryRealPath &&
         !fileRealPath.startsWith(`${repositoryRealPath}${sep}`))
     ) {
       invalid(code)
     }
     const bytes = await readFile(fileRealPath)
+    if (
+      bytes.byteLength !== details.size ||
+      (maxBytes !== null && bytes.byteLength > maxBytes)
+    ) {
+      invalid(code)
+    }
     if (sha256(bytes) !== expectedSha256) {
       invalid(code)
     }
@@ -197,6 +209,8 @@ async function readBoundJson(binding, code) {
     const bytes = await verifyRepositoryFileBinding(
       binding.path,
       binding.fileSha256,
+      'PDF_BENCHMARK_METRIC_BINDING_MISMATCH',
+      MAX_GOVERNANCE_JSON_BYTES,
     )
     return JSON.parse(bytes.toString('utf8'))
   } catch {
@@ -1325,7 +1339,18 @@ export async function validateIndependentIsolationEvidence(
   return true
 }
 
-function validEpubPackage(bytes) {
+function validEpubEntryName(name) {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    !name.startsWith('/') &&
+    !name.startsWith('\\') &&
+    !name.includes('\\') &&
+    name.split('/').every((part) => part.length > 0 && part !== '..')
+  )
+}
+
+export function validEpubPackage(bytes) {
   try {
     if (
       bytes.length < 30 ||
@@ -1341,25 +1366,49 @@ function validEpubPackage(bytes) {
     ) {
       return false
     }
-    const files = unzipSync(new Uint8Array(bytes))
+    const names = new Set()
+    let entryCount = 0
+    let inflatedBytes = 0
+    const files = unzipSync(new Uint8Array(bytes), {
+      filter: ({ name, size, originalSize, compression }) => {
+        if (
+          !validEpubEntryName(name) ||
+          names.has(name) ||
+          !Number.isSafeInteger(size) ||
+          !Number.isSafeInteger(originalSize) ||
+          size < 0 ||
+          originalSize < 0 ||
+          size > MAX_EPUB_COMPRESSED_BYTES ||
+          originalSize > MAX_EPUB_INFLATED_BYTES ||
+          (compression !== 0 && compression !== 8) ||
+          ++entryCount > MAX_EPUB_ENTRIES ||
+          (inflatedBytes += originalSize) > MAX_EPUB_INFLATED_BYTES
+        ) {
+          throw new Error('invalid EPUB archive metadata')
+        }
+        names.add(name)
+        return name === 'mimetype' || name === 'META-INF/container.xml'
+      },
+    })
     if (
       Buffer.from(files.mimetype ?? []).toString('utf8') !==
       'application/epub+zip'
     ) {
       return false
     }
-    const container = Buffer.from(files['META-INF/container.xml'] ?? []).toString(
-      'utf8',
-    )
+    const container = Buffer.from(
+      files['META-INF/container.xml'] ?? [],
+    ).toString('utf8')
     const rootfile = container.match(
       /<rootfile\b[^>]*\bfull-path=["']([^"']+)["'][^>]*>/u,
     )?.[1]
     return (
       typeof rootfile === 'string' &&
       rootfile.endsWith('.opf') &&
-      !rootfile.startsWith('/') &&
-      !rootfile.split('/').includes('..') &&
-      files[rootfile] instanceof Uint8Array
+      validEpubEntryName(rootfile) &&
+      unzipSync(new Uint8Array(bytes), {
+        filter: ({ name }) => name === rootfile,
+      })[rootfile] instanceof Uint8Array
     )
   } catch {
     return false
@@ -1402,6 +1451,7 @@ async function validateExactEpubExportEvidence(exportEvidence) {
     evidence.epubArtifact.path,
     evidence.epubArtifact.fileSha256,
     'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+    MAX_EPUB_COMPRESSED_BYTES,
   )
   if (evidence.exactArtifactSha256 !== evidence.epubArtifact.fileSha256) {
     invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
@@ -1625,6 +1675,22 @@ export async function validateNativeReaderEvidence(nativeReaderEvidence) {
     trustedAttestationVerified: false,
     trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
     verifiedReaderIds: [],
+  }
+}
+
+function unavailableNativeReaderEvidence() {
+  return {
+    exportEvidence: null,
+    ...Object.fromEntries(
+      Object.keys(REQUIRED_NATIVE_READER_TYPES).map((readerId) => [
+        readerId,
+        {
+          status: 'unavailable-blocker',
+          readerIdentity: null,
+          executionReceipt: null,
+        },
+      ]),
+    ),
   }
 }
 
@@ -1962,7 +2028,7 @@ export async function createPdfBenchmarkReadinessReceipt({
   const independentIsolationEvidenceVerified =
     await validateIndependentIsolationEvidence(registry, candidateCommitment)
   const nativeReaderEvidence = await validateNativeReaderEvidence(
-    registry.nativeReaderEvidence,
+    registry.nativeReaderEvidence ?? unavailableNativeReaderEvidence(),
   )
   const blind = registry.splits.find((split) => split.role === 'blind-test')
   const verifiedBlindSourcePolicy = blindSourcePolicyVerified(

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1759,6 +1759,17 @@ function extractZipEntryBounded(bytes, entry, maxBytes, collect = true) {
     if (!completed || emittedBytes !== entry.originalSize) {
       throw new Error('ZIP entry size mismatch')
     }
+    // fflate retains the final partially consumed byte in `p` and its bit
+    // position in `s.p`. A raw DEFLATE member may end mid-byte, but it must
+    // not leave a complete declared byte unconsumed after the final block.
+    const trailingInputBytes = inflate.p.byteLength
+    const finalBitOffset = inflate.s.p
+    if (
+      trailingInputBytes !== 0 &&
+      (trailingInputBytes !== 1 || finalBitOffset === 0)
+    ) {
+      throw new Error('ZIP entry has trailing compressed input')
+    }
     if ((runningCrc ^ 0xffffffff) >>> 0 !== entry.checksum) {
       throw new Error('ZIP entry checksum mismatch')
     }

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -2015,6 +2015,7 @@ export async function createPdfBenchmarkReadinessReceipt({
         registry.candidateCommitment.committedBeforePrivateLabelReveal,
       componentCommitmentSha256: candidateCommitment.componentCommitmentSha256,
     },
+    nativeReaderEvidence,
     criteria: assessment.criteria,
     gaps: assessment.gaps,
     ready: assessment.ready,

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1610,7 +1610,7 @@ function strictZipIndex(bytes) {
     if (
       !validEpubEntryName(name) ||
       names.has(name) ||
-      (flags & ~0x0806) !== 0 ||
+      (flags & ~0x080e) !== 0 ||
       (compression !== 0 && compression !== 8) ||
       size > MAX_EPUB_COMPRESSED_BYTES ||
       originalSize > MAX_EPUB_INFLATED_BYTES ||
@@ -1630,14 +1630,16 @@ function strictZipIndex(bytes) {
       originalSize,
       localOffset,
       nameBytes,
+      extraLength,
     })
     cursor = recordEnd
   }
   if (cursor !== endOffset) throw new Error('unindexed ZIP central bytes')
   let localCursor = 0
-  for (const entry of [...entries].sort(
+  const localEntries = [...entries].sort(
     (left, right) => left.localOffset - right.localOffset,
-  )) {
+  )
+  for (const [index, entry] of localEntries.entries()) {
     if (
       entry.localOffset !== localCursor ||
       entry.localOffset + 30 > centralOffset ||
@@ -1648,25 +1650,66 @@ function strictZipIndex(bytes) {
     const nameLength = view.getUint16(entry.localOffset + 26, true)
     const extraLength = view.getUint16(entry.localOffset + 28, true)
     const dataOffset = entry.localOffset + 30 + nameLength + extraLength
+    const nextLocalOffset =
+      localEntries[index + 1]?.localOffset ?? centralOffset
     const localNameBytes = Buffer.from(
       bytes.subarray(
         entry.localOffset + 30,
         entry.localOffset + 30 + nameLength,
       ),
     )
+    const hasDataDescriptor = (entry.flags & 0x0008) !== 0
     if (
       !localNameBytes.equals(entry.nameBytes) ||
+      (entry.name === 'mimetype' &&
+        (extraLength !== 0 || entry.extraLength !== 0)) ||
       view.getUint16(entry.localOffset + 6, true) !== entry.flags ||
       view.getUint16(entry.localOffset + 8, true) !== entry.compression ||
-      view.getUint32(entry.localOffset + 14, true) !== entry.checksum ||
-      view.getUint32(entry.localOffset + 18, true) !== entry.size ||
-      view.getUint32(entry.localOffset + 22, true) !== entry.originalSize ||
-      dataOffset + entry.size > centralOffset
+      dataOffset + entry.size > nextLocalOffset
     ) {
       throw new Error('ZIP local and central record mismatch')
     }
+    const localChecksum = view.getUint32(entry.localOffset + 14, true)
+    const localSize = view.getUint32(entry.localOffset + 18, true)
+    const localOriginalSize = view.getUint32(entry.localOffset + 22, true)
+    if (
+      !hasDataDescriptor &&
+      (localChecksum !== entry.checksum ||
+        localSize !== entry.size ||
+        localOriginalSize !== entry.originalSize)
+    ) {
+      throw new Error('ZIP local and central record mismatch')
+    }
+    let recordEnd = dataOffset + entry.size
+    if (hasDataDescriptor) {
+      if (localChecksum !== 0 || localSize !== 0 || localOriginalSize !== 0) {
+        throw new Error('ZIP local and central record mismatch')
+      }
+      const descriptorOffset = recordEnd
+      const descriptorSize = nextLocalOffset - descriptorOffset
+      if (descriptorSize !== 12 && descriptorSize !== 16) {
+        throw new Error('truncated ZIP data descriptor')
+      }
+      const descriptorHasSignature = descriptorSize === 16
+      if (
+        descriptorHasSignature &&
+        view.getUint32(descriptorOffset, true) !== 0x08074b50
+      ) {
+        throw new Error('ZIP data descriptor mismatch')
+      }
+      const descriptorFieldsOffset =
+        descriptorOffset + (descriptorHasSignature ? 4 : 0)
+      if (
+        view.getUint32(descriptorFieldsOffset, true) !== entry.checksum ||
+        view.getUint32(descriptorFieldsOffset + 4, true) !== entry.size ||
+        view.getUint32(descriptorFieldsOffset + 8, true) !== entry.originalSize
+      ) {
+        throw new Error('ZIP data descriptor mismatch')
+      }
+      recordEnd = nextLocalOffset
+    }
     entry.dataOffset = dataOffset
-    localCursor = dataOffset + entry.size
+    localCursor = recordEnd
   }
   if (localCursor !== centralOffset)
     throw new Error('unindexed ZIP local bytes')

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
 import { constants as fsConstants } from 'node:fs'
 import {
   lstat,
@@ -11,8 +12,9 @@ import {
 } from 'node:fs/promises'
 import { dirname, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 import Ajv2020 from 'ajv/dist/2020.js'
-import { XMLParser } from 'fast-xml-parser'
+import { XMLParser, XMLValidator } from 'fast-xml-parser'
 import { unzipSync } from 'fflate'
 import {
   canonicalJson,
@@ -39,7 +41,7 @@ const MAX_EPUB_COMPRESSED_BYTES = 256 * 1024 * 1024
 const MAX_EPUB_INFLATED_BYTES = 512 * 1024 * 1024
 const MAX_EPUB_ENTRIES = 544
 const MAX_EPUB_CONTAINER_BYTES = 64 * 1024
-const MAX_EPUB_PACKAGE_DOCUMENT_BYTES = 16 * 1024 * 1024
+const MAX_EPUB_PACKAGE_DOCUMENT_BYTES = 4 * 1024 * 1024
 const PROMOTION_PROTOCOL_IMPLEMENTED = false
 const CANDIDATE_COMPONENT_KINDS = [
   'provider',
@@ -75,6 +77,7 @@ const REQUIRED_NATIVE_READER_TYPES = {
   'independent-desktop-epub-reader': 'independent-desktop-epub-reader',
   'target-eink-reader-device': 'target-eink-reader-device',
 }
+const execFileAsync = promisify(execFile)
 
 function sha256(value) {
   return createHash('sha256').update(value).digest('hex')
@@ -125,6 +128,32 @@ function resolveRepositoryPath(repositoryPath) {
   return absolute
 }
 
+async function descriptorRealPath(handle, code) {
+  if (process.platform === 'linux') {
+    return realpath(`/proc/self/fd/${handle.fd}`)
+  }
+  if (process.platform === 'darwin') {
+    const { stdout } = await execFileAsync(
+      '/usr/sbin/lsof',
+      ['-a', '-p', String(process.pid), '-d', String(handle.fd), '-Fn'],
+      { encoding: 'utf8', maxBuffer: 64 * 1024, timeout: 5_000 },
+    )
+    const names = stdout
+      .split('\n')
+      .filter((line) => line.startsWith('n'))
+      .map((line) => line.slice(1))
+    if (
+      names.length !== 1 ||
+      !names[0].startsWith('/') ||
+      names[0].endsWith(' (deleted)')
+    ) {
+      invalid(code)
+    }
+    return names[0]
+  }
+  invalid(code)
+}
+
 async function readStableRegularFile(path, maxBytes, code) {
   let handle
   try {
@@ -134,9 +163,10 @@ async function readStableRegularFile(path, maxBytes, code) {
       fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
     )
     const before = await handle.stat({ bigint: true })
-    const [pathDetails, stableRealPath] = await Promise.all([
+    const [pathDetails, stableRealPath, openedRealPath] = await Promise.all([
       lstat(absolute, { bigint: true }),
       realpath(absolute),
+      descriptorRealPath(handle, code),
     ])
     if (
       !before.isFile() ||
@@ -144,6 +174,7 @@ async function readStableRegularFile(path, maxBytes, code) {
       pathDetails.isSymbolicLink() ||
       before.dev !== pathDetails.dev ||
       before.ino !== pathDetails.ino ||
+      openedRealPath !== stableRealPath ||
       before.size <= 0n ||
       before.size > BigInt(maxBytes)
     ) {
@@ -1521,13 +1552,24 @@ export function validEpubPackage(bytes) {
     ) {
       return false
     }
+    const rootfileBytes = unzipSync(new Uint8Array(bytes), {
+      filter: ({ name, originalSize }) =>
+        name === rootfile &&
+        originalSize > 0 &&
+        originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
+    })[rootfile]
+    if (!(rootfileBytes instanceof Uint8Array)) return false
+    const packageXml = Buffer.from(rootfileBytes).toString('utf8')
+    if (XMLValidator.validate(packageXml) !== true) return false
+    const packageDocument = new XMLParser({
+      ignoreAttributes: false,
+      processEntities: false,
+    }).parse(packageXml)
     return (
-      unzipSync(new Uint8Array(bytes), {
-        filter: ({ name, originalSize }) =>
-          name === rootfile &&
-          originalSize > 0 &&
-          originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
-      })[rootfile] instanceof Uint8Array
+      isRecord(packageDocument) &&
+      Object.keys(packageDocument).some(
+        (name) => name.split(':').at(-1) === 'package',
+      )
     )
   } catch {
     return false

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1559,27 +1559,29 @@ function strictZipIndex(bytes) {
     offset >= Math.max(0, bytes.byteLength - 65_557);
     offset -= 1
   ) {
-    if (view.getUint32(offset, true) === 0x06054b50) {
-      endOffset = offset
-      break
+    if (view.getUint32(offset, true) !== 0x06054b50) continue
+    const entryCount = view.getUint16(offset + 10, true)
+    const centralSize = view.getUint32(offset + 12, true)
+    const centralOffset = view.getUint32(offset + 16, true)
+    const commentLength = view.getUint16(offset + 20, true)
+    if (
+      view.getUint16(offset + 4, true) !== 0 ||
+      view.getUint16(offset + 6, true) !== 0 ||
+      view.getUint16(offset + 8, true) !== entryCount ||
+      entryCount === 0 ||
+      entryCount > MAX_EPUB_ENTRIES ||
+      centralOffset + centralSize !== offset ||
+      offset + 22 + commentLength !== bytes.byteLength
+    ) {
+      continue
     }
+    endOffset = offset
+    break
   }
   if (endOffset < 0) throw new Error('missing ZIP end record')
   const entryCount = view.getUint16(endOffset + 10, true)
   const centralSize = view.getUint32(endOffset + 12, true)
   const centralOffset = view.getUint32(endOffset + 16, true)
-  const commentLength = view.getUint16(endOffset + 20, true)
-  if (
-    view.getUint16(endOffset + 4, true) !== 0 ||
-    view.getUint16(endOffset + 6, true) !== 0 ||
-    view.getUint16(endOffset + 8, true) !== entryCount ||
-    entryCount === 0 ||
-    entryCount > MAX_EPUB_ENTRIES ||
-    centralOffset + centralSize !== endOffset ||
-    endOffset + 22 + commentLength !== bytes.byteLength
-  ) {
-    throw new Error('invalid ZIP end record')
-  }
   const entries = []
   const names = new Set()
   let cursor = centralOffset
@@ -1725,7 +1727,7 @@ function extractZipEntryBounded(bytes, entry, maxBytes, collect = true) {
     entry.dataOffset + entry.size,
   )
   let output
-  if (entry.originalSize === 0) {
+  if (entry.originalSize === 0 && entry.compression === 0) {
     if (entry.size !== 0 || entry.checksum !== 0) {
       throw new Error('invalid empty ZIP entry')
     }
@@ -1820,7 +1822,6 @@ export function validEpubPackage(bytes) {
     const rootfileEntry = entries.get(rootfile)
     if (
       typeof rootfile !== 'string' ||
-      !rootfile.endsWith('.opf') ||
       !validEpubEntryName(rootfile) ||
       rootfileEntry === undefined ||
       rootfileEntry.originalSize <= 0 ||

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1459,12 +1459,17 @@ function childElementInNamespace(
   namespaceScope = parent,
 ) {
   if (!isRecord(parent)) return null
-  const entry = Object.entries(parent).find(([name, child]) => {
+  const entry = Object.entries(parent).find(([name]) => {
     if (name.startsWith('@_') || name.split(':').at(-1) !== localName) {
       return false
     }
-    const prefix = name.includes(':') ? name.split(':')[0] : null
-    const namespaceAttribute = prefix === null ? '@_xmlns' : `@_xmlns:${prefix}`
+    return true
+  })
+  if (entry === undefined) return null
+  const prefix = entry[0].includes(':') ? entry[0].split(':')[0] : null
+  const namespaceAttribute = prefix === null ? '@_xmlns' : `@_xmlns:${prefix}`
+  const children = Array.isArray(entry[1]) ? entry[1] : [entry[1]]
+  const matching = children.filter((child) => {
     const effectiveNamespace = [child, parent, namespaceScope]
       .filter(isRecord)
       .find((scope) => Object.hasOwn(scope, namespaceAttribute))?.[
@@ -1472,7 +1477,7 @@ function childElementInNamespace(
     ]
     return effectiveNamespace === namespace
   })
-  return entry?.[1] ?? null
+  return Array.isArray(entry[1]) ? matching : (matching[0] ?? null)
 }
 
 function namespacedRoot(document, localName, namespace) {

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -125,20 +125,76 @@ function resolveRepositoryPath(repositoryPath) {
   return absolute
 }
 
-async function readJsonArtifact(path, code) {
+async function readStableRegularFile(path, maxBytes, code) {
+  let handle
   try {
     const absolute = resolve(path)
-    const details = await lstat(absolute)
+    handle = await open(
+      absolute,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+    )
+    const before = await handle.stat({ bigint: true })
+    const [pathDetails, stableRealPath] = await Promise.all([
+      lstat(absolute, { bigint: true }),
+      realpath(absolute),
+    ])
     if (
-      !details.isFile() ||
-      details.isSymbolicLink() ||
-      details.size <= 0 ||
-      details.size > MAX_GOVERNANCE_JSON_BYTES
+      !before.isFile() ||
+      !pathDetails.isFile() ||
+      pathDetails.isSymbolicLink() ||
+      before.dev !== pathDetails.dev ||
+      before.ino !== pathDetails.ino ||
+      before.size <= 0n ||
+      before.size > BigInt(maxBytes)
     ) {
       invalid(code)
     }
-    const bytes = await readFile(absolute)
-    if (bytes.byteLength !== details.size) invalid(code)
+    const expectedSize = Number(before.size)
+    const bytes = Buffer.allocUnsafe(expectedSize)
+    let offset = 0
+    while (offset < expectedSize) {
+      const { bytesRead } = await handle.read(
+        bytes,
+        offset,
+        expectedSize - offset,
+        offset,
+      )
+      if (bytesRead === 0) invalid(code)
+      offset += bytesRead
+    }
+    const probe = Buffer.allocUnsafe(1)
+    const { bytesRead: trailingBytes } = await handle.read(
+      probe,
+      0,
+      1,
+      expectedSize,
+    )
+    const after = await handle.stat({ bigint: true })
+    if (
+      trailingBytes !== 0 ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.size !== before.size ||
+      after.mtimeNs !== before.mtimeNs ||
+      after.ctimeNs !== before.ctimeNs
+    ) {
+      invalid(code)
+    }
+    return { bytes, realPath: stableRealPath }
+  } catch {
+    invalid(code)
+  } finally {
+    await handle?.close().catch(() => {})
+  }
+}
+
+export async function readJsonArtifact(path, code) {
+  try {
+    const { bytes } = await readStableRegularFile(
+      path,
+      MAX_GOVERNANCE_JSON_BYTES,
+      code,
+    )
     return {
       value: JSON.parse(bytes.toString('utf8')),
       bytes,
@@ -182,7 +238,6 @@ export async function verifyRepositoryFileBinding(
   code = 'PDF_BENCHMARK_METRIC_BINDING_MISMATCH',
   maxBytes = null,
 ) {
-  let handle
   try {
     const absolute = resolveRepositoryPath(repositoryPath)
     const [repositoryRealPath, fileRealPath] = await Promise.all([
@@ -195,58 +250,16 @@ export async function verifyRepositoryFileBinding(
     ) {
       invalid(code)
     }
-    handle = await open(
-      fileRealPath,
-      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
-    )
     const effectiveMaxBytes = maxBytes ?? MAX_EPUB_COMPRESSED_BYTES
-    const before = await handle.stat({ bigint: true })
-    const [pathDetails, stableRealPath] = await Promise.all([
-      lstat(fileRealPath, { bigint: true }),
-      realpath(fileRealPath),
-    ])
+    const { bytes, realPath: stableRealPath } = await readStableRegularFile(
+      fileRealPath,
+      effectiveMaxBytes,
+      code,
+    )
     if (
-      !before.isFile() ||
-      !pathDetails.isFile() ||
-      pathDetails.isSymbolicLink() ||
-      before.dev !== pathDetails.dev ||
-      before.ino !== pathDetails.ino ||
       stableRealPath !== fileRealPath ||
       (stableRealPath !== repositoryRealPath &&
-        !stableRealPath.startsWith(`${repositoryRealPath}${sep}`)) ||
-      before.size <= 0n ||
-      before.size > BigInt(effectiveMaxBytes)
-    ) {
-      invalid(code)
-    }
-    const expectedSize = Number(before.size)
-    const bytes = Buffer.allocUnsafe(expectedSize)
-    let offset = 0
-    while (offset < expectedSize) {
-      const { bytesRead } = await handle.read(
-        bytes,
-        offset,
-        expectedSize - offset,
-        offset,
-      )
-      if (bytesRead === 0) invalid(code)
-      offset += bytesRead
-    }
-    const probe = Buffer.allocUnsafe(1)
-    const { bytesRead: trailingBytes } = await handle.read(
-      probe,
-      0,
-      1,
-      expectedSize,
-    )
-    const after = await handle.stat({ bigint: true })
-    if (
-      trailingBytes !== 0 ||
-      after.dev !== before.dev ||
-      after.ino !== before.ino ||
-      after.size !== before.size ||
-      after.mtimeNs !== before.mtimeNs ||
-      after.ctimeNs !== before.ctimeNs
+        !stableRealPath.startsWith(`${repositoryRealPath}${sep}`))
     ) {
       invalid(code)
     }
@@ -256,8 +269,6 @@ export async function verifyRepositoryFileBinding(
     return bytes
   } catch {
     invalid(code)
-  } finally {
-    await handle?.close().catch(() => {})
   }
 }
 
@@ -1500,13 +1511,23 @@ export function validEpubPackage(bytes) {
     ).toString('utf8')
     const rootfile = epubRootfilePath(container)
     const rootfileEntry = entries.get(rootfile)
+    if (
+      typeof rootfile !== 'string' ||
+      !rootfile.endsWith('.opf') ||
+      !validEpubEntryName(rootfile) ||
+      rootfileEntry === undefined ||
+      rootfileEntry.originalSize <= 0 ||
+      rootfileEntry.originalSize > MAX_EPUB_PACKAGE_DOCUMENT_BYTES
+    ) {
+      return false
+    }
     return (
-      typeof rootfile === 'string' &&
-      rootfile.endsWith('.opf') &&
-      validEpubEntryName(rootfile) &&
-      rootfileEntry !== undefined &&
-      rootfileEntry.originalSize > 0 &&
-      rootfileEntry.originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES
+      unzipSync(new Uint8Array(bytes), {
+        filter: ({ name, originalSize }) =>
+          name === rootfile &&
+          originalSize > 0 &&
+          originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
+      })[rootfile] instanceof Uint8Array
     )
   } catch {
     return false

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1,9 +1,18 @@
 #!/usr/bin/env node
 import { createHash } from 'node:crypto'
-import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  writeFile,
+} from 'node:fs/promises'
 import { dirname, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import Ajv2020 from 'ajv/dist/2020.js'
+import { XMLParser } from 'fast-xml-parser'
 import { unzipSync } from 'fflate'
 import {
   canonicalJson,
@@ -29,6 +38,8 @@ const MAX_GOVERNANCE_JSON_BYTES = 16 * 1024 * 1024
 const MAX_EPUB_COMPRESSED_BYTES = 256 * 1024 * 1024
 const MAX_EPUB_INFLATED_BYTES = 512 * 1024 * 1024
 const MAX_EPUB_ENTRIES = 544
+const MAX_EPUB_CONTAINER_BYTES = 64 * 1024
+const MAX_EPUB_PACKAGE_DOCUMENT_BYTES = 16 * 1024 * 1024
 const PROMOTION_PROTOCOL_IMPLEMENTED = false
 const CANDIDATE_COMPONENT_KINDS = [
   'provider',
@@ -165,33 +176,77 @@ async function validateSchema(registry, schemaPath) {
   }
 }
 
-async function verifyRepositoryFileBinding(
+export async function verifyRepositoryFileBinding(
   repositoryPath,
   expectedSha256,
   code = 'PDF_BENCHMARK_METRIC_BINDING_MISMATCH',
   maxBytes = null,
 ) {
+  let handle
   try {
     const absolute = resolveRepositoryPath(repositoryPath)
-    const [details, repositoryRealPath, fileRealPath] = await Promise.all([
-      lstat(absolute),
+    const [repositoryRealPath, fileRealPath] = await Promise.all([
       realpath(REPOSITORY_ROOT),
       realpath(absolute),
     ])
     if (
-      !details.isFile() ||
-      details.isSymbolicLink() ||
-      (maxBytes !== null &&
-        (details.size <= 0 || details.size > maxBytes)) ||
-      (fileRealPath !== repositoryRealPath &&
-        !fileRealPath.startsWith(`${repositoryRealPath}${sep}`))
+      fileRealPath !== repositoryRealPath &&
+      !fileRealPath.startsWith(`${repositoryRealPath}${sep}`)
     ) {
       invalid(code)
     }
-    const bytes = await readFile(fileRealPath)
+    handle = await open(
+      fileRealPath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    )
+    const effectiveMaxBytes = maxBytes ?? MAX_EPUB_COMPRESSED_BYTES
+    const before = await handle.stat({ bigint: true })
+    const [pathDetails, stableRealPath] = await Promise.all([
+      lstat(fileRealPath, { bigint: true }),
+      realpath(fileRealPath),
+    ])
     if (
-      bytes.byteLength !== details.size ||
-      (maxBytes !== null && bytes.byteLength > maxBytes)
+      !before.isFile() ||
+      !pathDetails.isFile() ||
+      pathDetails.isSymbolicLink() ||
+      before.dev !== pathDetails.dev ||
+      before.ino !== pathDetails.ino ||
+      stableRealPath !== fileRealPath ||
+      (stableRealPath !== repositoryRealPath &&
+        !stableRealPath.startsWith(`${repositoryRealPath}${sep}`)) ||
+      before.size <= 0n ||
+      before.size > BigInt(effectiveMaxBytes)
+    ) {
+      invalid(code)
+    }
+    const expectedSize = Number(before.size)
+    const bytes = Buffer.allocUnsafe(expectedSize)
+    let offset = 0
+    while (offset < expectedSize) {
+      const { bytesRead } = await handle.read(
+        bytes,
+        offset,
+        expectedSize - offset,
+        offset,
+      )
+      if (bytesRead === 0) invalid(code)
+      offset += bytesRead
+    }
+    const probe = Buffer.allocUnsafe(1)
+    const { bytesRead: trailingBytes } = await handle.read(
+      probe,
+      0,
+      1,
+      expectedSize,
+    )
+    const after = await handle.stat({ bigint: true })
+    if (
+      trailingBytes !== 0 ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.size !== before.size ||
+      after.mtimeNs !== before.mtimeNs ||
+      after.ctimeNs !== before.ctimeNs
     ) {
       invalid(code)
     }
@@ -201,6 +256,8 @@ async function verifyRepositoryFileBinding(
     return bytes
   } catch {
     invalid(code)
+  } finally {
+    await handle?.close().catch(() => {})
   }
 }
 
@@ -1350,6 +1407,34 @@ function validEpubEntryName(name) {
   )
 }
 
+function epubRootfilePath(containerXml) {
+  const parsed = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    processEntities: false,
+  }).parse(containerXml)
+  let rootfile = null
+  const visit = (node) => {
+    if (rootfile !== null || node === null || typeof node !== 'object') return
+    if (Array.isArray(node)) {
+      node.forEach(visit)
+      return
+    }
+    for (const [key, child] of Object.entries(node)) {
+      if (key.split(':').at(-1) === 'rootfile' && isRecord(child)) {
+        const fullPath = child['@_full-path']
+        if (typeof fullPath === 'string') {
+          rootfile = fullPath
+          return
+        }
+      }
+      if (!key.startsWith('@_')) visit(child)
+    }
+  }
+  visit(parsed)
+  return rootfile
+}
+
 export function validEpubPackage(bytes) {
   try {
     if (
@@ -1367,6 +1452,7 @@ export function validEpubPackage(bytes) {
       return false
     }
     const names = new Set()
+    const entries = new Map()
     let entryCount = 0
     let inflatedBytes = 0
     const files = unzipSync(new Uint8Array(bytes), {
@@ -1387,6 +1473,19 @@ export function validEpubPackage(bytes) {
           throw new Error('invalid EPUB archive metadata')
         }
         names.add(name)
+        entries.set(name, { size, originalSize, compression })
+        if (
+          name === 'mimetype' &&
+          (compression !== 0 || size !== 20 || originalSize !== 20)
+        ) {
+          throw new Error('invalid EPUB mimetype entry')
+        }
+        if (
+          name === 'META-INF/container.xml' &&
+          originalSize > MAX_EPUB_CONTAINER_BYTES
+        ) {
+          throw new Error('oversized EPUB container')
+        }
         return name === 'mimetype' || name === 'META-INF/container.xml'
       },
     })
@@ -1399,16 +1498,15 @@ export function validEpubPackage(bytes) {
     const container = Buffer.from(
       files['META-INF/container.xml'] ?? [],
     ).toString('utf8')
-    const rootfile = container.match(
-      /<rootfile\b[^>]*\bfull-path=["']([^"']+)["'][^>]*>/u,
-    )?.[1]
+    const rootfile = epubRootfilePath(container)
+    const rootfileEntry = entries.get(rootfile)
     return (
       typeof rootfile === 'string' &&
       rootfile.endsWith('.opf') &&
       validEpubEntryName(rootfile) &&
-      unzipSync(new Uint8Array(bytes), {
-        filter: ({ name }) => name === rootfile,
-      })[rootfile] instanceof Uint8Array
+      rootfileEntry !== undefined &&
+      rootfileEntry.originalSize > 0 &&
+      rootfileEntry.originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES
     )
   } catch {
     return false
@@ -1474,7 +1572,8 @@ async function validateExactEpubExportEvidence(exportEvidence) {
     exportReceipt.kind !== 'pdf-benchmark-exact-epub-export-receipt' ||
     exportReceipt.exactArtifactSha256 !== evidence.exactArtifactSha256 ||
     exportReceipt.status !== 'passed' ||
-    sha256(canonicalJson(exportReceipt)) !== evidence.exportReceiptIdentitySha256
+    sha256(canonicalJson(exportReceipt)) !==
+      evidence.exportReceiptIdentitySha256
   ) {
     invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
   }
@@ -1484,7 +1583,8 @@ async function validateExactEpubExportEvidence(exportEvidence) {
   )
   if (
     !exactKeys(evidence.toolchainManifest, ['path', 'fileSha256']) ||
-    evidence.toolchainManifest.path !== 'src/publication/toolchain-manifest.json'
+    evidence.toolchainManifest.path !==
+      'src/publication/toolchain-manifest.json'
   ) {
     invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
   }
@@ -1543,7 +1643,8 @@ async function validateExactEpubExportEvidence(exportEvidence) {
       'stderrSha256',
     ]) ||
     epubCheckTranscript.schemaVersion !== '1.0.0' ||
-    epubCheckTranscript.kind !== 'pdf-benchmark-epubcheck-execution-transcript' ||
+    epubCheckTranscript.kind !==
+      'pdf-benchmark-epubcheck-execution-transcript' ||
     epubCheckTranscript.command !== 'epubcheck' ||
     epubCheckTranscript.exactArtifactSha256 !== evidence.exactArtifactSha256 ||
     epubCheckTranscript.checkerIdentitySha256 !== epubcheck.sha256 ||
@@ -1552,7 +1653,8 @@ async function validateExactEpubExportEvidence(exportEvidence) {
     epubCheckTranscript.epubCheckStatus !== 'passed' ||
     !SHA256.test(epubCheckTranscript.stdoutSha256 ?? '') ||
     !SHA256.test(epubCheckTranscript.stderrSha256 ?? '') ||
-    epubCheckReceipt.outputIdentitySha256 !== sha256(canonicalJson(epubCheckTranscript)) ||
+    epubCheckReceipt.outputIdentitySha256 !==
+      sha256(canonicalJson(epubCheckTranscript)) ||
     epubCheckReceipt.status !== 'passed'
   ) {
     invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
@@ -1564,7 +1666,8 @@ async function validateExactEpubExportEvidence(exportEvidence) {
     exportReceiptIdentitySha256: evidence.exportReceiptIdentitySha256,
     epubCheckReceiptEvidenceFileSha256: evidence.epubCheckReceipt.fileSha256,
     toolchainManifestFileSha256: evidence.toolchainManifest.fileSha256,
-    epubCheckTranscriptEvidenceFileSha256: evidence.epubCheckTranscript.fileSha256,
+    epubCheckTranscriptEvidenceFileSha256:
+      evidence.epubCheckTranscript.fileSha256,
   }
 }
 
@@ -1585,7 +1688,9 @@ export async function validateNativeReaderEvidence(nativeReaderEvidence) {
     REQUIRED_NATIVE_READER_TYPES,
   )) {
     const evidence = nativeReaderEvidence[readerId]
-    if (!exactKeys(evidence, ['status', 'readerIdentity', 'executionReceipt'])) {
+    if (
+      !exactKeys(evidence, ['status', 'readerIdentity', 'executionReceipt'])
+    ) {
       invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
     }
     if (
@@ -1647,8 +1752,10 @@ export async function validateNativeReaderEvidence(nativeReaderEvidence) {
       receipt.kind !== 'pdf-benchmark-native-reader-execution-receipt' ||
       receipt.readerId !== readerId ||
       receipt.readerType !== readerType ||
-      receipt.readerIdentityEvidenceFileSha256 !== evidence.readerIdentity.fileSha256 ||
-      receipt.exportEvidenceFileSha256 !== exportArtifact?.exportEvidenceFileSha256 ||
+      receipt.readerIdentityEvidenceFileSha256 !==
+        evidence.readerIdentity.fileSha256 ||
+      receipt.exportEvidenceFileSha256 !==
+        exportArtifact?.exportEvidenceFileSha256 ||
       receipt.exportReceiptEvidenceFileSha256 !==
         exportArtifact?.exportReceiptEvidenceFileSha256 ||
       receipt.exportReceiptIdentitySha256 !==

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import Ajv2020 from 'ajv/dist/2020.js'
 import { XMLParser, XMLValidator } from 'fast-xml-parser'
-import { unzipSync } from 'fflate'
+import { Unzip, UnzipInflate, unzipSync } from 'fflate'
 import {
   canonicalJson,
   validatePdfFidelityEvalSet,
@@ -1450,31 +1450,90 @@ function validEpubEntryName(name) {
 }
 
 function epubRootfilePath(containerXml) {
+  if (XMLValidator.validate(containerXml) !== true) return null
   const parsed = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
     processEntities: false,
   }).parse(containerXml)
-  let rootfile = null
-  const visit = (node) => {
-    if (rootfile !== null || node === null || typeof node !== 'object') return
-    if (Array.isArray(node)) {
-      node.forEach(visit)
-      return
-    }
-    for (const [key, child] of Object.entries(node)) {
-      if (key.split(':').at(-1) === 'rootfile' && isRecord(child)) {
-        const fullPath = child['@_full-path']
-        if (typeof fullPath === 'string') {
-          rootfile = fullPath
-          return
-        }
-      }
-      if (!key.startsWith('@_')) visit(child)
-    }
+  const container = parsed?.container
+  if (
+    !isRecord(container) ||
+    container['@_xmlns'] !==
+      'urn:oasis:names:tc:opendocument:xmlns:container' ||
+    !isRecord(container.rootfiles)
+  ) {
+    return null
   }
-  visit(parsed)
-  return rootfile
+  const rootfiles = Array.isArray(container.rootfiles.rootfile)
+    ? container.rootfiles.rootfile
+    : [container.rootfiles.rootfile]
+  const packageRootfile = rootfiles.find(
+    (rootfile) =>
+      isRecord(rootfile) &&
+      rootfile['@_media-type'] === 'application/oebps-package+xml' &&
+      typeof rootfile['@_full-path'] === 'string',
+  )
+  return packageRootfile?.['@_full-path'] ?? null
+}
+
+function extractEpubEntriesBounded(bytes, specifications) {
+  const requested = new Map(
+    specifications.map((specification) => [specification.name, specification]),
+  )
+  const extracted = new Map()
+  const archive = new Unzip((file) => {
+    const specification = requested.get(file.name)
+    if (specification === undefined) return
+    if (
+      extracted.has(file.name) ||
+      file.compression !== specification.compression ||
+      (Number.isSafeInteger(file.size) && file.size !== specification.size) ||
+      (Number.isSafeInteger(file.originalSize) &&
+        file.originalSize !== specification.originalSize)
+    ) {
+      throw new Error('EPUB local and central metadata mismatch')
+    }
+    const chunks = []
+    let emittedBytes = 0
+    file.ondata = (error, chunk, final) => {
+      if (error) throw error
+      emittedBytes += chunk.byteLength
+      if (
+        emittedBytes > specification.maxBytes ||
+        emittedBytes > specification.originalSize
+      ) {
+        file.terminate()
+        throw new Error('EPUB entry exceeds actual output limit')
+      }
+      chunks.push(chunk)
+      if (final) {
+        if (emittedBytes !== specification.originalSize) {
+          throw new Error('EPUB entry size mismatch')
+        }
+        extracted.set(
+          file.name,
+          Buffer.concat(
+            chunks.map((value) => Buffer.from(value)),
+            emittedBytes,
+          ),
+        )
+      }
+    }
+    file.start()
+  })
+  archive.register(UnzipInflate)
+  for (let offset = 0; offset < bytes.byteLength; offset += 256) {
+    archive.push(
+      bytes.subarray(offset, Math.min(offset + 256, bytes.byteLength)),
+      offset + 256 >= bytes.byteLength,
+    )
+    if (extracted.size === requested.size) break
+  }
+  if (extracted.size !== requested.size) {
+    throw new Error('missing bounded EPUB entry')
+  }
+  return extracted
 }
 
 export function validEpubPackage(bytes) {
@@ -1497,7 +1556,7 @@ export function validEpubPackage(bytes) {
     const entries = new Map()
     let entryCount = 0
     let inflatedBytes = 0
-    const files = unzipSync(new Uint8Array(bytes), {
+    unzipSync(new Uint8Array(bytes), {
       filter: ({ name, size, originalSize, compression }) => {
         if (
           !validEpubEntryName(name) ||
@@ -1508,6 +1567,7 @@ export function validEpubPackage(bytes) {
           originalSize < 0 ||
           size > MAX_EPUB_COMPRESSED_BYTES ||
           originalSize > MAX_EPUB_INFLATED_BYTES ||
+          (compression === 0 && size !== originalSize) ||
           (compression !== 0 && compression !== 8) ||
           ++entryCount > MAX_EPUB_ENTRIES ||
           (inflatedBytes += originalSize) > MAX_EPUB_INFLATED_BYTES
@@ -1528,18 +1588,29 @@ export function validEpubPackage(bytes) {
         ) {
           throw new Error('oversized EPUB container')
         }
-        return name === 'mimetype' || name === 'META-INF/container.xml'
+        return false
       },
     })
+    const headerEntries = extractEpubEntriesBounded(bytes, [
+      {
+        name: 'mimetype',
+        ...entries.get('mimetype'),
+        maxBytes: 20,
+      },
+      {
+        name: 'META-INF/container.xml',
+        ...entries.get('META-INF/container.xml'),
+        maxBytes: MAX_EPUB_CONTAINER_BYTES,
+      },
+    ])
     if (
-      Buffer.from(files.mimetype ?? []).toString('utf8') !==
-      'application/epub+zip'
+      headerEntries.get('mimetype')?.toString('utf8') !== 'application/epub+zip'
     ) {
       return false
     }
-    const container = Buffer.from(
-      files['META-INF/container.xml'] ?? [],
-    ).toString('utf8')
+    const container = headerEntries
+      .get('META-INF/container.xml')
+      .toString('utf8')
     const rootfile = epubRootfilePath(container)
     const rootfileEntry = entries.get(rootfile)
     if (
@@ -1552,24 +1623,26 @@ export function validEpubPackage(bytes) {
     ) {
       return false
     }
-    const rootfileBytes = unzipSync(new Uint8Array(bytes), {
-      filter: ({ name, originalSize }) =>
-        name === rootfile &&
-        originalSize > 0 &&
-        originalSize <= MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
-    })[rootfile]
-    if (!(rootfileBytes instanceof Uint8Array)) return false
+    const rootfileBytes = extractEpubEntriesBounded(bytes, [
+      {
+        name: rootfile,
+        ...rootfileEntry,
+        maxBytes: MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
+      },
+    ]).get(rootfile)
     const packageXml = Buffer.from(rootfileBytes).toString('utf8')
     if (XMLValidator.validate(packageXml) !== true) return false
     const packageDocument = new XMLParser({
       ignoreAttributes: false,
       processEntities: false,
     }).parse(packageXml)
+    const packageRoot = packageDocument?.package
     return (
-      isRecord(packageDocument) &&
-      Object.keys(packageDocument).some(
-        (name) => name.split(':').at(-1) === 'package',
-      )
+      isRecord(packageRoot) &&
+      packageRoot['@_xmlns'] === 'http://www.idpf.org/2007/opf' &&
+      Object.hasOwn(packageRoot, 'metadata') &&
+      Object.hasOwn(packageRoot, 'manifest') &&
+      Object.hasOwn(packageRoot, 'spine')
     )
   } catch {
     return false

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -4,6 +4,7 @@ import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import { dirname, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import Ajv2020 from 'ajv/dist/2020.js'
+import { unzipSync } from 'fflate'
 import {
   canonicalJson,
   validatePdfFidelityEvalSet,
@@ -19,7 +20,7 @@ const DEFAULT_SCHEMA_PATH = resolve(
 const DEFAULT_SCHEMA_ID =
   'https://ernie.sg/schemas/pdf-benchmark-readiness-registry-1.0.0.json'
 const DEFAULT_SCHEMA_SHA256 =
-  '3303e6f7041a8a72206c3be933e7d2f3c09026d2c686704e833be43fb981828a'
+  '97a7a359e988f6a30dd8202fd28806df1c5e50b935999416c0304625e8e0bf4e'
 const PUBLIC_ERROR_CODE = /^(?:INVALID|MISSING|PDF)_[A-Z0-9_]+$/
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$/
 const SAFE_FAILURE_CLASS = /^[a-z][a-z0-9]*(?:-[a-z0-9]+){0,11}$/
@@ -55,6 +56,11 @@ const PACKAGE_INTEGRITY_TEST_DEPENDENCIES = [
   'tools/pdf-private-fidelity-receipt.cases.mjs',
   'tools/pdf-private-fidelity-boundary.cases.mjs',
 ]
+const REQUIRED_NATIVE_READER_TYPES = {
+  'apple-books': 'apple-books',
+  'independent-desktop-epub-reader': 'independent-desktop-epub-reader',
+  'target-eink-reader-device': 'target-eink-reader-device',
+}
 
 function sha256(value) {
   return createHash('sha256').update(value).digest('hex')
@@ -1319,6 +1325,309 @@ export async function validateIndependentIsolationEvidence(
   return true
 }
 
+function validEpubPackage(bytes) {
+  try {
+    if (
+      bytes.length < 30 ||
+      bytes[0] !== 0x50 ||
+      bytes[1] !== 0x4b ||
+      bytes[2] !== 0x03 ||
+      bytes[3] !== 0x04 ||
+      bytes[8] !== 0 ||
+      bytes[9] !== 0 ||
+      bytes[26] !== 8 ||
+      bytes[27] !== 0 ||
+      Buffer.from(bytes.subarray(30, 38)).toString('ascii') !== 'mimetype'
+    ) {
+      return false
+    }
+    const files = unzipSync(new Uint8Array(bytes))
+    if (
+      Buffer.from(files.mimetype ?? []).toString('utf8') !==
+      'application/epub+zip'
+    ) {
+      return false
+    }
+    const container = Buffer.from(files['META-INF/container.xml'] ?? []).toString(
+      'utf8',
+    )
+    const rootfile = container.match(
+      /<rootfile\b[^>]*\bfull-path=["']([^"']+)["'][^>]*>/u,
+    )?.[1]
+    return (
+      typeof rootfile === 'string' &&
+      rootfile.endsWith('.opf') &&
+      !rootfile.startsWith('/') &&
+      !rootfile.split('/').includes('..') &&
+      files[rootfile] instanceof Uint8Array
+    )
+  } catch {
+    return false
+  }
+}
+
+async function validateExactEpubExportEvidence(exportEvidence) {
+  if (exportEvidence === null) return null
+  if (!exactKeys(exportEvidence, ['path', 'fileSha256'])) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const evidence = await readBoundJson(
+    exportEvidence,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  if (
+    !exactKeys(evidence, [
+      'schemaVersion',
+      'kind',
+      'epubArtifact',
+      'exactArtifactSha256',
+      'exportReceipt',
+      'exportReceiptIdentitySha256',
+      'toolchainManifest',
+      'epubCheckReceipt',
+      'epubCheckTranscript',
+      'status',
+    ]) ||
+    evidence.schemaVersion !== '1.0.0' ||
+    evidence.kind !== 'pdf-benchmark-exact-epub-export-evidence' ||
+    !exactKeys(evidence.epubArtifact, ['path', 'fileSha256']) ||
+    !evidence.epubArtifact.path.endsWith('.epub') ||
+    !SHA256.test(evidence.exactArtifactSha256 ?? '') ||
+    !SHA256.test(evidence.exportReceiptIdentitySha256 ?? '') ||
+    evidence.status !== 'passed'
+  ) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const epubBytes = await verifyRepositoryFileBinding(
+    evidence.epubArtifact.path,
+    evidence.epubArtifact.fileSha256,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  if (evidence.exactArtifactSha256 !== evidence.epubArtifact.fileSha256) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  if (!validEpubPackage(epubBytes)) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const exportReceipt = await readBoundJson(
+    evidence.exportReceipt,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  if (
+    !exactKeys(exportReceipt, [
+      'schemaVersion',
+      'kind',
+      'exactArtifactSha256',
+      'status',
+    ]) ||
+    exportReceipt.schemaVersion !== '1.0.0' ||
+    exportReceipt.kind !== 'pdf-benchmark-exact-epub-export-receipt' ||
+    exportReceipt.exactArtifactSha256 !== evidence.exactArtifactSha256 ||
+    exportReceipt.status !== 'passed' ||
+    sha256(canonicalJson(exportReceipt)) !== evidence.exportReceiptIdentitySha256
+  ) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const epubCheckReceipt = await readBoundJson(
+    evidence.epubCheckReceipt,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  if (
+    !exactKeys(evidence.toolchainManifest, ['path', 'fileSha256']) ||
+    evidence.toolchainManifest.path !== 'src/publication/toolchain-manifest.json'
+  ) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const toolchainManifest = await readBoundJson(
+    evidence.toolchainManifest,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  const epubcheck = toolchainManifest.epubcheck
+  const epubCheckTranscript = await readBoundJson(
+    evidence.epubCheckTranscript,
+    'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+  )
+  if (
+    !exactKeys(epubCheckReceipt, [
+      'schemaVersion',
+      'kind',
+      'exactArtifactSha256',
+      'toolchainManifestFileSha256',
+      'checkerIdentitySha256',
+      'checkerVersion',
+      'epubCheckTranscriptEvidenceFileSha256',
+      'inputIdentitySha256',
+      'outputIdentitySha256',
+      'status',
+    ]) ||
+    epubCheckReceipt.schemaVersion !== '1.0.0' ||
+    epubCheckReceipt.kind !== 'pdf-benchmark-epubcheck-execution-receipt' ||
+    epubCheckReceipt.exactArtifactSha256 !== evidence.exactArtifactSha256 ||
+    epubCheckReceipt.toolchainManifestFileSha256 !==
+      evidence.toolchainManifest.fileSha256 ||
+    !isRecord(epubcheck) ||
+    !exactKeys(epubcheck, ['package', 'packageVersion', 'version', 'sha256']) ||
+    epubCheckReceipt.checkerIdentitySha256 !== epubcheck.sha256 ||
+    epubCheckReceipt.checkerVersion !== epubcheck.version ||
+    epubCheckReceipt.epubCheckTranscriptEvidenceFileSha256 !==
+      evidence.epubCheckTranscript.fileSha256 ||
+    epubCheckReceipt.inputIdentitySha256 !==
+      sha256(
+        canonicalJson({
+          kind: 'pdf-benchmark-epubcheck-input-v1',
+          exactArtifactSha256: evidence.exactArtifactSha256,
+          checkerIdentitySha256: epubCheckReceipt.checkerIdentitySha256,
+          checkerVersion: epubCheckReceipt.checkerVersion,
+        }),
+      ) ||
+    !exactKeys(epubCheckTranscript, [
+      'schemaVersion',
+      'kind',
+      'command',
+      'exactArtifactSha256',
+      'checkerIdentitySha256',
+      'checkerVersion',
+      'exitCode',
+      'epubCheckStatus',
+      'stdoutSha256',
+      'stderrSha256',
+    ]) ||
+    epubCheckTranscript.schemaVersion !== '1.0.0' ||
+    epubCheckTranscript.kind !== 'pdf-benchmark-epubcheck-execution-transcript' ||
+    epubCheckTranscript.command !== 'epubcheck' ||
+    epubCheckTranscript.exactArtifactSha256 !== evidence.exactArtifactSha256 ||
+    epubCheckTranscript.checkerIdentitySha256 !== epubcheck.sha256 ||
+    epubCheckTranscript.checkerVersion !== epubcheck.version ||
+    epubCheckTranscript.exitCode !== 0 ||
+    epubCheckTranscript.epubCheckStatus !== 'passed' ||
+    !SHA256.test(epubCheckTranscript.stdoutSha256 ?? '') ||
+    !SHA256.test(epubCheckTranscript.stderrSha256 ?? '') ||
+    epubCheckReceipt.outputIdentitySha256 !== sha256(canonicalJson(epubCheckTranscript)) ||
+    epubCheckReceipt.status !== 'passed'
+  ) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  return {
+    exactArtifactSha256: evidence.exactArtifactSha256,
+    exportEvidenceFileSha256: exportEvidence.fileSha256,
+    exportReceiptEvidenceFileSha256: evidence.exportReceipt.fileSha256,
+    exportReceiptIdentitySha256: evidence.exportReceiptIdentitySha256,
+    epubCheckReceiptEvidenceFileSha256: evidence.epubCheckReceipt.fileSha256,
+    toolchainManifestFileSha256: evidence.toolchainManifest.fileSha256,
+    epubCheckTranscriptEvidenceFileSha256: evidence.epubCheckTranscript.fileSha256,
+  }
+}
+
+export async function validateNativeReaderEvidence(nativeReaderEvidence) {
+  if (
+    !exactKeys(nativeReaderEvidence, [
+      'exportEvidence',
+      ...Object.keys(REQUIRED_NATIVE_READER_TYPES),
+    ])
+  ) {
+    invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  }
+  const exportArtifact = await validateExactEpubExportEvidence(
+    nativeReaderEvidence.exportEvidence,
+  )
+  const structurallyValidatedReaderIds = []
+  for (const [readerId, readerType] of Object.entries(
+    REQUIRED_NATIVE_READER_TYPES,
+  )) {
+    const evidence = nativeReaderEvidence[readerId]
+    if (!exactKeys(evidence, ['status', 'readerIdentity', 'executionReceipt'])) {
+      invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+    }
+    if (
+      evidence.status === 'unavailable-blocker' &&
+      evidence.readerIdentity === null &&
+      evidence.executionReceipt === null
+    ) {
+      continue
+    }
+    if (
+      evidence.status !== 'passed' ||
+      !isRecord(evidence.readerIdentity) ||
+      !isRecord(evidence.executionReceipt)
+    ) {
+      invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+    }
+    const [identity, receipt] = await Promise.all([
+      readBoundJson(
+        evidence.readerIdentity,
+        'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+      ),
+      readBoundJson(
+        evidence.executionReceipt,
+        'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+      ),
+    ])
+    if (
+      !exactKeys(identity, [
+        'schemaVersion',
+        'kind',
+        'readerId',
+        'readerType',
+        'readerIdentitySha256',
+        'status',
+      ]) ||
+      identity.schemaVersion !== '1.0.0' ||
+      identity.kind !== 'pdf-benchmark-native-reader-identity-evidence' ||
+      identity.readerId !== readerId ||
+      identity.readerType !== readerType ||
+      !SHA256.test(identity.readerIdentitySha256 ?? '') ||
+      identity.status !== 'passed' ||
+      !exactKeys(receipt, [
+        'schemaVersion',
+        'kind',
+        'readerId',
+        'readerType',
+        'readerIdentityEvidenceFileSha256',
+        'exportEvidenceFileSha256',
+        'exportReceiptEvidenceFileSha256',
+        'exportReceiptIdentitySha256',
+        'epubCheckReceiptEvidenceFileSha256',
+        'toolchainManifestFileSha256',
+        'epubCheckTranscriptEvidenceFileSha256',
+        'exactArtifactSha256',
+        'executionIdentitySha256',
+        'status',
+      ]) ||
+      receipt.schemaVersion !== '1.0.0' ||
+      receipt.kind !== 'pdf-benchmark-native-reader-execution-receipt' ||
+      receipt.readerId !== readerId ||
+      receipt.readerType !== readerType ||
+      receipt.readerIdentityEvidenceFileSha256 !== evidence.readerIdentity.fileSha256 ||
+      receipt.exportEvidenceFileSha256 !== exportArtifact?.exportEvidenceFileSha256 ||
+      receipt.exportReceiptEvidenceFileSha256 !==
+        exportArtifact?.exportReceiptEvidenceFileSha256 ||
+      receipt.exportReceiptIdentitySha256 !==
+        exportArtifact?.exportReceiptIdentitySha256 ||
+      receipt.epubCheckReceiptEvidenceFileSha256 !==
+        exportArtifact?.epubCheckReceiptEvidenceFileSha256 ||
+      receipt.toolchainManifestFileSha256 !==
+        exportArtifact?.toolchainManifestFileSha256 ||
+      receipt.epubCheckTranscriptEvidenceFileSha256 !==
+        exportArtifact?.epubCheckTranscriptEvidenceFileSha256 ||
+      !SHA256.test(receipt.exactArtifactSha256 ?? '') ||
+      !SHA256.test(receipt.executionIdentitySha256 ?? '') ||
+      receipt.status !== 'passed' ||
+      exportArtifact === null ||
+      receipt.exactArtifactSha256 !== exportArtifact.exactArtifactSha256
+    ) {
+      invalid('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+    }
+    structurallyValidatedReaderIds.push(readerId)
+  }
+  return {
+    exactArtifactSha256: exportArtifact?.exactArtifactSha256 ?? null,
+    structurallyValidatedReaderIds,
+    trustedAttestationVerified: false,
+    trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+    verifiedReaderIds: [],
+  }
+}
+
 function blindSourcePolicyVerified(blind, sourcePoliciesByDocument) {
   return (
     blind.documentIds.length > 0 &&
@@ -1349,6 +1658,7 @@ export function assessPdfBenchmarkReadiness(
     blindSourcePolicyVerified: blindPolicyVerified = false,
     candidateCommitmentVerified = false,
     independentIsolationEvidenceVerified = false,
+    nativeReaderEvidenceVerified = false,
   } = {},
 ) {
   const blind = registry.splits.find((split) => split.role === 'blind-test')
@@ -1548,6 +1858,17 @@ export function assessPdfBenchmarkReadiness(
       REQUIRED_METRICS,
     ),
     criterion(
+      'native-reader-exact-artifact-coverage',
+      nativeReaderEvidenceVerified,
+      registry.nativeReaderEvidence,
+      {
+        'apple-books': 'hash-bound-passed-exact-artifact-receipt',
+        'independent-desktop-epub-reader':
+          'hash-bound-passed-exact-artifact-receipt',
+        'target-eink-reader-device': 'hash-bound-passed-exact-artifact-receipt',
+      },
+    ),
+    criterion(
       'promotion-protocol-implementation',
       PROMOTION_PROTOCOL_IMPLEMENTED,
       'not-implemented-in-readiness-v1',
@@ -1633,6 +1954,9 @@ export async function createPdfBenchmarkReadinessReceipt({
   const candidateCommitment = await validateCandidateCommitment(registry)
   const independentIsolationEvidenceVerified =
     await validateIndependentIsolationEvidence(registry, candidateCommitment)
+  const nativeReaderEvidence = await validateNativeReaderEvidence(
+    registry.nativeReaderEvidence,
+  )
   const blind = registry.splits.find((split) => split.role === 'blind-test')
   const verifiedBlindSourcePolicy = blindSourcePolicyVerified(
     blind,
@@ -1668,6 +1992,10 @@ export async function createPdfBenchmarkReadinessReceipt({
     blindSourcePolicyVerified: verifiedBlindSourcePolicy,
     candidateCommitmentVerified: candidateCommitment.verified,
     independentIsolationEvidenceVerified,
+    nativeReaderEvidenceVerified:
+      nativeReaderEvidence.trustedAttestationVerified &&
+      nativeReaderEvidence.verifiedReaderIds.length ===
+        Object.keys(REQUIRED_NATIVE_READER_TYPES).length,
   })
   const unsigned = {
     schemaVersion: PDF_BENCHMARK_READINESS_SCHEMA_VERSION,

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import Ajv2020 from 'ajv/dist/2020.js'
 import { XMLParser, XMLValidator } from 'fast-xml-parser'
-import { Unzip, UnzipInflate, unzipSync } from 'fflate'
+import { Inflate } from 'fflate'
 import {
   canonicalJson,
   validatePdfFidelityEvalSet,
@@ -1449,6 +1449,27 @@ function validEpubEntryName(name) {
   )
 }
 
+function childElementByLocalName(parent, localName) {
+  if (!isRecord(parent)) return null
+  return (
+    Object.entries(parent).find(
+      ([name]) =>
+        !name.startsWith('@_') && name.split(':').at(-1) === localName,
+    )?.[1] ?? null
+  )
+}
+
+function namespacedRoot(document, localName, namespace) {
+  if (!isRecord(document)) return null
+  const entry = Object.entries(document).find(
+    ([name]) => name.split(':').at(-1) === localName,
+  )
+  if (entry === undefined || !isRecord(entry[1])) return null
+  const prefix = entry[0].includes(':') ? entry[0].split(':')[0] : null
+  const namespaceAttribute = prefix === null ? '@_xmlns' : `@_xmlns:${prefix}`
+  return entry[1][namespaceAttribute] === namespace ? entry[1] : null
+}
+
 function epubRootfilePath(containerXml) {
   if (XMLValidator.validate(containerXml) !== true) return null
   const parsed = new XMLParser({
@@ -1456,18 +1477,21 @@ function epubRootfilePath(containerXml) {
     attributeNamePrefix: '@_',
     processEntities: false,
   }).parse(containerXml)
-  const container = parsed?.container
+  const container = namespacedRoot(
+    parsed,
+    'container',
+    'urn:oasis:names:tc:opendocument:xmlns:container',
+  )
+  const rootfilesNode = childElementByLocalName(container, 'rootfiles')
   if (
     !isRecord(container) ||
-    container['@_xmlns'] !==
-      'urn:oasis:names:tc:opendocument:xmlns:container' ||
-    !isRecord(container.rootfiles)
+    container['@_version'] !== '1.0' ||
+    !isRecord(rootfilesNode)
   ) {
     return null
   }
-  const rootfiles = Array.isArray(container.rootfiles.rootfile)
-    ? container.rootfiles.rootfile
-    : [container.rootfiles.rootfile]
+  const rootfileNode = childElementByLocalName(rootfilesNode, 'rootfile')
+  const rootfiles = Array.isArray(rootfileNode) ? rootfileNode : [rootfileNode]
   const packageRootfile = rootfiles.find(
     (rootfile) =>
       isRecord(rootfile) &&
@@ -1477,63 +1501,186 @@ function epubRootfilePath(containerXml) {
   return packageRootfile?.['@_full-path'] ?? null
 }
 
-function extractEpubEntriesBounded(bytes, specifications) {
-  const requested = new Map(
-    specifications.map((specification) => [specification.name, specification]),
-  )
-  const extracted = new Map()
-  const archive = new Unzip((file) => {
-    const specification = requested.get(file.name)
-    if (specification === undefined) return
-    if (
-      extracted.has(file.name) ||
-      file.compression !== specification.compression ||
-      (Number.isSafeInteger(file.size) && file.size !== specification.size) ||
-      (Number.isSafeInteger(file.originalSize) &&
-        file.originalSize !== specification.originalSize)
-    ) {
-      throw new Error('EPUB local and central metadata mismatch')
+const CRC32_TABLE = Uint32Array.from({ length: 256 }, (_, value) => {
+  let crc = value
+  for (let bit = 0; bit < 8; bit += 1) {
+    crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
+  }
+  return crc >>> 0
+})
+
+function crc32(bytes) {
+  let crc = 0xffffffff
+  for (const value of bytes) {
+    crc = CRC32_TABLE[(crc ^ value) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+function strictZipIndex(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  let endOffset = -1
+  for (
+    let offset = bytes.byteLength - 22;
+    offset >= Math.max(0, bytes.byteLength - 65_557);
+    offset -= 1
+  ) {
+    if (view.getUint32(offset, true) === 0x06054b50) {
+      endOffset = offset
+      break
     }
+  }
+  if (endOffset < 0) throw new Error('missing ZIP end record')
+  const entryCount = view.getUint16(endOffset + 10, true)
+  const centralSize = view.getUint32(endOffset + 12, true)
+  const centralOffset = view.getUint32(endOffset + 16, true)
+  const commentLength = view.getUint16(endOffset + 20, true)
+  if (
+    view.getUint16(endOffset + 4, true) !== 0 ||
+    view.getUint16(endOffset + 6, true) !== 0 ||
+    view.getUint16(endOffset + 8, true) !== entryCount ||
+    entryCount === 0 ||
+    entryCount > MAX_EPUB_ENTRIES ||
+    centralOffset + centralSize !== endOffset ||
+    endOffset + 22 + commentLength !== bytes.byteLength
+  ) {
+    throw new Error('invalid ZIP end record')
+  }
+  const entries = []
+  const names = new Set()
+  let cursor = centralOffset
+  let inflatedBytes = 0
+  for (let index = 0; index < entryCount; index += 1) {
+    if (
+      cursor + 46 > endOffset ||
+      view.getUint32(cursor, true) !== 0x02014b50
+    ) {
+      throw new Error('invalid ZIP central record')
+    }
+    const flags = view.getUint16(cursor + 8, true)
+    const compression = view.getUint16(cursor + 10, true)
+    const checksum = view.getUint32(cursor + 16, true)
+    const size = view.getUint32(cursor + 20, true)
+    const originalSize = view.getUint32(cursor + 24, true)
+    const nameLength = view.getUint16(cursor + 28, true)
+    const extraLength = view.getUint16(cursor + 30, true)
+    const entryCommentLength = view.getUint16(cursor + 32, true)
+    const localOffset = view.getUint32(cursor + 42, true)
+    const recordEnd =
+      cursor + 46 + nameLength + extraLength + entryCommentLength
+    if (recordEnd > endOffset) throw new Error('truncated ZIP central record')
+    const name = Buffer.from(
+      bytes.subarray(cursor + 46, cursor + 46 + nameLength),
+    ).toString('utf8')
+    if (
+      !validEpubEntryName(name) ||
+      names.has(name) ||
+      (flags & ~0x0800) !== 0 ||
+      (compression !== 0 && compression !== 8) ||
+      size > MAX_EPUB_COMPRESSED_BYTES ||
+      originalSize > MAX_EPUB_INFLATED_BYTES ||
+      (compression === 0 && size !== originalSize) ||
+      (inflatedBytes += originalSize) > MAX_EPUB_INFLATED_BYTES ||
+      localOffset >= centralOffset
+    ) {
+      throw new Error('invalid ZIP central metadata')
+    }
+    names.add(name)
+    entries.push({
+      name,
+      flags,
+      compression,
+      checksum,
+      size,
+      originalSize,
+      localOffset,
+    })
+    cursor = recordEnd
+  }
+  if (cursor !== endOffset) throw new Error('unindexed ZIP central bytes')
+  let localCursor = 0
+  for (const entry of [...entries].sort(
+    (left, right) => left.localOffset - right.localOffset,
+  )) {
+    if (
+      entry.localOffset !== localCursor ||
+      entry.localOffset + 30 > centralOffset ||
+      view.getUint32(entry.localOffset, true) !== 0x04034b50
+    ) {
+      throw new Error('hidden or invalid ZIP local record')
+    }
+    const nameLength = view.getUint16(entry.localOffset + 26, true)
+    const extraLength = view.getUint16(entry.localOffset + 28, true)
+    const dataOffset = entry.localOffset + 30 + nameLength + extraLength
+    const localName = Buffer.from(
+      bytes.subarray(
+        entry.localOffset + 30,
+        entry.localOffset + 30 + nameLength,
+      ),
+    ).toString('utf8')
+    if (
+      localName !== entry.name ||
+      view.getUint16(entry.localOffset + 6, true) !== entry.flags ||
+      view.getUint16(entry.localOffset + 8, true) !== entry.compression ||
+      view.getUint32(entry.localOffset + 14, true) !== entry.checksum ||
+      view.getUint32(entry.localOffset + 18, true) !== entry.size ||
+      view.getUint32(entry.localOffset + 22, true) !== entry.originalSize ||
+      dataOffset + entry.size > centralOffset
+    ) {
+      throw new Error('ZIP local and central record mismatch')
+    }
+    entry.dataOffset = dataOffset
+    localCursor = dataOffset + entry.size
+  }
+  if (localCursor !== centralOffset)
+    throw new Error('unindexed ZIP local bytes')
+  return new Map(entries.map((entry) => [entry.name, entry]))
+}
+
+function extractZipEntryBounded(bytes, entry, maxBytes) {
+  if (entry.originalSize <= 0 || entry.originalSize > maxBytes) {
+    throw new Error('ZIP entry exceeds output limit')
+  }
+  const compressed = bytes.subarray(
+    entry.dataOffset,
+    entry.dataOffset + entry.size,
+  )
+  let output
+  if (entry.compression === 0) {
+    output = Buffer.from(compressed)
+  } else {
     const chunks = []
     let emittedBytes = 0
-    file.ondata = (error, chunk, final) => {
-      if (error) throw error
+    let completed = false
+    const inflate = new Inflate((chunk, final) => {
       emittedBytes += chunk.byteLength
-      if (
-        emittedBytes > specification.maxBytes ||
-        emittedBytes > specification.originalSize
-      ) {
-        file.terminate()
-        throw new Error('EPUB entry exceeds actual output limit')
+      if (emittedBytes > maxBytes || emittedBytes > entry.originalSize) {
+        throw new Error('ZIP entry exceeds actual output limit')
       }
-      chunks.push(chunk)
-      if (final) {
-        if (emittedBytes !== specification.originalSize) {
-          throw new Error('EPUB entry size mismatch')
-        }
-        extracted.set(
-          file.name,
-          Buffer.concat(
-            chunks.map((value) => Buffer.from(value)),
-            emittedBytes,
-          ),
-        )
-      }
+      chunks.push(Buffer.from(chunk))
+      if (final) completed = true
+    })
+    for (let offset = 0; offset < compressed.byteLength; offset += 256) {
+      inflate.push(
+        compressed.subarray(
+          offset,
+          Math.min(offset + 256, compressed.byteLength),
+        ),
+        offset + 256 >= compressed.byteLength,
+      )
     }
-    file.start()
-  })
-  archive.register(UnzipInflate)
-  for (let offset = 0; offset < bytes.byteLength; offset += 256) {
-    archive.push(
-      bytes.subarray(offset, Math.min(offset + 256, bytes.byteLength)),
-      offset + 256 >= bytes.byteLength,
-    )
-    if (extracted.size === requested.size) break
+    if (!completed || emittedBytes !== entry.originalSize) {
+      throw new Error('ZIP entry size mismatch')
+    }
+    output = Buffer.concat(chunks, emittedBytes)
   }
-  if (extracted.size !== requested.size) {
-    throw new Error('missing bounded EPUB entry')
+  if (
+    output.byteLength !== entry.originalSize ||
+    crc32(output) !== entry.checksum
+  ) {
+    throw new Error('ZIP entry integrity mismatch')
   }
-  return extracted
+  return output
 }
 
 export function validEpubPackage(bytes) {
@@ -1552,65 +1699,25 @@ export function validEpubPackage(bytes) {
     ) {
       return false
     }
-    const names = new Set()
-    const entries = new Map()
-    let entryCount = 0
-    let inflatedBytes = 0
-    unzipSync(new Uint8Array(bytes), {
-      filter: ({ name, size, originalSize, compression }) => {
-        if (
-          !validEpubEntryName(name) ||
-          names.has(name) ||
-          !Number.isSafeInteger(size) ||
-          !Number.isSafeInteger(originalSize) ||
-          size < 0 ||
-          originalSize < 0 ||
-          size > MAX_EPUB_COMPRESSED_BYTES ||
-          originalSize > MAX_EPUB_INFLATED_BYTES ||
-          (compression === 0 && size !== originalSize) ||
-          (compression !== 0 && compression !== 8) ||
-          ++entryCount > MAX_EPUB_ENTRIES ||
-          (inflatedBytes += originalSize) > MAX_EPUB_INFLATED_BYTES
-        ) {
-          throw new Error('invalid EPUB archive metadata')
-        }
-        names.add(name)
-        entries.set(name, { size, originalSize, compression })
-        if (
-          name === 'mimetype' &&
-          (compression !== 0 || size !== 20 || originalSize !== 20)
-        ) {
-          throw new Error('invalid EPUB mimetype entry')
-        }
-        if (
-          name === 'META-INF/container.xml' &&
-          originalSize > MAX_EPUB_CONTAINER_BYTES
-        ) {
-          throw new Error('oversized EPUB container')
-        }
-        return false
-      },
-    })
-    const headerEntries = extractEpubEntriesBounded(bytes, [
-      {
-        name: 'mimetype',
-        ...entries.get('mimetype'),
-        maxBytes: 20,
-      },
-      {
-        name: 'META-INF/container.xml',
-        ...entries.get('META-INF/container.xml'),
-        maxBytes: MAX_EPUB_CONTAINER_BYTES,
-      },
-    ])
+    const entries = strictZipIndex(bytes)
+    const mimetypeEntry = entries.get('mimetype')
+    const containerEntry = entries.get('META-INF/container.xml')
     if (
-      headerEntries.get('mimetype')?.toString('utf8') !== 'application/epub+zip'
+      mimetypeEntry?.compression !== 0 ||
+      mimetypeEntry.size !== 20 ||
+      mimetypeEntry.originalSize !== 20 ||
+      containerEntry === undefined ||
+      containerEntry.originalSize > MAX_EPUB_CONTAINER_BYTES ||
+      extractZipEntryBounded(bytes, mimetypeEntry, 20).toString('utf8') !==
+        'application/epub+zip'
     ) {
       return false
     }
-    const container = headerEntries
-      .get('META-INF/container.xml')
-      .toString('utf8')
+    const container = extractZipEntryBounded(
+      bytes,
+      containerEntry,
+      MAX_EPUB_CONTAINER_BYTES,
+    ).toString('utf8')
     const rootfile = epubRootfilePath(container)
     const rootfileEntry = entries.get(rootfile)
     if (
@@ -1623,26 +1730,30 @@ export function validEpubPackage(bytes) {
     ) {
       return false
     }
-    const rootfileBytes = extractEpubEntriesBounded(bytes, [
-      {
-        name: rootfile,
-        ...rootfileEntry,
-        maxBytes: MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
-      },
-    ]).get(rootfile)
+    const rootfileBytes = extractZipEntryBounded(
+      bytes,
+      rootfileEntry,
+      MAX_EPUB_PACKAGE_DOCUMENT_BYTES,
+    )
     const packageXml = Buffer.from(rootfileBytes).toString('utf8')
     if (XMLValidator.validate(packageXml) !== true) return false
     const packageDocument = new XMLParser({
       ignoreAttributes: false,
       processEntities: false,
     }).parse(packageXml)
-    const packageRoot = packageDocument?.package
+    const packageRoot = namespacedRoot(
+      packageDocument,
+      'package',
+      'http://www.idpf.org/2007/opf',
+    )
     return (
       isRecord(packageRoot) &&
-      packageRoot['@_xmlns'] === 'http://www.idpf.org/2007/opf' &&
-      Object.hasOwn(packageRoot, 'metadata') &&
-      Object.hasOwn(packageRoot, 'manifest') &&
-      Object.hasOwn(packageRoot, 'spine')
+      /^3(?:\.\d+)+$/u.test(packageRoot['@_version'] ?? '') &&
+      typeof packageRoot['@_unique-identifier'] === 'string' &&
+      packageRoot['@_unique-identifier'].length > 0 &&
+      isRecord(childElementByLocalName(packageRoot, 'metadata')) &&
+      isRecord(childElementByLocalName(packageRoot, 'manifest')) &&
+      isRecord(childElementByLocalName(packageRoot, 'spine'))
     )
   } catch {
     return false

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -40,6 +40,10 @@ const MAX_GOVERNANCE_JSON_BYTES = 16 * 1024 * 1024
 const MAX_EPUB_COMPRESSED_BYTES = 256 * 1024 * 1024
 const MAX_EPUB_INFLATED_BYTES = 512 * 1024 * 1024
 const MAX_EPUB_ENTRIES = 544
+// A legal comment may contain EOCD magic, but each candidate triggers a
+// bounded full index parse. Allow normal nested comments without multiplying
+// the 544-entry parser across the whole 65,535-byte comment space.
+const MAX_EPUB_EOCD_CANDIDATES = 16
 const MAX_EPUB_CONTAINER_BYTES = 64 * 1024
 const MAX_EPUB_PACKAGE_DOCUMENT_BYTES = 4 * 1024 * 1024
 const PROMOTION_PROTOCOL_IMPLEMENTED = false
@@ -1553,6 +1557,7 @@ function crc32(bytes) {
 
 function strictZipIndex(bytes) {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  let candidateAttempts = 0
   for (
     let offset = bytes.byteLength - 22;
     offset >= Math.max(0, bytes.byteLength - 65_557);
@@ -1573,6 +1578,10 @@ function strictZipIndex(bytes) {
       offset + 22 + commentLength !== bytes.byteLength
     ) {
       continue
+    }
+    candidateAttempts += 1
+    if (candidateAttempts > MAX_EPUB_EOCD_CANDIDATES) {
+      throw new Error('ZIP end record candidate limit exceeded')
     }
     try {
       return strictZipIndexAt(bytes, view, offset, entryCount, centralOffset)

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1439,13 +1439,16 @@ export async function validateIndependentIsolationEvidence(
 }
 
 function validEpubEntryName(name) {
+  const parts = typeof name === 'string' ? name.split('/') : []
+  if (name?.endsWith('/')) parts.pop()
   return (
     typeof name === 'string' &&
     name.length > 0 &&
     !name.startsWith('/') &&
     !name.startsWith('\\') &&
     !name.includes('\\') &&
-    name.split('/').every((part) => part.length > 0 && part !== '..')
+    parts.length > 0 &&
+    parts.every((part) => part.length > 0 && part !== '.' && part !== '..')
   )
 }
 
@@ -1456,13 +1459,18 @@ function childElementInNamespace(
   namespaceScope = parent,
 ) {
   if (!isRecord(parent)) return null
-  const entry = Object.entries(parent).find(([name]) => {
+  const entry = Object.entries(parent).find(([name, child]) => {
     if (name.startsWith('@_') || name.split(':').at(-1) !== localName) {
       return false
     }
     const prefix = name.includes(':') ? name.split(':')[0] : null
     const namespaceAttribute = prefix === null ? '@_xmlns' : `@_xmlns:${prefix}`
-    return namespaceScope?.[namespaceAttribute] === namespace
+    const effectiveNamespace = [child, parent, namespaceScope]
+      .filter(isRecord)
+      .find((scope) => Object.hasOwn(scope, namespaceAttribute))?.[
+      namespaceAttribute
+    ]
+    return effectiveNamespace === namespace
   })
   return entry?.[1] ?? null
 }
@@ -1590,9 +1598,10 @@ function strictZipIndex(bytes) {
     const recordEnd =
       cursor + 46 + nameLength + extraLength + entryCommentLength
     if (recordEnd > endOffset) throw new Error('truncated ZIP central record')
-    const name = Buffer.from(
+    const nameBytes = Buffer.from(
       bytes.subarray(cursor + 46, cursor + 46 + nameLength),
-    ).toString('utf8')
+    )
+    const name = new TextDecoder('utf-8', { fatal: true }).decode(nameBytes)
     if (
       !validEpubEntryName(name) ||
       names.has(name) ||
@@ -1615,6 +1624,7 @@ function strictZipIndex(bytes) {
       size,
       originalSize,
       localOffset,
+      nameBytes,
     })
     cursor = recordEnd
   }
@@ -1633,14 +1643,14 @@ function strictZipIndex(bytes) {
     const nameLength = view.getUint16(entry.localOffset + 26, true)
     const extraLength = view.getUint16(entry.localOffset + 28, true)
     const dataOffset = entry.localOffset + 30 + nameLength + extraLength
-    const localName = Buffer.from(
+    const localNameBytes = Buffer.from(
       bytes.subarray(
         entry.localOffset + 30,
         entry.localOffset + 30 + nameLength,
       ),
-    ).toString('utf8')
+    )
     if (
-      localName !== entry.name ||
+      !localNameBytes.equals(entry.nameBytes) ||
       view.getUint16(entry.localOffset + 6, true) !== entry.flags ||
       view.getUint16(entry.localOffset + 8, true) !== entry.compression ||
       view.getUint32(entry.localOffset + 14, true) !== entry.checksum ||
@@ -1659,7 +1669,7 @@ function strictZipIndex(bytes) {
 }
 
 function extractZipEntryBounded(bytes, entry, maxBytes, collect = true) {
-  if (entry.originalSize <= 0 || entry.originalSize > maxBytes) {
+  if (entry.originalSize < 0 || entry.originalSize > maxBytes) {
     throw new Error('ZIP entry exceeds output limit')
   }
   const compressed = bytes.subarray(
@@ -1667,6 +1677,12 @@ function extractZipEntryBounded(bytes, entry, maxBytes, collect = true) {
     entry.dataOffset + entry.size,
   )
   let output
+  if (entry.originalSize === 0) {
+    if (entry.size !== 0 || entry.checksum !== 0) {
+      throw new Error('invalid empty ZIP entry')
+    }
+    return Buffer.alloc(0)
+  }
   if (entry.compression === 0) {
     output = collect ? Buffer.from(compressed) : compressed
   } else {

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1449,14 +1449,22 @@ function validEpubEntryName(name) {
   )
 }
 
-function childElementByLocalName(parent, localName) {
+function childElementInNamespace(
+  parent,
+  localName,
+  namespace,
+  namespaceScope = parent,
+) {
   if (!isRecord(parent)) return null
-  return (
-    Object.entries(parent).find(
-      ([name]) =>
-        !name.startsWith('@_') && name.split(':').at(-1) === localName,
-    )?.[1] ?? null
-  )
+  const entry = Object.entries(parent).find(([name]) => {
+    if (name.startsWith('@_') || name.split(':').at(-1) !== localName) {
+      return false
+    }
+    const prefix = name.includes(':') ? name.split(':')[0] : null
+    const namespaceAttribute = prefix === null ? '@_xmlns' : `@_xmlns:${prefix}`
+    return namespaceScope?.[namespaceAttribute] === namespace
+  })
+  return entry?.[1] ?? null
 }
 
 function namespacedRoot(document, localName, namespace) {
@@ -1482,7 +1490,12 @@ function epubRootfilePath(containerXml) {
     'container',
     'urn:oasis:names:tc:opendocument:xmlns:container',
   )
-  const rootfilesNode = childElementByLocalName(container, 'rootfiles')
+  const containerNamespace = 'urn:oasis:names:tc:opendocument:xmlns:container'
+  const rootfilesNode = childElementInNamespace(
+    container,
+    'rootfiles',
+    containerNamespace,
+  )
   if (
     !isRecord(container) ||
     container['@_version'] !== '1.0' ||
@@ -1490,7 +1503,12 @@ function epubRootfilePath(containerXml) {
   ) {
     return null
   }
-  const rootfileNode = childElementByLocalName(rootfilesNode, 'rootfile')
+  const rootfileNode = childElementInNamespace(
+    rootfilesNode,
+    'rootfile',
+    containerNamespace,
+    container,
+  )
   const rootfiles = Array.isArray(rootfileNode) ? rootfileNode : [rootfileNode]
   const packageRootfile = rootfiles.find(
     (rootfile) =>
@@ -1509,12 +1527,15 @@ const CRC32_TABLE = Uint32Array.from({ length: 256 }, (_, value) => {
   return crc >>> 0
 })
 
-function crc32(bytes) {
-  let crc = 0xffffffff
+function crc32Update(crc, bytes) {
   for (const value of bytes) {
     crc = CRC32_TABLE[(crc ^ value) & 0xff] ^ (crc >>> 8)
   }
-  return (crc ^ 0xffffffff) >>> 0
+  return crc >>> 0
+}
+
+function crc32(bytes) {
+  return (crc32Update(0xffffffff, bytes) ^ 0xffffffff) >>> 0
 }
 
 function strictZipIndex(bytes) {
@@ -1575,7 +1596,7 @@ function strictZipIndex(bytes) {
     if (
       !validEpubEntryName(name) ||
       names.has(name) ||
-      (flags & ~0x0800) !== 0 ||
+      (flags & ~0x0806) !== 0 ||
       (compression !== 0 && compression !== 8) ||
       size > MAX_EPUB_COMPRESSED_BYTES ||
       originalSize > MAX_EPUB_INFLATED_BYTES ||
@@ -1637,7 +1658,7 @@ function strictZipIndex(bytes) {
   return new Map(entries.map((entry) => [entry.name, entry]))
 }
 
-function extractZipEntryBounded(bytes, entry, maxBytes) {
+function extractZipEntryBounded(bytes, entry, maxBytes, collect = true) {
   if (entry.originalSize <= 0 || entry.originalSize > maxBytes) {
     throw new Error('ZIP entry exceeds output limit')
   }
@@ -1647,17 +1668,19 @@ function extractZipEntryBounded(bytes, entry, maxBytes) {
   )
   let output
   if (entry.compression === 0) {
-    output = Buffer.from(compressed)
+    output = collect ? Buffer.from(compressed) : compressed
   } else {
     const chunks = []
     let emittedBytes = 0
     let completed = false
+    let runningCrc = 0xffffffff
     const inflate = new Inflate((chunk, final) => {
       emittedBytes += chunk.byteLength
       if (emittedBytes > maxBytes || emittedBytes > entry.originalSize) {
         throw new Error('ZIP entry exceeds actual output limit')
       }
-      chunks.push(Buffer.from(chunk))
+      runningCrc = crc32Update(runningCrc, chunk)
+      if (collect) chunks.push(Buffer.from(chunk))
       if (final) completed = true
     })
     for (let offset = 0; offset < compressed.byteLength; offset += 256) {
@@ -1672,12 +1695,12 @@ function extractZipEntryBounded(bytes, entry, maxBytes) {
     if (!completed || emittedBytes !== entry.originalSize) {
       throw new Error('ZIP entry size mismatch')
     }
-    output = Buffer.concat(chunks, emittedBytes)
+    if ((runningCrc ^ 0xffffffff) >>> 0 !== entry.checksum) {
+      throw new Error('ZIP entry checksum mismatch')
+    }
+    output = collect ? Buffer.concat(chunks, emittedBytes) : null
   }
-  if (
-    output.byteLength !== entry.originalSize ||
-    crc32(output) !== entry.checksum
-  ) {
+  if (entry.compression === 0 && crc32(output) !== entry.checksum) {
     throw new Error('ZIP entry integrity mismatch')
   }
   return output
@@ -1746,15 +1769,43 @@ export function validEpubPackage(bytes) {
       'package',
       'http://www.idpf.org/2007/opf',
     )
-    return (
+    const structurallyValid =
       isRecord(packageRoot) &&
       /^3(?:\.\d+)+$/u.test(packageRoot['@_version'] ?? '') &&
       typeof packageRoot['@_unique-identifier'] === 'string' &&
       packageRoot['@_unique-identifier'].length > 0 &&
-      isRecord(childElementByLocalName(packageRoot, 'metadata')) &&
-      isRecord(childElementByLocalName(packageRoot, 'manifest')) &&
-      isRecord(childElementByLocalName(packageRoot, 'spine'))
-    )
+      isRecord(
+        childElementInNamespace(
+          packageRoot,
+          'metadata',
+          'http://www.idpf.org/2007/opf',
+        ),
+      ) &&
+      isRecord(
+        childElementInNamespace(
+          packageRoot,
+          'manifest',
+          'http://www.idpf.org/2007/opf',
+        ),
+      ) &&
+      isRecord(
+        childElementInNamespace(
+          packageRoot,
+          'spine',
+          'http://www.idpf.org/2007/opf',
+        ),
+      )
+    if (!structurallyValid) return false
+    for (const entry of entries.values()) {
+      if (
+        entry.name !== 'mimetype' &&
+        entry.name !== 'META-INF/container.xml' &&
+        entry.name !== rootfile
+      ) {
+        extractZipEntryBounded(bytes, entry, entry.originalSize, false)
+      }
+    }
+    return true
   } catch {
     return false
   }

--- a/tools/pdf-benchmark-readiness.mjs
+++ b/tools/pdf-benchmark-readiness.mjs
@@ -1659,6 +1659,13 @@ export function assessPdfBenchmarkReadiness(
     candidateCommitmentVerified = false,
     independentIsolationEvidenceVerified = false,
     nativeReaderEvidenceVerified = false,
+    nativeReaderEvidenceSummary = {
+      exactArtifactSha256: null,
+      structurallyValidatedReaderIds: [],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    },
   } = {},
 ) {
   const blind = registry.splits.find((split) => split.role === 'blind-test')
@@ -1860,7 +1867,7 @@ export function assessPdfBenchmarkReadiness(
     criterion(
       'native-reader-exact-artifact-coverage',
       nativeReaderEvidenceVerified,
-      registry.nativeReaderEvidence,
+      nativeReaderEvidenceSummary,
       {
         'apple-books': 'hash-bound-passed-exact-artifact-receipt',
         'independent-desktop-epub-reader':
@@ -1996,6 +2003,7 @@ export async function createPdfBenchmarkReadinessReceipt({
       nativeReaderEvidence.trustedAttestationVerified &&
       nativeReaderEvidence.verifiedReaderIds.length ===
         Object.keys(REQUIRED_NATIVE_READER_TYPES).length,
+    nativeReaderEvidenceSummary: nativeReaderEvidence,
   })
   const unsigned = {
     schemaVersion: PDF_BENCHMARK_READINESS_SCHEMA_VERSION,

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -13,6 +13,7 @@ import {
   assessPdfBenchmarkReadiness,
   createPdfBenchmarkSplitIdentitySha256,
   createPdfBenchmarkReadinessReceipt,
+  readJsonArtifact,
   validateCandidateCommitment,
   validateIndependentIsolationEvidence,
   validateNativeReaderEvidence,
@@ -399,7 +400,7 @@ describe('PDF benchmark readiness registry', () => {
       }),
       'EPUB/package.opf',
     )
-    expect(validEpubPackage(corruptPackagePayload)).toBe(true)
+    expect(validEpubPackage(corruptPackagePayload)).toBe(false)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {
@@ -486,6 +487,36 @@ describe('PDF benchmark readiness registry', () => {
       })
       await rm(repositoryBinding.path, { force: true })
       await writeFile(repositoryBinding.path, strToU8('inside'))
+    }
+  })
+
+  it('reads registry JSON from one bounded descriptor during replacement', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pdf-registry-race-'))
+    evidenceDirectories.push(directory)
+    const registryArtifact = join(directory, 'registry.json')
+    const outsideArtifact = join(directory, 'outside.json')
+    await writeFile(outsideArtifact, JSON.stringify({ outside: true }))
+
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      await writeFile(registryArtifact, JSON.stringify({ inside: true }))
+      const validation = readJsonArtifact(
+        registryArtifact,
+        'INVALID_PDF_BENCHMARK_REGISTRY_SCHEMA',
+      ).then(
+        (artifact) => ({ artifact, error: null }),
+        (error) => ({ artifact: null, error }),
+      )
+      await rm(registryArtifact, { force: true })
+      await symlink(outsideArtifact, registryArtifact)
+      const outcome = await validation
+      if (outcome.artifact !== null) {
+        expect(outcome.artifact.value).toEqual({ inside: true })
+      } else {
+        expect(outcome.error).toMatchObject({
+          message: 'INVALID_PDF_BENCHMARK_REGISTRY_SCHEMA',
+        })
+      }
+      await rm(registryArtifact, { force: true })
     }
   })
 

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -381,7 +381,7 @@ describe('PDF benchmark readiness registry', () => {
     const oversizedRootfile = patchZipCentralDirectoryEntry(
       validFixture,
       'EPUB/package.opf',
-      { originalSize: 16 * 1024 * 1024 + 1 },
+      { originalSize: 4 * 1024 * 1024 + 1 },
     )
     expect(validEpubPackage(oversizedRootfile)).toBe(false)
 
@@ -401,6 +401,21 @@ describe('PDF benchmark readiness registry', () => {
       'EPUB/package.opf',
     )
     expect(validEpubPackage(corruptPackagePayload)).toBe(false)
+
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8('<package><metadata></package>'),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8('<not-a-package />'),
+        }),
+      ),
+    ).toBe(false)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -103,6 +103,43 @@ function patchZipCentralDirectoryEntry(bytes, entryName, changes) {
   throw new Error(`missing ZIP central-directory entry: ${entryName}`)
 }
 
+function patchZipLocalHeaderEntry(bytes, entryName, changes) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  for (let offset = 0; offset <= patched.byteLength - 30;) {
+    if (view.getUint32(offset, true) !== 0x04034b50) break
+    const compressedSize = view.getUint32(offset + 18, true)
+    const nameLength = view.getUint16(offset + 26, true)
+    const extraLength = view.getUint16(offset + 28, true)
+    const name = Buffer.from(
+      patched.subarray(offset + 30, offset + 30 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      if (changes.compressedSize !== undefined) {
+        view.setUint32(offset + 18, changes.compressedSize, true)
+      }
+      if (changes.originalSize !== undefined) {
+        view.setUint32(offset + 22, changes.originalSize, true)
+      }
+      return patched
+    }
+    offset += 30 + nameLength + extraLength + compressedSize
+  }
+  throw new Error(`missing ZIP local entry: ${entryName}`)
+}
+
+function patchZipEntrySizes(bytes, entryName, changes) {
+  return patchZipCentralDirectoryEntry(
+    patchZipLocalHeaderEntry(bytes, entryName, changes),
+    entryName,
+    changes,
+  )
+}
+
 function corruptZipLocalEntryPayload(bytes, entryName) {
   const patched = new Uint8Array(bytes)
   const view = new DataView(
@@ -133,9 +170,11 @@ function createValidEpub(extraEntries = {}) {
   return zipSync({
     mimetype: [strToU8('application/epub+zip'), { level: 0 }],
     'META-INF/container.xml': strToU8(
-      '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+      '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
     ),
-    'EPUB/package.opf': strToU8('<package version="3.0" />'),
+    'EPUB/package.opf': strToU8(
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/><manifest/><spine/></package>',
+    ),
     ...extraEntries,
   })
 }
@@ -388,15 +427,19 @@ describe('PDF benchmark readiness registry', () => {
     const compressedMimetype = zipSync({
       mimetype: strToU8('application/epub+zip'),
       'META-INF/container.xml': strToU8(
-        '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+        '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
       ),
-      'EPUB/package.opf': strToU8('<package version="3.0" />'),
+      'EPUB/package.opf': strToU8(
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/><manifest/><spine/></package>',
+      ),
     })
     expect(validEpubPackage(compressedMimetype)).toBe(false)
 
     const corruptPackagePayload = corruptZipLocalEntryPayload(
       createValidEpub({
-        'EPUB/package.opf': strToU8('<package>'.repeat(4096)),
+        'EPUB/package.opf': strToU8(
+          `<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata><meta>${'x'.repeat(64 * 1024)}</meta></metadata><manifest/><spine/></package>`,
+        ),
       }),
       'EPUB/package.opf',
     )
@@ -416,6 +459,37 @@ describe('PDF benchmark readiness registry', () => {
         }),
       ),
     ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8(
+            '<x:package xmlns:x="urn:evil"><metadata/><manifest/><spine/></x:package>',
+          ),
+        }),
+      ),
+    ).toBe(false)
+
+    const underdeclaredPackage = patchZipEntrySizes(
+      createValidEpub({
+        'EPUB/package.opf': strToU8(
+          `<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata><meta>${'x'.repeat(8 * 1024 * 1024)}</meta></metadata><manifest/><spine/></package>`,
+        ),
+      }),
+      'EPUB/package.opf',
+      { originalSize: 25 },
+    )
+    expect(underdeclaredPackage.byteLength).toBeLessThan(64 * 1024)
+    expect(validEpubPackage(underdeclaredPackage)).toBe(false)
+
+    const underdeclaredContainer = patchZipEntrySizes(
+      createValidEpub({
+        'META-INF/container.xml': strToU8('<rootfile'.repeat(128 * 1024)),
+      }),
+      'META-INF/container.xml',
+      { originalSize: 80 },
+    )
+    expect(underdeclaredContainer.byteLength).toBeLessThan(32 * 1024)
+    expect(validEpubPackage(underdeclaredContainer)).toBe(false)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {
@@ -1455,7 +1529,7 @@ describe('PDF benchmark readiness registry', () => {
       zipSync({
         mimetype: [strToU8('application/epub+zip'), { level: 0 }],
         'META-INF/container.xml': strToU8(
-          '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+          '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
         ),
         'EPUB/package.opf': strToU8(
           '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="pub-id">urn:fixture</dc:identifier><dc:title>Fixture</dc:title><dc:language>en</dc:language></metadata><manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
@@ -1782,7 +1856,7 @@ describe('PDF benchmark readiness registry', () => {
         'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
       )
     }
-  })
+  }, 30_000)
 
   it('emits only a stable error code when CLI inputs fail', () => {
     const result = spawnSync(

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -166,6 +166,57 @@ function corruptZipLocalEntryPayload(bytes, entryName) {
   throw new Error(`missing ZIP local entry: ${entryName}`)
 }
 
+function zipEndRecordOffset(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  for (let offset = bytes.byteLength - 22; offset >= 0; offset -= 1) {
+    if (view.getUint32(offset, true) === 0x06054b50) return offset
+  }
+  throw new Error('missing ZIP end record')
+}
+
+function prependUnindexedLocalEntry(bytes, entryName, value) {
+  const hiddenArchive = zipSync({ [entryName]: value })
+  const hiddenView = new DataView(
+    hiddenArchive.buffer,
+    hiddenArchive.byteOffset,
+    hiddenArchive.byteLength,
+  )
+  const hiddenLocalBytes = hiddenArchive.subarray(
+    0,
+    hiddenView.getUint32(zipEndRecordOffset(hiddenArchive) + 16, true),
+  )
+  const patched = new Uint8Array(hiddenLocalBytes.byteLength + bytes.byteLength)
+  patched.set(hiddenLocalBytes)
+  patched.set(bytes, hiddenLocalBytes.byteLength)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(patched)
+  const entryCount = view.getUint16(endOffset + 10, true)
+  const centralOffset = view.getUint32(endOffset + 16, true)
+  const shiftedCentralOffset = centralOffset + hiddenLocalBytes.byteLength
+  view.setUint32(endOffset + 16, shiftedCentralOffset, true)
+  let cursor = shiftedCentralOffset
+  for (let index = 0; index < entryCount; index += 1) {
+    if (view.getUint32(cursor, true) !== 0x02014b50) {
+      throw new Error('invalid ZIP central record')
+    }
+    view.setUint32(
+      cursor + 42,
+      view.getUint32(cursor + 42, true) + hiddenLocalBytes.byteLength,
+      true,
+    )
+    cursor +=
+      46 +
+      view.getUint16(cursor + 28, true) +
+      view.getUint16(cursor + 30, true) +
+      view.getUint16(cursor + 32, true)
+  }
+  return patched
+}
+
 function createValidEpub(extraEntries = {}) {
   return zipSync({
     mimetype: [strToU8('application/epub+zip'), { level: 0 }],
@@ -173,7 +224,7 @@ function createValidEpub(extraEntries = {}) {
       '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
     ),
     'EPUB/package.opf': strToU8(
-      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/><manifest/><spine/></package>',
+      '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata><identifier id="pub-id">urn:fixture</identifier></metadata><manifest><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
     ),
     ...extraEntries,
   })
@@ -430,7 +481,7 @@ describe('PDF benchmark readiness registry', () => {
         '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
       ),
       'EPUB/package.opf': strToU8(
-        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><metadata/><manifest/><spine/></package>',
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata><identifier id="pub-id">urn:fixture</identifier></metadata><manifest><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
       ),
     })
     expect(validEpubPackage(compressedMimetype)).toBe(false)
@@ -452,6 +503,15 @@ describe('PDF benchmark readiness registry', () => {
         }),
       ),
     ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8(
+            '<opf:package xmlns:opf="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><opf:metadata><opf:identifier id="pub-id">urn:fixture</opf:identifier></opf:metadata><opf:manifest><opf:item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></opf:manifest><opf:spine><opf:itemref idref="content"/></opf:spine></opf:package>',
+          ),
+        }),
+      ),
+    ).toBe(true)
     expect(
       validEpubPackage(
         createValidEpub({
@@ -490,6 +550,15 @@ describe('PDF benchmark readiness registry', () => {
     )
     expect(underdeclaredContainer.byteLength).toBeLessThan(32 * 1024)
     expect(validEpubPackage(underdeclaredContainer)).toBe(false)
+
+    const hiddenPackageRecord = prependUnindexedLocalEntry(
+      createValidEpub(),
+      'EPUB/package.opf',
+      strToU8(
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="hidden"><metadata><identifier id="hidden">urn:hidden</identifier></metadata><manifest><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
+      ),
+    )
+    expect(validEpubPackage(hiddenPackageRecord)).toBe(false)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
+import { strToU8, zipSync } from 'fflate'
 import { canonicalJson } from './pdf-fidelity-eval.mjs'
 import {
   assessPdfBenchmarkReadiness,
@@ -13,6 +14,7 @@ import {
   createPdfBenchmarkReadinessReceipt,
   validateCandidateCommitment,
   validateIndependentIsolationEvidence,
+  validateNativeReaderEvidence,
   validateObservationBinding,
   validateSourcePdfDocumentIdentities,
 } from './pdf-benchmark-readiness.mjs'
@@ -59,7 +61,12 @@ async function createEvidenceWriter() {
   evidenceDirectories.push(directory)
   return async (name, value) => {
     const absolutePath = join(directory, name)
-    await writeFile(absolutePath, `${JSON.stringify(value, null, 2)}\n`)
+    await writeFile(
+      absolutePath,
+      value instanceof Uint8Array
+        ? value
+        : `${JSON.stringify(value, null, 2)}\n`,
+    )
     return fileBinding(relative(process.cwd(), absolutePath))
   }
 }
@@ -141,8 +148,12 @@ describe('PDF benchmark readiness registry', () => {
       )
       const invalidRegistryPath = await writeRegistry(invalidRegistry)
       await expect(
-        createPdfBenchmarkReadinessReceipt({ registryPath: invalidRegistryPath }),
-      ).rejects.toThrow(/PDF_BENCHMARK_METRIC_BINDING_MISMATCH|INVALID_PDF_BENCHMARK_REGISTRY_SCHEMA|INVALID_PDF_BENCHMARK_REGISTRY/)
+        createPdfBenchmarkReadinessReceipt({
+          registryPath: invalidRegistryPath,
+        }),
+      ).rejects.toThrow(
+        /PDF_BENCHMARK_METRIC_BINDING_MISMATCH|INVALID_PDF_BENCHMARK_REGISTRY_SCHEMA|INVALID_PDF_BENCHMARK_REGISTRY/,
+      )
     }
 
     await expect(
@@ -161,7 +172,9 @@ describe('PDF benchmark readiness registry', () => {
       dependency.fileSha256 = '0'.repeat(64)
       const invalidRegistryPath = await writeRegistry(invalidRegistry)
       await expect(
-        createPdfBenchmarkReadinessReceipt({ registryPath: invalidRegistryPath }),
+        createPdfBenchmarkReadinessReceipt({
+          registryPath: invalidRegistryPath,
+        }),
       ).rejects.toThrow('PDF_BENCHMARK_METRIC_BINDING_MISMATCH')
     }
   })
@@ -194,6 +207,7 @@ describe('PDF benchmark readiness registry', () => {
       'candidate-commitment-frozen-before-label-reveal',
       'target-free-end-to-end-track',
       'metric-coverage',
+      'native-reader-exact-artifact-coverage',
       'promotion-protocol-implementation',
     ])
     expect(receipt.sources).toHaveLength(2)
@@ -1074,10 +1088,17 @@ describe('PDF benchmark readiness registry', () => {
     )
 
     expect(assessment.ready).toBe(false)
-    expect(assessment.gaps).toEqual(['promotion-protocol-implementation'])
+    expect(assessment.gaps).toEqual([
+      'native-reader-exact-artifact-coverage',
+      'promotion-protocol-implementation',
+    ])
     expect(
       assessment.criteria
-        .filter((item) => item.id !== 'promotion-protocol-implementation')
+        .filter(
+          (item) =>
+            item.id !== 'native-reader-exact-artifact-coverage' &&
+            item.id !== 'promotion-protocol-implementation',
+        )
         .every((item) => item.passed),
     ).toBe(true)
 
@@ -1087,6 +1108,7 @@ describe('PDF benchmark readiness registry', () => {
     })
     expect(unverifiedMetrics.gaps).toEqual([
       'metric-coverage',
+      'native-reader-exact-artifact-coverage',
       'promotion-protocol-implementation',
     ])
 
@@ -1095,13 +1117,18 @@ describe('PDF benchmark readiness registry', () => {
         ...evidence,
         blindSourcePolicyVerified: false,
       }).gaps,
-    ).toEqual(['blind-split-frozen', 'promotion-protocol-implementation'])
+    ).toEqual([
+      'blind-split-frozen',
+      'native-reader-exact-artifact-coverage',
+      'promotion-protocol-implementation',
+    ])
 
     registry.tracks.endToEndBlind.promotionAuthority = false
     expect(
       assessPdfBenchmarkReadiness(registry, inventory, evidence).gaps,
     ).toEqual([
       'target-free-end-to-end-track',
+      'native-reader-exact-artifact-coverage',
       'promotion-protocol-implementation',
     ])
     registry.tracks.endToEndBlind.promotionAuthority = true
@@ -1110,8 +1137,331 @@ describe('PDF benchmark readiness registry', () => {
       assessPdfBenchmarkReadiness(registry, inventory, evidence).gaps,
     ).toEqual([
       'target-free-end-to-end-track',
+      'native-reader-exact-artifact-coverage',
       'promotion-protocol-implementation',
     ])
+  })
+
+  it('requires hash-bound exact-artifact receipts from all required native readers', async () => {
+    const writeEvidence = await createEvidenceWriter()
+    const exactEpubArtifact = await writeEvidence(
+      'exact-artifact.epub',
+      zipSync({
+        mimetype: [strToU8('application/epub+zip'), { level: 0 }],
+        'META-INF/container.xml': strToU8(
+          '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+        ),
+        'EPUB/package.opf': strToU8(
+          '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="pub-id">urn:fixture</dc:identifier><dc:title>Fixture</dc:title><dc:language>en</dc:language></metadata><manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
+        ),
+        'EPUB/nav.xhtml': strToU8(
+          '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Fixture</title></head><body><nav epub:type="toc" xmlns:epub="http://www.idpf.org/2007/ops"><ol><li><a href="content.xhtml">Fixture</a></li></ol></nav></body></html>',
+        ),
+        'EPUB/content.xhtml': strToU8(
+          '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Fixture</title></head><body><p>Fixture</p></body></html>',
+        ),
+      }),
+    )
+    const exactArtifactSha256 = exactEpubArtifact.fileSha256
+    const exportReceipt = {
+      schemaVersion: '1.0.0',
+      kind: 'pdf-benchmark-exact-epub-export-receipt',
+      exactArtifactSha256,
+      status: 'passed',
+    }
+    const exportReceiptIdentitySha256 = createHash('sha256')
+      .update(canonicalJson(exportReceipt))
+      .digest('hex')
+    const exportReceiptEvidence = await writeEvidence(
+      'export-receipt.json',
+      exportReceipt,
+    )
+    const toolchainManifest = await fileBinding(
+      'src/publication/toolchain-manifest.json',
+    )
+    const toolchain = JSON.parse(
+      await readFile('src/publication/toolchain-manifest.json', 'utf8'),
+    )
+    const checkerIdentitySha256 = toolchain.epubcheck.sha256
+    const checkerVersion = toolchain.epubcheck.version
+    const epubCheckInputIdentitySha256 = createHash('sha256')
+      .update(
+        canonicalJson({
+          kind: 'pdf-benchmark-epubcheck-input-v1',
+          exactArtifactSha256,
+          checkerIdentitySha256,
+          checkerVersion,
+        }),
+      )
+      .digest('hex')
+    const epubCheckTranscript = {
+      schemaVersion: '1.0.0',
+      kind: 'pdf-benchmark-epubcheck-execution-transcript',
+      command: 'epubcheck',
+      exactArtifactSha256,
+      checkerIdentitySha256,
+      checkerVersion,
+      exitCode: 0,
+      epubCheckStatus: 'passed',
+      stdoutSha256: 'b'.repeat(64),
+      stderrSha256: 'c'.repeat(64),
+    }
+    const epubCheckOutputIdentitySha256 = createHash('sha256')
+      .update(canonicalJson(epubCheckTranscript))
+      .digest('hex')
+    const epubCheckReceipt = {
+      schemaVersion: '1.0.0',
+      kind: 'pdf-benchmark-epubcheck-execution-receipt',
+      exactArtifactSha256,
+      toolchainManifestFileSha256: toolchainManifest.fileSha256,
+      checkerIdentitySha256,
+      checkerVersion,
+      epubCheckTranscriptEvidenceFileSha256: null,
+      inputIdentitySha256: epubCheckInputIdentitySha256,
+      outputIdentitySha256: epubCheckOutputIdentitySha256,
+      status: 'passed',
+    }
+    const epubCheckTranscriptEvidence = await writeEvidence(
+      'epubcheck-transcript.json',
+      epubCheckTranscript,
+    )
+    epubCheckReceipt.epubCheckTranscriptEvidenceFileSha256 =
+      epubCheckTranscriptEvidence.fileSha256
+    const epubCheckReceiptEvidence = await writeEvidence(
+      'epubcheck-receipt.json',
+      epubCheckReceipt,
+    )
+    const exportEvidence = await writeEvidence('export-evidence.json', {
+      schemaVersion: '1.0.0',
+      kind: 'pdf-benchmark-exact-epub-export-evidence',
+      epubArtifact: exactEpubArtifact,
+      exactArtifactSha256,
+      exportReceipt: exportReceiptEvidence,
+      exportReceiptIdentitySha256,
+      toolchainManifest,
+      epubCheckReceipt: epubCheckReceiptEvidence,
+      epubCheckTranscript: epubCheckTranscriptEvidence,
+      status: 'passed',
+    })
+    const writeCompleteExportEvidence = (name, overrides = {}) =>
+      writeEvidence(name, {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-benchmark-exact-epub-export-evidence',
+        epubArtifact: exactEpubArtifact,
+        exactArtifactSha256,
+        exportReceipt: exportReceiptEvidence,
+        exportReceiptIdentitySha256,
+        toolchainManifest,
+        epubCheckReceipt: epubCheckReceiptEvidence,
+        epubCheckTranscript: epubCheckTranscriptEvidence,
+        status: 'passed',
+        ...overrides,
+      })
+    const readerReceipts = await Promise.all(
+      [
+        ['apple-books', 'apple-books'],
+        ['independent-desktop-epub-reader', 'independent-desktop-epub-reader'],
+        ['target-eink-reader-device', 'target-eink-reader-device'],
+      ].map(async ([readerId, readerType], index) => {
+        const readerIdentity = await writeEvidence(`${readerId}-identity.json`, {
+          schemaVersion: '1.0.0',
+          kind: 'pdf-benchmark-native-reader-identity-evidence',
+          readerId,
+          readerType,
+          readerIdentitySha256: (index + 4).toString(16).repeat(64),
+          status: 'passed',
+        })
+        return {
+          readerId,
+          readerType,
+          readerIdentity,
+          executionReceipt: await writeEvidence(`${readerId}.json`, {
+            schemaVersion: '1.0.0',
+            kind: 'pdf-benchmark-native-reader-execution-receipt',
+            readerId,
+            readerType,
+            readerIdentityEvidenceFileSha256: readerIdentity.fileSha256,
+            exportEvidenceFileSha256: exportEvidence.fileSha256,
+            exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
+            exportReceiptIdentitySha256,
+            epubCheckReceiptEvidenceFileSha256:
+              epubCheckReceiptEvidence.fileSha256,
+            toolchainManifestFileSha256: toolchainManifest.fileSha256,
+            epubCheckTranscriptEvidenceFileSha256:
+              epubCheckTranscriptEvidence.fileSha256,
+            exactArtifactSha256,
+            executionIdentitySha256: (index + 1).toString(16).repeat(64),
+            status: 'passed',
+          }),
+        }
+      }),
+    )
+    const nativeReaderEvidence = Object.fromEntries(
+      readerReceipts.map(({ readerId, readerIdentity, executionReceipt }) => [
+        readerId,
+        {
+          status: 'passed',
+          readerIdentity,
+          executionReceipt,
+        },
+      ]),
+    )
+    nativeReaderEvidence.exportEvidence = exportEvidence
+
+    await expect(
+      validateNativeReaderEvidence(nativeReaderEvidence),
+    ).resolves.toEqual({
+      exactArtifactSha256,
+      structurallyValidatedReaderIds: [
+        'apple-books',
+        'independent-desktop-epub-reader',
+        'target-eink-reader-device',
+      ],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    })
+
+    const unavailable = structuredClone(nativeReaderEvidence)
+    unavailable['apple-books'] = {
+      status: 'unavailable-blocker',
+      readerIdentity: null,
+      executionReceipt: null,
+    }
+    await expect(validateNativeReaderEvidence(unavailable)).resolves.toEqual({
+      exactArtifactSha256,
+      structurallyValidatedReaderIds: [
+        'independent-desktop-epub-reader',
+        'target-eink-reader-device',
+      ],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    })
+
+    const browserSubstitution = structuredClone(nativeReaderEvidence)
+    browserSubstitution['apple-books'].executionReceipt = await writeEvidence(
+      'browser-substitution.json',
+      {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-benchmark-native-reader-execution-receipt',
+        readerId: 'apple-books',
+        readerType: 'chromium',
+        readerIdentityEvidenceFileSha256:
+          nativeReaderEvidence['apple-books'].readerIdentity.fileSha256,
+        exportEvidenceFileSha256: exportEvidence.fileSha256,
+        exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
+        exportReceiptIdentitySha256,
+        epubCheckReceiptEvidenceFileSha256: epubCheckReceiptEvidence.fileSha256,
+        exactArtifactSha256,
+        executionIdentitySha256: 'b'.repeat(64),
+        status: 'passed',
+      },
+    )
+    await expect(
+      validateNativeReaderEvidence(browserSubstitution),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    const arbitrarySharedClaim = structuredClone(nativeReaderEvidence)
+    for (const readerId of [
+      'apple-books',
+      'independent-desktop-epub-reader',
+      'target-eink-reader-device',
+    ]) {
+      arbitrarySharedClaim[readerId].executionReceipt = await writeEvidence(
+        `${readerId}-arbitrary-claim.json`,
+        {
+          schemaVersion: '1.0.0',
+          kind: 'pdf-benchmark-native-reader-execution-receipt',
+          readerId,
+          readerType: readerId,
+          readerIdentityEvidenceFileSha256:
+            nativeReaderEvidence[readerId].readerIdentity.fileSha256,
+          exportEvidenceFileSha256: exportEvidence.fileSha256,
+          exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
+          exportReceiptIdentitySha256,
+          epubCheckReceiptEvidenceFileSha256:
+            epubCheckReceiptEvidence.fileSha256,
+          exactArtifactSha256: 'e'.repeat(64),
+          executionIdentitySha256: 'c'.repeat(64),
+          status: 'passed',
+        },
+      )
+    }
+    await expect(
+      validateNativeReaderEvidence(arbitrarySharedClaim),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    const unboundIdentity = structuredClone(nativeReaderEvidence)
+    unboundIdentity['apple-books'].executionReceipt = await writeEvidence(
+      'unbound-identity.json',
+      {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-benchmark-native-reader-execution-receipt',
+        readerId: 'apple-books',
+        readerType: 'apple-books',
+        readerIdentityEvidenceFileSha256: '0'.repeat(64),
+        exportEvidenceFileSha256: exportEvidence.fileSha256,
+        exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
+        exportReceiptIdentitySha256,
+        epubCheckReceiptEvidenceFileSha256: epubCheckReceiptEvidence.fileSha256,
+        exactArtifactSha256,
+        executionIdentitySha256: 'a'.repeat(64),
+        status: 'passed',
+      },
+    )
+    await expect(
+      validateNativeReaderEvidence(unboundIdentity),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    const renamedJsonArtifact = await writeEvidence('renamed-json.epub', {
+      not: 'an epub archive',
+    })
+    const malformedArtifactEvidence = await writeCompleteExportEvidence(
+      'malformed-artifact-export-evidence.json',
+      {
+        epubArtifact: renamedJsonArtifact,
+        exactArtifactSha256: renamedJsonArtifact.fileSha256,
+      },
+    )
+    const malformedArtifact = structuredClone(nativeReaderEvidence)
+    malformedArtifact.exportEvidence = malformedArtifactEvidence
+    await expect(
+      validateNativeReaderEvidence(malformedArtifact),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    const missingEpubCheck = structuredClone(nativeReaderEvidence)
+    missingEpubCheck.exportEvidence = await writeCompleteExportEvidence(
+      'missing-epubcheck-export-evidence.json',
+      {
+        epubCheckReceipt: null,
+      },
+    )
+    await expect(
+      validateNativeReaderEvidence(missingEpubCheck),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    for (const [name, value] of [
+      [
+        'forged',
+        { ...epubCheckReceipt, outputIdentitySha256: '0'.repeat(64) },
+      ],
+      [
+        'mismatched',
+        { ...epubCheckReceipt, exactArtifactSha256: 'b'.repeat(64) },
+      ],
+      ['failed', { ...epubCheckReceipt, status: 'failed' }],
+    ]) {
+      const receipt = await writeEvidence(`epubcheck-${name}.json`, value)
+      const rejected = structuredClone(nativeReaderEvidence)
+      rejected.exportEvidence = await writeCompleteExportEvidence(
+        `epubcheck-${name}-export-evidence.json`,
+        { epubCheckReceipt: receipt },
+      )
+      await expect(
+        validateNativeReaderEvidence(rejected),
+      ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+    }
   })
 
   it('emits only a stable error code when CLI inputs fail', () => {

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -1338,6 +1338,35 @@ describe('PDF benchmark readiness registry', () => {
       verifiedReaderIds: [],
     })
 
+    const populatedRegistry = await readRegistry()
+    populatedRegistry.nativeReaderEvidence = nativeReaderEvidence
+    const populatedReceipt = await createPdfBenchmarkReadinessReceipt({
+      registryPath: await writeRegistry(populatedRegistry),
+    })
+    const nativeReaderSummary = {
+      exactArtifactSha256,
+      structurallyValidatedReaderIds: [
+        'apple-books',
+        'independent-desktop-epub-reader',
+        'target-eink-reader-device',
+      ],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    }
+    expect(populatedReceipt.nativeReaderEvidence).toEqual(nativeReaderSummary)
+    expect(
+      populatedReceipt.criteria.find(
+        ({ id }) => id === 'native-reader-exact-artifact-coverage',
+      ).observed,
+    ).toEqual(nativeReaderSummary)
+    const serializedReceipt = JSON.stringify(populatedReceipt)
+    expect(serializedReceipt).not.toContain(exportEvidence.path)
+    for (const { readerIdentity, executionReceipt } of readerReceipts) {
+      expect(serializedReceipt).not.toContain(readerIdentity.path)
+      expect(serializedReceipt).not.toContain(executionReceipt.path)
+    }
+
     const unavailable = structuredClone(nativeReaderEvidence)
     unavailable['apple-books'] = {
       status: 'unavailable-blocker',

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -319,6 +319,32 @@ function zipEndRecordOffset(bytes) {
   throw new Error('missing ZIP end record')
 }
 
+function appendZipComment(bytes, comment) {
+  const original = new Uint8Array(bytes)
+  const commentBytes = Uint8Array.from(comment)
+  const endOffset = zipEndRecordOffset(original)
+  const patched = new Uint8Array(original.byteLength + commentBytes.byteLength)
+  patched.set(original)
+  patched.set(commentBytes, original.byteLength)
+  new DataView(patched.buffer).setUint16(
+    endOffset + 20,
+    commentBytes.byteLength,
+    true,
+  )
+  return patched
+}
+
+function patchZipEndRecordCommentLength(bytes, commentLength) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(patched.buffer)
+  for (let offset = 0; offset <= patched.byteLength - 22; offset += 1) {
+    if (view.getUint32(offset, true) !== 0x06054b50) continue
+    view.setUint16(offset + 20, commentLength, true)
+    return patched
+  }
+  throw new Error('missing ZIP end record')
+}
+
 function prependUnindexedLocalEntry(bytes, entryName, value) {
   const hiddenArchive = zipSync({ [entryName]: value })
   const hiddenView = new DataView(
@@ -917,8 +943,34 @@ describe('PDF benchmark readiness registry', () => {
     const { validEpubPackage } = pdfBenchmarkReadiness
     const validFixture = createValidEpub({
       'EPUB/payload.bin': [strToU8('fixture'), { level: 0 }],
+      'EPUB/empty.bin': strToU8(''),
     })
     expect(validEpubPackage(validFixture)).toBe(true)
+
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'META-INF/container.xml': strToU8(
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.xml" media-type="application/oebps-package+xml" /></rootfiles></container>',
+          ),
+          'EPUB/package.xml': strToU8(
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata><identifier id="pub-id">urn:fixture</identifier></metadata><manifest><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
+          ),
+        }),
+      ),
+    ).toBe(true)
+
+    const eocdMagicComment = appendZipComment(validFixture, [
+      0x50,
+      0x4b,
+      0x05,
+      0x06,
+      ...Array(18).fill(0),
+    ])
+    expect(validEpubPackage(eocdMagicComment)).toBe(true)
+    expect(
+      validEpubPackage(patchZipEndRecordCommentLength(eocdMagicComment, 21)),
+    ).toBe(false)
 
     const descriptorPackage = addZipDataDescriptor(
       validFixture,

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -270,6 +270,303 @@ function createValidEpub(extraEntries = {}) {
   })
 }
 
+function addZipDataDescriptor(bytes, entryName, { signature = true } = {}) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  let centralEntryOffset = centralOffset
+  let localOffset = null
+  let checksum = null
+  let compressedSize = null
+  let originalSize = null
+  for (; centralEntryOffset < endOffset;) {
+    const nameLength = originalView.getUint16(centralEntryOffset + 28, true)
+    const extraLength = originalView.getUint16(centralEntryOffset + 30, true)
+    const commentLength = originalView.getUint16(centralEntryOffset + 32, true)
+    const name = Buffer.from(
+      original.subarray(
+        centralEntryOffset + 46,
+        centralEntryOffset + 46 + nameLength,
+      ),
+    ).toString('utf8')
+    if (name === entryName) {
+      checksum = originalView.getUint32(centralEntryOffset + 16, true)
+      compressedSize = originalView.getUint32(centralEntryOffset + 20, true)
+      originalSize = originalView.getUint32(centralEntryOffset + 24, true)
+      localOffset = originalView.getUint32(centralEntryOffset + 42, true)
+      break
+    }
+    centralEntryOffset += 46 + nameLength + extraLength + commentLength
+  }
+  if (localOffset === null) throw new Error(`missing ZIP entry: ${entryName}`)
+
+  const localNameLength = originalView.getUint16(localOffset + 26, true)
+  const localExtraLength = originalView.getUint16(localOffset + 28, true)
+  const descriptorOffset =
+    localOffset + 30 + localNameLength + localExtraLength + compressedSize
+  const descriptor = new Uint8Array(signature ? 16 : 12)
+  const descriptorView = new DataView(descriptor.buffer)
+  const fieldsOffset = signature ? 4 : 0
+  if (signature) descriptorView.setUint32(0, 0x08074b50, true)
+  descriptorView.setUint32(fieldsOffset, checksum, true)
+  descriptorView.setUint32(fieldsOffset + 4, compressedSize, true)
+  descriptorView.setUint32(fieldsOffset + 8, originalSize, true)
+  const patched = new Uint8Array(original.byteLength + descriptor.byteLength)
+  patched.set(original.subarray(0, descriptorOffset))
+  patched.set(descriptor, descriptorOffset)
+  patched.set(
+    original.subarray(descriptorOffset),
+    descriptorOffset + descriptor.byteLength,
+  )
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  const shiftedCentralOffset = centralOffset + descriptor.byteLength
+  const shiftedEndOffset = endOffset + descriptor.byteLength
+  view.setUint16(
+    localOffset + 6,
+    view.getUint16(localOffset + 6, true) | 0x0008,
+    true,
+  )
+  view.setUint32(localOffset + 14, 0, true)
+  view.setUint32(localOffset + 18, 0, true)
+  view.setUint32(localOffset + 22, 0, true)
+  let cursor = shiftedCentralOffset
+  while (cursor < shiftedEndOffset) {
+    const nameLength = view.getUint16(cursor + 28, true)
+    const extraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      patched.subarray(cursor + 46, cursor + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      view.setUint16(
+        cursor + 8,
+        view.getUint16(cursor + 8, true) | 0x0008,
+        true,
+      )
+    }
+    if (view.getUint32(cursor + 42, true) > localOffset) {
+      view.setUint32(
+        cursor + 42,
+        view.getUint32(cursor + 42, true) + descriptor.byteLength,
+        true,
+      )
+    }
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  view.setUint32(shiftedEndOffset + 16, shiftedCentralOffset, true)
+  return patched
+}
+
+function corruptZipDataDescriptor(bytes, entryName) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(patched)
+  const centralOffset = view.getUint32(endOffset + 16, true)
+  for (let cursor = centralOffset; cursor < endOffset;) {
+    const nameLength = view.getUint16(cursor + 28, true)
+    const extraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      patched.subarray(cursor + 46, cursor + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      const localOffset = view.getUint32(cursor + 42, true)
+      const localNameLength = view.getUint16(localOffset + 26, true)
+      const localExtraLength = view.getUint16(localOffset + 28, true)
+      const descriptorOffset =
+        localOffset +
+        30 +
+        localNameLength +
+        localExtraLength +
+        view.getUint32(cursor + 20, true)
+      view.setUint32(descriptorOffset + 4, 0, true)
+      return patched
+    }
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  throw new Error(`missing ZIP entry: ${entryName}`)
+}
+
+function addZipMimetypeExtraFields(bytes) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  const localNameLength = originalView.getUint16(26, true)
+  const localExtraLength = originalView.getUint16(28, true)
+  if (
+    Buffer.from(original.subarray(30, 30 + localNameLength)).toString(
+      'ascii',
+    ) !== 'mimetype'
+  ) {
+    throw new Error('expected mimetype local entry first')
+  }
+  const extra = Uint8Array.from([0xca, 0xfe])
+  const localExtraOffset = 30 + localNameLength + localExtraLength
+  const withLocalExtra = new Uint8Array(original.byteLength + extra.byteLength)
+  withLocalExtra.set(original.subarray(0, localExtraOffset))
+  withLocalExtra.set(extra, localExtraOffset)
+  withLocalExtra.set(
+    original.subarray(localExtraOffset),
+    localExtraOffset + extra.byteLength,
+  )
+  const localView = new DataView(
+    withLocalExtra.buffer,
+    withLocalExtra.byteOffset,
+    withLocalExtra.byteLength,
+  )
+  localView.setUint16(28, localExtraLength + extra.byteLength, true)
+  const shiftedCentralOffset = centralOffset + extra.byteLength
+  const shiftedEndOffset = endOffset + extra.byteLength
+  localView.setUint32(shiftedEndOffset + 16, shiftedCentralOffset, true)
+
+  let mimetypeCentralOffset = shiftedCentralOffset
+  const centralNameLength = localView.getUint16(
+    mimetypeCentralOffset + 28,
+    true,
+  )
+  const centralExtraLength = localView.getUint16(
+    mimetypeCentralOffset + 30,
+    true,
+  )
+  const centralExtraOffset =
+    mimetypeCentralOffset + 46 + centralNameLength + centralExtraLength
+  const patched = new Uint8Array(withLocalExtra.byteLength + extra.byteLength)
+  patched.set(withLocalExtra.subarray(0, centralExtraOffset))
+  patched.set(extra, centralExtraOffset)
+  patched.set(
+    withLocalExtra.subarray(centralExtraOffset),
+    centralExtraOffset + extra.byteLength,
+  )
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  view.setUint16(
+    mimetypeCentralOffset + 30,
+    centralExtraLength + extra.byteLength,
+    true,
+  )
+  const finalEndOffset = shiftedEndOffset + extra.byteLength
+  view.setUint32(
+    finalEndOffset + 12,
+    view.getUint32(finalEndOffset + 12, true) + extra.byteLength,
+    true,
+  )
+  for (let cursor = shiftedCentralOffset; cursor < finalEndOffset;) {
+    const nameLength = view.getUint16(cursor + 28, true)
+    const extraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    if (view.getUint32(cursor + 42, true) !== 0) {
+      view.setUint32(
+        cursor + 42,
+        view.getUint32(cursor + 42, true) + extra.byteLength,
+        true,
+      )
+    }
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  return patched
+}
+
+function addZipMimetypeLocalExtraField(bytes) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  const nameLength = originalView.getUint16(26, true)
+  const extraLength = originalView.getUint16(28, true)
+  const insertionOffset = 30 + nameLength + extraLength
+  const extra = Uint8Array.from([0xca, 0xfe])
+  const patched = new Uint8Array(original.byteLength + extra.byteLength)
+  patched.set(original.subarray(0, insertionOffset))
+  patched.set(extra, insertionOffset)
+  patched.set(
+    original.subarray(insertionOffset),
+    insertionOffset + extra.byteLength,
+  )
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  view.setUint16(28, extraLength + extra.byteLength, true)
+  const shiftedCentralOffset = centralOffset + extra.byteLength
+  const shiftedEndOffset = endOffset + extra.byteLength
+  view.setUint32(shiftedEndOffset + 16, shiftedCentralOffset, true)
+  for (let cursor = shiftedCentralOffset; cursor < shiftedEndOffset;) {
+    const centralNameLength = view.getUint16(cursor + 28, true)
+    const centralExtraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    if (view.getUint32(cursor + 42, true) !== 0) {
+      view.setUint32(
+        cursor + 42,
+        view.getUint32(cursor + 42, true) + extra.byteLength,
+        true,
+      )
+    }
+    cursor += 46 + centralNameLength + centralExtraLength + commentLength
+  }
+  return patched
+}
+
+function addZipMimetypeCentralExtraField(bytes) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  const nameLength = originalView.getUint16(centralOffset + 28, true)
+  const extraLength = originalView.getUint16(centralOffset + 30, true)
+  const insertionOffset = centralOffset + 46 + nameLength + extraLength
+  const extra = Uint8Array.from([0xca, 0xfe])
+  const patched = new Uint8Array(original.byteLength + extra.byteLength)
+  patched.set(original.subarray(0, insertionOffset))
+  patched.set(extra, insertionOffset)
+  patched.set(
+    original.subarray(insertionOffset),
+    insertionOffset + extra.byteLength,
+  )
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  view.setUint16(centralOffset + 30, extraLength + extra.byteLength, true)
+  const shiftedEndOffset = endOffset + extra.byteLength
+  view.setUint32(
+    shiftedEndOffset + 12,
+    view.getUint32(shiftedEndOffset + 12, true) + extra.byteLength,
+    true,
+  )
+  return patched
+}
+
 function reviewerIdentityEvidence(reviewerId, subjectIdentitySha256) {
   return {
     schemaVersion: '1.0.0',
@@ -477,6 +774,34 @@ describe('PDF benchmark readiness registry', () => {
       'EPUB/payload.bin': [strToU8('fixture'), { level: 0 }],
     })
     expect(validEpubPackage(validFixture)).toBe(true)
+
+    const descriptorPackage = addZipDataDescriptor(
+      validFixture,
+      'EPUB/package.opf',
+    )
+    expect(validEpubPackage(descriptorPackage)).toBe(true)
+    expect(
+      validEpubPackage(
+        addZipDataDescriptor(validFixture, 'EPUB/package.opf', {
+          signature: false,
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      validEpubPackage(
+        corruptZipDataDescriptor(descriptorPackage, 'EPUB/package.opf'),
+      ),
+    ).toBe(false)
+
+    expect(validEpubPackage(addZipMimetypeExtraFields(validFixture))).toBe(
+      false,
+    )
+    expect(validEpubPackage(addZipMimetypeLocalExtraField(validFixture))).toBe(
+      false,
+    )
+    expect(
+      validEpubPackage(addZipMimetypeCentralExtraField(validFixture)),
+    ).toBe(false)
 
     const oversizedCompressed = patchZipCentralDirectoryEntry(
       validFixture,

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -229,6 +229,22 @@ describe('PDF benchmark readiness registry', () => {
     expect(receipt.receiptSha256).toMatch(/^[a-f0-9]{64}$/)
   })
 
+  it('preserves the privacy-safe native reader validation summary in the hash-bound receipt', async () => {
+    const receipt = await createPdfBenchmarkReadinessReceipt({ registryPath })
+
+    expect(receipt.nativeReaderEvidence).toEqual({
+      exactArtifactSha256: null,
+      structurallyValidatedReaderIds: [],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    })
+    const { receiptSha256, ...unsignedReceipt } = receipt
+    expect(receiptSha256).toBe(
+      createHash('sha256').update(canonicalJson(unsignedReceipt)).digest('hex'),
+    )
+  })
+
   it('fails closed when a bound artifact hash changes', async () => {
     const registry = await readRegistry()
     registry.sources[0].evalSet.fileSha256 = '0'.repeat(64)
@@ -1340,22 +1356,17 @@ describe('PDF benchmark readiness registry', () => {
     })
 
     const browserSubstitution = structuredClone(nativeReaderEvidence)
+    const appleBooksExecutionReceipt = JSON.parse(
+      await readFile(
+        nativeReaderEvidence['apple-books'].executionReceipt.path,
+        'utf8',
+      ),
+    )
     browserSubstitution['apple-books'].executionReceipt = await writeEvidence(
       'browser-substitution.json',
       {
-        schemaVersion: '1.0.0',
-        kind: 'pdf-benchmark-native-reader-execution-receipt',
-        readerId: 'apple-books',
+        ...appleBooksExecutionReceipt,
         readerType: 'chromium',
-        readerIdentityEvidenceFileSha256:
-          nativeReaderEvidence['apple-books'].readerIdentity.fileSha256,
-        exportEvidenceFileSha256: exportEvidence.fileSha256,
-        exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
-        exportReceiptIdentitySha256,
-        epubCheckReceiptEvidenceFileSha256: epubCheckReceiptEvidence.fileSha256,
-        exactArtifactSha256,
-        executionIdentitySha256: 'b'.repeat(64),
-        status: 'passed',
       },
     )
     await expect(
@@ -1368,23 +1379,17 @@ describe('PDF benchmark readiness registry', () => {
       'independent-desktop-epub-reader',
       'target-eink-reader-device',
     ]) {
+      const executionReceipt = JSON.parse(
+        await readFile(
+          nativeReaderEvidence[readerId].executionReceipt.path,
+          'utf8',
+        ),
+      )
       arbitrarySharedClaim[readerId].executionReceipt = await writeEvidence(
         `${readerId}-arbitrary-claim.json`,
         {
-          schemaVersion: '1.0.0',
-          kind: 'pdf-benchmark-native-reader-execution-receipt',
-          readerId,
-          readerType: readerId,
-          readerIdentityEvidenceFileSha256:
-            nativeReaderEvidence[readerId].readerIdentity.fileSha256,
-          exportEvidenceFileSha256: exportEvidence.fileSha256,
-          exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
-          exportReceiptIdentitySha256,
-          epubCheckReceiptEvidenceFileSha256:
-            epubCheckReceiptEvidence.fileSha256,
+          ...executionReceipt,
           exactArtifactSha256: 'e'.repeat(64),
-          executionIdentitySha256: 'c'.repeat(64),
-          status: 'passed',
         },
       )
     }
@@ -1393,21 +1398,17 @@ describe('PDF benchmark readiness registry', () => {
     ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
 
     const unboundIdentity = structuredClone(nativeReaderEvidence)
+    const unboundIdentityReceipt = JSON.parse(
+      await readFile(
+        nativeReaderEvidence['apple-books'].executionReceipt.path,
+        'utf8',
+      ),
+    )
     unboundIdentity['apple-books'].executionReceipt = await writeEvidence(
       'unbound-identity.json',
       {
-        schemaVersion: '1.0.0',
-        kind: 'pdf-benchmark-native-reader-execution-receipt',
-        readerId: 'apple-books',
-        readerType: 'apple-books',
+        ...unboundIdentityReceipt,
         readerIdentityEvidenceFileSha256: '0'.repeat(64),
-        exportEvidenceFileSha256: exportEvidence.fileSha256,
-        exportReceiptEvidenceFileSha256: exportReceiptEvidence.fileSha256,
-        exportReceiptIdentitySha256,
-        epubCheckReceiptEvidenceFileSha256: epubCheckReceiptEvidence.fileSha256,
-        exactArtifactSha256,
-        executionIdentitySha256: 'a'.repeat(64),
-        status: 'passed',
       },
     )
     await expect(

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -345,6 +345,29 @@ function patchZipEndRecordCommentLength(bytes, commentLength) {
   throw new Error('missing ZIP end record')
 }
 
+function appendPlausibleFakeZipEndRecordComment(bytes) {
+  const original = new Uint8Array(bytes)
+  const fake = new Uint8Array(22)
+  const view = new DataView(fake.buffer)
+  view.setUint32(0, 0x06054b50, true)
+  view.setUint16(8, 1, true)
+  view.setUint16(10, 1, true)
+  view.setUint32(12, 1, true)
+  view.setUint32(16, original.byteLength, true)
+  return appendZipComment(original, [0, ...fake])
+}
+
+function eraseFirstZipEndRecordSignature(bytes) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(patched.buffer)
+  for (let offset = 0; offset <= patched.byteLength - 22; offset += 1) {
+    if (view.getUint32(offset, true) !== 0x06054b50) continue
+    view.setUint32(offset, 0, true)
+    return patched
+  }
+  throw new Error('missing ZIP end record')
+}
+
 function prependUnindexedLocalEntry(bytes, entryName, value) {
   const hiddenArchive = zipSync({ [entryName]: value })
   const hiddenView = new DataView(
@@ -971,6 +994,18 @@ describe('PDF benchmark readiness registry', () => {
     expect(
       validEpubPackage(patchZipEndRecordCommentLength(eocdMagicComment, 21)),
     ).toBe(false)
+
+    const plausibleFakeEocdComment =
+      appendPlausibleFakeZipEndRecordComment(validFixture)
+    expect(validEpubPackage(plausibleFakeEocdComment)).toBe(true)
+    expect(
+      validEpubPackage(
+        eraseFirstZipEndRecordSignature(plausibleFakeEocdComment),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(appendZipComment(validFixture, Array(65_535).fill(0))),
+    ).toBe(true)
 
     const descriptorPackage = addZipDataDescriptor(
       validFixture,

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { readFile, rm, truncate, writeFile } from 'node:fs/promises'
+import { readFile, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -18,6 +18,7 @@ import {
   validateNativeReaderEvidence,
   validateObservationBinding,
   validateSourcePdfDocumentIdentities,
+  verifyRepositoryFileBinding,
 } from './pdf-benchmark-readiness.mjs'
 
 const registryPath = 'benchmarks/pdf/benchmark-readiness-registry-v1.json'
@@ -99,6 +100,32 @@ function patchZipCentralDirectoryEntry(bytes, entryName, changes) {
     offset += nameLength + extraLength + commentLength
   }
   throw new Error(`missing ZIP central-directory entry: ${entryName}`)
+}
+
+function corruptZipLocalEntryPayload(bytes, entryName) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  for (let offset = 0; offset <= patched.byteLength - 30;) {
+    if (view.getUint32(offset, true) !== 0x04034b50) break
+    const compressedSize = view.getUint32(offset + 18, true)
+    const nameLength = view.getUint16(offset + 26, true)
+    const extraLength = view.getUint16(offset + 28, true)
+    const payloadOffset = offset + 30 + nameLength + extraLength
+    const name = Buffer.from(
+      patched.subarray(offset + 30, offset + 30 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      if (compressedSize === 0) throw new Error(`empty ZIP entry: ${entryName}`)
+      patched[payloadOffset + Math.floor(compressedSize / 2)] ^= 0xff
+      return patched
+    }
+    offset = payloadOffset + compressedSize
+  }
+  throw new Error(`missing ZIP local entry: ${entryName}`)
 }
 
 function createValidEpub(extraEntries = {}) {
@@ -343,6 +370,36 @@ describe('PDF benchmark readiness registry', () => {
       ),
     )
     expect(validEpubPackage(tooManyEntries)).toBe(false)
+
+    const oversizedContainer = createValidEpub({
+      'META-INF/container.xml': strToU8('<rootfile'.repeat(64 * 1024)),
+    })
+    expect(oversizedContainer.byteLength).toBeLessThan(16 * 1024)
+    expect(validEpubPackage(oversizedContainer)).toBe(false)
+
+    const oversizedRootfile = patchZipCentralDirectoryEntry(
+      validFixture,
+      'EPUB/package.opf',
+      { originalSize: 16 * 1024 * 1024 + 1 },
+    )
+    expect(validEpubPackage(oversizedRootfile)).toBe(false)
+
+    const compressedMimetype = zipSync({
+      mimetype: strToU8('application/epub+zip'),
+      'META-INF/container.xml': strToU8(
+        '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+      ),
+      'EPUB/package.opf': strToU8('<package version="3.0" />'),
+    })
+    expect(validEpubPackage(compressedMimetype)).toBe(false)
+
+    const corruptPackagePayload = corruptZipLocalEntryPayload(
+      createValidEpub({
+        'EPUB/package.opf': strToU8('<package>'.repeat(4096)),
+      }),
+      'EPUB/package.opf',
+    )
+    expect(validEpubPackage(corruptPackagePayload)).toBe(true)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {
@@ -393,6 +450,43 @@ describe('PDF benchmark readiness registry', () => {
         'target-eink-reader-device': unavailableReaders,
       }),
     ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+  })
+
+  it('never accepts outside bytes while a repository binding is replaced', async () => {
+    const writeEvidence = await createEvidenceWriter()
+    const repositoryBinding = await writeEvidence(
+      'descriptor-race.json',
+      strToU8('inside'),
+    )
+    const outsideDirectory = await mkdtemp(
+      join(tmpdir(), 'pdf-binding-outside-'),
+    )
+    evidenceDirectories.push(outsideDirectory)
+    const outsidePath = join(outsideDirectory, 'outside.json')
+    const outsideBytes = strToU8('outside')
+    await writeFile(outsidePath, outsideBytes)
+    const outsideHash = createHash('sha256').update(outsideBytes).digest('hex')
+
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const validation = verifyRepositoryFileBinding(
+        repositoryBinding.path,
+        outsideHash,
+        'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+        64,
+      ).then(
+        () => ({ accepted: true, error: null }),
+        (error) => ({ accepted: false, error }),
+      )
+      await rm(repositoryBinding.path, { force: true })
+      await symlink(outsidePath, repositoryBinding.path)
+      const outcome = await validation
+      expect(outcome.accepted).toBe(false)
+      expect(outcome.error).toMatchObject({
+        message: 'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+      })
+      await rm(repositoryBinding.path, { force: true })
+      await writeFile(repositoryBinding.path, strToU8('inside'))
+    }
   })
 
   it('fails closed when a bound artifact hash changes', async () => {
@@ -1429,14 +1523,17 @@ describe('PDF benchmark readiness registry', () => {
         ['independent-desktop-epub-reader', 'independent-desktop-epub-reader'],
         ['target-eink-reader-device', 'target-eink-reader-device'],
       ].map(async ([readerId, readerType], index) => {
-        const readerIdentity = await writeEvidence(`${readerId}-identity.json`, {
-          schemaVersion: '1.0.0',
-          kind: 'pdf-benchmark-native-reader-identity-evidence',
-          readerId,
-          readerType,
-          readerIdentitySha256: (index + 4).toString(16).repeat(64),
-          status: 'passed',
-        })
+        const readerIdentity = await writeEvidence(
+          `${readerId}-identity.json`,
+          {
+            schemaVersion: '1.0.0',
+            kind: 'pdf-benchmark-native-reader-identity-evidence',
+            readerId,
+            readerType,
+            readerIdentitySha256: (index + 4).toString(16).repeat(64),
+            status: 'passed',
+          },
+        )
         return {
           readerId,
           readerType,
@@ -1590,9 +1687,9 @@ describe('PDF benchmark readiness registry', () => {
         readerIdentityEvidenceFileSha256: '0'.repeat(64),
       },
     )
-    await expect(
-      validateNativeReaderEvidence(unboundIdentity),
-    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+    await expect(validateNativeReaderEvidence(unboundIdentity)).rejects.toThrow(
+      'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+    )
 
     const renamedJsonArtifact = await writeEvidence('renamed-json.epub', {
       not: 'an epub archive',
@@ -1622,10 +1719,7 @@ describe('PDF benchmark readiness registry', () => {
     ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
 
     for (const [name, value] of [
-      [
-        'forged',
-        { ...epubCheckReceipt, outputIdentitySha256: '0'.repeat(64) },
-      ],
+      ['forged', { ...epubCheckReceipt, outputIdentitySha256: '0'.repeat(64) }],
       [
         'mismatched',
         { ...epubCheckReceipt, exactArtifactSha256: 'b'.repeat(64) },
@@ -1638,9 +1732,9 @@ describe('PDF benchmark readiness registry', () => {
         `epubcheck-${name}-export-evidence.json`,
         { epubCheckReceipt: receipt },
       )
-      await expect(
-        validateNativeReaderEvidence(rejected),
-      ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+      await expect(validateNativeReaderEvidence(rejected)).rejects.toThrow(
+        'PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH',
+      )
     }
   })
 

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -217,6 +217,46 @@ function prependUnindexedLocalEntry(bytes, entryName, value) {
   return patched
 }
 
+function patchZipMismatchedInvalidNameBytes(bytes, entryName) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  let localPatched = false
+  for (let offset = 0; offset <= patched.byteLength - 30;) {
+    if (view.getUint32(offset, true) !== 0x04034b50) break
+    const compressedSize = view.getUint32(offset + 18, true)
+    const nameLength = view.getUint16(offset + 26, true)
+    const extraLength = view.getUint16(offset + 28, true)
+    const name = Buffer.from(
+      patched.subarray(offset + 30, offset + 30 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      patched[offset + 30 + nameLength - 1] = 0xff
+      localPatched = true
+      break
+    }
+    offset += 30 + nameLength + extraLength + compressedSize
+  }
+  let centralPatched = false
+  for (let offset = 0; offset <= patched.byteLength - 46; offset += 1) {
+    if (view.getUint32(offset, true) !== 0x02014b50) continue
+    const nameLength = view.getUint16(offset + 28, true)
+    const name = Buffer.from(
+      patched.subarray(offset + 46, offset + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      patched[offset + 46 + nameLength - 1] = 0xfe
+      centralPatched = true
+      break
+    }
+  }
+  if (!localPatched || !centralPatched) throw new Error('missing ZIP entry')
+  return patched
+}
+
 function createValidEpub(extraEntries = {}) {
   return zipSync({
     mimetype: [strToU8('application/epub+zip'), { level: 0 }],
@@ -578,6 +618,31 @@ describe('PDF benchmark readiness registry', () => {
       'EPUB/content.xhtml',
     )
     expect(validEpubPackage(corruptContentPayload)).toBe(false)
+
+    const invalidNameBytes = patchZipMismatchedInvalidNameBytes(
+      createValidEpub({ 'EPUB/extra.txt': strToU8('extra') }),
+      'EPUB/extra.txt',
+    )
+    expect(validEpubPackage(invalidNameBytes)).toBe(false)
+
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'META-INF/container.xml': strToU8(
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles xmlns="urn:evil"><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml" /></rootfiles></container>',
+          ),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8(
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><metadata xmlns="urn:evil"><identifier id="pub-id">urn:fixture</identifier></metadata><manifest><item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="content"/></spine></package>',
+          ),
+        }),
+      ),
+    ).toBe(false)
   })
 
   it('accepts the repository-published EPUB profile', async () => {
@@ -585,6 +650,14 @@ describe('PDF benchmark readiness registry', () => {
       'public/research/if-letters-home-could-sing/if-letters-home-could-sing.epub',
     )
     expect(pdfBenchmarkReadiness.validEpubPackage(published)).toBe(true)
+  })
+
+  it('accepts safe directory and empty resource entries', () => {
+    const fixture = createValidEpub({
+      'EPUB/': [new Uint8Array(), { level: 0 }],
+      'EPUB/empty.css': [new Uint8Array(), { level: 0 }],
+    })
+    expect(pdfBenchmarkReadiness.validEpubPackage(fixture)).toBe(true)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { readFile, rm, writeFile } from 'node:fs/promises'
+import { readFile, rm, truncate, writeFile } from 'node:fs/promises'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import { strToU8, zipSync } from 'fflate'
 import { canonicalJson } from './pdf-fidelity-eval.mjs'
+import * as pdfBenchmarkReadiness from './pdf-benchmark-readiness.mjs'
 import {
   assessPdfBenchmarkReadiness,
   createPdfBenchmarkSplitIdentitySha256,
@@ -69,6 +70,46 @@ async function createEvidenceWriter() {
     )
     return fileBinding(relative(process.cwd(), absolutePath))
   }
+}
+
+function patchZipCentralDirectoryEntry(bytes, entryName, changes) {
+  const patched = new Uint8Array(bytes)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  for (let offset = 0; offset <= patched.byteLength - 46; offset += 1) {
+    if (view.getUint32(offset, true) !== 0x02014b50) continue
+    const nameLength = view.getUint16(offset + 28, true)
+    const extraLength = view.getUint16(offset + 30, true)
+    const commentLength = view.getUint16(offset + 32, true)
+    const name = Buffer.from(
+      patched.subarray(offset + 46, offset + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      if (changes.compressedSize !== undefined) {
+        view.setUint32(offset + 20, changes.compressedSize, true)
+      }
+      if (changes.originalSize !== undefined) {
+        view.setUint32(offset + 24, changes.originalSize, true)
+      }
+      return patched
+    }
+    offset += nameLength + extraLength + commentLength
+  }
+  throw new Error(`missing ZIP central-directory entry: ${entryName}`)
+}
+
+function createValidEpub(extraEntries = {}) {
+  return zipSync({
+    mimetype: [strToU8('application/epub+zip'), { level: 0 }],
+    'META-INF/container.xml': strToU8(
+      '<container><rootfiles><rootfile full-path="EPUB/package.opf" /></rootfiles></container>',
+    ),
+    'EPUB/package.opf': strToU8('<package version="3.0" />'),
+    ...extraEntries,
+  })
 }
 
 function reviewerIdentityEvidence(reviewerId, subjectIdentitySha256) {
@@ -243,6 +284,115 @@ describe('PDF benchmark readiness registry', () => {
     expect(receiptSha256).toBe(
       createHash('sha256').update(canonicalJson(unsignedReceipt)).digest('hex'),
     )
+  })
+
+  it('accepts legacy v1 registries without native-reader evidence as canonical blockers', async () => {
+    const legacyRegistry = await readRegistry()
+    delete legacyRegistry.nativeReaderEvidence
+
+    const receipt = await createPdfBenchmarkReadinessReceipt({
+      registryPath: await writeRegistry(legacyRegistry),
+    })
+    expect(receipt.ready).toBe(false)
+    expect(receipt.gaps).toContain('native-reader-exact-artifact-coverage')
+    expect(receipt.nativeReaderEvidence).toEqual({
+      exactArtifactSha256: null,
+      structurallyValidatedReaderIds: [],
+      trustedAttestationVerified: false,
+      trustedAttestationReason: 'trusted-attestation-verifier-not-implemented',
+      verifiedReaderIds: [],
+    })
+
+    const malformedPresentRegistry = await readRegistry()
+    malformedPresentRegistry.nativeReaderEvidence = { malformed: true }
+    await expect(
+      createPdfBenchmarkReadinessReceipt({
+        registryPath: await writeRegistry(malformedPresentRegistry),
+      }),
+    ).rejects.toThrow(/INVALID_PDF_BENCHMARK_REGISTRY/)
+  })
+
+  it('bounds EPUB archive metadata before inflation', () => {
+    expect(typeof pdfBenchmarkReadiness.validEpubPackage).toBe('function')
+    const { validEpubPackage } = pdfBenchmarkReadiness
+    const validFixture = createValidEpub({
+      'EPUB/payload.bin': [strToU8('fixture'), { level: 0 }],
+    })
+    expect(validEpubPackage(validFixture)).toBe(true)
+
+    const oversizedCompressed = patchZipCentralDirectoryEntry(
+      validFixture,
+      'EPUB/payload.bin',
+      { compressedSize: 256 * 1024 * 1024 + 1 },
+    )
+    expect(validEpubPackage(oversizedCompressed)).toBe(false)
+
+    const oversizedInflated = patchZipCentralDirectoryEntry(
+      validFixture,
+      'EPUB/payload.bin',
+      { originalSize: 512 * 1024 * 1024 + 1 },
+    )
+    expect(validEpubPackage(oversizedInflated)).toBe(false)
+
+    const tooManyEntries = createValidEpub(
+      Object.fromEntries(
+        Array.from({ length: 542 }, (_, index) => [
+          `EPUB/extra-${index}.txt`,
+          [strToU8('x'), { level: 0 }],
+        ]),
+      ),
+    )
+    expect(validEpubPackage(tooManyEntries)).toBe(false)
+  })
+
+  it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {
+    const writeEvidence = await createEvidenceWriter()
+    const oversizedEpub = await writeEvidence(
+      'oversized-before-read.epub',
+      createValidEpub(),
+    )
+    await truncate(oversizedEpub.path, 256 * 1024 * 1024 + 1)
+    const exportEvidence = await writeEvidence(
+      'oversized-export-evidence.json',
+      {
+        schemaVersion: '1.0.0',
+        kind: 'pdf-benchmark-exact-epub-export-evidence',
+        epubArtifact: oversizedEpub,
+        exactArtifactSha256: oversizedEpub.fileSha256,
+        exportReceipt: oversizedEpub,
+        exportReceiptIdentitySha256: 'a'.repeat(64),
+        toolchainManifest: oversizedEpub,
+        epubCheckReceipt: oversizedEpub,
+        epubCheckTranscript: oversizedEpub,
+        status: 'passed',
+      },
+    )
+    const unavailableReaders = {
+      status: 'unavailable-blocker',
+      readerIdentity: null,
+      executionReceipt: null,
+    }
+    await expect(
+      validateNativeReaderEvidence({
+        exportEvidence,
+        'apple-books': unavailableReaders,
+        'independent-desktop-epub-reader': unavailableReaders,
+        'target-eink-reader-device': unavailableReaders,
+      }),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
+
+    const oversizedJson = await writeEvidence('oversized-governance.json', {
+      fixture: true,
+    })
+    await truncate(oversizedJson.path, 16 * 1024 * 1024 + 1)
+    await expect(
+      validateNativeReaderEvidence({
+        exportEvidence: oversizedJson,
+        'apple-books': unavailableReaders,
+        'independent-desktop-epub-reader': unavailableReaders,
+        'target-eink-reader-device': unavailableReaders,
+      }),
+    ).rejects.toThrow('PDF_BENCHMARK_NATIVE_READER_EVIDENCE_MISMATCH')
   })
 
   it('fails closed when a bound artifact hash changes', async () => {

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -357,6 +357,34 @@ function appendPlausibleFakeZipEndRecordComment(bytes) {
   return appendZipComment(original, [0, ...fake])
 }
 
+function appendPlausibleFakeZipEndRecordStorm(bytes, fakeCount) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const entryCount = originalView.getUint16(endOffset + 10, true)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  const comment = new Uint8Array(fakeCount * 22)
+  const view = new DataView(comment.buffer)
+  for (let index = 0; index < fakeCount; index += 1) {
+    const offset = index * 22
+    view.setUint32(offset, 0x06054b50, true)
+    view.setUint16(offset + 8, entryCount, true)
+    view.setUint16(offset + 10, entryCount, true)
+    view.setUint32(
+      offset + 12,
+      original.byteLength + offset - centralOffset,
+      true,
+    )
+    view.setUint32(offset + 16, centralOffset, true)
+    view.setUint16(offset + 20, comment.byteLength - offset - 22, true)
+  }
+  return appendZipComment(original, comment)
+}
+
 function eraseFirstZipEndRecordSignature(bytes) {
   const patched = new Uint8Array(bytes)
   const view = new DataView(patched.buffer)
@@ -1002,6 +1030,12 @@ describe('PDF benchmark readiness registry', () => {
       validEpubPackage(
         eraseFirstZipEndRecordSignature(plausibleFakeEocdComment),
       ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(appendPlausibleFakeZipEndRecordStorm(validFixture, 2)),
+    ).toBe(true)
+    expect(
+      validEpubPackage(appendPlausibleFakeZipEndRecordStorm(validFixture, 16)),
     ).toBe(false)
     expect(
       validEpubPackage(appendZipComment(validFixture, Array(65_535).fill(0))),

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -166,6 +166,151 @@ function corruptZipLocalEntryPayload(bytes, entryName) {
   throw new Error(`missing ZIP local entry: ${entryName}`)
 }
 
+function appendZipCompressedPayloadByte(bytes, entryName, byte) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  let localOffset = null
+  let compressedSize = null
+  for (let cursor = centralOffset; cursor < endOffset;) {
+    const nameLength = originalView.getUint16(cursor + 28, true)
+    const extraLength = originalView.getUint16(cursor + 30, true)
+    const commentLength = originalView.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      original.subarray(cursor + 46, cursor + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      localOffset = originalView.getUint32(cursor + 42, true)
+      compressedSize = originalView.getUint32(cursor + 20, true)
+      break
+    }
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  if (localOffset === null || compressedSize === null) {
+    throw new Error(`missing ZIP entry: ${entryName}`)
+  }
+  const nameLength = originalView.getUint16(localOffset + 26, true)
+  const extraLength = originalView.getUint16(localOffset + 28, true)
+  const payloadEnd =
+    localOffset + 30 + nameLength + extraLength + compressedSize
+  const patched = new Uint8Array(original.byteLength + 1)
+  patched.set(original.subarray(0, payloadEnd))
+  patched[payloadEnd] = byte
+  patched.set(original.subarray(payloadEnd), payloadEnd + 1)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  const shiftedCentralOffset = centralOffset + 1
+  const shiftedEndOffset = endOffset + 1
+  view.setUint32(localOffset + 18, compressedSize + 1, true)
+  for (let cursor = shiftedCentralOffset; cursor < shiftedEndOffset;) {
+    const centralNameLength = view.getUint16(cursor + 28, true)
+    const centralExtraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      patched.subarray(cursor + 46, cursor + 46 + centralNameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      view.setUint32(cursor + 20, compressedSize + 1, true)
+    }
+    if (view.getUint32(cursor + 42, true) > localOffset) {
+      view.setUint32(cursor + 42, view.getUint32(cursor + 42, true) + 1, true)
+    }
+    cursor += 46 + centralNameLength + centralExtraLength + commentLength
+  }
+  view.setUint32(shiftedEndOffset + 16, shiftedCentralOffset, true)
+  return patched
+}
+
+function appendZipDescriptorPayloadByte(bytes, entryName, byte) {
+  const original = new Uint8Array(bytes)
+  const originalView = new DataView(
+    original.buffer,
+    original.byteOffset,
+    original.byteLength,
+  )
+  const endOffset = zipEndRecordOffset(original)
+  const centralOffset = originalView.getUint32(endOffset + 16, true)
+  let localOffset = null
+  let compressedSize = null
+  for (let cursor = centralOffset; cursor < endOffset;) {
+    const nameLength = originalView.getUint16(cursor + 28, true)
+    const extraLength = originalView.getUint16(cursor + 30, true)
+    const commentLength = originalView.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      original.subarray(cursor + 46, cursor + 46 + nameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      localOffset = originalView.getUint32(cursor + 42, true)
+      compressedSize = originalView.getUint32(cursor + 20, true)
+      break
+    }
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  if (localOffset === null || compressedSize === null) {
+    throw new Error(`missing ZIP entry: ${entryName}`)
+  }
+  const nextLocalOffset = (() => {
+    let next = centralOffset
+    for (let cursor = centralOffset; cursor < endOffset;) {
+      const candidate = originalView.getUint32(cursor + 42, true)
+      if (candidate > localOffset && candidate < next) next = candidate
+      cursor +=
+        46 +
+        originalView.getUint16(cursor + 28, true) +
+        originalView.getUint16(cursor + 30, true) +
+        originalView.getUint16(cursor + 32, true)
+    }
+    return next
+  })()
+  const nameLength = originalView.getUint16(localOffset + 26, true)
+  const extraLength = originalView.getUint16(localOffset + 28, true)
+  const descriptorOffset =
+    localOffset + 30 + nameLength + extraLength + compressedSize
+  const descriptorSize = nextLocalOffset - descriptorOffset
+  if (descriptorSize !== 12 && descriptorSize !== 16) {
+    throw new Error(`missing ZIP data descriptor: ${entryName}`)
+  }
+  const patched = new Uint8Array(original.byteLength + 1)
+  patched.set(original.subarray(0, descriptorOffset))
+  patched[descriptorOffset] = byte
+  patched.set(original.subarray(descriptorOffset), descriptorOffset + 1)
+  const view = new DataView(
+    patched.buffer,
+    patched.byteOffset,
+    patched.byteLength,
+  )
+  const shiftedCentralOffset = centralOffset + 1
+  const shiftedEndOffset = endOffset + 1
+  const descriptorFieldsOffset =
+    descriptorOffset + 1 + (descriptorSize === 16 ? 4 : 0)
+  view.setUint32(descriptorFieldsOffset + 4, compressedSize + 1, true)
+  for (let cursor = shiftedCentralOffset; cursor < shiftedEndOffset;) {
+    const centralNameLength = view.getUint16(cursor + 28, true)
+    const centralExtraLength = view.getUint16(cursor + 30, true)
+    const commentLength = view.getUint16(cursor + 32, true)
+    const name = Buffer.from(
+      patched.subarray(cursor + 46, cursor + 46 + centralNameLength),
+    ).toString('utf8')
+    if (name === entryName) {
+      view.setUint32(cursor + 20, compressedSize + 1, true)
+    }
+    if (view.getUint32(cursor + 42, true) > localOffset) {
+      view.setUint32(cursor + 42, view.getUint32(cursor + 42, true) + 1, true)
+    }
+    cursor += 46 + centralNameLength + centralExtraLength + commentLength
+  }
+  view.setUint32(shiftedEndOffset + 16, shiftedCentralOffset, true)
+  return patched
+}
+
 function zipEndRecordOffset(bytes) {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
   for (let offset = bytes.byteLength - 22; offset >= 0; offset -= 1) {
@@ -782,6 +927,20 @@ describe('PDF benchmark readiness registry', () => {
     expect(validEpubPackage(descriptorPackage)).toBe(true)
     expect(
       validEpubPackage(
+        appendZipDescriptorPayloadByte(
+          descriptorPackage,
+          'EPUB/package.opf',
+          0xaa,
+        ),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        appendZipCompressedPayloadByte(validFixture, 'EPUB/package.opf', 0xaa),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
         addZipDataDescriptor(validFixture, 'EPUB/package.opf', {
           signature: false,
         }),
@@ -792,6 +951,24 @@ describe('PDF benchmark readiness registry', () => {
         corruptZipDataDescriptor(descriptorPackage, 'EPUB/package.opf'),
       ),
     ).toBe(false)
+
+    const unsignedDescriptorCrcAmbiguity = addZipDataDescriptor(
+      createValidEpub({
+        'EPUB/payload.bin': [
+          Uint8Array.from([
+            ...strToU8('zip-descriptor-ambiguity'),
+            0x56,
+            0x42,
+            0x90,
+            0x7e,
+          ]),
+          { level: 0 },
+        ],
+      }),
+      'EPUB/payload.bin',
+      { signature: false },
+    )
+    expect(validEpubPackage(unsignedDescriptorCrcAmbiguity)).toBe(true)
 
     expect(validEpubPackage(addZipMimetypeExtraFields(validFixture))).toBe(
       false,

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -546,6 +546,24 @@ describe('PDF benchmark readiness registry', () => {
     expect(
       validEpubPackage(
         createValidEpub({
+          'META-INF/container.xml': strToU8(
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/decoy.opf" media-type="text/plain"/><rootfile xmlns="urn:evil" full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/></rootfiles></container>',
+          ),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'META-INF/container.xml': strToU8(
+            '<c:container xmlns:c="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><c:rootfiles><c:rootfile full-path="EPUB/decoy.opf" media-type="text/plain"/><c:rootfile xmlns:c="urn:evil" full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/></c:rootfiles></c:container>',
+          ),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
           'EPUB/package.opf': strToU8(
             '<package xmlns="http://www.idpf.org/2007/opf" xmlns:evil="urn:evil" version="3.0" unique-identifier="pub-id"><evil:metadata><evil:identifier id="pub-id">urn:fixture</evil:identifier></evil:metadata><evil:manifest><evil:item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></evil:manifest><evil:spine><evil:itemref idref="content"/></evil:spine></package>',
           ),

--- a/tools/pdf-benchmark-readiness.test.mjs
+++ b/tools/pdf-benchmark-readiness.test.mjs
@@ -507,6 +507,15 @@ describe('PDF benchmark readiness registry', () => {
       validEpubPackage(
         createValidEpub({
           'EPUB/package.opf': strToU8(
+            '<package xmlns="http://www.idpf.org/2007/opf" xmlns:evil="urn:evil" version="3.0" unique-identifier="pub-id"><evil:metadata><evil:identifier id="pub-id">urn:fixture</evil:identifier></evil:metadata><evil:manifest><evil:item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></evil:manifest><evil:spine><evil:itemref idref="content"/></evil:spine></package>',
+          ),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      validEpubPackage(
+        createValidEpub({
+          'EPUB/package.opf': strToU8(
             '<opf:package xmlns:opf="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id"><opf:metadata><opf:identifier id="pub-id">urn:fixture</opf:identifier></opf:metadata><opf:manifest><opf:item id="content" href="content.xhtml" media-type="application/xhtml+xml"/></opf:manifest><opf:spine><opf:itemref idref="content"/></opf:spine></opf:package>',
           ),
         }),
@@ -559,6 +568,23 @@ describe('PDF benchmark readiness registry', () => {
       ),
     )
     expect(validEpubPackage(hiddenPackageRecord)).toBe(false)
+
+    const corruptContentPayload = corruptZipLocalEntryPayload(
+      createValidEpub({
+        'EPUB/content.xhtml': strToU8(
+          `<html xmlns="http://www.w3.org/1999/xhtml"><body>${'content'.repeat(4096)}</body></html>`,
+        ),
+      }),
+      'EPUB/content.xhtml',
+    )
+    expect(validEpubPackage(corruptContentPayload)).toBe(false)
+  })
+
+  it('accepts the repository-published EPUB profile', async () => {
+    const published = await readFile(
+      'public/research/if-letters-home-could-sing/if-letters-home-could-sing.epub',
+    )
+    expect(pdfBenchmarkReadiness.validEpubPackage(published)).toBe(true)
   })
 
   it('rejects oversized EPUB and governance bindings from lstat metadata', async () => {

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -10,15 +10,82 @@ import {
 } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import Ajv2020 from 'ajv/dist/2020.js'
+import reportSchema from '../docs/schemas/extraction-bakeoff-report.schema.json' with { type: 'json' }
 import {
   createExtractionArchitectureDecision,
   EXTRACTION_BAKEOFF_STRATA,
   runExtractionBakeoff,
 } from '../src/research/extraction-bakeoff.ts'
+import { structuredExtractionHash } from '../src/research/structured-extraction.ts'
 
 const SHA_A = 'a'.repeat(64)
 const SHA_B = 'b'.repeat(64)
 const SCORE_LEDGER_SCHEMA_VERSION = '1.0.0'
+const validateReportSchema = new Ajv2020({ strict: false }).compile(
+  reportSchema,
+)
+const SYNTHETIC_AUTHORITY = Object.freeze({
+  kind: 'synthetic-contract-self-test',
+  realProviderCalls: 0,
+  realProviderAuthority: false,
+  promotionEligible: false,
+})
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(value, keys) {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length === keys.length &&
+    keys.every((key) => Object.hasOwn(value, key))
+  )
+}
+
+function authorityIsSynthetic(authority) {
+  return (
+    exactKeys(authority, [
+      'kind',
+      'realProviderCalls',
+      'realProviderAuthority',
+      'promotionEligible',
+    ]) &&
+    authority.kind === SYNTHETIC_AUTHORITY.kind &&
+    authority.realProviderCalls === SYNTHETIC_AUTHORITY.realProviderCalls &&
+    authority.realProviderAuthority ===
+      SYNTHETIC_AUTHORITY.realProviderAuthority &&
+    authority.promotionEligible === SYNTHETIC_AUTHORITY.promotionEligible
+  )
+}
+
+export function validateSyntheticBakeoffReport(report) {
+  if (!isRecord(report) || !authorityIsSynthetic(report.authority))
+    throw new Error('INVALID_SYNTHETIC_BAKEOFF_AUTHORITY')
+  const { reportSha256, ...reportWithoutHash } = report
+  if (
+    typeof reportSha256 !== 'string' ||
+    structuredExtractionHash(reportWithoutHash) !== reportSha256
+  ) {
+    throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT_HASH')
+  }
+  if (!validateReportSchema(report))
+    throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT_SCHEMA')
+  return report
+}
+
+function syntheticReport(report) {
+  const { reportSha256: _priorReportSha256, ...reportWithoutHash } = report
+  const reportWithAuthority = {
+    ...reportWithoutHash,
+    authority: SYNTHETIC_AUTHORITY,
+  }
+  return {
+    ...reportWithAuthority,
+    reportSha256: structuredExtractionHash(reportWithAuthority),
+  }
+}
 
 async function loadScoreLedger(path) {
   let value
@@ -219,6 +286,41 @@ function arm(id) {
 
 async function main() {
   const args = process.argv.slice(2)
+  const validationIndex = args.indexOf('--validate-report')
+  if (validationIndex >= 0) {
+    const reportPath = args[validationIndex + 1]
+    if (!reportPath) throw new Error('--validate-report requires a path')
+    let report
+    try {
+      report = JSON.parse(await readFile(reportPath, 'utf8'))
+    } catch {
+      throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+    }
+    validateSyntheticBakeoffReport(report)
+    return
+  }
+  const stampIndex = args.indexOf('--stamp-report')
+  if (stampIndex >= 0) {
+    const inputPath = args[stampIndex + 1]
+    if (!inputPath) throw new Error('--stamp-report requires a path')
+    const reportOutIndex = args.indexOf('--report-out')
+    const outputPath = args[reportOutIndex + 1]
+    if (reportOutIndex < 0 || !outputPath)
+      throw new Error('--stamp-report requires --report-out <path>')
+    let report
+    try {
+      report = JSON.parse(await readFile(inputPath, 'utf8'))
+    } catch {
+      throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+    }
+    validateSyntheticBakeoffReport(report)
+    await writeFile(
+      outputPath,
+      `${JSON.stringify(syntheticReport(report), null, 2)}\n`,
+      'utf8',
+    )
+    return
+  }
   if (!args.includes('--self-test')) {
     process.stderr.write(
       'Usage: node --experimental-strip-types tools/pdf-extraction-bakeoff.mjs --self-test --score-ledger <path> [--out <path>]\n',
@@ -230,16 +332,18 @@ async function main() {
   const scoreLedgerPath = args[scoreLedgerIndex + 1]
   if (scoreLedgerIndex < 0 || !scoreLedgerPath)
     throw new Error('--score-ledger requires a path')
-  const report = await withScoreLedger(scoreLedgerPath, (scoredHeldOutKeys) =>
-    runExtractionBakeoff({
-      corpus: makeCorpus(),
-      arms: [
-        arm('geometric-baseline'),
-        arm('llm-authored'),
-        arm('llm-grounded'),
-      ],
-      scoredHeldOutKeys,
-    }),
+  const report = syntheticReport(
+    await withScoreLedger(scoreLedgerPath, (scoredHeldOutKeys) =>
+      runExtractionBakeoff({
+        corpus: makeCorpus(),
+        arms: [
+          arm('geometric-baseline'),
+          arm('llm-authored'),
+          arm('llm-grounded'),
+        ],
+        scoredHeldOutKeys,
+      }),
+    ),
   )
   const decision = createExtractionArchitectureDecision({ report })
   const payload = `${JSON.stringify({ report, decision }, null, 2)}\n`

--- a/tools/pdf-extraction-bakeoff.mjs
+++ b/tools/pdf-extraction-bakeoff.mjs
@@ -8,6 +8,7 @@ import {
   unlink,
   writeFile,
 } from 'node:fs/promises'
+import { constants as fsConstants } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import Ajv2020 from 'ajv/dist/2020.js'
@@ -22,6 +23,7 @@ import { structuredExtractionHash } from '../src/research/structured-extraction.
 const SHA_A = 'a'.repeat(64)
 const SHA_B = 'b'.repeat(64)
 const SCORE_LEDGER_SCHEMA_VERSION = '1.0.0'
+const MAX_REPORT_BYTES = 16 * 1024 * 1024
 const validateReportSchema = new Ajv2020({ strict: false }).compile(
   reportSchema,
 )
@@ -84,6 +86,55 @@ function syntheticReport(report) {
   return {
     ...reportWithAuthority,
     reportSha256: structuredExtractionHash(reportWithAuthority),
+  }
+}
+
+async function readBoundedReport(path) {
+  let handle
+  try {
+    handle = await open(
+      resolve(path),
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW | fsConstants.O_NONBLOCK,
+    )
+    const before = await handle.stat({ bigint: true })
+    if (!before.isFile() || before.size > BigInt(MAX_REPORT_BYTES))
+      throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+    const expectedSize = Number(before.size)
+    const bytes = Buffer.allocUnsafe(expectedSize)
+    let offset = 0
+    while (offset < expectedSize) {
+      const { bytesRead } = await handle.read(
+        bytes,
+        offset,
+        expectedSize - offset,
+        offset,
+      )
+      if (bytesRead === 0) throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+      offset += bytesRead
+    }
+    const probe = Buffer.allocUnsafe(1)
+    const { bytesRead: trailingBytes } = await handle.read(
+      probe,
+      0,
+      1,
+      expectedSize,
+    )
+    const after = await handle.stat({ bigint: true })
+    if (
+      trailingBytes !== 0 ||
+      after.dev !== before.dev ||
+      after.ino !== before.ino ||
+      after.size !== before.size ||
+      after.mtimeNs !== before.mtimeNs ||
+      after.ctimeNs !== before.ctimeNs
+    ) {
+      throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+    }
+    return bytes.toString('utf8')
+  } catch {
+    throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+  } finally {
+    await handle?.close().catch(() => undefined)
   }
 }
 
@@ -292,7 +343,7 @@ async function main() {
     if (!reportPath) throw new Error('--validate-report requires a path')
     let report
     try {
-      report = JSON.parse(await readFile(reportPath, 'utf8'))
+      report = JSON.parse(await readBoundedReport(reportPath))
     } catch {
       throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
     }
@@ -309,7 +360,7 @@ async function main() {
       throw new Error('--stamp-report requires --report-out <path>')
     let report
     try {
-      report = JSON.parse(await readFile(inputPath, 'utf8'))
+      report = JSON.parse(await readBoundedReport(inputPath))
     } catch {
       throw new Error('INVALID_SYNTHETIC_BAKEOFF_REPORT')
     }

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -268,6 +268,30 @@ describe('extraction bake-off CLI', () => {
     expect(JSON.stringify(validate.errors)).toContain('structureHash')
   })
 
+  it('rejects a passed case whose structure hash is null even after recomputing its report hash', () => {
+    const schema = JSON.parse(
+      readFileSync(
+        'docs/schemas/extraction-bakeoff-report.schema.json',
+        'utf8',
+      ),
+    )
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const { reportSha256: _reportSha256, ...withoutHash } = report
+    const mutated = structuredClone(withoutHash)
+    mutated.arms['llm-grounded'].documents[0].caseScores[0].structureHash =
+      null
+    const forged = {
+      ...mutated,
+      reportSha256: structuredExtractionHash(mutated),
+    }
+
+    expect(validate(forged)).toBe(false)
+    expect(JSON.stringify(validate.errors)).toContain('structureHash')
+  })
+
   it('refuses to stamp an authority-absent report', () => {
     const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
     const source = spawnSync(

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -133,7 +133,48 @@ describe('extraction bake-off CLI', () => {
     expect(result.status, result.stderr).toBe(0)
   })
 
-  it('schemas the synthetic authority as non-promotable and provider-free', () => {
+  it('keeps the synthetic CLI validator closed to owner-local provider authority', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const { reportSha256: _reportSha256, ...withoutHash } = report
+    const realReport = {
+      ...withoutHash,
+      authority: {
+        kind: 'owner-local-real-provider-evidence',
+        realProviderCalls: 1,
+        realProviderAuthority: true,
+        promotionEligible: false,
+        providerExecutionReceiptSha256: 'c'.repeat(64),
+      },
+    }
+    const reportPath = join(directory, 'owner-local-real-report.json')
+    writeFileSync(
+      reportPath,
+      `${JSON.stringify({
+        ...realReport,
+        reportSha256: structuredExtractionHash(realReport),
+      })}\n`,
+    )
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--validate-report',
+        reportPath,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_AUTHORITY')
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('accepts raw reports and a privacy-safe owner-local real-provider receipt', () => {
     const schema = JSON.parse(
       readFileSync(
         'docs/schemas/extraction-bakeoff-report.schema.json',
@@ -146,6 +187,42 @@ describe('extraction bake-off CLI', () => {
     const validate = new Ajv2020({ strict: false }).compile(schema)
 
     expect(validate(report), JSON.stringify(validate.errors)).toBe(true)
+    const { authority: _authority, reportSha256: _reportSha256, ...raw } = report
+    const rawReport = {
+      ...raw,
+      reportSha256: structuredExtractionHash(raw),
+    }
+    expect(validate(rawReport), JSON.stringify(validate.errors)).toBe(true)
+    const realAuthorityReport = {
+      ...raw,
+      authority: {
+        kind: 'owner-local-real-provider-evidence',
+        realProviderCalls: 1,
+        realProviderAuthority: true,
+        promotionEligible: false,
+        providerExecutionReceiptSha256: 'c'.repeat(64),
+      },
+    }
+    expect(
+      validate({
+        ...realAuthorityReport,
+        reportSha256: structuredExtractionHash(realAuthorityReport),
+      }),
+      JSON.stringify(validate.errors),
+    ).toBe(true)
+    const { providerExecutionReceiptSha256: _receipt, ...unboundAuthority } =
+      realAuthorityReport.authority
+    const unboundRealReport = {
+      ...raw,
+      authority: unboundAuthority,
+    }
+    expect(
+      validate({
+        ...unboundRealReport,
+        reportSha256: structuredExtractionHash(unboundRealReport),
+      }),
+    ).toBe(false)
+
     for (const authority of [
       { ...report.authority, promotionEligible: true },
       { ...report.authority, realProviderAuthority: true },
@@ -159,23 +236,36 @@ describe('extraction bake-off CLI', () => {
         ...report,
         authority: {
           kind: 'real-provider-promotion-evidence',
-          realProviderCalls: 1,
-          realProviderAuthority: true,
-          promotionEligible: true,
-        },
-      }),
-    ).toBe(false)
-    expect(
-      validate({
-        ...report,
-        authority: {
-          kind: 'real-provider-promotion-evidence',
           realProviderCalls: Number.MAX_SAFE_INTEGER + 1,
           realProviderAuthority: true,
           promotionEligible: true,
         },
       }),
     ).toBe(false)
+  })
+
+  it('rejects a report whose case structure hash was deleted even after recomputing its report hash', () => {
+    const schema = JSON.parse(
+      readFileSync(
+        'docs/schemas/extraction-bakeoff-report.schema.json',
+        'utf8',
+      ),
+    )
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+    const { reportSha256: _reportSha256, ...withoutHash } = report
+    const mutated = structuredClone(withoutHash)
+    delete mutated.arms['geometric-baseline'].documents[0].caseScores[0]
+      .structureHash
+    const forged = {
+      ...mutated,
+      reportSha256: structuredExtractionHash(mutated),
+    }
+
+    expect(validate(forged)).toBe(false)
+    expect(JSON.stringify(validate.errors)).toContain('structureHash')
   })
 
   it('refuses to stamp an authority-absent report', () => {

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -1,8 +1,16 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import Ajv2020 from 'ajv/dist/2020.js'
 import { describe, expect, it } from 'vitest'
+import { structuredExtractionHash } from '../src/research/structured-extraction.ts'
 import { withScoreLedger } from './pdf-extraction-bakeoff.mjs'
 
 describe('extraction bake-off CLI', () => {
@@ -23,11 +31,260 @@ describe('extraction bake-off CLI', () => {
     const payload = JSON.parse(result.stdout)
     expect(payload.report.heldOutScoredOnce).toBe(true)
     expect(payload.report.comparison).toHaveLength(16)
+    expect(payload.report.authority).toEqual({
+      kind: 'synthetic-contract-self-test',
+      realProviderCalls: 0,
+      realProviderAuthority: false,
+      promotionEligible: false,
+    })
     expect(
       payload.report.candidateIdentities['llm-grounded'].promptHash,
     ).toMatch(/^[a-f0-9]{64}$/u)
-    expect(payload.decision.owner).toBe('llm-grounded')
+    expect(payload.decision.owner).toBe('pending')
+    expect(payload.decision.humanDecisionRequired).toBe(true)
     expect(payload.report).not.toHaveProperty('sourceText')
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('reproduces the committed synthetic report and pending decision', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--self-test',
+        '--score-ledger',
+        join(directory, 'score-ledger.json'),
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+    expect(result.status, result.stderr).toBe(0)
+    const payload = JSON.parse(result.stdout)
+    expect(payload.report).toEqual(
+      JSON.parse(
+        readFileSync(
+          'benchmarks/pdf/extraction-bakeoff-report-v1.json',
+          'utf8',
+        ),
+      ),
+    )
+    expect(payload.decision).toEqual(
+      JSON.parse(
+        readFileSync(
+          'docs/research/semantic-responsive-typesetting/extraction-architecture-decision-v1.json',
+          'utf8',
+        ),
+      ),
+    )
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it.each([
+    ['promotion eligibility', { promotionEligible: true }],
+    ['real-provider authority', { realProviderAuthority: true }],
+  ])('rejects a synthetic report claiming %s', (_claim, override) => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const reportPath = join(directory, 'forged-report.json')
+    writeFileSync(
+      reportPath,
+      `${JSON.stringify({
+        ...report,
+        authority: {
+          kind: 'synthetic-contract-self-test',
+          realProviderCalls: 0,
+          realProviderAuthority: false,
+          promotionEligible: false,
+          ...override,
+        },
+      })}\n`,
+    )
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--validate-report',
+        reportPath,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_AUTHORITY')
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('accepts the committed synthetic report only with its authority block', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--validate-report',
+        'benchmarks/pdf/extraction-bakeoff-report-v1.json',
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+    expect(result.status, result.stderr).toBe(0)
+  })
+
+  it('schemas the synthetic authority as non-promotable and provider-free', () => {
+    const schema = JSON.parse(
+      readFileSync(
+        'docs/schemas/extraction-bakeoff-report.schema.json',
+        'utf8',
+      ),
+    )
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const validate = new Ajv2020({ strict: false }).compile(schema)
+
+    expect(validate(report), JSON.stringify(validate.errors)).toBe(true)
+    for (const authority of [
+      { ...report.authority, promotionEligible: true },
+      { ...report.authority, realProviderAuthority: true },
+      { ...report.authority, realProviderCalls: 1 },
+      { ...report.authority, unverifiedClaim: false },
+    ]) {
+      expect(validate({ ...report, authority })).toBe(false)
+    }
+    expect(
+      validate({
+        ...report,
+        authority: {
+          kind: 'real-provider-promotion-evidence',
+          realProviderCalls: 1,
+          realProviderAuthority: true,
+          promotionEligible: true,
+        },
+      }),
+    ).toBe(false)
+    expect(
+      validate({
+        ...report,
+        authority: {
+          kind: 'real-provider-promotion-evidence',
+          realProviderCalls: Number.MAX_SAFE_INTEGER + 1,
+          realProviderAuthority: true,
+          promotionEligible: true,
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('refuses to stamp an authority-absent report', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const source = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--self-test',
+        '--score-ledger',
+        join(directory, 'score-ledger.json'),
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+    expect(source.status, source.stderr).toBe(0)
+    const markedReport = JSON.parse(source.stdout).report
+    const { authority: _authority, ...unmarkedReport } = markedReport
+    const inputPath = join(directory, 'unmarked-report.json')
+    const outputPath = join(directory, 'stamped-report.json')
+    writeFileSync(inputPath, `${JSON.stringify(unmarkedReport)}\n`)
+
+    const stamped = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--stamp-report',
+        inputPath,
+        '--report-out',
+        outputPath,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+    expect(stamped.status).toBe(1)
+    expect(stamped.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_AUTHORITY')
+    expect(existsSync(outputPath)).toBe(false)
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('refuses to stamp a report with a forged authority claim', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const report = JSON.parse(
+      readFileSync('benchmarks/pdf/extraction-bakeoff-report-v1.json', 'utf8'),
+    )
+    const inputPath = join(directory, 'forged-report.json')
+    const outputPath = join(directory, 'stamped-report.json')
+    writeFileSync(
+      inputPath,
+      `${JSON.stringify({
+        ...report,
+        authority: { ...report.authority, promotionEligible: true },
+      })}\n`,
+    )
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--stamp-report',
+        inputPath,
+        '--report-out',
+        outputPath,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_AUTHORITY')
+    expect(existsSync(outputPath)).toBe(false)
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  it('refuses to stamp a schema-invalid report even when its hash matches', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const authority = {
+      kind: 'synthetic-contract-self-test',
+      realProviderCalls: 0,
+      realProviderAuthority: false,
+      promotionEligible: false,
+    }
+    const report = { authority }
+    const inputPath = join(directory, 'minimal-report.json')
+    const outputPath = join(directory, 'stamped-report.json')
+    writeFileSync(
+      inputPath,
+      `${JSON.stringify({
+        ...report,
+        reportSha256: structuredExtractionHash(report),
+      })}\n`,
+    )
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        'tools/pdf-extraction-bakeoff.mjs',
+        '--stamp-report',
+        inputPath,
+        '--report-out',
+        outputPath,
+      ],
+      { encoding: 'utf8', timeout: 30_000 },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_REPORT_SCHEMA')
+    expect(existsSync(outputPath)).toBe(false)
     rmSync(directory, { recursive: true, force: true })
   })
 

--- a/tools/pdf-extraction-bakeoff.test.mjs
+++ b/tools/pdf-extraction-bakeoff.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  truncateSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -131,6 +132,42 @@ describe('extraction bake-off CLI', () => {
       { encoding: 'utf8', timeout: 30_000 },
     )
     expect(result.status, result.stderr).toBe(0)
+  })
+
+  it.each([
+    ['--validate-report', 'oversized'],
+    ['--stamp-report', 'oversized'],
+    ['--validate-report', 'FIFO'],
+    ['--stamp-report', 'FIFO'],
+  ])('rejects a %s input that is %s before parsing', (command, kind) => {
+    const directory = mkdtempSync(join(tmpdir(), 'extraction-bakeoff-'))
+    const inputPath = join(directory, 'untrusted-report.json')
+    const outputPath = join(directory, 'stamped-report.json')
+    if (kind === 'oversized') {
+      writeFileSync(inputPath, '{}')
+      truncateSync(inputPath, 16 * 1024 * 1024 + 1)
+    } else {
+      const fifo = spawnSync('mkfifo', [inputPath], { encoding: 'utf8' })
+      expect(fifo.status, fifo.stderr).toBe(0)
+    }
+
+    const args = [
+      '--experimental-strip-types',
+      'tools/pdf-extraction-bakeoff.mjs',
+      command,
+      inputPath,
+    ]
+    if (command === '--stamp-report') args.push('--report-out', outputPath)
+    const result = spawnSync(process.execPath, args, {
+      encoding: 'utf8',
+      timeout: 1_000,
+    })
+
+    expect(result.status, result.stderr).toBe(1)
+    expect(result.signal).toBeNull()
+    expect(result.stderr).toContain('INVALID_SYNTHETIC_BAKEOFF_REPORT')
+    expect(existsSync(outputPath)).toBe(false)
+    rmSync(directory, { recursive: true, force: true })
   })
 
   it('keeps the synthetic CLI validator closed to owner-local provider authority', () => {


### PR DESCRIPTION
Closes #290

## Summary
- keep browser PDF imports in explicitly labelled readable-fallback mode because the static route does not consult Codex; ready DOCX publication remains unchanged
- make the synthetic extraction bakeoff schema-bound, reproducible, and permanently non-promotable from report-only metadata
- require structurally hash-bound exact-EPUB/native-reader evidence while keeping repository-authored receipts non-authoritative until a trusted attestation verifier exists

## Validation
- focused changed-scope suite: 70 passed
- `npm test`: 3,938 passed, 6 skipped; association audit 5 passed
- `npm run build`: production publication matrix passed structural, accessibility, EPUBCheck, and PDF checks
- `scripts/agent-evidence`: `.agent/evidence/20260901T043430967Z/manifest.json` passed on exact head `cafb6865d294d4b4825a9bcbea44e48316f28ac0`
- final independent exact-head review: PASS