### PR TITLE
fix(pdf): keep listing lines in the line-boundary ledger; add reader success scorecard

### DIFF
--- a/docs/issues/052-pdf-epub-reader-success-criteria-and-diverse-corpus-scorecard.md
+++ b/docs/issues/052-pdf-epub-reader-success-criteria-and-diverse-corpus-scorecard.md
@@ -1,0 +1,183 @@
+# Define reader-facing PDF-to-EPUB success criteria and score every diverse corpus run against them
+
+depends-on: 037,042,043,044
+
+## Provider
+
+vm-codex
+
+## Goal
+
+Make "PDF to EPUB works" a measurable statement. The pipeline already emits
+more than sixty diagnostic codes and a fail-closed publication gate, but the
+only number anyone reads is the binary `ready` count, which has been zero on
+every corpus run since July. Nothing reports how close each paper is on the
+things a reader notices: whether the prose reads continuously, whether every
+figure arrived with its caption, whether footnotes and links resolve, whether
+running heads and journal names stayed out of the text. This spec names those
+criteria, binds each to existing diagnostic and completeness counters, and
+requires a per-criterion, per-stratum scorecard on a corpus that is diverse by
+construction, so a regression on one criterion or one layout family is visible
+in one table.
+
+## Observed failure
+
+- On 2026-09-04 the default branch crashed on 61 of 94 corpus PDFs with
+  `Cannot replay source line boundaries for partial PDF region …`, and the
+  corpus audit reported each as a generic `AUDIT_FAILED` with the cause
+  suppressed. The regression landed on 2026-08-01 (listing lines were removed
+  from the line-boundary ledger) and stayed invisible for five weeks because
+  CI runs fixture tests only; real papers are audited owner-locally and no
+  run had been made since.
+- The frozen and seeded-random corpus lanes contain arXiv LaTeX papers only.
+  No publisher PDF with running heads, no OJS/Word-processor PDF, and no
+  scanned chapter is in any lane, so the furniture and OCR criteria have never
+  been exercised on the inputs that produce them.
+- `review-required` hides every gradient. Two papers that differ by one
+  unresolved hyperlink versus forty scrambled paragraphs get the same label.
+
+## Success criteria
+
+Each criterion names what a reader notices, the existing evidence that decides
+it, when it applies, and the degenerate-answer guard. A document passes a
+criterion only when every listed blocker is absent; the criterion is
+not applicable when the source carries no such objects, so silence never
+scores a pass.
+
+1. **Reconstruction completes.** No crash, parse failure, timeout, or stall.
+   A crashed document fails every other criterion; it is never dropped from a
+   denominator.
+2. **Text is continuous and flows naturally.** Text coverage at least 0.98,
+   zero missing source regions, zero unresolved corrupting joins, zero
+   reading-order diagnostics, complete line-boundary and semantic-flow
+   ledgers, no isolated glyphs, no low-confidence blocks, no sanitization
+   loss. Guard: coverage alone never passes; the order, join, and ledger
+   counters must all be clean.
+3. **Every figure and diagram is extracted and owns its caption.** Asset
+   coverage 1, zero unresolved visual objects, zero unreferenced assets, zero
+   ambiguous visual matches, zero unresolved captions. Applies when the
+   source has at least one asset.
+4. **Footnotes and endnotes are extracted and linked both ways.** Zero
+   unresolved or ambiguous note references, zero unreferenced notes, zero
+   dangling note links. Applies when note markers were classified or note
+   objects exist.
+5. **Formatting and structure are kept.** Inline-style coverage 1, semantic
+   table coverage 1 where tables exist, zero unresolved equations,
+   preformatted blocks, algorithm blocks, or front matter. Guard: a bounded
+   crop of a table or formula is loss-preserving fallback, not structure.
+6. **Hyperlinks, citations, and cross-references resolve.** Hyperlink
+   coverage 1, relationship coverage 1, zero unresolved or unmapped citation
+   and cross-reference anchors, zero dangling internal EPUB links. Applies
+   when the source carries link annotations or scholarly relationships.
+7. **Page furniture stays out of the flow.** Zero furniture contamination and
+   zero furniture review obligations, and the pipeline must have accounted
+   for at least one excluded run on any document longer than two pages.
+   Guard: a pipeline that never classifies furniture cannot pass by silence.
+8. **Scanned pages are recovered.** Zero OCR-required pages remain. Applies to
+   scanned inputs and to any document that reported OCR obligations.
+9. **Publication gate.** The existing fail-closed `ready` verdict, reported
+   last and never instead of the eight criteria above.
+
+## Corpus diversity
+
+The scorecard is only meaningful on a corpus that is diverse by construction.
+The run must report, per stratum and with every document in every
+denominator:
+
+- layout: one-column and two-column, each with at least ten documents;
+- source family: LaTeX/arXiv, publisher-typeset (Springer, Elsevier, IEEE
+  and similar, which carry running heads and journal names), word-processor
+  exports (OJS, Word, Google Docs), and scanned or print-captured pages, each
+  with at least three documents;
+- content: at least five documents each with tables, display equations,
+  code or algorithm listings, footnotes, and more than ten figures.
+
+Strata labels come from a manifest keyed by basename, derived from the source
+PDF (producer string, layout gap share, text density), never from pipeline
+output. Source PDFs stay owner-local; the manifest and scorecard carry
+basenames, hashes, counts, and diagnostic codes only.
+
+## Acceptance tests
+
+- `node tools/pdf-success-scorecard.mjs <corpus-audit.json>... --strata <manifest> --markdown`
+  prints one table with the nine criteria as rows (applicable, passed, pass
+  rate, top blockers) and one table per stratum key, from the existing
+  corpus-audit report schema, with no new pipeline run.
+- A crashed or empty report counts as a failure of every criterion; a
+  document with no figures, notes, links, or styles is `n/a` on those
+  criteria rather than a pass; a twenty-page document with no accounted
+  furniture fails criterion 7. Unit tests cover each guard.
+- The trusted VM runs the corpus audit plus scorecard on the owner-local
+  diverse corpus after every merge to `main` that touches `src/research/**`,
+  `src/struct/**`, or `tools/pdf-*`, and posts the criterion table (counts
+  only) to the PR or issue. A drop in any criterion's pass rate, or any
+  crash, blocks the guarded auto-merge.
+- The listing-in-prose regression that hid for five weeks is covered by a
+  unit test (`src/research/pdf-layout-preformatted-residual.test.ts`) and by
+  the crash row of the scorecard.
+
+## Definition of done
+
+Per-criterion pass rates on the diverse corpus, every document in every
+denominator:
+
+- criterion 1 at 100%;
+- criteria 2, 7 at or above 95% of applicable documents;
+- criteria 3, 4, 6 at or above 90% of applicable documents;
+- criterion 5 at or above 80% of applicable documents;
+- criterion 8 at or above 80% of scanned documents;
+- criterion 9 at or above 50%, rising to the 20/20 held-out claim in #202
+  only after the eight reader criteria hold.
+
+Until then the scorecard is the progress report and the corpus audit's binary
+gate remains the release gate.
+
+## Validation command
+
+```bash
+npx vitest run tools/pdf-success-scorecard.test.mjs src/research/pdf-layout-preformatted-residual.test.ts
+npm run pdf:corpus-audit -- --report-only <owner-local corpus dir> > corpus-audit.json
+node tools/pdf-success-scorecard.mjs corpus-audit.json --strata <manifest> --markdown
+npm test
+npm run build
+```
+
+## Allowed secrets
+
+None. Source PDFs, rendered pages, and any text remain owner-local.
+
+## Artifact outputs
+
+`tools/pdf-success-scorecard.mjs` with tests; a strata manifest schema; a
+scorecard JSON and Markdown table per corpus run; a VM recipe that runs the
+audit and scorecard after merges and posts counts.
+
+## Stop conditions
+
+Stop before letting a criterion pass by omission, before deriving strata from
+pipeline output, before dropping a crashed document from a denominator, and
+before treating any per-criterion pass rate as a substitute for the
+fail-closed publication gate.
+
+## Human clarification protocol
+
+If a criterion cannot be bound to an existing counter without a new pipeline
+signal, ship it as reported-only with the missing signal named, rather than
+approximating it with a text regex.
+
+## Recommended response
+
+Bind the criteria to the counters that already exist and run them on a
+corpus that includes publisher, word-processor, and scanned inputs, because
+the current lanes never exercise the furniture or OCR criteria at all.
+
+## Trade-offs
+
+Criterion applicability rules are conservative and will mark some documents
+`n/a` that a human would score; that under-counts progress rather than
+over-claiming it, which is the right direction for a gate.
+
+## Free-form response
+
+The binary gate hid a 65% crash rate for five weeks. A nine-row table that
+runs after every merge would have shown it the same day.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2019,7 +2019,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2042,7 +2041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2059,7 +2057,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2076,7 +2073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2099,7 +2095,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2119,7 +2114,6 @@
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2139,7 +2133,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7595,9 +7588,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7704,9 +7697,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7723,11 +7716,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7846,9 +7839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8703,9 +8696,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "license": "ISC"
     },
     "node_modules/emmet": {
@@ -9207,9 +9200,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -13492,9 +13485,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16808,7 +16801,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16831,7 +16823,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -16854,7 +16845,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16871,7 +16861,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16888,7 +16877,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16905,7 +16893,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16922,7 +16909,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16939,7 +16925,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16956,7 +16941,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16973,7 +16957,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -16990,7 +16973,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17013,7 +16995,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17036,7 +17017,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17059,7 +17039,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17082,7 +17061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17105,7 +17083,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -17128,7 +17105,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -17148,7 +17124,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -17168,7 +17143,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -18843,9 +18817,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/research/pdf-layout-preformatted-residual.test.ts
+++ b/src/research/pdf-layout-preformatted-residual.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { PdfPageAnalysis, PdfSourceRun } from './import-types'
+import { reconstructPageAnalyses } from './pdf-layout'
+import { validateLineBoundaryLedger } from './pdf-quality-line-boundary-analysis'
+
+function run(
+  text: string,
+  y: number,
+  width: number,
+  fontName: string,
+): PdfSourceRun {
+  return {
+    page: 1,
+    text,
+    x: 0.1,
+    y,
+    width,
+    height: 0.018,
+    rotation: 0,
+    method: 'pdf-text',
+    fontName,
+    fontSize: 10,
+    confidence: 1,
+  }
+}
+
+function listingInsideProsePage(): PdfPageAnalysis {
+  const runs = [
+    run(
+      'The following session was captured verbatim from the tool:',
+      0.2,
+      0.6,
+      'NimbusRomNo9L-Regu',
+    ),
+    run('$ tool --version', 0.222, 0.3, 'NimbusMonoPS-Regular'),
+    run('tool 4.2.0', 0.244, 0.2, 'NimbusMonoPS-Regular'),
+    run('$ exit', 0.266, 0.1, 'NimbusMonoPS-Regular'),
+    run(
+      'The transcript above shows the version negotiation in full.',
+      0.288,
+      0.6,
+      'NimbusRomNo9L-Regu',
+    ),
+  ]
+  return {
+    page: 1,
+    kind: 'born-digital',
+    width: 612,
+    height: 792,
+    rotation: 0,
+    textCharacters: runs.reduce((total, item) => total + item.text.length, 0),
+    imageCount: 0,
+    runs,
+  }
+}
+
+describe('preformatted listings inside prose regions', () => {
+  it('keeps the line-boundary ledger complete when a listing consumes part of a prose region', async () => {
+    const result = await reconstructPageAnalyses({
+      pages: [listingInsideProsePage()],
+      sourceHash: '2'.repeat(64),
+      fileName: 'listing-inside-prose.pdf',
+      byteLength: 2048,
+    })
+
+    const listing = result.visualRelationships.find(
+      (relationship) => relationship.preformatted,
+    )
+    expect(listing?.sourceLineIds?.length ?? 0).toBeGreaterThan(1)
+
+    // Every adjacent source-line transition in every region must keep its
+    // decision: the region-text replay that carves retained prose out of a
+    // partially consumed region depends on the complete ledger, and the
+    // completeness gate independently requires it.
+    const ledger = validateLineBoundaryLedger(
+      result.regions,
+      result.lineBoundaryDecisions,
+      result.unresolvedCorruptingJoinCount,
+      result.structurallyConsumedLineBoundaryCount,
+    )
+    expect(ledger.decided).toBe(ledger.expected)
+    expect(ledger.valid).toBe(true)
+    expect(
+      result.diagnostics.map((diagnostic) => diagnostic.code),
+    ).not.toContain('INVALID_LINE_BOUNDARY_LEDGER')
+  })
+})

--- a/src/research/pdf-layout.ts
+++ b/src/research/pdf-layout.ts
@@ -1233,20 +1233,11 @@ export async function reconstructPageAnalyses({
     onProgress,
     signal,
   })
-  const preformattedLineSets = visualResult.relationships.flatMap(
-    (relationship) =>
-      relationship.preformatted && relationship.sourceLineIds
-        ? [new Set(relationship.sourceLineIds)]
-        : [],
-  )
-  regionResult.lineBoundaryDecisions =
-    regionResult.lineBoundaryDecisions.filter(
-      (decision) =>
-        !preformattedLineSets.some(
-          (lineIds) =>
-            lineIds.has(decision.fromLineId) && lineIds.has(decision.toLineId),
-        ),
-    )
+  // Listing lines stay in the line-boundary ledger. Dropping their transitions
+  // breaks the region-text replay that carves retained prose out of a
+  // partially consumed region and leaves the ledger short of one decision per
+  // adjacent source-line transition; structural ownership is classified later
+  // by classifyStructuralLineBoundaryDecisions instead.
   throwIfPdfReconstructionAborted(signal)
   onProgress?.({
     phase: 'asset-packaging',

--- a/tools/pdf-corpus-audit-lib.mjs
+++ b/tools/pdf-corpus-audit-lib.mjs
@@ -1932,6 +1932,10 @@ export async function auditPdfPath(
     ) {
       throw error
     }
+    if (process.env.PDF_CORPUS_AUDIT_DEBUG_ERRORS === '1') {
+      // Opt-in operator diagnostics only: stderr, never the report.
+      console.error('[pdf-corpus-audit] audit failure:', error)
+    }
     return {
       document: createSafeAuditFailureDocument(
         stableBasename,

--- a/tools/pdf-success-scorecard.mjs
+++ b/tools/pdf-success-scorecard.mjs
@@ -1,0 +1,574 @@
+#!/usr/bin/env node
+// Reader-facing success scorecard for PDF-to-EPUB reconstruction.
+//
+// The corpus audit answers one binary question per document ("ready" or not)
+// and nothing has ever passed it. This tool re-reads the same privacy-safe
+// audit reports and answers the questions a reader actually asks, one
+// criterion at a time, per document and per corpus stratum, so progress on any
+// single criterion is visible before the binary gate flips.
+//
+// Input reports are `pdf-corpus-audit` JSON (schema 1.x). Output contains
+// basenames, hashes, counts, and diagnostic codes only.
+import { readFile, writeFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+export const SCORECARD_SCHEMA_VERSION = '1.0.0'
+
+const CRASH_CODES = new Set([
+  'AUDIT_FAILED',
+  'PDF_PARSE_FAILED',
+  'PDF_DOCUMENT_TIMEOUT',
+  'PDF_DOCUMENT_STALLED',
+  'PDF_DOCUMENT_WORKER_FAILED',
+  'IMPORT_CANCELLED',
+  'OVERSIZED_PDF',
+])
+
+const count = (document, code) => document.diagnosticCounts?.[code] ?? 0
+const anyOf = (document, codes) =>
+  codes.filter((code) => count(document, code) > 0)
+const objects = (document) => document.completeness?.unresolvedObjects ?? {}
+
+function blockersFrom(document, codes, extra = []) {
+  return [...new Set([...anyOf(document, codes), ...extra])].sort()
+}
+
+/**
+ * Each criterion states what a reader notices, which diagnostic codes and
+ * completeness counters decide it, when it applies to a document, and the
+ * degenerate-answer guard that stops an empty or silent pipeline from
+ * scoring a pass.
+ */
+export const SUCCESS_CRITERIA = [
+  {
+    id: 'pipeline-completes',
+    title: 'Reconstruction completes without crashing',
+    guard:
+      'A crash, timeout, or parse failure fails every other criterion too.',
+    evaluate(document) {
+      const crashed = Boolean(document.code) && CRASH_CODES.has(document.code)
+      return {
+        applicable: true,
+        pass: !crashed,
+        blockers: crashed ? [document.code] : [],
+        metrics: {},
+      }
+    },
+  },
+  {
+    id: 'prose-continuity',
+    title: 'Text is continuous and flows naturally',
+    guard:
+      'Text coverage alone is not enough; reading-order, join, ledger, and provenance counters must all be clean.',
+    codes: [
+      'AMBIGUOUS_READING_ORDER',
+      'READING_ORDER_CYCLE',
+      'CANONICAL_FLOW_ORDER_VIOLATION',
+      'CANONICAL_VISUAL_ORDER_VIOLATION',
+      'UNRESOLVED_CORRUPTING_JOIN',
+      'ISOLATED_PROSE_GLYPH',
+      'INCOMPLETE_TEXT_COVERAGE',
+      'MISSING_SOURCE_REGION',
+      'UNPROVENANCED_RENDERED_UNIT',
+      'DUPLICATE_CANONICAL_SPAN',
+      'DUPLICATE_CANONICAL_ROLE',
+      'EPUB_TEXT_SANITIZATION_LOSS',
+      'INVALID_LINE_BOUNDARY_LEDGER',
+      'INVALID_SOURCE_SEMANTIC_FLOW_BOUNDARY_LEDGER',
+      'INVALID_CANONICAL_HYPHEN_BOUNDARY_LEDGER',
+      'LOW_CONFIDENCE_BLOCK',
+      'NO_RECONSTRUCTABLE_TEXT',
+    ],
+    evaluate(document) {
+      const completeness = document.completeness ?? {}
+      const extra = []
+      if ((completeness.textCoverage ?? 0) < 0.98)
+        extra.push('TEXT_COVERAGE_BELOW_0.98')
+      if ((completeness.unresolvedCorruptingJoinCount ?? 0) > 0) {
+        extra.push('UNRESOLVED_CORRUPTING_JOIN')
+      }
+      if ((completeness.readingOrderDiagnostics ?? 0) > 0) {
+        extra.push('AMBIGUOUS_READING_ORDER')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      return {
+        applicable: (completeness.sourceTextCharacters ?? 0) > 0,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: {
+          textCoverage: completeness.textCoverage ?? null,
+          unresolvedCorruptingJoinCount:
+            completeness.unresolvedCorruptingJoinCount ?? null,
+          readingOrderDiagnostics: completeness.readingOrderDiagnostics ?? null,
+        },
+      }
+    },
+  },
+  {
+    id: 'figures-and-captions',
+    title: 'Every figure and diagram is extracted and owns its caption',
+    guard:
+      'Only documents with at least one source asset count; a document with no figures cannot pass this criterion by omission.',
+    codes: [
+      'UNRESOLVED_VISUAL_OBJECT',
+      'UNREFERENCED_VISUAL_ASSET',
+      'AMBIGUOUS_VISUAL_MATCH',
+      'INCOMPLETE_ASSET_COVERAGE',
+      'MISSING_IMAGE_CAPTION',
+    ],
+    evaluate(document) {
+      const completeness = document.completeness ?? {}
+      const extra = []
+      if ((objects(document).assets ?? 0) > 0)
+        extra.push('UNRESOLVED_ASSET_OBJECTS')
+      if ((objects(document).captions ?? 0) > 0)
+        extra.push('UNRESOLVED_CAPTIONS')
+      if (
+        completeness.assetCoverage !== undefined &&
+        completeness.assetCoverage < 1
+      ) {
+        extra.push('INCOMPLETE_ASSET_COVERAGE')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      return {
+        applicable:
+          (completeness.sourceAssetCount ?? 0) > 0 || blockers.length > 0,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: {
+          sourceAssetCount: completeness.sourceAssetCount ?? null,
+          exportedAssetCount: completeness.exportedAssetCount ?? null,
+          assetCoverage: completeness.assetCoverage ?? null,
+        },
+      }
+    },
+  },
+  {
+    id: 'footnotes-and-notes',
+    title: 'Footnotes and endnotes are extracted and linked both ways',
+    guard:
+      'Applies only when the source shows note markers or note objects; silence about notes is not a pass.',
+    codes: [
+      'UNRESOLVED_NOTE_REFERENCE',
+      'UNREFERENCED_NOTE',
+      'AMBIGUOUS_NOTE_MATCH',
+      'DANGLING_NOTE_REFERENCE',
+    ],
+    evaluate(document) {
+      const extra = []
+      if ((objects(document).footnotes ?? 0) > 0)
+        extra.push('UNRESOLVED_FOOTNOTES')
+      if ((objects(document).footnoteReferences ?? 0) > 0) {
+        extra.push('UNRESOLVED_FOOTNOTE_REFERENCES')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      const evidence = count(document, 'CLASSIFIED_NOTE_MARKER') > 0
+      return {
+        applicable: evidence || blockers.length > 0,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: {
+          classifiedNoteMarkers: count(document, 'CLASSIFIED_NOTE_MARKER'),
+        },
+      }
+    },
+  },
+  {
+    id: 'formatting-and-structure',
+    title:
+      'Inline formatting, headings, tables, equations, and listings are kept as structure',
+    guard:
+      'Applies when the source has inline styles, tables, equations, or listings; an image of a table or formula is fallback, not structure.',
+    codes: [
+      'INCOMPLETE_INLINE_STYLE_COVERAGE',
+      'INCOMPLETE_SEMANTIC_TABLE_COVERAGE',
+      'BOUNDED_TABLE_FALLBACK',
+      'UNRESOLVED_EQUATION_TRANSCRIPT',
+      'UNRESOLVED_PREFORMATTED_BLOCK',
+      'UNRESOLVED_PREFORMATTED_TRANSCRIPT',
+      'UNRESOLVED_ALGORITHM_BLOCK',
+      'UNRESOLVED_ALGORITHM_TRANSCRIPT',
+      'UNRESOLVED_FRONT_MATTER',
+    ],
+    evaluate(document) {
+      const completeness = document.completeness ?? {}
+      const extra = []
+      if ((objects(document).tables ?? 0) > 0) extra.push('UNRESOLVED_TABLES')
+      if ((objects(document).equations ?? 0) > 0)
+        extra.push('UNRESOLVED_EQUATIONS')
+      if (
+        completeness.inlineSpanCoverage !== undefined &&
+        completeness.inlineSpanCoverage < 1
+      ) {
+        extra.push('INCOMPLETE_INLINE_STYLE_COVERAGE')
+      }
+      if (
+        completeness.semanticTableCoverage !== undefined &&
+        (completeness.expectedSemanticTableCount ?? 0) > 0 &&
+        completeness.semanticTableCoverage < 1
+      ) {
+        extra.push('INCOMPLETE_SEMANTIC_TABLE_COVERAGE')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      const applicable =
+        (completeness.expectedInlineSpanCount ?? 0) > 0 ||
+        (completeness.expectedSemanticTableCount ?? 0) > 0 ||
+        blockers.length > 0
+      return {
+        applicable,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: {
+          inlineSpanCoverage: completeness.inlineSpanCoverage ?? null,
+          semanticTableCoverage: completeness.semanticTableCoverage ?? null,
+          expectedSemanticTableCount:
+            completeness.expectedSemanticTableCount ?? null,
+        },
+      }
+    },
+  },
+  {
+    id: 'hyperlinks-and-references',
+    title:
+      'Hyperlinks, citations, and cross-references resolve to real targets',
+    guard:
+      'Applies when the source carries link annotations or scholarly relationships; unresolved links stay visible as text and count as failures.',
+    codes: [
+      'UNRESOLVED_HYPERLINK',
+      'UNRESOLVED_CITATION_REFERENCE',
+      'UNMAPPED_CITATION_ANCHOR',
+      'UNRESOLVED_SCHOLARLY_CROSS_REFERENCE',
+      'AMBIGUOUS_SCHOLARLY_CROSS_REFERENCE',
+      'UNMAPPED_SCHOLARLY_CROSS_REFERENCE_ANCHOR',
+      'DANGLING_EPUB_INTERNAL_REFERENCE',
+      'INCOMPLETE_RELATIONSHIP_COVERAGE',
+    ],
+    evaluate(document) {
+      const completeness = document.completeness ?? {}
+      const extra = []
+      if ((objects(document).citations ?? 0) > 0)
+        extra.push('UNRESOLVED_CITATIONS')
+      if (
+        completeness.hyperlinkCoverage !== undefined &&
+        (completeness.expectedHyperlinkCount ?? 0) > 0 &&
+        completeness.hyperlinkCoverage < 1
+      ) {
+        extra.push('UNRESOLVED_HYPERLINK')
+      }
+      if (
+        completeness.relationshipCoverage !== undefined &&
+        (completeness.expectedRelationshipCount ?? 0) > 0 &&
+        completeness.relationshipCoverage < 1
+      ) {
+        extra.push('INCOMPLETE_RELATIONSHIP_COVERAGE')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      const applicable =
+        (completeness.expectedHyperlinkCount ?? 0) > 0 ||
+        (completeness.expectedRelationshipCount ?? 0) > 0 ||
+        blockers.length > 0
+      return {
+        applicable,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: {
+          hyperlinkCoverage: completeness.hyperlinkCoverage ?? null,
+          expectedHyperlinkCount: completeness.expectedHyperlinkCount ?? null,
+          relationshipCoverage: completeness.relationshipCoverage ?? null,
+        },
+      }
+    },
+  },
+  {
+    id: 'page-furniture-excluded',
+    title:
+      'Running heads, journal names, page numbers, and margin stamps stay out of the flow',
+    guard:
+      'A multi-page document passes only when furniture was actually accounted for; a pipeline that never classifies furniture cannot pass by silence.',
+    codes: ['FURNITURE_CONTAMINATION', 'FURNITURE_REVIEW_REQUIRED'],
+    evaluate(document) {
+      const completeness = document.completeness ?? {}
+      const pageCount = document.pageCount ?? 0
+      const extra = []
+      if ((completeness.furnitureContaminationCount ?? 0) > 0) {
+        extra.push('FURNITURE_CONTAMINATION')
+      }
+      const blockers = blockersFrom(document, this.codes, extra)
+      const accounted =
+        (completeness.furnitureExcludedRunCount ?? 0) > 0 ||
+        count(document, 'REPEATED_MARGIN_TEXT') > 0
+      const applicable = pageCount > 1
+      const pass = blockers.length === 0 && (accounted || pageCount <= 2)
+      if (applicable && !pass && blockers.length === 0) {
+        blockers.push('NO_FURNITURE_ACCOUNTED')
+      }
+      return {
+        applicable,
+        pass,
+        blockers,
+        metrics: {
+          furnitureExcludedRunCount:
+            completeness.furnitureExcludedRunCount ?? null,
+          furnitureContaminationCount:
+            completeness.furnitureContaminationCount ?? null,
+        },
+      }
+    },
+  },
+  {
+    id: 'scanned-pages-recovered',
+    title: 'Scanned or image-only pages are recovered rather than skipped',
+    guard: 'Applies only to documents that needed OCR on at least one page.',
+    codes: [
+      'OCR_REQUIRED',
+      'LOW_CONFIDENCE_OCR',
+      'MIXED_OCR_CONFLICT',
+      'OCR_LANGUAGE_UNAVAILABLE',
+      'OCR_NETWORK_FORBIDDEN',
+      'NO_RECONSTRUCTABLE_TEXT',
+    ],
+    evaluate(document, strata) {
+      const pages = document.completeness?.ocrRequiredPages ?? []
+      const blockers = blockersFrom(
+        document,
+        this.codes,
+        pages.length ? ['OCR_REQUIRED'] : [],
+      )
+      const applicable = strata?.kind === 'scanned' || blockers.length > 0
+      return {
+        applicable,
+        pass: blockers.length === 0,
+        blockers,
+        metrics: { ocrRequiredPageCount: pages.length },
+      }
+    },
+  },
+  {
+    id: 'publication-ready',
+    title: 'Document passes the fail-closed publication gate',
+    guard:
+      'This is the existing binary gate; it is reported last, not instead of the criteria above.',
+    evaluate(document) {
+      const ready = Boolean(document.readiness?.ready)
+      return {
+        applicable: true,
+        pass: ready,
+        blockers: ready
+          ? []
+          : (document.readiness?.blockingDiagnosticCodes ?? []),
+        metrics: {},
+      }
+    },
+  },
+]
+
+export function scoreDocument(document, strata = null) {
+  const crashed = Boolean(document.code) && CRASH_CODES.has(document.code)
+  const criteria = {}
+  for (const criterion of SUCCESS_CRITERIA) {
+    if (crashed && criterion.id !== 'pipeline-completes') {
+      criteria[criterion.id] = {
+        applicable: true,
+        pass: false,
+        blockers: [document.code],
+        metrics: {},
+      }
+      continue
+    }
+    criteria[criterion.id] = criterion.evaluate(document, strata)
+  }
+  return {
+    basename: document.basename,
+    sha256: document.sha256 ?? null,
+    pageCount: document.pageCount ?? null,
+    strata: strata ?? null,
+    criteria,
+  }
+}
+
+function rate(passed, applicable) {
+  return applicable === 0 ? null : Number((passed / applicable).toFixed(4))
+}
+
+function summarize(scored) {
+  const criteria = SUCCESS_CRITERIA.map((criterion) => {
+    const blockers = new Map()
+    let applicable = 0
+    let passed = 0
+    for (const document of scored) {
+      const result = document.criteria[criterion.id]
+      if (!result.applicable) continue
+      applicable += 1
+      if (result.pass) passed += 1
+      for (const code of result.blockers) {
+        blockers.set(code, (blockers.get(code) ?? 0) + 1)
+      }
+    }
+    return {
+      id: criterion.id,
+      title: criterion.title,
+      guard: criterion.guard,
+      applicable,
+      passed,
+      passRate: rate(passed, applicable),
+      topBlockers: [...blockers]
+        .sort(
+          (left, right) =>
+            right[1] - left[1] || left[0].localeCompare(right[0]),
+        )
+        .slice(0, 6)
+        .map(([code, documents]) => ({ code, documents })),
+    }
+  })
+  return criteria
+}
+
+function summarizeStrata(scored, keys) {
+  const strata = {}
+  for (const key of keys) {
+    const groups = new Map()
+    for (const document of scored) {
+      const value = document.strata?.[key] ?? 'unknown'
+      const group = groups.get(value) ?? []
+      group.push(document)
+      groups.set(value, group)
+    }
+    strata[key] = Object.fromEntries(
+      [...groups]
+        .sort((left, right) => left[0].localeCompare(right[0]))
+        .map(([value, documents]) => [
+          value,
+          {
+            documents: documents.length,
+            criteria: Object.fromEntries(
+              summarize(documents).map((criterion) => [
+                criterion.id,
+                {
+                  applicable: criterion.applicable,
+                  passed: criterion.passed,
+                  passRate: criterion.passRate,
+                },
+              ]),
+            ),
+          },
+        ]),
+    )
+  }
+  return strata
+}
+
+export function buildScorecard(reports, { strataManifest = null } = {}) {
+  const documents = reports.flatMap((report) => report.documents ?? [])
+  const scored = documents.map((document) =>
+    scoreDocument(
+      document,
+      strataManifest?.documents?.[document.basename] ?? null,
+    ),
+  )
+  const strataKeys = strataManifest ? ['layout', 'source', 'kind'] : []
+  return {
+    schemaVersion: SCORECARD_SCHEMA_VERSION,
+    privacy: 'basenames-hashes-counts-diagnostic-codes-only',
+    documents: scored.length,
+    criteria: summarize(scored),
+    strata: summarizeStrata(scored, strataKeys),
+    perDocument: scored.map((document) => ({
+      basename: document.basename,
+      strata: document.strata,
+      criteria: Object.fromEntries(
+        Object.entries(document.criteria).map(([id, result]) => [
+          id,
+          result.applicable ? (result.pass ? 'pass' : 'fail') : 'n/a',
+        ]),
+      ),
+    })),
+  }
+}
+
+export function renderMarkdown(scorecard) {
+  const percent = (value) =>
+    value === null ? 'n/a' : `${Math.round(value * 100)}%`
+  const lines = [
+    `# PDF-to-EPUB success scorecard (${scorecard.documents} documents)`,
+    '',
+    '| Criterion | Applicable | Passed | Pass rate | Top blockers |',
+    '| --- | ---: | ---: | ---: | --- |',
+  ]
+  for (const criterion of scorecard.criteria) {
+    lines.push(
+      `| ${criterion.title} | ${criterion.applicable} | ${criterion.passed} | ${percent(criterion.passRate)} | ${criterion.topBlockers
+        .slice(0, 3)
+        .map((blocker) => `${blocker.code} (${blocker.documents})`)
+        .join(', ')} |`,
+    )
+  }
+  for (const [key, groups] of Object.entries(scorecard.strata)) {
+    lines.push('', `## By ${key}`, '')
+    const ids = scorecard.criteria.map((criterion) => criterion.id)
+    lines.push(`| ${key} | docs | ${ids.join(' | ')} |`)
+    lines.push(`| --- | ---: | ${ids.map(() => '---:').join(' | ')} |`)
+    for (const [value, group] of Object.entries(groups)) {
+      lines.push(
+        `| ${value} | ${group.documents} | ${ids
+          .map((id) => percent(group.criteria[id]?.passRate ?? null))
+          .join(' | ')} |`,
+      )
+    }
+  }
+  return `${lines.join('\n')}\n`
+}
+
+function usage() {
+  return 'Usage: node tools/pdf-success-scorecard.mjs <corpus-audit.json>... [--strata <manifest.json>] [--out <scorecard.json>] [--markdown]\n'
+}
+
+export async function readReport(path) {
+  const text = await readFile(path, 'utf8')
+  const start = text.indexOf('{')
+  if (start < 0) throw new Error(`No JSON object in ${path}`)
+  return JSON.parse(text.slice(start))
+}
+
+async function main(args) {
+  const inputs = []
+  let strataPath = null
+  let out = null
+  let markdown = false
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--strata') {
+      strataPath = args[index + 1] ?? null
+      index += 1
+    } else if (argument === '--out') {
+      out = args[index + 1] ?? null
+      index += 1
+    } else if (argument === '--markdown') {
+      markdown = true
+    } else if (argument.startsWith('--')) {
+      throw new Error('INVALID_USAGE')
+    } else {
+      inputs.push(argument)
+    }
+  }
+  if (inputs.length === 0) throw new Error('INVALID_USAGE')
+  const reports = await Promise.all(inputs.map(readReport))
+  const strataManifest = strataPath ? await readReport(strataPath) : null
+  const scorecard = buildScorecard(reports, { strataManifest })
+  if (out) await writeFile(out, `${JSON.stringify(scorecard, null, 2)}\n`)
+  process.stdout.write(
+    markdown
+      ? renderMarkdown(scorecard)
+      : `${JSON.stringify(scorecard, null, 2)}\n`,
+  )
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(
+      error instanceof Error && error.message === 'INVALID_USAGE'
+        ? usage()
+        : `${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  })
+}

--- a/tools/pdf-success-scorecard.test.mjs
+++ b/tools/pdf-success-scorecard.test.mjs
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SUCCESS_CRITERIA,
+  buildScorecard,
+  renderMarkdown,
+  scoreDocument,
+} from './pdf-success-scorecard.mjs'
+
+function completeness(overrides = {}) {
+  return {
+    sourceTextCharacters: 10000,
+    textCoverage: 1,
+    missingSourceRegionCount: 0,
+    unresolvedCorruptingJoinCount: 0,
+    readingOrderDiagnostics: 0,
+    expectedInlineSpanCount: 12,
+    inlineSpanCoverage: 1,
+    expectedHyperlinkCount: 4,
+    hyperlinkCoverage: 1,
+    sourceAssetCount: 2,
+    exportedAssetCount: 2,
+    assetCoverage: 1,
+    expectedRelationshipCount: 3,
+    relationshipCoverage: 1,
+    expectedSemanticTableCount: 1,
+    semanticTableCoverage: 1,
+    unresolvedObjects: {
+      assets: 0,
+      captions: 0,
+      tables: 0,
+      equations: 0,
+      citations: 0,
+      footnoteReferences: 0,
+      footnotes: 0,
+    },
+    ocrRequiredPages: [],
+    furnitureExcludedRunCount: 6,
+    furnitureContaminationCount: 0,
+    ...overrides,
+  }
+}
+
+const readyDocument = {
+  basename: 'ready.pdf',
+  sha256: 'a'.repeat(64),
+  pageCount: 8,
+  completeness: completeness(),
+  readiness: { status: 'ready', ready: true, blockingDiagnosticCodes: [] },
+  diagnosticCounts: { CLASSIFIED_NOTE_MARKER: 3, REPEATED_MARGIN_TEXT: 1 },
+}
+
+const reviewDocument = {
+  basename: 'review.pdf',
+  sha256: 'b'.repeat(64),
+  pageCount: 12,
+  completeness: completeness({
+    textCoverage: 0.97,
+    unresolvedCorruptingJoinCount: 2,
+    assetCoverage: 0.5,
+    exportedAssetCount: 1,
+    hyperlinkCoverage: 0.25,
+    unresolvedObjects: {
+      assets: 1,
+      captions: 0,
+      tables: 0,
+      equations: 4,
+      citations: 0,
+      footnoteReferences: 1,
+      footnotes: 0,
+    },
+  }),
+  readiness: {
+    status: 'review-required',
+    ready: false,
+    blockingDiagnosticCodes: [
+      'UNRESOLVED_VISUAL_OBJECT',
+      'FURNITURE_CONTAMINATION',
+    ],
+  },
+  diagnosticCounts: {
+    UNRESOLVED_VISUAL_OBJECT: 1,
+    UNRESOLVED_CORRUPTING_JOIN: 2,
+    UNRESOLVED_NOTE_REFERENCE: 1,
+    UNRESOLVED_EQUATION_TRANSCRIPT: 4,
+    UNRESOLVED_HYPERLINK: 3,
+    FURNITURE_CONTAMINATION: 1,
+  },
+}
+
+const crashedDocument = {
+  basename: 'crashed.pdf',
+  sha256: null,
+  code: 'AUDIT_FAILED',
+  message:
+    'The PDF could not be audited; local path and document details were suppressed.',
+}
+
+describe('PDF success scorecard', () => {
+  it('names every reader-facing criterion with a degenerate-answer guard', () => {
+    expect(SUCCESS_CRITERIA.map((criterion) => criterion.id)).toEqual([
+      'pipeline-completes',
+      'prose-continuity',
+      'figures-and-captions',
+      'footnotes-and-notes',
+      'formatting-and-structure',
+      'hyperlinks-and-references',
+      'page-furniture-excluded',
+      'scanned-pages-recovered',
+      'publication-ready',
+    ])
+    for (const criterion of SUCCESS_CRITERIA) {
+      expect(criterion.guard.length).toBeGreaterThan(20)
+    }
+  })
+
+  it('passes a clean document on every applicable criterion', () => {
+    const scored = scoreDocument(readyDocument, { kind: 'born-digital' })
+    const verdicts = Object.fromEntries(
+      Object.entries(scored.criteria).map(([id, result]) => [
+        id,
+        result.applicable ? result.pass : 'n/a',
+      ]),
+    )
+    expect(verdicts).toEqual({
+      'pipeline-completes': true,
+      'prose-continuity': true,
+      'figures-and-captions': true,
+      'footnotes-and-notes': true,
+      'formatting-and-structure': true,
+      'hyperlinks-and-references': true,
+      'page-furniture-excluded': true,
+      'scanned-pages-recovered': 'n/a',
+      'publication-ready': true,
+    })
+  })
+
+  it('attributes each failure to the criterion a reader would notice', () => {
+    const scored = scoreDocument(reviewDocument, { kind: 'born-digital' })
+    expect(scored.criteria['prose-continuity']).toMatchObject({
+      pass: false,
+      blockers: expect.arrayContaining([
+        'TEXT_COVERAGE_BELOW_0.98',
+        'UNRESOLVED_CORRUPTING_JOIN',
+      ]),
+    })
+    expect(scored.criteria['figures-and-captions'].blockers).toEqual(
+      expect.arrayContaining([
+        'UNRESOLVED_VISUAL_OBJECT',
+        'UNRESOLVED_ASSET_OBJECTS',
+      ]),
+    )
+    expect(scored.criteria['footnotes-and-notes'].blockers).toEqual(
+      expect.arrayContaining([
+        'UNRESOLVED_NOTE_REFERENCE',
+        'UNRESOLVED_FOOTNOTE_REFERENCES',
+      ]),
+    )
+    expect(scored.criteria['formatting-and-structure'].blockers).toEqual(
+      expect.arrayContaining([
+        'UNRESOLVED_EQUATION_TRANSCRIPT',
+        'UNRESOLVED_EQUATIONS',
+      ]),
+    )
+    expect(scored.criteria['hyperlinks-and-references'].blockers).toContain(
+      'UNRESOLVED_HYPERLINK',
+    )
+    expect(scored.criteria['page-furniture-excluded']).toMatchObject({
+      pass: false,
+      blockers: ['FURNITURE_CONTAMINATION'],
+    })
+    expect(scored.criteria['publication-ready'].pass).toBe(false)
+  })
+
+  it('fails every criterion for a crashed document instead of skipping it', () => {
+    const scored = scoreDocument(crashedDocument)
+    for (const [id, result] of Object.entries(scored.criteria)) {
+      expect(result.applicable, id).toBe(true)
+      expect(result.pass, id).toBe(false)
+      expect(result.blockers, id).toEqual(['AUDIT_FAILED'])
+    }
+  })
+
+  it('does not let silence score a pass', () => {
+    const silent = {
+      basename: 'silent.pdf',
+      sha256: 'c'.repeat(64),
+      pageCount: 20,
+      completeness: completeness({
+        sourceAssetCount: 0,
+        exportedAssetCount: 0,
+        expectedHyperlinkCount: 0,
+        expectedRelationshipCount: 0,
+        expectedInlineSpanCount: 0,
+        expectedSemanticTableCount: 0,
+        furnitureExcludedRunCount: 0,
+      }),
+      readiness: { status: 'ready', ready: true, blockingDiagnosticCodes: [] },
+      diagnosticCounts: {},
+    }
+    const scored = scoreDocument(silent, { kind: 'born-digital' })
+    expect(scored.criteria['figures-and-captions'].applicable).toBe(false)
+    expect(scored.criteria['footnotes-and-notes'].applicable).toBe(false)
+    expect(scored.criteria['hyperlinks-and-references'].applicable).toBe(false)
+    expect(scored.criteria['formatting-and-structure'].applicable).toBe(false)
+    expect(scored.criteria['page-furniture-excluded']).toMatchObject({
+      applicable: true,
+      pass: false,
+      blockers: ['NO_FURNITURE_ACCOUNTED'],
+    })
+  })
+
+  it('aggregates pass rates per criterion and per stratum without document content', () => {
+    const scorecard = buildScorecard(
+      [
+        { documents: [readyDocument, reviewDocument] },
+        { documents: [crashedDocument] },
+      ],
+      {
+        strataManifest: {
+          documents: {
+            'ready.pdf': {
+              layout: 'one-column',
+              source: 'latex',
+              kind: 'born-digital',
+            },
+            'review.pdf': {
+              layout: 'two-column',
+              source: 'publisher',
+              kind: 'born-digital',
+            },
+          },
+        },
+      },
+    )
+    expect(scorecard.documents).toBe(3)
+    const byId = Object.fromEntries(
+      scorecard.criteria.map((criterion) => [criterion.id, criterion]),
+    )
+    expect(byId['pipeline-completes']).toMatchObject({
+      applicable: 3,
+      passed: 2,
+    })
+    expect(byId['publication-ready']).toMatchObject({
+      applicable: 3,
+      passed: 1,
+    })
+    expect(byId['figures-and-captions'].topBlockers[0]).toEqual({
+      code: 'AUDIT_FAILED',
+      documents: 1,
+    })
+    expect(
+      scorecard.strata.layout['two-column'].criteria['prose-continuity'],
+    ).toMatchObject({
+      applicable: 1,
+      passed: 0,
+      passRate: 0,
+    })
+    expect(scorecard.strata.layout.unknown.documents).toBe(1)
+    expect(
+      scorecard.perDocument.map(
+        (document) => document.criteria['publication-ready'],
+      ),
+    ).toEqual(['pass', 'fail', 'fail'])
+    const serialized = JSON.stringify(scorecard)
+    expect(serialized).not.toContain('suppressed')
+    expect(serialized).not.toContain('/Users/')
+
+    const markdown = renderMarkdown(scorecard)
+    expect(markdown).toContain(
+      '| Reconstruction completes without crashing | 3 | 2 | 67% |',
+    )
+    expect(markdown).toContain('## By layout')
+  })
+})


### PR DESCRIPTION
Closes #293

## Summary
- Remove the Aug 1 filter that dropped intra-listing line-boundary decisions; the region-text replay and the ledger validator both need the complete set. Regression test: `src/research/pdf-layout-preformatted-residual.test.ts`.
- `PDF_CORPUS_AUDIT_DEBUG_ERRORS=1` prints the real audit exception to stderr (opt-in, never into the report).
- `tools/pdf-success-scorecard.mjs` (+tests): scores corpus-audit reports on nine reader-facing criteria per document and per layout/source stratum, with degenerate-answer guards.
- `docs/issues/052`: success criteria, corpus diversity minimums, done thresholds.

## Evidence (owner-local, 80-document diverse corpus)
Passed of applicable, before → after:
- pipeline completes: 33/80 → 79/80 (remaining one exceeds the 50 MB limit)
- prose continuity 1/78 → 2/78; figures+captions 1/80 → 2/80; footnotes 10/78 → 24/77
- formatting 0/80 → 0/80; links 0/78 → 0/78; page furniture 14/80 → 33/80; ready 0/80 → 0/80

## Validation
- `npx vitest run src/research/pdf-layout-preformatted-residual.test.ts src/research/pdf-visuals-preformatted.test.ts src/research/pdf-region-fragments.test.ts src/research/pdf-quality-line-boundary-analysis.test.ts src/research/decision-record.test.ts tools/pdf-success-scorecard.test.mjs`: 103 passed
- `npm test`: 6991 passed; the 12 repo files that fail (publication toolchain pins, missing `pdf-lib` in local node_modules) fail identically on clean `main` at 495f221
- `tsc --noEmit`: no errors outside stray `tmp/` copies